### PR TITLE
feat(config-runtime): pull Neon Auth / Data API enablement in pullConfig

### DIFF
--- a/.changeset/pull-config-auth-dataapi.md
+++ b/.changeset/pull-config-auth-dataapi.md
@@ -1,0 +1,5 @@
+---
+"@neondatabase/config-runtime": minor
+---
+
+`pullConfig` now reverse-engineers the branch's **Neon Auth** and **Data API** enablement into the returned `config` (`config.auth = {}` / `config.dataApi = {}` when each integration is enabled on the branch). Previously only branch/postgres settings and the `preview` block (buckets, functions, AI Gateway) were surfaced, so a config pulled from a branch with Auth or Data API enabled did not round-trip through `resolveConfig` / `fetchEnv` — and the matching `NEON_AUTH_BASE_URL` / `NEON_DATA_API_URL` secrets were never injected. Data API is enabled per branch + database, so `pullConfig` probes the branch's default database (`neondb`, else the first database) to detect it.

--- a/packages/config-runtime/src/lib/pull-config.test.ts
+++ b/packages/config-runtime/src/lib/pull-config.test.ts
@@ -48,4 +48,121 @@ describe("pullConfig", () => {
 			postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
 		});
 	});
+
+	test("omits auth/dataApi when neither integration is enabled", async () => {
+		const api = new FakeNeonApi();
+		const projectId = "proj-none";
+		api.seedProject({
+			project: {
+				id: projectId,
+				name: "none",
+				regionId: "aws-us-east-1",
+				pgVersion: 17,
+			},
+			branches: [
+				{ branch: { id: "br-main", name: "main", isDefault: true } },
+			],
+		});
+
+		const pulled = await pullConfig({
+			api,
+			projectId,
+			branchId: "br-main",
+		});
+
+		expect(pulled.config.auth).toBeUndefined();
+		expect(pulled.config.dataApi).toBeUndefined();
+	});
+
+	test("sets config.auth when a Neon Auth integration is enabled", async () => {
+		const api = new FakeNeonApi();
+		const projectId = "proj-auth";
+		api.seedProject({
+			project: {
+				id: projectId,
+				name: "auth",
+				regionId: "aws-us-east-1",
+				pgVersion: 17,
+			},
+			branches: [
+				{ branch: { id: "br-main", name: "main", isDefault: true } },
+			],
+		});
+		api.seedNeonAuth(projectId, "br-main", {
+			projectId: "auth-proj",
+			jwksUrl: "https://example.test/jwks",
+			baseUrl: "https://example.test/auth",
+		});
+
+		const pulled = await pullConfig({
+			api,
+			projectId,
+			branchId: "br-main",
+		});
+
+		expect(pulled.config.auth).toEqual({});
+		expect(pulled.config.dataApi).toBeUndefined();
+	});
+
+	test("sets config.dataApi when a Data API integration is enabled", async () => {
+		const api = new FakeNeonApi();
+		const projectId = "proj-dataapi";
+		api.seedProject({
+			project: {
+				id: projectId,
+				name: "dataapi",
+				regionId: "aws-us-east-1",
+				pgVersion: 17,
+			},
+			branches: [
+				{ branch: { id: "br-main", name: "main", isDefault: true } },
+			],
+		});
+		// The branch is seeded with a default `neondb` database, which pullConfig probes.
+		api.seedNeonDataApi(projectId, "br-main", "neondb", {
+			url: "https://example.test/data-api/neondb",
+		});
+
+		const pulled = await pullConfig({
+			api,
+			projectId,
+			branchId: "br-main",
+		});
+
+		expect(pulled.config.dataApi).toEqual({});
+		expect(pulled.config.auth).toBeUndefined();
+	});
+
+	test("sets both auth and dataApi when both are enabled", async () => {
+		const api = new FakeNeonApi();
+		const projectId = "proj-both";
+		api.seedProject({
+			project: {
+				id: projectId,
+				name: "both",
+				regionId: "aws-us-east-1",
+				pgVersion: 17,
+			},
+			branches: [
+				{ branch: { id: "br-main", name: "main", isDefault: true } },
+			],
+		});
+		api.seedNeonAuth(projectId, "br-main", {
+			projectId: "auth-proj",
+			jwksUrl: "https://example.test/jwks",
+			baseUrl: "https://example.test/auth",
+		});
+		api.seedNeonDataApi(projectId, "br-main", "neondb", {
+			url: "https://example.test/data-api/neondb",
+		});
+
+		const pulled = await pullConfig({
+			api,
+			projectId,
+			branchId: "br-main",
+		});
+
+		expect(pulled.config.auth).toEqual({});
+		expect(pulled.config.dataApi).toEqual({});
+	});
 });

