### PR TITLE
fix: repair tsdown peer-context in lockfile for config-runtime

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,7 +215,7 @@ importers:
         version: 0.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2


### PR DESCRIPTION
## Problem

`pnpm install --frozen-lockfile` fails on `main`:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'tsdown@0.14.1(typescript@5.8.2)' in pnpm-lock.yaml
```

This breaks CI (the `prepare` action installs with `--frozen-lockfile`) and the downstream secure-release workflow, which also installs frozen.

## Root cause

A badly-merged lockfile across two recent PRs:

- **#156** (`integrity-pin @arethetypeswrong/cli`) added `@arethetypeswrong/cli`, pulling `@arethetypeswrong/core@0.18.2` into the tree. That changed tsdown's peer-resolution key to `tsdown@0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)` for **every** workspace.
- **#152** (`feat(config): add preview namespace`) added `packages/config-runtime` but was branched **before** #156, so its importer entry kept the old `tsdown@0.14.1(typescript@5.8.2)` reference — a snapshot #156 had renamed away. The result is a single dangling reference.

`--frozen-lockfile`'s integrity check catches it; the default install / `--lockfile-only` path does not (the manifest specifier still matches), which is how it merged green.

## Fix

`pnpm install --fix-lockfile` regenerated the one stale reference. Net change is a single line in `pnpm-lock.yaml` — `packages/config-runtime`'s tsdown now points at the existing `(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)` snapshot. No integrity churn; #156's pin is preserved.

## Verification

- `pnpm install --frozen-lockfile` → passes ✅
- `pnpm run build` → passes ✅

This pull request and its description were written by Isaac.
