### PR TITLE
CI: add @neondatabase/functions to the dist-typecheck matrix

### DIFF
--- a/.github/workflows/dist-typecheck.yml
+++ b/.github/workflows/dist-typecheck.yml
@@ -29,6 +29,8 @@ jobs:
                       dir: config-runtime
                     - name: "@neondatabase/env"
                       dir: env
+                    - name: "@neondatabase/functions"
+                      dir: functions
         steps:
             - name: Harden the runner (Audit all outbound calls)
               uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0


### PR DESCRIPTION
## Problem

`@neondatabase/functions` is an active, published library (`exports` + `types`), but it was missing from the `Type Check Distribution` (attw) matrix — which only covered `config`, `config-runtime`, `env`, `neon-new`, `vite-plugin-neon-new`. Its distributed types were never checked, so an `exports`/types regression would ship unnoticed.

The four deprecated rename-shims (`get-db`, `neondb`, `vite-plugin-db`, `vite-plugin-postgres`) are intentionally left out.

## Summary of changes

- Add `@neondatabase/functions` (dir `functions`) to the `dist-typecheck.yml` matrix.

Verified locally: it builds and passes `attw --pack packages/functions --profile esm-only` (node16-from-ESM 🟢, bundler 🟢; node10 / node16-from-CJS are profile-ignored).