### PR TITLE
ci: install dependencies from the Databricks JFrog mirror

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,6 +4,26 @@ name: Prepare
 
 runs:
   steps:
+    # The protected runner group has no egress to the public npm registry — it
+    # can only reach the Databricks JFrog mirror. Mint a short-lived token via
+    # OIDC and point npm/pnpm at the mirror before anything fetches packages
+    # (including pnpm's own self-installer). Mirrors neondatabase/neonctl.
+    # The caller must grant `id-token: write`.
+    - name: Setup JFrog CLI with OIDC
+      id: setup-jfrog
+      uses: jfrog/setup-jfrog-cli@279b1f629f43dd5bc658d8361ac4802a7ef8d2d5 # v4.9.1
+      env:
+        JF_URL: https://databricks.jfrog.io
+      with:
+        oidc-provider-name: github-actions
+    - name: Configure npm registry (Databricks JFrog mirror)
+      shell: bash
+      run: |
+        cat > ~/.npmrc <<EOF
+        registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+        //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${{ steps.setup-jfrog.outputs.oidc-token }}
+        always-auth=true
+        EOF
     - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ name: CI
 
 permissions:
     contents: read
+    id-token: write # mint the JFrog OIDC token in ./.github/actions/prepare
 
 on:
     pull_request: ~

--- a/.github/workflows/dist-typecheck.yml
+++ b/.github/workflows/dist-typecheck.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
     contents: read
+    id-token: write # mint the JFrog OIDC token in ./.github/actions/prepare
 
 jobs:
     typecheck-dist:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -47,6 +47,7 @@ jobs:
     permissions:
       contents: write # push the release branch
       pull-requests: write # open the release PR
+      id-token: write # mint the JFrog OIDC token in ./.github/actions/prepare
 
     steps:
       - name: Harden the runner (Audit all outbound calls)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"*": "biome check --write --no-errors-on-unmatched --files-ignore-unknown=true"
 	},
 	"devDependencies": {
-		"@arethetypeswrong/cli": "^0.18.2",
+		"@arethetypeswrong/cli": "^0.18.3",
 		"@biomejs/biome": "catalog:",
 		"@changesets/cli": "^2.29.7",
 		"console-fail-test": "0.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
   .:
     devDependencies:
       '@arethetypeswrong/cli':
-        specifier: ^0.18.2
-        version: 0.18.2
+        specifier: ^0.18.3
+        version: 0.18.3
       '@biomejs/biome':
         specifier: 'catalog:'
         version: 2.2.4
@@ -181,7 +181,7 @@ importers:
         version: 0.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -215,7 +215,7 @@ importers:
         version: 0.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -252,7 +252,7 @@ importers:
         version: 0.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -273,7 +273,7 @@ importers:
         version: 0.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -295,7 +295,7 @@ importers:
         version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -335,7 +335,7 @@ importers:
         version: 0.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -393,7 +393,7 @@ importers:
         version: 15.5.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -415,7 +415,7 @@ importers:
         version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -437,7 +437,7 @@ importers:
         version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -465,7 +465,7 @@ importers:
         version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -490,7 +490,7 @@ importers:
         version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2)
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -510,13 +510,13 @@ packages:
   '@andrewbranch/untar.js@1.0.3':
     resolution: {integrity: sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw==}
 
