### PR TITLE
feat(config-runtime): make the function bundler injectable

### DIFF
--- a/.changeset/injectable-function-bundler.md
+++ b/.changeset/injectable-function-bundler.md
@@ -1,5 +1,0 @@
----
-"@neondatabase/config-runtime": minor
----
-
-`apply` / `pushConfig` now accept an optional `bundleFunction` ({@link FunctionBundler}) so the caller can supply its own function bundler. When omitted, the default lazily `import()`s the esbuild-backed `buildFunctionBundle`, keeping esbuild out of `config-runtime`'s static module graph — so a consumer that injects its own bundler (e.g. neonctl, which already ships esbuild) never drags a second copy into its packaged snapshot. Exports the `FunctionBundler` type from `v1`.

--- a/.changeset/injectable-function-bundler.md
+++ b/.changeset/injectable-function-bundler.md
@@ -1,0 +1,5 @@
+---
+"@neondatabase/config-runtime": minor
+---
+
+`apply` / `pushConfig` now accept an optional `bundleFunction` ({@link FunctionBundler}) so the caller can supply its own function bundler. When omitted, the default lazily `import()`s the esbuild-backed `buildFunctionBundle`, keeping esbuild out of `config-runtime`'s static module graph — so a consumer that injects its own bundler (e.g. neonctl, which already ships esbuild) never drags a second copy into its packaged snapshot. Exports the `FunctionBundler` type from `v1`.

--- a/.changeset/pull-config-auth-dataapi.md
+++ b/.changeset/pull-config-auth-dataapi.md
@@ -1,5 +1,0 @@
----
-"@neondatabase/config-runtime": minor
----
-
-`pullConfig` now reverse-engineers the branch's **Neon Auth** and **Data API** enablement into the returned `config` (`config.auth = {}` / `config.dataApi = {}` when each integration is enabled on the branch). Previously only branch/postgres settings and the `preview` block (buckets, functions, AI Gateway) were surfaced, so a config pulled from a branch with Auth or Data API enabled did not round-trip through `resolveConfig` / `fetchEnv` — and the matching `NEON_AUTH_BASE_URL` / `NEON_DATA_API_URL` secrets were never injected. Data API is enabled per branch + database, so `pullConfig` probes the branch's default database (`neondb`, else the first database) to detect it.

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config-runtime
 
+## 0.2.0
+
+### Minor Changes
+
+- 135a173: `apply` / `pushConfig` now accept an optional `bundleFunction` ({@link FunctionBundler}) so the caller can supply its own function bundler. When omitted, the default lazily `import()`s the esbuild-backed `buildFunctionBundle`, keeping esbuild out of `config-runtime`'s static module graph — so a consumer that injects its own bundler (e.g. neonctl, which already ships esbuild) never drags a second copy into its packaged snapshot. Exports the `FunctionBundler` type from `v1`.
+- 5ddace9: `pullConfig` now reverse-engineers the branch's **Neon Auth** and **Data API** enablement into the returned `config` (`config.auth = {}` / `config.dataApi = {}` when each integration is enabled on the branch). Previously only branch/postgres settings and the `preview` block (buckets, functions, AI Gateway) were surfaced, so a config pulled from a branch with Auth or Data API enabled did not round-trip through `resolveConfig` / `fetchEnv` — and the matching `NEON_AUTH_BASE_URL` / `NEON_DATA_API_URL` secrets were never injected. Data API is enabled per branch + database, so `pullConfig` probes the branch's default database (`neondb`, else the first database) to detect it.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -6,6 +6,18 @@ import {
 } from "@neondatabase/config";
 
 /**
+ * Builds the deployable ZIP bundle for a single function. The default
+ * implementation ({@link buildFunctionBundle}) shells out to esbuild, but
+ * `pushConfig` / `apply` accept a custom bundler so a consumer that can't ship
+ * esbuild's native binary (e.g. a single-file CLI) can supply its own — a WASM
+ * build, an esbuild binary on PATH, etc. — without this package dragging esbuild
+ * into their bundle.
+ */
+export type FunctionBundler = (
+	fn: ResolvedFunctionConfig,
+) => Promise<Uint8Array>;
+
+/**
  * Build the deployable bundle (a ZIP archive of the esbuild-bundled source) for a function.
  *
  * This is the **imperative shell** step of function deploys, and the reason it lives in

--- a/packages/config-runtime/src/lib/operations.ts
+++ b/packages/config-runtime/src/lib/operations.ts
@@ -1,4 +1,5 @@
 import type { Config, PushResult } from "@neondatabase/config";
+import type { FunctionBundler } from "./function-bundle.js";
 import { type PulledBranchConfig, pullConfig } from "./pull-config.js";
 import { type PushConfigOptions, pushConfig } from "./push-config.js";
 
@@ -35,6 +36,12 @@ export interface ApplyOptions extends ConfigOperationOptions {
 	updateExisting?: boolean;
 	/** Auto-confirm applying to a branch marked `protected` on Neon. */
 	allowProtectedBranch?: boolean;
