### PR TITLE
Switch to ASCII Box Art Neon Logo

### DIFF
--- a/packages/neondb/src/lib/texts.ts
+++ b/packages/neondb/src/lib/texts.ts
@@ -5,7 +5,7 @@ export const INTRO_ART = `
 
     ▟████████████▙
     ██          ██
-    ██    ▗▅▖   ██       neon.com
+    ██    ▗▅▖   ██       https://neon.com
     ██    ████▙ ██       ├── /docs
     ██    ██ ▜████       └── /discord
     ██    ██   ▜█▛


### PR DESCRIPTION
## Overview

I spoke briefly with @atilafassina about contributing this very important improvement of an updated Neon logo in ASCII box art instead of the auto-generated characters...


Before:
<img width="405" alt="image" src="https://github.com/user-attachments/assets/1908acf3-5331-4079-a265-e1d21d696011" />

After:
<img width="362" alt="image" src="https://github.com/user-attachments/assets/373ca5c2-b523-4c19-bc44-e1c024769420" />

I also made the Neon URL absolute so that it was clickable in certain terminals like VS Code