### PR TITLE
chore: disable npm provenance (published from a private mirror)

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -65,6 +65,6 @@
 		"node": ">=22"
 	},
 	"publishConfig": {
-		"provenance": true
+		"provenance": false
 	}
 }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -70,6 +70,6 @@
 		"node": ">=22"
 	},
 	"publishConfig": {
-		"provenance": true
+		"provenance": false
 	}
 }

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -59,6 +59,6 @@
 		"node": ">=22"
 	},
 	"publishConfig": {
-		"provenance": true
+		"provenance": false
 	}
 }

--- a/packages/get-db/package.json
+++ b/packages/get-db/package.json
@@ -61,7 +61,7 @@
 		"node": ">=22"
 	},
 	"publishConfig": {
-		"provenance": true
+		"provenance": false
 	},
 	"dependencies": {
 		"neon-new": "workspace:*"

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -60,6 +60,6 @@
 		"node": ">=22"
 	},
 	"publishConfig": {
-		"provenance": true
+		"provenance": false
 	}
 }

--- a/packages/neon-new/package.json
+++ b/packages/neon-new/package.json
@@ -66,7 +66,7 @@
 		"node": ">=22"
 	},
 	"publishConfig": {
-		"provenance": true
+		"provenance": false
 	},
 	"dependencies": {
 		"@clack/prompts": "0.10.1",

--- a/packages/neondb/package.json
+++ b/packages/neondb/package.json
@@ -61,7 +61,7 @@
 		"node": ">=22"
 	},
 	"publishConfig": {
-		"provenance": true
+		"provenance": false
 	},
 	"dependencies": {
 		"neon-new": "workspace:*"


### PR DESCRIPTION
## What

Set `publishConfig.provenance: false` on every package that had it `true` (config, env, functions, get-db, init, neon-new, neondb). `config-runtime` was already `false`, so this just makes the repo consistent.

## Why

These packages are published **only** from a private mirror — the secure Stage-2 release workflow in `databricks/secure-public-registry-releases-eng` (Stage 1 here never publishes; no npm token lives in this repo). npm provenance **requires a public source repository**, so publishing with `provenance: true` from the private mirror is rejected:

```
npm error code E422
npm error 422 Unprocessable Entity — Error verifying sigstore provenance bundle:
Unsupported GitHub Actions source repository visibility: "private".
Only public source repositories are supported when publishing with provenance.
```

Since these packages can never be published from a public repo, `provenance: true` can never be honored — it just breaks every real publish. Disabling it is the correct fix.

This pull request and its description were written by Isaac.
