### PR TITLE
ci: run all workflows on the protected runner group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 jobs:
     build:
         name: Build
-        runs-on: ubuntu-latest
+        runs-on:
+            group: neondatabase-protected-runner-group
+            labels: linux-ubuntu-latest
         steps:
             - name: Harden the runner (Audit all outbound calls)
               uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
@@ -13,7 +15,9 @@ jobs:
             - run: pnpm build
     lint:
         name: Lint
-        runs-on: ubuntu-latest
+        runs-on:
+            group: neondatabase-protected-runner-group
+            labels: linux-ubuntu-latest
         steps:
             - name: Harden the runner (Audit all outbound calls)
               uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
@@ -25,7 +29,9 @@ jobs:
             - run: pnpm lint:ci
     test:
         name: Test
-        runs-on: ubuntu-latest
+        runs-on:
+            group: neondatabase-protected-runner-group
+            labels: linux-ubuntu-latest
         steps:
             - name: Harden the runner (Audit all outbound calls)
               uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/.github/workflows/dist-typecheck.yml
+++ b/.github/workflows/dist-typecheck.yml
@@ -12,7 +12,9 @@ permissions:
 jobs:
     typecheck-dist:
         name: Check ${{ matrix.name }} distributed types
-        runs-on: ubuntu-latest
+        runs-on:
+            group: neondatabase-protected-runner-group
+            labels: linux-ubuntu-latest
         strategy:
             matrix:
                 include:


### PR DESCRIPTION
Switch `ci.yml` (build / lint / test) and `dist-typecheck.yml` from GitHub-hosted `ubuntu-latest` to the `neondatabase-protected-runner-group` (label `linux-ubuntu-latest`), so all four workflows run on the protected runner group — same as the release workflows.