--- a/packages/config-runtime/src/lib/pull-config.ts
+++ b/packages/config-runtime/src/lib/pull-config.ts
@@ -7,6 +7,7 @@ import {
 	type NeonApi,
 	type NeonBranchSnapshot,
 	type NeonBucketSnapshot,
+	type NeonDatabaseSnapshot,
 	type NeonEndpointSnapshot,
 	type NeonFunctionSnapshot,
 	type NeonProjectSnapshot,
@@ -74,16 +75,44 @@ export async function pullConfig(
 	const endpoint = endpoints.find(
 		(ep) => ep.type === "read_write" && ep.branchId === branch.id,
 	);
-	const [buckets, functions, aiGatewayEnabled] = await Promise.all([
-		api.listBranchBuckets(projectId, branch.id),
-		api.listBranchFunctions(projectId, branch.id),
-		api.getAiGatewayEnabled(projectId, branch.id),
-	]);
+
+	// Data API is enabled per branch + database, so resolve a database to probe.
+	const databases = await api.listBranchDatabases(projectId, branch.id);
+	const probeDatabase = pickProbeDatabase(databases);
+
+	const [buckets, functions, aiGatewayEnabled, auth, dataApi] =
+		await Promise.all([
+			api.listBranchBuckets(projectId, branch.id),
+			api.listBranchFunctions(projectId, branch.id),
+			api.getAiGatewayEnabled(projectId, branch.id),
+			api.getNeonAuth(projectId, branch.id),
+			probeDatabase
+				? api.getNeonDataApi(projectId, branch.id, probeDatabase)
+				: Promise.resolve(null),
+		]);
+
 	return buildPulledBranchConfig(project, branch, branches, endpoint, {
 		buckets,
 		functions,
 		aiGatewayEnabled,
+		authEnabled: auth !== null,
+		dataApiEnabled: dataApi !== null,
 	});
+}
+
+/**
+ * Pick the database to probe for a Data API integration. Data API is enabled per
+ * branch + database; for read-back we only need to know whether *any* database has it
+ * on, so prefer the conventional default (`neondb`) and otherwise fall back to the first
+ * database. Returns `undefined` when the branch has no databases.
+ */
+function pickProbeDatabase(
+	databases: NeonDatabaseSnapshot[],
+): string | undefined {
+	if (databases.length === 0) return undefined;
+	const byName = databases.find((d) => d.name === "neondb");
+	if (byName) return byName.name;
+	return databases[0].name;
 }
 
 function createApiFromOptions(options: PullConfigOptions): NeonApi {
@@ -101,12 +130,22 @@ export function buildPulledBranchConfig(
 		buckets: NeonBucketSnapshot[];
 		functions: NeonFunctionSnapshot[];
 		aiGatewayEnabled: boolean;
+		/** Whether a Neon Auth integration is enabled on the branch. */
+		authEnabled?: boolean;
+		/** Whether a Neon Data API integration is enabled on the branch. */
+		dataApiEnabled?: boolean;
 	},
 ): PulledBranchConfig {
 	const parent = branch.parentId
 		? branches.find((b) => b.id === branch.parentId)
 		: undefined;
-	const config: BranchConfig = {};
+	// Auth/Data API live on the branch's service config (not under `preview`), so a
+	// config pulled from a branch with them enabled round-trips through `resolveConfig`
+	// / `fetchEnv` and the matching secrets get injected.
+	const config: BranchConfig = {
+		...(previewState?.authEnabled ? { auth: {} } : {}),
+		...(previewState?.dataApiEnabled ? { dataApi: {} } : {}),
+	};
 	if (parent) config.parent = parent.name;
 	if (branch.expiresAt) config.ttl = branch.expiresAt;
 	if (branch.protected) config.protected = true;


### PR DESCRIPTION
## Summary

`pullConfig` now reverse-engineers a branch's **Neon Auth** and **Data API** enablement into the returned `config` (`config.auth = {}` / `config.dataApi = {}` when each integration is enabled on the branch), alongside the branch/postgres settings and the existing `preview` block (buckets, functions, AI Gateway).

### Why

`pullConfig` is meant to be a faithful mirror of a branch's live state — the "source of truth of what's remote." But until now it never surfaced Auth / Data API enablement, only postgres + preview features. That means a config produced from a branch with Auth or Data API enabled did **not** round-trip through `resolveConfig` / `fetchEnv`: `authEnabled` / `dataApiEnabled` resolved to `false`, so `NEON_AUTH_BASE_URL` / `NEON_DATA_API_URL` were never injected.

The concrete consumer is `neon dev` in neonctl. Its no-`neon.ts` tier derives a config from `pullConfig` and hands it to `fetchEnv` to inject the branch's secrets locally. Without this change, that tier can only ever inject `DATABASE_URL[_UNPOOLED]`, even when the branch has Auth / Data API on. (The neonctl-side change that depends on this is stacked separately.)

### What

- `pullConfig` now also calls `getNeonAuth` and `getNeonDataApi` and sets `config.auth = {}` / `config.dataApi = {}` when each is present.
- Data API is enabled per branch **+ database**, so `pullConfig` resolves a probe database (the conventional `neondb`, else the first database on the branch) to detect it. Degrades to "not enabled" when the branch has no databases.
- `buildPulledBranchConfig` gains optional `authEnabled` / `dataApiEnabled` inputs that flow into the `config`'s service block. Auth/Data API live on the branch service config (not under `preview`), which is exactly where `resolveConfig` / `fetchEnv` read them.
- Changeset: `minor` for `@neondatabase/config-runtime`.

## Test plan

- `pnpm --filter @neondatabase/config-runtime build` (tsc typecheck + tsdown) — green
- `pnpm --filter @neondatabase/config-runtime exec vitest run` — 30/30 green, including 4 new `pull-config` cases (none / auth-only / dataApi-only / both)
- `biome check` on the changed files — clean