+	/**
+	 * Custom function bundler. Defaults to esbuild (`buildFunctionBundle`); inject
+	 * your own to deploy functions without pulling esbuild's native binary into
+	 * your build. See {@link FunctionBundler}.
+	 */
+	bundleFunction?: FunctionBundler;
 }
 
 /**
@@ -99,5 +106,8 @@ export async function apply(
 		...(options.apiKey ? { apiKey: options.apiKey } : {}),
 		...(options.updateExisting ? { updateExisting: true } : {}),
 		...(options.allowProtectedBranch ? { allowProtectedBranch: true } : {}),
+		...(options.bundleFunction
+			? { bundleFunction: options.bundleFunction }
+			: {}),
 	});
 }

--- a/packages/config-runtime/src/lib/push-config.test.ts
+++ b/packages/config-runtime/src/lib/push-config.test.ts
@@ -328,6 +328,42 @@ describe("pushConfig", () => {
 		).toEqual(["uploads"]);
 	});
 
+	test("uses an injected bundleFunction instead of the default esbuild bundler", async () => {
+		const { api, projectId } = seededFake();
+		const config = defineConfig(() => ({
+			preview: {
+				functions: [
+					{
+						name: "Hello World",
+						slug: "hello-world",
+						source: fnSource,
+					},
+				],
+			},
+		}));
+
+		const bundled: string[] = [];
+		const sentinel = new Uint8Array([1, 2, 3, 4]);
+		await pushConfig(config, {
+			api,
+			projectId,
+			branchId: "br-main",
+			// A bundler that never touches esbuild — proves the seam is honored.
+			bundleFunction: async (fn) => {
+				bundled.push(fn.slug);
+				return sentinel;
+			},
+		});
+
+		expect(bundled).toEqual(["hello-world"]);
+		const deploys = api.history.filter(
+			(h) => h.method === "deployBranchFunction",
+		);
+		expect(deploys).toHaveLength(1);
+		const input = (deploys[0].args[3] as { bundle: Uint8Array }).bundle;
+		expect(Array.from(input)).toEqual([1, 2, 3, 4]);
+	});
+
 	test("re-deploys an existing function but does not recreate it", async () => {
 		const { api, projectId } = seededFake();
 		api.seedFunction(projectId, "br-main", {

--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -14,9 +14,24 @@ import {
 	type RemotePreviewState,
 	type RemoteServiceState,
 	type RemoteState,
+	type ResolvedFunctionConfig,
 	resolveConfig,
 } from "@neondatabase/config";
-import { buildFunctionBundle } from "./function-bundle.js";
+import type { FunctionBundler } from "./function-bundle.js";
+
+/**
+ * Default function bundler (esbuild), loaded lazily so that `buildFunctionBundle`
+ * — and the esbuild it pulls in — only enters the module graph when a deploy
+ * actually needs it AND no custom `bundleFunction` was injected. A consumer that
+ * injects its own bundler never triggers this import, so esbuild can be dropped
+ * from their build entirely.
+ */
+const defaultBundleFunction: FunctionBundler = async (
+	fn: ResolvedFunctionConfig,
+): Promise<Uint8Array> => {
+	const { buildFunctionBundle } = await import("./function-bundle.js");
+	return buildFunctionBundle(fn);
+};
 
 export interface PushConfigOptions {
 	/**
@@ -72,6 +87,12 @@ export interface PushConfigOptions {
 	 * Never invoked on `dryRun`.
 	 */
 	confirm?: (context: PushConfirmContext) => boolean | Promise<boolean>;
+	/**
+	 * Custom bundler for function source. Defaults to {@link buildFunctionBundle}
+	 * (esbuild). Inject your own to deploy functions without this package pulling
+	 * esbuild's native binary into your build — see {@link FunctionBundler}.
+	 */
+	bundleFunction?: FunctionBundler;
 	/**
 	 * When `true`, compute the full plan against the live remote state but **do not
 	 * execute any mutations**. The resulting `PushResult.applied` array records every
@@ -222,6 +243,8 @@ export async function pushConfig(
 					remoteProjectId: remoteProject.id,
 					branchById,
 					branchByName,
+					bundleFunction:
+						options.bundleFunction ?? defaultBundleFunction,
 				});
 		applied.push(change);
 	}
@@ -455,6 +478,7 @@ interface ApplyContext {
 	remoteProjectId: string;
 	branchById: Map<string, NeonBranchSnapshot>;
 	branchByName: Map<string, NeonBranchSnapshot>;
+	bundleFunction: FunctionBundler;
 }
 
 async function applyStep(
@@ -580,7 +604,7 @@ async function applyStep(
 			};
 		}
 		case "deploy-function": {
-			const bundle = await buildFunctionBundle(step.fn);
+			const bundle = await ctx.bundleFunction(step.fn);
 			const deployment = await ctx.api.deployBranchFunction(
 				ctx.remoteProjectId,
 				step.branchId,

--- a/packages/config-runtime/src/v1.ts
+++ b/packages/config-runtime/src/v1.ts
@@ -52,6 +52,7 @@ export {
 	PushAbortedError,
 	PushConflictError,
 } from "@neondatabase/config";
+export type { FunctionBundler } from "./lib/function-bundle.js";
 // ─── Function bundling (esbuild + zip) ────────────────────────────────────────
 export { buildFunctionBundle } from "./lib/function-bundle.js";
 // ─── Operations (intent-revealing entry points) ───────────────────────────────


### PR DESCRIPTION
## Summary

`apply` / `pushConfig` now accept an optional `bundleFunction` (`FunctionBundler`) so the caller can supply its own function bundler. When omitted, the default lazily `import()`s the esbuild-backed `buildFunctionBundle`.

### Why

Bundling a Neon Function pulls in esbuild (a native binary). Keeping esbuild out of `config-runtime`'s **static** module graph means a consumer that already ships esbuild — notably the neonctl CLI, whose `config apply` / `deploy` commands bundle with neonctl's own shared esbuild helper — can inject that bundler instead of dragging a second copy into its packaged snapshot. The deploy-side `config`/`deploy` commands in neonctl depend on this option.

### What

- New `FunctionBundler` type (`(fn: ResolvedFunctionConfig) => Promise<Uint8Array>`), exported from `v1`.
- `pushConfig` / `apply` take an optional `bundleFunction`; default lazily imports `buildFunctionBundle` so the static graph stays esbuild-free.
- Changeset: `minor` for `@neondatabase/config-runtime`.

## Test plan

- `pnpm --filter @neondatabase/config-runtime build` (tsc typecheck + tsdown) — green
- `pnpm --filter @neondatabase/config-runtime exec vitest run` — 27/27 green, incl. a new test asserting the injected bundler is used instead of esbuild
- `biome check` on the changed files — clean

## Note

This is a clean re-cut off current `main` of an earlier `feat/injectable-function-bundler` branch, dropping that branch's stale `provenance: false → true` package.json edits (which conflicted with #163's deliberate provenance change on main).