### PR TITLE
feat(config): add per-function dev block (port, portless) to FunctionConfig

### DIFF
--- a/.changeset/function-dev-config.md
+++ b/.changeset/function-dev-config.md
@@ -1,0 +1,5 @@
+---
+"@neondatabase/config": minor
+---
+
+Add an optional `dev` block to `FunctionConfig` for local development with `neon dev`: `dev?: { port?: number; portless?: boolean }`. It is typed as a discriminated union so `portless: true` requires a concrete `port` (validated at both the type level and by the zod schema). `dev` is passed through untouched onto `ResolvedFunctionConfig` (no defaults applied) and is ignored at deploy time — only `neon dev` reads it (to serve every function declared in `neon.ts` on its configured port, optionally via `portless`).

--- a/.changeset/function-dev-config.md
+++ b/.changeset/function-dev-config.md
@@ -1,5 +1,0 @@
----
-"@neondatabase/config": minor
----
-
-Add an optional `dev` block to `FunctionConfig` for local development with `neon dev`: `dev?: { port?: number; portless?: boolean }`. It is typed as a discriminated union so `portless: true` requires a concrete `port` (validated at both the type level and by the zod schema). `dev` is passed through untouched onto `ResolvedFunctionConfig` (no defaults applied) and is ignored at deploy time — only `neon dev` reads it (to serve every function declared in `neon.ts` on its configured port, optionally via `portless`).

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config-runtime
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [ff7103b]
+  - @neondatabase/config@0.2.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config
 
+## 0.2.0
+
+### Minor Changes
+
+- ff7103b: Add an optional `dev` block to `FunctionConfig` for local development with `neon dev`: `dev?: { port?: number; portless?: boolean }`. It is typed as a discriminated union so `portless: true` requires a concrete `port` (validated at both the type level and by the zod schema). `dev` is passed through untouched onto `ResolvedFunctionConfig` (no defaults applied) and is ignored at deploy time — only `neon dev` reads it (to serve every function declared in `neon.ts` on its configured port, optionally via `portless`).
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -113,6 +113,44 @@ describe("resolveConfig", () => {
 		expect(resolved.preview?.aiGatewayEnabled).toBe(false);
 	});
 
