### PR TITLE
chore(release): version @neondatabase/functions and @neondatabase/config-runtime to 0.1.0

### DIFF
--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @neondatabase/config-runtime
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release of `@neondatabase/config-runtime` — the imperative runtime for `@neondatabase/config`. Reads a branch's live state, diffs a policy against it, applies changes, and bundles + deploys Neon Functions. Function bundling pulls in `esbuild`, so this is the package CLIs and CI import — keeping `esbuild` out of the dependency tree of anyone who only imports `defineConfig` from `neon.ts`.
+
+  - `inspect` / `plan` / `apply` (Terraform-style), plus the lower-level `pushConfig` / `pullConfig` engine.
+  - Preview features are applied **additively** (buckets and functions are created and the AI Gateway is enabled; nothing is auto-deleted), and `inspect` / `pullConfig` reports a branch's live Preview state.
+  - `buildFunctionBundle` — bundles a function's `source` with esbuild and zips it for deploy.

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# @neondatabase/functions
+
+## 0.1.0
+
+### Minor Changes
+
+- Initial release of `@neondatabase/functions` — runtime helpers for Neon Functions.
+
+  - `waitUntil()` — returns a function for deferring background work past a response, mirroring the Cloudflare Workers / Vercel `ctx.waitUntil(promise)` primitive.
+
+  > **Not implemented yet.** `waitUntil()` currently returns a no-op placeholder; the promise is accepted and ignored until the Neon Functions runtime integration ships.

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/functions",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Runtime helpers for Neon Functions. Currently provides a `waitUntil` primitive for deferring async work past a response.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Summary

Releases the first versions of the two packages that were intentionally held back at `0.0.0` when config/env were released:

- `@neondatabase/functions` — `0.0.0` → `0.1.0`
- `@neondatabase/config-runtime` — `0.0.0` → `0.1.0`

Each is released by adding its initial-release changeset and running `changeset version`, which bumps the `package.json` version, writes the package `CHANGELOG.md`, and consumes the changeset.

### `@neondatabase/functions`

Runtime helpers for Neon Functions. Ships the `waitUntil()` primitive — a function for deferring background work past a response, mirroring the Cloudflare Workers / Vercel `ctx.waitUntil(promise)` API.

> **Note:** `waitUntil()` is currently a no-op placeholder; the promise is accepted and ignored until the Neon Functions runtime integration ships.

### `@neondatabase/config-runtime`

The imperative runtime for `@neondatabase/config`: reads a branch's live state, diffs a policy against it, applies changes, and bundles + deploys Neon Functions (`inspect` / `plan` / `apply`, plus `pushConfig` / `pullConfig` and `buildFunctionBundle`). Pulls in `esbuild`, so it's the package CLIs and CI import — keeping `esbuild` out of the dependency tree of anyone who only imports `defineConfig` from `neon.ts`.

## Changes

- `packages/functions/package.json` — `version` → `0.1.0`
- `packages/functions/CHANGELOG.md` — new (generated by `changeset version`)
- `packages/config-runtime/package.json` — `version` → `0.1.0`
- `packages/config-runtime/CHANGELOG.md` — new (generated by `changeset version`)
- initial-release changesets for both packages — consumed (removed) by `changeset version`

## Test plan

- [x] `pnpm --filter @neondatabase/functions build` (includes `tsc --noEmit`) passes
- [x] `pnpm --filter @neondatabase/config-runtime build` (includes `tsc --noEmit`) passes
- [ ] CI green
- [ ] Merge triggers npm publish of `@neondatabase/functions@0.1.0` and `@neondatabase/config-runtime@0.1.0`