-  '@arethetypeswrong/cli@0.18.2':
-    resolution: {integrity: sha512-PcFM20JNlevEDKBg4Re29Rtv2xvjvQZzg7ENnrWFSS0PHgdP2njibVFw+dRUhNkPgNfac9iUqO0ohAXqQL4hbw==}
+  '@arethetypeswrong/cli@0.18.3':
+    resolution: {integrity: sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@arethetypeswrong/core@0.18.2':
-    resolution: {integrity: sha512-GiwTmBFOU1/+UVNqqCGzFJYfBXEytUkiI+iRZ6Qx7KmUVtLm00sYySkfe203C9QtPG11yOz1ZaMek8dT/xnlgg==}
+  '@arethetypeswrong/core@0.18.3':
+    resolution: {integrity: sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw==}
     engines: {node: '>=20'}
 
   '@asamuzakjp/css-color@3.2.0':
@@ -4692,9 +4692,9 @@ snapshots:
 
   '@andrewbranch/untar.js@1.0.3': {}
 
-  '@arethetypeswrong/cli@0.18.2':
+  '@arethetypeswrong/cli@0.18.3':
     dependencies:
-      '@arethetypeswrong/core': 0.18.2
+      '@arethetypeswrong/core': 0.18.3
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 10.0.1
@@ -4702,7 +4702,7 @@ snapshots:
       marked-terminal: 7.3.0(marked@9.1.6)
       semver: 7.7.2
 
-  '@arethetypeswrong/core@0.18.2':
+  '@arethetypeswrong/core@0.18.3':
     dependencies:
       '@andrewbranch/untar.js': 1.0.3
       '@loaderkit/resolve': 1.0.6
@@ -8659,7 +8659,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.2
 
-  tsdown@0.14.1(@arethetypeswrong/core@0.18.2)(typescript@5.8.2):
+  tsdown@0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2):
     dependencies:
       ansis: 4.2.0
       cac: 6.7.14
@@ -8676,7 +8676,7 @@ snapshots:
       tree-kill: 1.2.2
       unconfig: 7.3.2
     optionalDependencies:
-      '@arethetypeswrong/core': 0.18.2
+      '@arethetypeswrong/core': 0.18.3
       typescript: 5.8.2
     transitivePeerDependencies:
       - '@typescript/native-preview'


### PR DESCRIPTION
## Problem

Since #155 moved CI to the `neondatabase-protected-runner-group`, **every** CI run has failed. Two separate issues:

1. **No npm egress (the actual breakage).** All jobs die in `./.github/actions/prepare` at pnpm's self-installer:
   ```
   GET https://registry.npmjs.org/pnpm error (ECONNRESET)
   ERR_PNPM_META_FETCH_FAIL ... Client network socket disconnected before secure TLS connection was established
   ```
   These runners have **no outbound HTTPS to the public npm registry** — DNS resolves, but the connection to `registry.npmjs.org` is reset. Only the internal Databricks JFrog mirror is reachable. `harden-runner` (`egress-policy: audit`) is non-blocking and not the cause. (Last green CI was 2026-03-16, on `ubuntu-latest`.)

2. **`attw` crash (pre-existing, unmasked by fixing #1).** `Type Check Distribution` runs `@arethetypeswrong/cli` 0.18.2, which crashes with `Cannot read properties of undefined (reading 'filename')` on any package whose tarball gunzips into more than one `fflate` chunk — its `extractTarball` keeps only the last (empty) chunk, so `data[0]` is undefined. It tripped on `@neondatabase/config-runtime` (~108 kB unpacked; smaller packages fit in one chunk and survived). This check had never completed in CI before — `config-runtime` was added after the last green run, and CI was red on egress since.

## Summary of changes

- **`./.github/actions/prepare`** — mint a short-lived JFrog token via OIDC (`jfrog/setup-jfrog-cli`, `JF_URL=https://databricks.jfrog.io`) and write `~/.npmrc` pointing npm/pnpm at `https://databricks.jfrog.io/artifactory/api/npm/db-npm/` **before** anything fetches packages (so even pnpm's self-installer uses the mirror). Mirrors `neondatabase/neonctl`.
- **`ci.yml`, `dist-typecheck.yml`, `prepare-release.yml`** — grant `id-token: write` (required for the OIDC exchange). `post-release.yml` is untouched; it doesn't install deps.
- **`package.json` + `pnpm-lock.yaml`** — bump `@arethetypeswrong/cli` `^0.18.2` → `^0.18.3`, which fixes the gunzip crash.

Verified on this PR: **CI** green (Lint / Test / Build) and **Type Check Distribution** green (all 5 matrix legs: `config`, `config-runtime`, `env`, `neon-new`, `vite-plugin-neon-new`).

> **Note — fork PRs:** GitHub won't grant `id-token: write` to fork PRs, so the JFrog OIDC step will fail for them. This PR fixes pushes + same-repo PRs (all the currently-failing runs); a fork-safe path is a separate follow-up.