+	test("passes a function dev block through untouched", () => {
+		const config = defineConfig(() => ({
+			preview: {
+				functions: [
+					{
+						name: "Hello",
+						slug: "hello",
+						source: "./hello.ts",
+						dev: { port: 8787, portless: true },
+					},
+				],
+			},
+		}));
+		const resolved = resolveConfig(config, {
+			name: "preview-1",
+			exists: false,
+		});
+		expect(resolved.preview?.functions[0].dev).toEqual({
+			port: 8787,
+			portless: true,
+		});
+	});
+
+	test("omits dev from the resolved function when not provided", () => {
+		const config = defineConfig(() => ({
+			preview: {
+				functions: [
+					{ name: "Hello", slug: "hello", source: "./hello.ts" },
+				],
+			},
+		}));
+		const resolved = resolveConfig(config, {
+			name: "preview-1",
+			exists: false,
+		});
+		expect(resolved.preview?.functions[0]).not.toHaveProperty("dev");
+	});
+
 	test("rejects a function env value that is undefined (e.g. unset process.env)", () => {
 		const config = defineConfig(() => ({
 			preview: {

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -7,6 +7,7 @@ import type {
 	FunctionConfig,
 	PreviewConfig,
 	ResolvedBranchConfig,
+	ResolvedFunctionConfig,
 	ResolvedPreviewConfig,
 } from "./types.js";
 
@@ -130,7 +131,7 @@ function resolvePreviewConfig(preview: PreviewConfig): ResolvedPreviewConfig {
 	};
 }
 
-function resolveFunctionConfig(fn: FunctionConfig) {
+function resolveFunctionConfig(fn: FunctionConfig): ResolvedFunctionConfig {
 	return {
 		slug: fn.slug,
 		name: fn.name,
@@ -138,6 +139,8 @@ function resolveFunctionConfig(fn: FunctionConfig) {
 		env: { ...(fn.env ?? {}) },
 		runtime: fn.runtime ?? DEFAULT_FUNCTION_RUNTIME,
 		memoryMib: fn.memoryMib ?? DEFAULT_FUNCTION_MEMORY_MIB,
+		// Passed through untouched (no defaults); only `neon dev` reads it.
+		...(fn.dev ? { dev: fn.dev } : {}),
 	};
 }
 

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -68,6 +68,81 @@ describe("branchConfigSchema", () => {
 		});
 		expect(result.success).toBe(false);
 	});
+
+	test("accepts a function dev block with port and portless", () => {
+		const result = branchConfigSchema.safeParse({
+			preview: {
+				functions: [
+					{
+						slug: "hello-world",
+						name: "Hello World",
+						source: "./hello.ts",
+						dev: { port: 8787, portless: true },
+					},
+				],
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts dev with no port when portless is not set", () => {
+		const result = branchConfigSchema.safeParse({
+			preview: {
+				functions: [
+					{ slug: "f", name: "F", source: "./f.ts", dev: {} },
+				],
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects dev.portless true without a port", () => {
+		const result = branchConfigSchema.safeParse({
+			preview: {
+				functions: [
+					{
+						slug: "f",
+						name: "F",
+						source: "./f.ts",
+						dev: { portless: true },
+					},
+				],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects an out-of-range dev.port", () => {
+		const result = branchConfigSchema.safeParse({
+			preview: {
+				functions: [
+					{
+						slug: "f",
+						name: "F",
+						source: "./f.ts",
+						dev: { port: 0 },
+					},
+				],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects an unknown key inside dev", () => {
+		const result = branchConfigSchema.safeParse({
+			preview: {
+				functions: [
+					{
+						slug: "f",
+						name: "F",
+						source: "./f.ts",
+						dev: { port: 8787, typo: true },
+					},
+				],
+			},
+		});
+		expect(result.success).toBe(false);
+	});
 });
 
 describe("formatZodIssues", () => {

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -88,6 +88,29 @@ const functionSlugSchema = z
  */
 const functionEnvSchema = z.record(z.string(), z.string());
 
+/**
+ * TCP port for a function's local dev server. Excludes 0 (which means "any port" to the OS
+ * — `neon dev` expresses "pick one for me" by omitting `port`, not by passing 0).
+ */
+const devPortSchema = z.number().int().min(1).max(65535);
+
+/**
+ * Local-dev settings for a function (`neon dev` only; never affects deploy). Modeled as a
+ * union of two strict shapes so the inferred type *is* the {@link FunctionDevConfig}
+ * discriminated union — `portless: true` carries a required `port` (portless needs a concrete
+ * port to map its `slug.localhost` name to); otherwise `port` is optional.
+ */
+const functionDevConfigSchema = z.union([
+	z.strictObject({
+		portless: z.literal(true),
+		port: devPortSchema,
+	}),
+	z.strictObject({
+		portless: z.literal(false).optional(),
+		port: devPortSchema.optional(),
+	}),
+]);
+
 export const functionConfigSchema = z.strictObject({
 	slug: functionSlugSchema,
 	name: z.string().min(1).max(255),
@@ -104,6 +127,7 @@ export const functionConfigSchema = z.strictObject({
 			z.literal(8192),
 		])
 		.optional(),
+	dev: functionDevConfigSchema.optional(),
 });
 
 export const bucketConfigSchema = z.strictObject({

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -86,6 +86,23 @@ export type FunctionRuntime = "nodejs24";
 export type FunctionMemoryMib = 256 | 512 | 1024 | 2048 | 4096 | 8192;
 
 /**
+ * Local-development settings for a function, used by `neon dev` when it serves every
+ * function declared in `neon.ts` (i.e. invoked with no `--source`). Never affects deploy.
+ *
+ * Typed as a discriminated union so the `portless` ⇒ `port` requirement is enforced at
+ * compile time: a `portless` route needs a concrete port to map its `slug.localhost`
+ * name to, so `port` is mandatory when `portless: true`.
+ *
+ * - `{ portless: true; port }` — wrap this function with `portless run <slug> …` so it gets
+ *   a stable `slug.localhost` URL. `port` is required.
+ * - `{ portless?: false; port? }` — serve directly. `port` is optional: when set it is bound
+ *   exactly (and `neon dev` fails loudly if it is taken); when omitted a free port is found.
+ */
+export type FunctionDevConfig =
+	| { portless: true; port: number }
+	| { portless?: false; port?: number };
+
+/**
  * A single Neon Function deployed to a branch (Preview feature).
  *
  * A function is invoked like a Cloudflare/Vercel handler — its source module
@@ -124,6 +141,11 @@ export interface FunctionConfig {
 	runtime?: FunctionRuntime;
 	/** Memory allotted to each invocation, in MiB. Defaults to `512`. */
 	memoryMib?: FunctionMemoryMib;
+	/**
+	 * Local-development settings used by `neon dev` when serving every function from
+	 * `neon.ts`. Ignored at deploy time. See {@link FunctionDevConfig}.
+	 */
+	dev?: FunctionDevConfig;
 }
 
 /** Anonymous-access level for a branchable object-storage bucket. */
@@ -191,6 +213,11 @@ export interface ResolvedFunctionConfig {
 	env: Record<string, string>;
 	runtime: FunctionRuntime;
 	memoryMib: FunctionMemoryMib;
+	/**
+	 * Local-development settings, passed through untouched from {@link FunctionConfig.dev}
+	 * (no defaults applied). Only consumed by `neon dev`; deploy ignores it.
+	 */
+	dev?: FunctionDevConfig;
 }
 
 /** A bucket with its access level defaulted to `private`. */

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -135,6 +135,7 @@ export type {
 	Config,
 	ConflictReport,
 	FunctionConfig,
+	FunctionDevConfig,
 	FunctionMemoryMib,
 	FunctionRuntime,
 	PostgresConfig,

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/env
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [ff7103b]
+  - @neondatabase/config@0.2.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a single `env run -- <cmd>` CLI.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Summary

Adds an optional `dev` block to a function's `neon.ts` config, for local development with `neon dev`:

```ts
preview: {
  functions: [
    {
      slug: "hello-world",
      name: "Hello World",
      source: "./functions/hello.ts",
      dev: { port: 8787, portless: true },
    },
  ],
}
```

### Why

`neon dev` is gaining a mode where, invoked with no `--source`, it serves **every** function declared in `neon.ts` at once. Each function needs to say which port it runs on locally (and optionally that it should be exposed via `portless` for a stable `slug.localhost` URL). That local-dev intent belongs next to the function definition, so it lives on `FunctionConfig`. It never affects deploy.

### What

- `FunctionConfig.dev?: FunctionDevConfig` where:
  ```ts
  type FunctionDevConfig =
    | { portless: true; port: number }     // portless needs a concrete port
    | { portless?: false; port?: number }; // otherwise port is optional
  ```
- The `portless: true ⇒ port required` rule is enforced **both** at the type level (discriminated union) and by the zod schema (a `z.union` of two strict shapes, so the inferred type *is* the union — no refinement/infer mismatch, no casts).
- `port` is validated as an integer in `1..65535` (0 excluded — "pick one for me" is expressed by omitting `port`, not by `0`).
- `dev` is passed through untouched onto `ResolvedFunctionConfig` (no defaults applied), and omitted entirely when not provided.
- Ignored at deploy time; only `neon dev` reads it.
- Changeset: `minor` for `@neondatabase/config`.

## Test plan

- `pnpm --filter @neondatabase/config build` (tsc typecheck + tsdown) — green
- `pnpm --filter @neondatabase/config exec vitest run` — 132/132, incl. new schema cases (valid dev, dev without port when not portless, `portless:true` without port rejected, out-of-range port rejected, unknown key rejected) and resolveConfig passthrough/omit cases
- `biome check` on changed files — clean
- Downstream `@neondatabase/config-runtime` + `@neondatabase/env` rebuild cleanly against the new types