### PR TITLE
feat(config)!: static config shape + tuning-only branch closure (0.3.0)

### DIFF
--- a/.changeset/static-config-shape.md
+++ b/.changeset/static-config-shape.md
@@ -1,0 +1,41 @@
+---
+"@neondatabase/config": major
+"@neondatabase/config-runtime": major
+"@neondatabase/env": major
+---
+
+Reshape `defineConfig` into a static existential set + a tuning-only `branch` closure.
+
+**Breaking.** `defineConfig` now takes an **object**, not a function:
+
+```ts
+export default defineConfig({
+  auth: true,
+  dataApi: false,
+  preview: {
+    aiGateway: false,
+    functions: {
+      hello: { name: "Hello", source: "./functions/hello.ts", dev: { port: 8787 } },
+    },
+    buckets: { uploads: { access: "public_read" } },
+  },
+  branch: (branch) => ({
+    protected: branch.name === "main",
+    preview: { functions: { hello: { memoryMib: 1024 } } },
+  }),
+});
+```
+
+- GA service toggles (`auth`, `dataApi`) and the beta `preview` block (`aiGateway`,
+  `functions`, `buckets`) are **static and top-level**, so the secret set is known at the
+  type level. `functions`/`buckets` are **records keyed by slug/name** (regex-enforced,
+  dup-free).
+- The `branch` closure is **tuning-only** (`parent`/`ttl`/`protected`/`postgres` + per-function
+  `memoryMib`/`runtime`), and is type-constrained to only reference declared function slugs.
+  It cannot add or remove services or functions.
+- `resolveConfig` still returns the same `ResolvedBranchConfig`, so `diff`/`plan`/`apply`
+  are unchanged at runtime. `pullConfig` now returns the new `Config` shape.
+- `@neondatabase/env`: `NeonEnv<C>` is derived directly from the static toggles, so it is
+  exact. `parseEnv` drops the `branchName` argument and takes an optional **scope** — omit
+  for external env, or pass a function slug to also get a typed `function` namespace of that
+  function's declared env keys.

--- a/packages/config-runtime/e2e/conflict.e2e.test.ts
+++ b/packages/config-runtime/e2e/conflict.e2e.test.ts
@@ -25,7 +25,9 @@ describe("e2e — branch-scoped push conflicts", () => {
 				(b) => b.isDefault,
 			)?.id;
 			if (!branchId) throw new Error("missing default branch");
-			const config = defineConfig(() => ({ protected: true }));
+			const config = defineConfig({
+				branch: () => ({ protected: true }),
+			});
 			await expect(
 				pushConfig(config, { api, projectId, branchId }),
 			).rejects.toMatchObject({ code: "PLATFORM_PUSH_CONFLICT" });

--- a/packages/config-runtime/e2e/lifecycle.e2e.test.ts
+++ b/packages/config-runtime/e2e/lifecycle.e2e.test.ts
@@ -25,11 +25,12 @@ describe("e2e — branch policy lifecycle", () => {
 				(b) => b.isDefault,
 			);
 			if (!main) throw new Error("missing default branch");
-			const config = defineConfig((b) =>
-				b.name === main.name
-					? { protected: true }
-					: { parent: main.name, ttl: "1h" },
-			);
+			const config = defineConfig({
+				branch: (b) =>
+					b.name === main.name
+						? { protected: true }
+						: { parent: main.name, ttl: "1h" },
+			});
 			const created = await api.createBranch(projectId, {
 				name: "dev",
 				parentId: main.id,

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/src/lib/operations.test.ts
+++ b/packages/config-runtime/src/lib/operations.test.ts
@@ -41,7 +41,7 @@ describe("inspect", () => {
 describe("plan", () => {
 	test("computes a dry-run plan without mutating", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({ auth: {} }));
+		const config = defineConfig({ auth: {} });
 		const result = await plan(config, {
 			api,
 			projectId,
@@ -69,7 +69,7 @@ describe("plan", () => {
 describe("apply", () => {
 	test("applies the branch policy to the selected branch", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({ auth: {} }));
+		const config = defineConfig({ auth: {} });
 		const result = await apply(config, {
 			api,
 			projectId,
@@ -89,9 +89,11 @@ describe("apply", () => {
 
 	test("surfaces drift as a PushConflictError without updateExisting", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 		await expect(
 			apply(config, { api, projectId, branchId: "br-main" }),
 		).rejects.toMatchObject({ code: ErrorCode.PushConflict });
@@ -99,9 +101,11 @@ describe("apply", () => {
 
 	test("applies drift to a protected branch with both override flags", async () => {
 		const { api, projectId } = seededFake({ protected: true });
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 		const result = await apply(config, {
 			api,
 			projectId,
@@ -126,7 +130,7 @@ describe("branch not found (id-only lookup)", () => {
 
 	test("plan throws BranchNotFound for an unknown id", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({}));
+		const config = defineConfig({});
 		await expect(
 			plan(config, { api, projectId, branchId: "br-does-not-exist" }),
 		).rejects.toMatchObject({ code: ErrorCode.BranchNotFound });
@@ -134,7 +138,7 @@ describe("branch not found (id-only lookup)", () => {
 
 	test("apply throws BranchNotFound for an unknown id", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({}));
+		const config = defineConfig({});
 		await expect(
 			apply(config, { api, projectId, branchId: "br-does-not-exist" }),
 		).rejects.toMatchObject({ code: ErrorCode.BranchNotFound });

--- a/packages/config-runtime/src/lib/pull-config.test.ts
+++ b/packages/config-runtime/src/lib/pull-config.test.ts
@@ -1,4 +1,4 @@
-import { ErrorCode, PlatformError } from "@neondatabase/config";
+import { ErrorCode, PlatformError, resolveConfig } from "@neondatabase/config";
 import { describe, expect, test } from "vitest";
 import { FakeNeonApi } from "./fake-neon-api.js";
 import { pullConfig } from "./pull-config.js";
@@ -51,6 +51,48 @@ describe("pullConfig", () => {
 			protected: true,
 			postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
 		});
+	});
+
+	test("pulled config from a branch with an expiry resolves without a ttl parse crash", async () => {
+		// Regression: `pullConfig` must not emit the branch's `expiresAt` (an ISO timestamp)
+		// as the policy `ttl` — `ttl` is a creation-time duration, and feeding a timestamp
+		// to `parseDuration` would make `resolveConfig` (and therefore `fetchEnv` /
+		// `neon dev` / `neon env pull` in the no-policy tier) throw on any branch that has a
+		// TTL. The expiry is reported on `branch.expiresAt` instead.
+		const api = new FakeNeonApi();
+		const projectId = "proj-ttl";
+		api.seedProject({
+			project: {
+				id: projectId,
+				name: "ttl",
+				regionId: "aws-us-east-1",
+				pgVersion: 17,
+			},
+			branches: [
+				{ branch: { id: "br-main", name: "main", isDefault: true } },
+				{
+					branch: {
+						id: "br-ttl",
+						name: "preview",
+						isDefault: false,
+						parentId: "br-main",
+						expiresAt: "2099-01-01T00:00:00.000Z",
+					},
+				},
+			],
+		});
+
+		const pulled = await pullConfig({ api, projectId, branchId: "br-ttl" });
+
+		expect(pulled.branch.expiresAt).toBe("2099-01-01T00:00:00.000Z");
+		expect(() =>
+			resolveConfig(pulled.config, { name: "preview", exists: true }),
+		).not.toThrow();
+		// expiry is not smuggled into the policy as a (bogus) ttl duration.
+		expect(
+			resolveConfig(pulled.config, { name: "preview", exists: true })
+				.ttlSeconds,
+		).toBeUndefined();
 	});
 
 	test("omits auth/dataApi when neither integration is enabled", async () => {

--- a/packages/config-runtime/src/lib/pull-config.test.ts
+++ b/packages/config-runtime/src/lib/pull-config.test.ts
@@ -43,7 +43,10 @@ describe("pullConfig", () => {
 			parent: "main",
 			protected: true,
 		});
-		expect(pulled.config).toMatchObject({
+		// Branch lifecycle/compute is carried by the `branch` tuning closure now.
+		expect(
+			pulled.config.branch?.({ name: "dev-a", exists: true }),
+		).toMatchObject({
 			parent: "main",
 			protected: true,
 			postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
@@ -101,7 +104,7 @@ describe("pullConfig", () => {
 			branchId: "br-main",
 		});
 
-		expect(pulled.config.auth).toEqual({});
+		expect(pulled.config.auth).toBe(true);
 		expect(pulled.config.dataApi).toBeUndefined();
 	});
 
@@ -130,7 +133,7 @@ describe("pullConfig", () => {
 			branchId: "br-main",
 		});
 
-		expect(pulled.config.dataApi).toEqual({});
+		expect(pulled.config.dataApi).toBe(true);
 		expect(pulled.config.auth).toBeUndefined();
 	});
 
@@ -163,8 +166,8 @@ describe("pullConfig", () => {
 			branchId: "br-main",
 		});
 
-		expect(pulled.config.auth).toEqual({});
-		expect(pulled.config.dataApi).toEqual({});
+		expect(pulled.config.auth).toBe(true);
+		expect(pulled.config.dataApi).toBe(true);
 	});
 
 	test("degrades when a Preview feature is unavailable, still pulling auth/dataApi", async () => {
@@ -205,7 +208,7 @@ describe("pullConfig", () => {
 		});
 
 		// Auth still pulled; the unavailable AI Gateway degrades to "off" rather than throwing.
-		expect(pulled.config.auth).toEqual({});
+		expect(pulled.config.auth).toBe(true);
 		expect(pulled.preview?.aiGatewayEnabled ?? false).toBe(false);
 	});
 });

--- a/packages/config-runtime/src/lib/pull-config.ts
+++ b/packages/config-runtime/src/lib/pull-config.ts
@@ -1,7 +1,8 @@
 import {
-	type BranchConfig,
-	type BucketConfig,
+	type BranchTuning,
+	type BucketAccessLevel,
 	type ComputeSettings,
+	type Config,
 	createNeonApiFromOptions,
 	ErrorCode,
 	type NeonApi,
@@ -32,7 +33,7 @@ export interface PullConfigOptions {
  * function is reported as `{ slug, name }` (no `source`).
  */
 export interface PulledPreview {
-	buckets: BucketConfig[];
+	buckets: Array<{ name: string; access: BucketAccessLevel }>;
 	functions: Array<{ slug: string; name: string }>;
 	aiGatewayEnabled: boolean;
 }
@@ -53,7 +54,13 @@ export interface PulledBranchConfig {
 		protected: boolean;
 		expiresAt?: string;
 	};
-	config: BranchConfig;
+	/**
+	 * The branch's live state expressed as a {@link Config}: static `auth` / `dataApi`
+	 * toggles plus a `branch` closure carrying the branch's lifecycle/compute tuning.
+	 * Preview functions/buckets are reported separately in {@link PulledBranchConfig.preview}
+	 * because functions cannot round-trip (the remote has no `source` path).
+	 */
+	config: Config;
 	/**
 	 * Live Preview-feature state, when the branch has any buckets/functions or an enabled
 	 * AI Gateway. Omitted entirely when there is nothing to report.
@@ -176,20 +183,23 @@ export function buildPulledBranchConfig(
 	const parent = branch.parentId
 		? branches.find((b) => b.id === branch.parentId)
 		: undefined;
-	// Auth/Data API live on the branch's service config (not under `preview`), so a
-	// config pulled from a branch with them enabled round-trips through `resolveConfig`
-	// / `fetchEnv` and the matching secrets get injected.
-	const config: BranchConfig = {
-		...(previewState?.authEnabled ? { auth: {} } : {}),
-		...(previewState?.dataApiEnabled ? { dataApi: {} } : {}),
-	};
-	if (parent) config.parent = parent.name;
-	if (branch.expiresAt) config.ttl = branch.expiresAt;
-	if (branch.protected) config.protected = true;
+	// Auth/Data API are static top-level toggles, so a config pulled from a branch with
+	// them enabled round-trips through `resolveConfig` / `fetchEnv` and the matching
+	// secrets get injected. Branch lifecycle/compute is per-branch tuning, so it goes in
+	// the `branch` closure.
+	const tuning: BranchTuning = {};
+	if (parent) tuning.parent = parent.name;
+	if (branch.expiresAt) tuning.ttl = branch.expiresAt;
+	if (branch.protected) tuning.protected = true;
 	if (endpoint) {
 		const compute = endpointToComputeSettings(endpoint, project);
-		if (compute) config.postgres = { computeSettings: compute };
+		if (compute) tuning.postgres = { computeSettings: compute };
 	}
+	const config: Config = {
+		...(previewState?.authEnabled ? { auth: true } : {}),
+		...(previewState?.dataApiEnabled ? { dataApi: true } : {}),
+		...(Object.keys(tuning).length > 0 ? { branch: () => tuning } : {}),
+	};
 	const result: PulledBranchConfig = {
 		project: {
 			id: project.id,

--- a/packages/config-runtime/src/lib/pull-config.ts
+++ b/packages/config-runtime/src/lib/pull-config.ts
@@ -189,7 +189,11 @@ export function buildPulledBranchConfig(
 	// the `branch` closure.
 	const tuning: BranchTuning = {};
 	if (parent) tuning.parent = parent.name;
-	if (branch.expiresAt) tuning.ttl = branch.expiresAt;
+	// Deliberately NOT emitting `ttl` from `branch.expiresAt`: policy `ttl` is a
+	// creation-time *duration*, while `expiresAt` is an absolute timestamp. Feeding the
+	// timestamp through `parseDuration` (in `resolveConfig`) would throw, breaking
+	// `fetchEnv` / `neon dev` / `neon env pull` for any branch that has a TTL. The expiry
+	// is reported faithfully on `branch.expiresAt` above.
 	if (branch.protected) tuning.protected = true;
 	if (endpoint) {
 		const compute = endpointToComputeSettings(endpoint, project);

--- a/packages/config-runtime/src/lib/push-config.test.ts
+++ b/packages/config-runtime/src/lib/push-config.test.ts
@@ -51,15 +51,17 @@ function seededFake(opts?: { protected?: boolean }) {
 describe("pushConfig", () => {
 	test("applies branch-scoped service enables to the selected branch", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig((branch) => ({
-			postgres: {
-				computeSettings: {
-					autoscalingLimitMaxCu: branch.name === "main" ? 4 : 1,
-				},
-			},
+		const config = defineConfig({
 			auth: {},
 			dataApi: {},
-		}));
+			branch: (branch) => ({
+				postgres: {
+					computeSettings: {
+						autoscalingLimitMaxCu: branch.name === "main" ? 4 : 1,
+					},
+				},
+			}),
+		});
 
 		const result = await pushConfig(config, {
 			api,
@@ -90,9 +92,11 @@ describe("pushConfig", () => {
 
 	test("reports mutable branch drift as conflict without updateExisting", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 
 		await expect(
 			pushConfig(config, { api, projectId, branchId: "br-main" }),
@@ -103,9 +107,11 @@ describe("pushConfig", () => {
 
 	test("confirm callback applies mutable drift when user accepts", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 
 		const calls: Array<{
 			protectedBranch: boolean;
@@ -142,9 +148,11 @@ describe("pushConfig", () => {
 
 	test("confirm callback returning false aborts with PushAbortedError", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 
 		await expect(
 			pushConfig(config, {
@@ -161,7 +169,7 @@ describe("pushConfig", () => {
 
 	test("protected branch triggers confirm even when no drift", async () => {
 		const { api, projectId } = seededFake({ protected: true });
-		const config = defineConfig(() => ({ auth: {} }));
+		const config = defineConfig({ auth: {} });
 
 		const ctxs: Array<{
 			protectedBranch: boolean;
@@ -192,9 +200,11 @@ describe("pushConfig", () => {
 
 	test("protected branch + drift collapses into a single confirm call", async () => {
 		const { api, projectId } = seededFake({ protected: true });
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 
 		const ctxs: Array<{
 			protectedBranch: boolean;
@@ -220,9 +230,11 @@ describe("pushConfig", () => {
 
 	test("allowProtectedBranch + updateExisting skip the confirm callback", async () => {
 		const { api, projectId } = seededFake({ protected: true });
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 
 		let called = false;
 		await pushConfig(config, {
@@ -245,9 +257,11 @@ describe("pushConfig", () => {
 
 	test("dryRun never invokes the confirm callback", async () => {
 		const { api, projectId } = seededFake({ protected: true });
-		const config = defineConfig(() => ({
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
-		}));
+		const config = defineConfig({
+			branch: () => ({
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 4 } },
+			}),
+		});
 
 		let called = false;
 		const result = await pushConfig(config, {
@@ -267,20 +281,19 @@ describe("pushConfig", () => {
 
 	test("creates buckets, creates + deploys functions, and enables AI Gateway", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: {
-				functions: [
-					{
+				functions: {
+					fn1: {
 						name: "Hello World",
-						slug: "fn1",
 						source: fnSource,
 						env: { RESEND_API_KEY: "re_abc" },
 					},
-				],
-				buckets: [{ name: "uploads" }],
+				},
+				buckets: { uploads: {} },
 				aiGateway: {},
 			},
-		}));
+		});
 
 		const result = await pushConfig(config, {
 			api,
@@ -331,13 +344,11 @@ describe("pushConfig", () => {
 	test("only probes the Preview features the policy declares", async () => {
 		const { api, projectId } = seededFake();
 		// Policy declares functions only — no buckets, no aiGateway.
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: {
-				functions: [
-					{ name: "Hello World", slug: "fn1", source: fnSource },
-				],
+				functions: { fn1: { name: "Hello World", source: fnSource } },
 			},
-		}));
+		});
 
 		await pushConfig(config, { api, projectId, branchId: "br-main" });
 
@@ -352,17 +363,11 @@ describe("pushConfig", () => {
 
 	test("uses an injected bundleFunction instead of the default esbuild bundler", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: {
-				functions: [
-					{
-						name: "Hello World",
-						slug: "fn1",
-						source: fnSource,
-					},
-				],
+				functions: { fn1: { name: "Hello World", source: fnSource } },
 			},
-		}));
+		});
 
 		const bundled: string[] = [];
 		const sentinel = new Uint8Array([1, 2, 3, 4]);
@@ -394,17 +399,11 @@ describe("pushConfig", () => {
 			name: "Hello World",
 			invocationUrl: "https://x/functions/fn1",
 		});
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: {
-				functions: [
-					{
-						name: "Hello World",
-						slug: "fn1",
-						source: fnSource,
-					},
-				],
+				functions: { fn1: { name: "Hello World", source: fnSource } },
 			},
-		}));
+		});
 
 		await pushConfig(config, { api, projectId, branchId: "br-main" });
 
@@ -418,9 +417,9 @@ describe("pushConfig", () => {
 
 	test("dryRun plans preview steps without mutating", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
-			preview: { buckets: [{ name: "uploads" }], aiGateway: {} },
-		}));
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} }, aiGateway: {} },
+		});
 
 		const result = await pushConfig(config, {
 			api,
@@ -445,10 +444,10 @@ describe("pushConfig", () => {
 
 	test("dryRun surfaces selected branch plan without mutating", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({
-			protected: true,
+		const config = defineConfig({
 			auth: {},
-		}));
+			branch: () => ({ protected: true }),
+		});
 
 		const result = await pushConfig(config, {
 			api,

--- a/packages/config-runtime/src/v1.test.ts
+++ b/packages/config-runtime/src/v1.test.ts
@@ -20,10 +20,12 @@ describe("config-runtime v1 surface", () => {
 	});
 
 	test("re-exports defineConfig from @neondatabase/config for one-stop deploy scripts", () => {
-		const config = defineConfig((branch) => ({
-			parent: branch.name === "main" ? undefined : "main",
-		}));
-		expect(config({ name: "dev", exists: false })).toEqual({
+		const config = defineConfig({
+			branch: (branch) => ({
+				parent: branch.name === "main" ? undefined : "main",
+			}),
+		});
+		expect(config.branch?.({ name: "dev", exists: false })).toEqual({
 			parent: "main",
 		});
 	});

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -16,17 +16,30 @@ npm install @neondatabase/config
 // neon.ts
 import { defineConfig } from "@neondatabase/config/v1";
 
-export default defineConfig((branch) => {
-  if (branch.name === "main") {
-    return { protected: true, auth: {} };
-  }
-  return { parent: "main", ttl: "7d" };
+export default defineConfig({
+  // Static: what *exists* on every branch. GA service toggles drive the typed env.
+  auth: true,
+  dataApi: false,
+  // Beta (Preview) features, keyed by slug / name.
+  preview: {
+    functions: {
+      hello: { name: "Hello", source: "./functions/hello.ts", dev: { port: 8787 } },
+    },
+  },
+  // Dynamic: per-branch tuning only. Cannot add/remove services or functions.
+  branch: (branch) => ({
+    protected: branch.name === "main",
+    ...(branch.name === "main" ? {} : { parent: "main", ttl: "7d" }),
+  }),
 });
 ```
 
-The `branch` argument is a **read-only descriptor** (`BranchTarget`) of the branch this policy is being evaluated for — `name`, `id`, `exists`, `isDefault`, `isProtected`, `parentId`, `expiresAt`. It is not a live branch handle: don't mutate it, just switch on its fields and **return** the desired config. The same callback runs both against existing branches and during pre-create evaluation (`exists: false`).
+A policy is split into a **static** existential set and a **dynamic** `branch` closure:
 
-`parent` and `ttl` are branch lifecycle fields. Product-specific settings live under product namespaces such as `postgres`, `auth`, and `dataApi`.
+- **Static top-level** — `auth` / `dataApi` (GA service toggles) and the beta `preview` block (`aiGateway`, `functions` keyed by slug, `buckets` keyed by name). Because this is static, the secret set is known at the type level, so `parseEnv` / `fetchEnv` from `@neondatabase/env` return an exact `NeonEnv`.
+- **`branch` closure** — receives a **read-only descriptor** (`BranchTarget`) of the branch being evaluated (`name`, `id`, `exists`, `isDefault`, `isProtected`, `parentId`, `expiresAt`) and returns per-branch *tuning*: `parent`, `ttl`, `protected`, `postgres.computeSettings`, and per-function `memoryMib` / `runtime`. It runs both against existing branches and during pre-create evaluation (`exists: false`). It **cannot** change which services or functions exist — that is what keeps the static secret set sound.
+
+Service toggles accept `true` / `{}` / `{ enabled: true }` (enabled) and `false` / `{ enabled: false }` (disabled). Function slugs (record keys) must match `^[a-z0-9]{1,20}$`.
 
 ## Functions
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -285,6 +285,18 @@ describe("resolveConfig", () => {
 		expect(resolved.preview?.functions[0].memoryMib).toBe(512);
 	});
 
+	test("passes the branch target to the closure for per-branch decisions", () => {
+		const config = defineConfig({
+			branch: (branch) => ({ protected: branch.name === "main" }),
+		});
+		expect(
+			resolveConfig(config, { name: "main", exists: true }).protected,
+		).toBe(true);
+		expect(
+			resolveConfig(config, { name: "dev", exists: false }).protected,
+		).toBe(false);
+	});
+
 	test("treats a branch closure returning undefined as no tuning", () => {
 		const config = defineConfig({
 			auth: true,

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -26,6 +26,19 @@ describe("defineConfig", () => {
 			ConfigValidationError,
 		);
 	});
+
+	test("rejects a non-object input", () => {
+		expect(() => defineConfig(null as never)).toThrow(
+			ConfigValidationError,
+		);
+		expect(() => defineConfig(42 as never)).toThrow(ConfigValidationError);
+	});
+
+	test("rejects a `branch` that is not a function", () => {
+		expect(() => defineConfig({ branch: {} as never })).toThrow(
+			ConfigValidationError,
+		);
+	});
 });
 
 describe("resolveConfig", () => {
@@ -248,5 +261,68 @@ describe("resolveConfig", () => {
 			resolveConfig(config, { name: "preview-1", exists: false }).preview
 				?.functions[0].slug,
 		).toBe("fn1");
+	});
+
+	test("ignores branch tuning for a function slug not declared statically", () => {
+		// The type system blocks unknown slugs in the closure (see the type-constraint
+		// tests); at runtime an unknown slug that slips past types is simply ignored — it
+		// can never fabricate a function that isn't statically declared.
+		const config = defineConfig({
+			preview: {
+				functions: { hello: { name: "Hello", source: "./h.ts" } },
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: exercising the runtime guard past types.
+			branch: () =>
+				({
+					preview: { functions: { ghost: { memoryMib: 2048 } } },
+				}) as any,
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions.map((f) => f.slug)).toEqual([
+			"hello",
+		]);
+		// hello keeps the default memory (the ghost tuning never applied to it).
+		expect(resolved.preview?.functions[0].memoryMib).toBe(512);
+	});
+
+	test("treats a branch closure returning undefined as no tuning", () => {
+		const config = defineConfig({
+			auth: true,
+			// biome-ignore lint/suspicious/noConfusingVoidType: closure may legitimately return nothing.
+			branch: (() => undefined) as never,
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.authEnabled).toBe(true);
+		expect(resolved.parent).toBeUndefined();
+		expect(resolved.protected).toBeUndefined();
+	});
+});
+
+describe("defineConfig type constraints (compile-time)", () => {
+	test("the branch closure cannot tune an undeclared function slug", () => {
+		defineConfig({
+			preview: { functions: { hello: { name: "H", source: "./h.ts" } } },
+			// @ts-expect-error "goodbye" is not a declared function slug.
+			branch: () => ({
+				preview: { functions: { goodbye: { memoryMib: 512 } } },
+			}),
+		});
+	});
+
+	test("the branch closure cannot add a service toggle", () => {
+		defineConfig({
+			// @ts-expect-error `auth` is a static top-level toggle, not branch tuning.
+			branch: () => ({ auth: true }),
+		});
+	});
+
+	test("the branch closure cannot redeclare a function's source", () => {
+		defineConfig({
+			preview: { functions: { hello: { name: "H", source: "./h.ts" } } },
+			// @ts-expect-error `source` is static; tuning only sets memoryMib/runtime.
+			branch: () => ({
+				preview: { functions: { hello: { source: "./other.ts" } } },
+			}),
+		});
 	});
 });

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -3,20 +3,25 @@ import { defineConfig, resolveConfig } from "./define-config.js";
 import { ConfigValidationError } from "./errors.js";
 
 describe("defineConfig", () => {
-	test("accepts a branch policy function and preserves literal behavior", () => {
-		const config = defineConfig((branch) => {
-			if (branch.name === "main")
-				return { protected: true, auth: { enabled: true } };
-			return { parent: "main", ttl: "7d" };
-		});
-		expect(typeof config).toBe("function");
-		expect(config({ name: "main", exists: true })).toEqual({
-			protected: true,
+	test("accepts a static policy object and freezes it", () => {
+		const config = defineConfig({
 			auth: { enabled: true },
+			branch: (branch) => ({ protected: branch.name === "main" }),
 		});
+		expect(typeof config).toBe("object");
+		expect(config.auth).toEqual({ enabled: true });
+		expect(Object.isFrozen(config)).toBe(true);
 	});
 
-	test("rejects object configs so project-level config is not accepted", () => {
+	test("rejects a function config so the old closure form is not accepted", () => {
+		expect(() =>
+			defineConfig(((branch: { name: string }) => ({
+				parent: branch.name,
+			})) as never),
+		).toThrow(ConfigValidationError);
+	});
+
+	test("rejects an unknown top-level key", () => {
 		expect(() => defineConfig({ project: { name: "x" } } as never)).toThrow(
 			ConfigValidationError,
 		);
@@ -24,15 +29,17 @@ describe("defineConfig", () => {
 });
 
 describe("resolveConfig", () => {
-	test("normalizes branch policy output", () => {
-		const config = defineConfig(() => ({
-			parent: "main",
-			ttl: "1h",
-			protected: true,
-			postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
+	test("normalizes static services and branch tuning", () => {
+		const config = defineConfig({
 			auth: {},
 			dataApi: {},
-		}));
+			branch: () => ({
+				parent: "main",
+				ttl: "1h",
+				protected: true,
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
+			}),
+		});
 		const resolved = resolveConfig(config, {
 			name: "dev-a",
 			exists: false,
@@ -47,11 +54,11 @@ describe("resolveConfig", () => {
 		});
 	});
 
-	test("treats explicit service false as disabled", () => {
-		const config = defineConfig(() => ({
-			auth: { enabled: false },
+	test("treats boolean and explicit service false as disabled", () => {
+		const config = defineConfig({
+			auth: false,
 			dataApi: { enabled: false },
-		}));
+		});
 		const resolved = resolveConfig(config, {
 			name: "dev-a",
 			exists: false,
@@ -60,28 +67,36 @@ describe("resolveConfig", () => {
 		expect(resolved.dataApiEnabled).toBe(false);
 	});
 
-	test("reports invalid returned branch config", () => {
-		const config = defineConfig(() => ({ parent: "preview-*" }));
+	test("treats `auth: true` as enabled", () => {
+		const config = defineConfig({ auth: true });
+		expect(
+			resolveConfig(config, { name: "main", exists: true }).authEnabled,
+		).toBe(true);
+	});
+
+	test("reports invalid branch tuning output", () => {
+		const config = defineConfig({
+			branch: () => ({ parent: "preview-*" }),
+		});
 		expect(() =>
 			resolveConfig(config, { name: "dev", exists: false }),
 		).toThrow(ConfigValidationError);
 	});
 
 	test("resolves preview functions with deploy defaults and buckets with private access", () => {
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: {
-				functions: [
-					{
+				functions: {
+					fn1: {
 						name: "Hello World",
-						slug: "fn1",
 						source: "./functions/hello-world.ts",
 						env: { RESEND_API_KEY: "re_abc" },
 					},
-				],
-				buckets: [{ name: "uploads" }],
+				},
+				buckets: { uploads: {} },
 				aiGateway: { enabled: true },
 			},
-		}));
+		});
 		const resolved = resolveConfig(config, {
 			name: "preview-1",
 			exists: false,
@@ -102,10 +117,32 @@ describe("resolveConfig", () => {
 		});
 	});
 
+	test("applies per-branch function tuning (memoryMib / runtime) over defaults", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					hello: { name: "Hello", source: "./hello.ts" },
+				},
+			},
+			branch: () => ({
+				preview: { functions: { hello: { memoryMib: 2048 } } },
+			}),
+		});
+		const resolved = resolveConfig(config, {
+			name: "main",
+			exists: true,
+		});
+		expect(resolved.preview?.functions[0]).toMatchObject({
+			slug: "hello",
+			memoryMib: 2048,
+			runtime: "nodejs24",
+		});
+	});
+
 	test("treats aiGateway enabled:false as disabled", () => {
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: { aiGateway: { enabled: false } },
-		}));
+		});
 		const resolved = resolveConfig(config, {
 			name: "preview-1",
 			exists: false,
@@ -114,18 +151,17 @@ describe("resolveConfig", () => {
 	});
 
 	test("passes a function dev block through untouched", () => {
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: {
-				functions: [
-					{
+				functions: {
+					hello: {
 						name: "Hello",
-						slug: "hello",
 						source: "./hello.ts",
 						dev: { port: 8787, portless: true },
 					},
-				],
+				},
 			},
-		}));
+		});
 		const resolved = resolveConfig(config, {
 			name: "preview-1",
 			exists: false,
@@ -137,13 +173,11 @@ describe("resolveConfig", () => {
 	});
 
 	test("omits dev from the resolved function when not provided", () => {
-		const config = defineConfig(() => ({
+		const config = defineConfig({
 			preview: {
-				functions: [
-					{ name: "Hello", slug: "hello", source: "./hello.ts" },
-				],
+				functions: { hello: { name: "Hello", source: "./hello.ts" } },
 			},
-		}));
+		});
 		const resolved = resolveConfig(config, {
 			name: "preview-1",
 			exists: false,
@@ -151,87 +185,68 @@ describe("resolveConfig", () => {
 		expect(resolved.preview?.functions[0]).not.toHaveProperty("dev");
 	});
 
-	test("rejects a function env value that is undefined (e.g. unset process.env)", () => {
-		const config = defineConfig(() => ({
-			preview: {
-				functions: [
-					{
-						name: "Hello",
-						slug: "hello",
-						source: "./hello.ts",
-						// Simulates `RESEND_API_KEY: process.env.RESEND_API_KEY` when unset.
-						env: { RESEND_API_KEY: undefined as unknown as string },
-					},
-				],
-			},
-		}));
+	test("rejects a function env value that is undefined (e.g. unset process.env) at definition time", () => {
 		expect(() =>
-			resolveConfig(config, { name: "preview-1", exists: false }),
+			defineConfig({
+				preview: {
+					functions: {
+						hello: {
+							name: "Hello",
+							source: "./hello.ts",
+							// Simulates `RESEND_API_KEY: process.env.RESEND_API_KEY` when unset.
+							env: {
+								RESEND_API_KEY: undefined as unknown as string,
+							},
+						},
+					},
+				},
+			}),
 		).toThrow(ConfigValidationError);
 	});
 
-	test("rejects an invalid function slug", () => {
-		const config = defineConfig(() => ({
-			preview: {
-				functions: [
-					{ name: "Bad", slug: "Hello World", source: "./x.ts" },
-				],
-			},
-		}));
+	test("rejects an invalid function slug (record key) at definition time", () => {
 		expect(() =>
-			resolveConfig(config, { name: "preview-1", exists: false }),
+			defineConfig({
+				preview: {
+					functions: {
+						"Hello World": { name: "Bad", source: "./x.ts" },
+					},
+				},
+			}),
 		).toThrow(ConfigValidationError);
 	});
 
 	test("rejects a hyphenated function slug (only letters and digits allowed)", () => {
-		const config = defineConfig(() => ({
-			preview: {
-				functions: [
-					{ name: "H", slug: "hello-world", source: "./x.ts" },
-				],
-			},
-		}));
 		expect(() =>
-			resolveConfig(config, { name: "preview-1", exists: false }),
+			defineConfig({
+				preview: {
+					functions: {
+						"hello-world": { name: "H", source: "./x.ts" },
+					},
+				},
+			}),
 		).toThrow(ConfigValidationError);
 	});
 
 	test("rejects a function slug longer than 20 chars", () => {
-		const config = defineConfig(() => ({
-			preview: {
-				functions: [
-					{ name: "L", slug: "a".repeat(21), source: "./x.ts" },
-				],
-			},
-		}));
 		expect(() =>
-			resolveConfig(config, { name: "preview-1", exists: false }),
+			defineConfig({
+				preview: {
+					functions: {
+						["a".repeat(21)]: { name: "L", source: "./x.ts" },
+					},
+				},
+			}),
 		).toThrow(ConfigValidationError);
 	});
 
 	test("accepts a valid alphanumeric function slug", () => {
-		const config = defineConfig(() => ({
-			preview: {
-				functions: [{ name: "OK", slug: "fn1", source: "./x.ts" }],
-			},
-		}));
+		const config = defineConfig({
+			preview: { functions: { fn1: { name: "OK", source: "./x.ts" } } },
+		});
 		expect(
 			resolveConfig(config, { name: "preview-1", exists: false }).preview
 				?.functions[0].slug,
 		).toBe("fn1");
-	});
-
-	test("rejects duplicate function slugs", () => {
-		const config = defineConfig(() => ({
-			preview: {
-				functions: [
-					{ name: "A", slug: "dup", source: "./a.ts" },
-					{ name: "B", slug: "dup", source: "./b.ts" },
-				],
-			},
-		}));
-		expect(() =>
-			resolveConfig(config, { name: "preview-1", exists: false }),
-		).toThrow(ConfigValidationError);
 	});
 });

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -101,26 +101,17 @@ export function resolveConfig(
 ): ResolvedBranchConfig {
 	const tuning = evaluateBranchTuning(config.branch, branch);
 
-	const issues: string[] = [];
-	let ttlSeconds: number | undefined;
-	if (tuning.ttl !== undefined) {
-		const parsedTtl = parseDuration(tuning.ttl);
-		if ("error" in parsedTtl) {
-			issues.push(`ttl: ${parsedTtl.error}`);
-		} else {
-			ttlSeconds = parsedTtl.seconds;
-		}
-	}
-	if (issues.length > 0) {
-		throw new ConfigValidationError(issues);
-	}
-
 	const resolved: ResolvedBranchConfig = {
 		authEnabled: isServiceEnabled(config.auth),
 		dataApiEnabled: isServiceEnabled(config.dataApi),
 	};
 	if (tuning.parent !== undefined) resolved.parent = tuning.parent;
-	if (ttlSeconds !== undefined) resolved.ttlSeconds = ttlSeconds;
+	if (tuning.ttl !== undefined) {
+		// `branchTuningSchema` already validated `ttl` with the same `parseDuration`, so
+		// this only converts the validated value to seconds — it cannot fail here.
+		const parsedTtl = parseDuration(tuning.ttl);
+		if (!("error" in parsedTtl)) resolved.ttlSeconds = parsedTtl.seconds;
+	}
 	if (tuning.protected !== undefined) resolved.protected = tuning.protected;
 	if (tuning.postgres?.computeSettings) {
 		resolved.postgres = {

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -1,14 +1,22 @@
 import { parseDuration } from "./duration.js";
 import { ConfigValidationError } from "./errors.js";
-import { branchConfigSchema, formatZodIssues } from "./schema.js";
+import {
+	branchTuningSchema,
+	configInputSchema,
+	formatZodIssues,
+} from "./schema.js";
 import type {
 	BranchTarget,
+	BranchTuning,
+	BranchTuningFn,
 	Config,
-	FunctionConfig,
-	PreviewConfig,
+	FunctionDef,
+	FunctionTuning,
+	PreviewInput,
 	ResolvedBranchConfig,
 	ResolvedFunctionConfig,
 	ResolvedPreviewConfig,
+	ServiceToggleInput,
 } from "./types.js";
 
 /** Default deploy parameters applied to functions that omit them in `neon.ts`. */
@@ -24,62 +32,79 @@ const REGION_PREFIX = /^(aws|azure|gcp)-/;
  * ```ts
  * import { defineConfig } from "@neondatabase/config/v1";
  *
- * export default defineConfig((branch) => {
- *   if (branch.name === "main") {
- *     return { protected: true, auth: {} };
- *   }
- *   return { parent: "main", ttl: "7d" };
+ * export default defineConfig({
+ *   auth: true,
+ *   preview: {
+ *     functions: {
+ *       hello: { name: "Hello", source: "./functions/hello.ts", dev: { port: 8787 } },
+ *     },
+ *   },
+ *   branch: (branch) => ({ protected: branch.name === "main" }),
  * });
  * ```
  *
- * The `branch` parameter is a **read-only {@link BranchTarget} descriptor** of the branch
- * this policy invocation is deciding for — not a live branch handle. You don't mutate it
- * (`branch.protected = true` does nothing); you switch on its facts (`branch.name`,
- * `branch.isDefault`, `branch.exists`, …) and **return** the desired {@link BranchConfig}.
- * The same callback runs in two modes: against an existing branch (fields populated from
- * Neon) and during pre-create evaluation (`exists: false`, `id` undefined).
+ * The policy is split into a **static** existential set (top-level `auth` / `dataApi`
+ * toggles and the beta `preview` block) and a **dynamic** per-branch `branch` closure. The
+ * static half determines which secrets exist — so `NeonEnv<typeof config>` and `parseEnv`
+ * are exact — while the closure can only *tune* a branch (lifecycle, compute, per-function
+ * deploy settings), never change what exists.
  *
- * Pure function — no I/O, no side effects. The returned policy validates its output every
- * time it is evaluated so errors point at the concrete branch target that triggered them.
+ * The `branch` callback receives a read-only {@link BranchTarget} descriptor of the branch
+ * being decided for (not a live handle); switch on its facts (`branch.name`,
+ * `branch.isDefault`, `branch.exists`, …) and **return** the desired tuning. It runs in two
+ * modes: against an existing branch (fields populated from Neon) and during pre-create
+ * evaluation (`exists: false`, `id` undefined).
+ *
+ * Pure: no I/O, no side effects. The static parts are validated here; the closure's output
+ * is validated every time it is evaluated so errors point at the concrete branch target.
  */
-export function defineConfig<const C extends Config>(input: C): C {
-	if (typeof input !== "function") {
+export function defineConfig<
+	const Auth extends ServiceToggleInput | undefined = undefined,
+	const DataApi extends ServiceToggleInput | undefined = undefined,
+	const Preview extends PreviewInput | undefined = undefined,
+>(input: {
+	auth?: Auth;
+	dataApi?: DataApi;
+	preview?: Preview;
+	branch?: BranchTuningFn<Preview>;
+}): Config<Auth, DataApi, Preview> {
+	if (typeof input === "function") {
 		throw new ConfigValidationError([
-			"defineConfig expects a function: `export default defineConfig((branch) => ({ ... }))`.",
-			"Project-level config has moved to `neonctl link`; neon.ts now describes branch-level policy only.",
+			"defineConfig now expects an object, not a function: `export default defineConfig({ auth: true, preview: { … }, branch: (branch) => ({ … }) })`.",
+			"The static services/preview set moved to the top level; per-branch logic moved into the `branch` closure.",
+		]);
+	}
+	if (input === null || typeof input !== "object") {
+		throw new ConfigValidationError([
+			"defineConfig expects a configuration object: `export default defineConfig({ … })`.",
 		]);
 	}
 
-	return Object.freeze(input) as C;
+	const parsed = configInputSchema.safeParse(input);
+	if (!parsed.success) {
+		throw new ConfigValidationError(formatZodIssues(parsed.error));
+	}
+
+	return Object.freeze({ ...input }) as Config<Auth, DataApi, Preview>;
 }
 
 /**
  * Evaluate a branch policy for a specific branch target and return a normalized config.
+ *
+ * Merges the static existential set (services + preview functions/buckets) with the
+ * per-branch tuning returned by the `branch` closure into the same {@link
+ * ResolvedBranchConfig} the rest of the runtime (diff / push / fetchEnv) consumes.
  */
 export function resolveConfig(
 	config: Config,
 	branch: BranchTarget,
 ): ResolvedBranchConfig {
-	let raw: unknown;
-	try {
-		raw = config(Object.freeze({ ...branch }));
-	} catch (cause) {
-		throw new ConfigValidationError([
-			`Config function threw while evaluating branch "${branch.name}".`,
-			(cause as Error)?.message ?? String(cause),
-		]);
-	}
+	const tuning = evaluateBranchTuning(config.branch, branch);
 
-	const parsed = branchConfigSchema.safeParse(raw);
-	if (!parsed.success) {
-		throw new ConfigValidationError(formatZodIssues(parsed.error));
-	}
-
-	const cfg = parsed.data;
 	const issues: string[] = [];
 	let ttlSeconds: number | undefined;
-	if (cfg.ttl !== undefined) {
-		const parsedTtl = parseDuration(cfg.ttl);
+	if (tuning.ttl !== undefined) {
+		const parsedTtl = parseDuration(tuning.ttl);
 		if ("error" in parsedTtl) {
 			issues.push(`ttl: ${parsedTtl.error}`);
 		} else {
@@ -91,56 +116,99 @@ export function resolveConfig(
 	}
 
 	const resolved: ResolvedBranchConfig = {
-		authEnabled: isServiceEnabled(cfg.auth),
-		dataApiEnabled: isServiceEnabled(cfg.dataApi),
+		authEnabled: isServiceEnabled(config.auth),
+		dataApiEnabled: isServiceEnabled(config.dataApi),
 	};
-	if (cfg.parent !== undefined) resolved.parent = cfg.parent;
+	if (tuning.parent !== undefined) resolved.parent = tuning.parent;
 	if (ttlSeconds !== undefined) resolved.ttlSeconds = ttlSeconds;
-	if (cfg.protected !== undefined) resolved.protected = cfg.protected;
-	if (cfg.postgres) {
+	if (tuning.protected !== undefined) resolved.protected = tuning.protected;
+	if (tuning.postgres?.computeSettings) {
 		resolved.postgres = {
-			...(cfg.postgres.computeSettings
-				? { computeSettings: { ...cfg.postgres.computeSettings } }
-				: {}),
+			computeSettings: { ...tuning.postgres.computeSettings },
 		};
 	}
-	if (cfg.preview) {
-		resolved.preview = resolvePreviewConfig(cfg.preview);
-	}
+
+	const preview = resolvePreviewConfig(config.preview, tuning);
+	if (preview) resolved.preview = preview;
+
 	return resolved;
 }
 
-function isServiceEnabled(service: { enabled?: boolean } | undefined): boolean {
-	return service !== undefined && service.enabled !== false;
+/**
+ * Run the `branch` closure (when present) for the target and validate its output. The
+ * closure is optional — a fully static policy resolves with empty tuning.
+ */
+function evaluateBranchTuning(
+	branchFn: BranchTuningFn | undefined,
+	target: BranchTarget,
+): BranchTuning {
+	if (!branchFn) return {};
+	let raw: unknown;
+	try {
+		raw = branchFn(Object.freeze({ ...target }));
+	} catch (cause) {
+		throw new ConfigValidationError([
+			`Branch policy threw while evaluating branch "${target.name}".`,
+			(cause as Error)?.message ?? String(cause),
+		]);
+	}
+	const parsed = branchTuningSchema.safeParse(raw ?? {});
+	if (!parsed.success) {
+		throw new ConfigValidationError(formatZodIssues(parsed.error));
+	}
+	return parsed.data as BranchTuning;
+}
+
+function isServiceEnabled(toggle: ServiceToggleInput | undefined): boolean {
+	if (toggle === undefined) return false;
+	if (typeof toggle === "boolean") return toggle;
+	return toggle.enabled !== false;
 }
 
 /**
- * Normalize a {@link PreviewConfig} into a {@link ResolvedPreviewConfig}: apply per-function
- * deploy defaults, default each bucket's access level to `private`, and collapse the
- * `aiGateway` toggle to a boolean using the same present-and-not-`false` rule as
- * `auth` / `dataApi`.
+ * Normalize the static {@link PreviewInput} (merged with per-branch function tuning) into a
+ * {@link ResolvedPreviewConfig}. Returns `undefined` when the policy declares no `preview`
+ * block so the field can be omitted entirely. Function slugs / bucket names come from the
+ * record keys.
  */
-function resolvePreviewConfig(preview: PreviewConfig): ResolvedPreviewConfig {
+function resolvePreviewConfig(
+	preview: PreviewInput | undefined,
+	tuning: BranchTuning,
+): ResolvedPreviewConfig | undefined {
+	if (!preview) return undefined;
+	const fnTuning = tuning.preview?.functions ?? {};
+	const functions: ResolvedFunctionConfig[] = Object.entries(
+		preview.functions ?? {},
+	).map(([slug, def]) =>
+		resolveFunctionConfig(slug, def, fnTuning[slug] ?? {}),
+	);
+	const buckets = Object.entries(preview.buckets ?? {}).map(
+		([name, def]) => ({
+			name,
+			access: def.access ?? "private",
+		}),
+	);
 	return {
-		functions: (preview.functions ?? []).map(resolveFunctionConfig),
-		buckets: (preview.buckets ?? []).map((bucket) => ({
-			name: bucket.name,
-			access: bucket.access ?? "private",
-		})),
+		functions,
+		buckets,
 		aiGatewayEnabled: isServiceEnabled(preview.aiGateway),
 	};
 }
 
-function resolveFunctionConfig(fn: FunctionConfig): ResolvedFunctionConfig {
+function resolveFunctionConfig(
+	slug: string,
+	def: FunctionDef,
+	tuning: FunctionTuning,
+): ResolvedFunctionConfig {
 	return {
-		slug: fn.slug,
-		name: fn.name,
-		source: fn.source,
-		env: { ...(fn.env ?? {}) },
-		runtime: fn.runtime ?? DEFAULT_FUNCTION_RUNTIME,
-		memoryMib: fn.memoryMib ?? DEFAULT_FUNCTION_MEMORY_MIB,
+		slug,
+		name: def.name,
+		source: def.source,
+		env: { ...(def.env ?? {}) },
+		runtime: tuning.runtime ?? DEFAULT_FUNCTION_RUNTIME,
+		memoryMib: tuning.memoryMib ?? DEFAULT_FUNCTION_MEMORY_MIB,
 		// Passed through untouched (no defaults); only `neon dev` reads it.
-		...(fn.dev ? { dev: fn.dev } : {}),
+		...(def.dev ? { dev: def.dev } : {}),
 	};
 }
 

--- a/packages/config/src/lib/loader.test.ts
+++ b/packages/config/src/lib/loader.test.ts
@@ -7,14 +7,15 @@ const PLATFORM_SRC = new URL("../v1.ts", import.meta.url).pathname;
 describe("loadConfigFromFile", () => {
 	test("loads a neon.ts branch policy", async () => {
 		const repo = makeTempRepo({
-			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}"; export default defineConfig((branch) => ({ parent: branch.name === "main" ? undefined : "main" }));`,
+			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}"; export default defineConfig({ auth: true, branch: (branch) => ({ parent: branch.name === "main" ? undefined : "main" }) });`,
 		});
 		try {
 			const { config, resolvedPath } = await loadConfigFromFile({
 				cwd: repo.root,
 			});
 			expect(resolvedPath.endsWith("neon.ts")).toBe(true);
-			expect(config({ name: "dev", exists: false })).toEqual({
+			expect(config.auth).toBe(true);
+			expect(config.branch?.({ name: "dev", exists: false })).toEqual({
 				parent: "main",
 			});
 		} finally {

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
-	branchConfigSchema,
+	branchTuningSchema,
 	computeSettingsSchema,
+	configInputSchema,
 	formatZodIssues,
 } from "./schema.js";
 
@@ -27,127 +28,107 @@ describe("computeSettingsSchema", () => {
 	});
 });
 
-describe("branchConfigSchema", () => {
-	test("accepts branch-level lifecycle and product namespaces", () => {
-		expect(
-			branchConfigSchema.parse({
-				parent: "main",
-				ttl: "7d",
-				postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
-				auth: { enabled: true },
-			}),
-		).toMatchObject({ parent: "main", auth: { enabled: true } });
-	});
-
-	test("rejects wildcard parent", () => {
-		const result = branchConfigSchema.safeParse({ parent: "preview-*" });
-		expect(result.success).toBe(false);
-	});
-
-	test("accepts a preview block with functions, buckets, and aiGateway", () => {
-		const result = branchConfigSchema.safeParse({
+describe("configInputSchema", () => {
+	test("accepts top-level services, a preview block, and a branch closure", () => {
+		const result = configInputSchema.safeParse({
+			auth: true,
+			dataApi: { enabled: false },
 			preview: {
-				functions: [
-					{
-						slug: "fn1",
+				functions: {
+					fn1: {
 						name: "Hello World",
 						source: "./hello.ts",
 						env: { KEY: "value" },
 					},
-				],
-				buckets: [{ name: "uploads", access: "public_read" }],
+				},
+				buckets: { uploads: { access: "public_read" } },
 				aiGateway: { enabled: true },
 			},
+			branch: () => ({}),
 		});
 		expect(result.success).toBe(true);
 	});
 
+	test("rejects an invalid function slug used as a record key", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: { "Bad Slug": { name: "x", source: "./x.ts" } },
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
 	test("rejects an unknown key inside preview", () => {
-		const result = branchConfigSchema.safeParse({
-			preview: { functions: [], typo: true },
+		const result = configInputSchema.safeParse({
+			preview: { functions: {}, typo: true },
 		});
 		expect(result.success).toBe(false);
 	});
 
 	test("accepts a function dev block with port and portless", () => {
-		const result = branchConfigSchema.safeParse({
+		const result = configInputSchema.safeParse({
 			preview: {
-				functions: [
-					{
-						slug: "fn1",
+				functions: {
+					fn1: {
 						name: "Hello World",
 						source: "./hello.ts",
 						dev: { port: 8787, portless: true },
 					},
-				],
-			},
-		});
-		expect(result.success).toBe(true);
-	});
-
-	test("accepts dev with no port when portless is not set", () => {
-		const result = branchConfigSchema.safeParse({
-			preview: {
-				functions: [
-					{ slug: "f", name: "F", source: "./f.ts", dev: {} },
-				],
-			},
-		});
-		expect(result.success).toBe(true);
-	});
-
-	test("accepts dev.portless true without a port (portless assigns the port)", () => {
-		const result = branchConfigSchema.safeParse({
-			preview: {
-				functions: [
-					{
-						slug: "f",
-						name: "F",
-						source: "./f.ts",
-						dev: { portless: true },
-					},
-				],
+				},
 			},
 		});
 		expect(result.success).toBe(true);
 	});
 
 	test("rejects an out-of-range dev.port", () => {
-		const result = branchConfigSchema.safeParse({
+		const result = configInputSchema.safeParse({
 			preview: {
-				functions: [
-					{
-						slug: "f",
-						name: "F",
-						source: "./f.ts",
-						dev: { port: 0 },
-					},
-				],
+				functions: {
+					f: { name: "F", source: "./f.ts", dev: { port: 0 } },
+				},
 			},
 		});
 		expect(result.success).toBe(false);
 	});
 
 	test("rejects an unknown key inside dev", () => {
-		const result = branchConfigSchema.safeParse({
+		const result = configInputSchema.safeParse({
 			preview: {
-				functions: [
-					{
-						slug: "f",
+				functions: {
+					f: {
 						name: "F",
 						source: "./f.ts",
 						dev: { port: 8787, typo: true },
 					},
-				],
+				},
 			},
 		});
 		expect(result.success).toBe(false);
 	});
 });
 
+describe("branchTuningSchema", () => {
+	test("accepts branch lifecycle, postgres, and per-function tuning", () => {
+		expect(
+			branchTuningSchema.parse({
+				parent: "main",
+				ttl: "7d",
+				protected: true,
+				postgres: { computeSettings: { autoscalingLimitMaxCu: 2 } },
+				preview: { functions: { hello: { memoryMib: 1024 } } },
+			}),
+		).toMatchObject({ parent: "main", protected: true });
+	});
+
+	test("rejects wildcard parent", () => {
+		const result = branchTuningSchema.safeParse({ parent: "preview-*" });
+		expect(result.success).toBe(false);
+	});
+});
+
 describe("formatZodIssues", () => {
 	test("renders paths", () => {
-		const result = branchConfigSchema.safeParse({
+		const result = branchTuningSchema.safeParse({
 			postgres: {
 				computeSettings: {
 					autoscalingLimitMinCu: 8,

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -62,9 +62,16 @@ export const computeSettingsSchema = z
 		}
 	});
 
+/** Object form of a service toggle (`{ enabled?: boolean }`). */
 export const serviceToggleSchema = z.strictObject({
 	enabled: z.boolean().optional(),
 });
+
+/** A service toggle as written in a policy: `boolean` or `{ enabled?: boolean }`. */
+export const serviceToggleInputSchema = z.union([
+	z.boolean(),
+	serviceToggleSchema,
+]);
 
 export const postgresConfigSchema = z.strictObject({
 	computeSettings: computeSettingsSchema.optional(),
@@ -73,6 +80,9 @@ export const postgresConfigSchema = z.strictObject({
 /**
  * Branch-unique function slug. Mirrors the Neon Functions API path-segment rule
  * (`platform/internal/platform/functions/name.go`): 1–20 lowercase letters and digits.
+ * Used as the **key schema** of the `preview.functions` record, so a bad slug fails
+ * validation with a path pointing at the offending key and duplicate slugs are impossible
+ * by construction (object keys are unique).
  */
 const functionSlugSchema = z
 	.string()
@@ -80,6 +90,9 @@ const functionSlugSchema = z
 		/^[a-z0-9]{1,20}$/,
 		"function slug must be 1-20 lowercase letters and digits (no hyphens or other characters)",
 	);
+
+/** Bucket name: 1–255 chars. Used as the key schema of the `preview.buckets` record. */
+const bucketNameSchema = z.string().min(1).max(255);
 
 /**
  * Per-function environment map. Every value must be a defined string: a `process.env.X`
@@ -105,83 +118,59 @@ const functionDevConfigSchema = z.strictObject({
 	portless: z.boolean().optional(),
 });
 
-export const functionConfigSchema = z.strictObject({
-	slug: functionSlugSchema,
+const memoryMibSchema = z.union([
+	z.literal(256),
+	z.literal(512),
+	z.literal(1024),
+	z.literal(2048),
+	z.literal(4096),
+	z.literal(8192),
+]);
+
+const runtimeSchema = z.literal("nodejs24");
+
+/**
+ * Static definition of a function (existence). The slug is the record key (validated by
+ * {@link functionSlugSchema}), so it is not a field here. Deploy tuning (`memoryMib`,
+ * `runtime`) lives in the `branch` closure, not here.
+ */
+export const functionDefSchema = z.strictObject({
 	name: z.string().min(1).max(255),
 	source: z.string().min(1),
 	env: functionEnvSchema.optional(),
-	runtime: z.literal("nodejs24").optional(),
-	memoryMib: z
-		.union([
-			z.literal(256),
-			z.literal(512),
-			z.literal(1024),
-			z.literal(2048),
-			z.literal(4096),
-			z.literal(8192),
-		])
-		.optional(),
 	dev: functionDevConfigSchema.optional(),
 });
 
-export const bucketConfigSchema = z.strictObject({
-	name: z.string().min(1).max(255),
+/** Static definition of a bucket (existence). Name is the record key. */
+export const bucketDefSchema = z.strictObject({
 	access: z
 		.union([z.literal("private"), z.literal("public_read")])
 		.optional(),
 });
 
-export const previewConfigSchema = z
-	.strictObject({
-		functions: z.array(functionConfigSchema).optional(),
-		buckets: z.array(bucketConfigSchema).optional(),
-		aiGateway: serviceToggleSchema.optional(),
-	})
-	.superRefine((preview, ctx) => {
-		assertUnique({
-			ctx,
-			path: ["functions"],
-			items: preview.functions ?? [],
-			key: (fn) => fn.slug,
-			label: "function slug",
-		});
-		assertUnique({
-			ctx,
-			path: ["buckets"],
-			items: preview.buckets ?? [],
-			key: (bucket) => bucket.name,
-			label: "bucket name",
-		});
-	});
+/** Static, beta Preview feature set: AI Gateway toggle + functions/buckets records. */
+export const previewInputSchema = z.strictObject({
+	aiGateway: serviceToggleInputSchema.optional(),
+	functions: z.record(functionSlugSchema, functionDefSchema).optional(),
+	buckets: z.record(bucketNameSchema, bucketDefSchema).optional(),
+});
+
+/** Per-function deploy tuning returned by the `branch` closure. */
+export const functionTuningSchema = z.strictObject({
+	memoryMib: memoryMibSchema.optional(),
+	runtime: runtimeSchema.optional(),
+});
+
+/** Per-branch Preview tuning. Keys must be slugs declared in the static `preview`. */
+const previewTuningSchema = z.strictObject({
+	functions: z.record(functionSlugSchema, functionTuningSchema).optional(),
+});
 
 /**
- * Flag duplicate keys within a Preview collection so a typo in two function slugs (or two
- * buckets) surfaces as a config error rather than the second silently clobbering the first
- * at apply time.
+ * The object returned by the `branch` closure. Validated on every `resolveConfig` call so
+ * tuning errors point at the concrete branch target that triggered them.
  */
-function assertUnique<T>(args: {
-	ctx: z.RefinementCtx;
-	path: (string | number)[];
-	items: T[];
-	key: (item: T) => string;
-	label: string;
-}): void {
-	const { ctx, path, items, key, label } = args;
-	const seen = new Set<string>();
-	items.forEach((item, index) => {
-		const value = key(item);
-		if (seen.has(value)) {
-			ctx.addIssue({
-				code: "custom",
-				path: [...path, index],
-				message: `duplicate ${label}: ${JSON.stringify(value)}`,
-			});
-		}
-		seen.add(value);
-	});
-}
-
-export const branchConfigSchema = z
+export const branchTuningSchema = z
 	.strictObject({
 		parent: z.string().optional(),
 		protected: z.boolean().optional(),
@@ -196,9 +185,7 @@ export const branchConfigSchema = z
 				}
 			}),
 		postgres: postgresConfigSchema.optional(),
-		auth: serviceToggleSchema.optional(),
-		dataApi: serviceToggleSchema.optional(),
-		preview: previewConfigSchema.optional(),
+		preview: previewTuningSchema.optional(),
 	})
 	.superRefine((cfg, ctx) => {
 		validateParentReference({
@@ -207,6 +194,26 @@ export const branchConfigSchema = z
 			parent: cfg.parent,
 		});
 	});
+
+/**
+ * The top-level object accepted by `defineConfig`. The `branch` closure is validated
+ * structurally as a function here; its returned tuning is validated per-evaluation by
+ * {@link branchTuningSchema} inside `resolveConfig`.
+ */
+export const configInputSchema = z.strictObject({
+	auth: serviceToggleInputSchema.optional(),
+	dataApi: serviceToggleInputSchema.optional(),
+	preview: previewInputSchema.optional(),
+	branch: z
+		.custom<(...args: unknown[]) => unknown>(
+			(value) => typeof value === "function",
+			{
+				message:
+					"branch must be a function: `branch: (branch) => ({ … })`",
+			},
+		)
+		.optional(),
+});
 
 function validateParentReference(args: {
 	ctx: z.RefinementCtx;
@@ -227,11 +234,6 @@ function validateParentReference(args: {
 		});
 	}
 }
-
-export const configSchema = z.function({
-	input: [z.unknown()],
-	output: z.unknown(),
-});
 
 /**
  * Convert the structured {@link z.ZodError} produced by `configSchema.safeParse` into the

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -63,10 +63,27 @@ export interface BranchTarget {
 	expiresAt?: string;
 }
 
+/**
+ * Object form of a branch-scoped service toggle. `{}` or `{ enabled: true }` enables it;
+ * `{ enabled: false }` opts out. Used as the object half of {@link ServiceToggleInput}.
+ */
 export interface ServiceToggle {
 	/** Defaults to `true` when the service namespace is present. Set `false` to opt out. */
 	enabled?: boolean;
 }
+
+/**
+ * How a branch-scoped service (Neon Auth, Data API, AI Gateway) is toggled in a policy.
+ *
+ * - `true` / `{}` / `{ enabled: true }` — enabled.
+ * - `false` / `{ enabled: false }` — disabled.
+ * - omitted (`undefined`) — not part of the policy at all.
+ *
+ * These toggles are **static** (they live in the top-level `defineConfig({ … })` object,
+ * not in the per-branch `branch` closure) so the secret set they imply can be derived at
+ * the type level — that's what makes `NeonEnv<typeof config>` exact.
+ */
+export type ServiceToggleInput = boolean | ServiceToggle;
 
 export interface PostgresConfig {
 	computeSettings?: ComputeSettings;
@@ -111,20 +128,20 @@ export interface FunctionDevConfig {
 }
 
 /**
- * A single Neon Function deployed to a branch (Preview feature).
+ * Static definition of a Neon Function (Preview feature). Declares that the function
+ * **exists** on every branch; its branch-unique slug is the **record key** in
+ * {@link PreviewInput.functions} (not a field here), so slugs are statically enumerable,
+ * cannot duplicate, and the `branch` closure can only tune slugs that are declared here.
  *
  * A function is invoked like a Cloudflare/Vercel handler — its source module
  * `export default { fetch }` or `export async function handler(req): Response`. The
- * `source` path is bundled (esbuild) and uploaded as a deployment; the newest
- * deployment becomes active.
+ * `source` path is bundled (esbuild) and uploaded as a deployment; the newest deployment
+ * becomes active.
+ *
+ * Deploy tuning (`memoryMib`, `runtime`) is **not** here — it varies per branch and lives
+ * in the `branch` closure (see {@link FunctionTuning}).
  */
-export interface FunctionConfig {
-	/**
-	 * Branch-unique slug used as the path segment in the function's invocation URL.
-	 * Immutable once created. 1–20 lowercase letters and digits: `^[a-z0-9]{1,20}$`.
-	 * @example "hellofn"
-	 */
-	slug: string;
+export interface FunctionDef {
 	/** Free-form display name. @example "Hello World" */
 	name: string;
 	/**
@@ -139,16 +156,16 @@ export interface FunctionConfig {
 	 */
 	source: string;
 	/**
-	 * Environment variables injected into the deployed function. Every value must be a
-	 * defined string — a `process.env.X` that is `undefined` (unset) errors at validation
-	 * time rather than silently shipping `undefined`.
-	 * @example { RESEND_API_KEY: process.env.RESEND_API_KEY }
+	 * Environment variables injected into the deployed function, keyed by the var name the
+	 * function reads at runtime. The **keys** are static (preserved at the type level so
+	 * `parseEnv(config, "<slug>").function.<key>` is typed); the **values** are arbitrary
+	 * strings evaluated when `neon.ts` is loaded (typically `process.env.X`) and uploaded
+	 * at `config apply`. Every value must be a defined string — a `process.env.X` that is
+	 * `undefined` (unset) errors at validation time rather than silently shipping
+	 * `undefined`.
+	 * @example { resendApiKey: process.env.RESEND_API_KEY ?? "" }
 	 */
 	env?: Record<string, string>;
-	/** Runtime to execute the function with. Defaults to `"nodejs24"`. */
-	runtime?: FunctionRuntime;
-	/** Memory allotted to each invocation, in MiB. Defaults to `512`. */
-	memoryMib?: FunctionMemoryMib;
 	/**
 	 * Local-development settings used by `neon dev` when serving every function from
 	 * `neon.ts`. Ignored at deploy time. See {@link FunctionDevConfig}.
@@ -160,11 +177,11 @@ export interface FunctionConfig {
 export type BucketAccessLevel = "private" | "public_read";
 
 /**
- * A branchable object-storage bucket on a branch (Preview feature).
+ * Static definition of a branchable object-storage bucket (Preview feature). The bucket's
+ * name is the **record key** in {@link PreviewInput.buckets}, so names are statically
+ * enumerable and cannot duplicate.
  */
-export interface BucketConfig {
-	/** Bucket name, unique within a branch. 1–255 chars. */
-	name: string;
+export interface BucketDef {
 	/**
 	 * Anonymous access level. `private` (default) requires authenticated reads/writes;
 	 * `public_read` allows anonymous GetObject/HeadObject.
@@ -173,19 +190,48 @@ export interface BucketConfig {
 }
 
 /**
- * Branch-scoped Preview features. Grouped under `preview` to signal they are backed by
- * Neon `x-stability-level: beta` endpoints and may change before GA.
+ * Static, branch-scoped **Preview** features. Grouped under `preview` to signal they are
+ * backed by Neon `x-stability-level: beta` endpoints and may change before GA. Everything
+ * here is existential (it determines what exists on the branch); per-branch tuning lives in
+ * the `branch` closure.
  */
-export interface PreviewConfig {
-	/** Functions to deploy on the branch. */
-	functions?: FunctionConfig[];
-	/** Object-storage buckets to create on the branch. */
-	buckets?: BucketConfig[];
+export interface PreviewInput {
 	/** Enable/disable the AI Gateway on the branch (toggle, like auth / dataApi). */
-	aiGateway?: ServiceToggle;
+	aiGateway?: ServiceToggleInput;
+	/** Functions to deploy, keyed by branch-unique slug (`^[a-z0-9]{1,20}$`). */
+	functions?: Record<string, FunctionDef>;
+	/** Object-storage buckets to create, keyed by bucket name. */
+	buckets?: Record<string, BucketDef>;
 }
 
-interface BranchConfigBase {
+/**
+ * Per-branch deploy tuning for a single function. Returned (per slug) by the `branch`
+ * closure. Deliberately **cannot** change the function's existence, source, name, or env
+ * **keys** — only how it is deployed — so the static secret/function set stays sound.
+ */
+export interface FunctionTuning {
+	/** Memory allotted to each invocation, in MiB. Defaults to `512`. */
+	memoryMib?: FunctionMemoryMib;
+	/** Runtime to execute the function with. Defaults to `"nodejs24"`. */
+	runtime?: FunctionRuntime;
+}
+
+/**
+ * Per-branch tuning of Preview features. Only existing function slugs (those declared in
+ * the static {@link PreviewInput.functions}) may be tuned — `Slug` is constrained to the
+ * declared keys by {@link BranchTuningFn}.
+ */
+export interface PreviewTuning<Slug extends string = string> {
+	functions?: Partial<Record<Slug, FunctionTuning>>;
+}
+
+/**
+ * The per-branch tuning object returned by the `branch` closure. It can adjust branch
+ * lifecycle (`parent`, `ttl`, `protected`), Postgres compute settings, and per-function
+ * deploy tuning — but **cannot** add/remove services or functions. That guarantee is what
+ * keeps the static secret set (and therefore `NeonEnv`) exact.
+ */
+export interface BranchTuning<Slug extends string = string> {
 	/** Parent branch name used when creating a new branch. Not a Postgres setting. */
 	parent?: string;
 	/** Time-to-live applied when creating a new branch, or reconciled on existing branches. */
@@ -193,22 +239,56 @@ interface BranchConfigBase {
 	/** Whether the selected branch should be protected. Undefined means "leave as-is". */
 	protected?: boolean;
 	postgres?: PostgresConfig;
-	/**
-	 * Branch-scoped Preview features (functions, object-storage buckets, AI Gateway).
-	 * Backed by Neon `x-stability-level: beta` endpoints — see {@link PreviewConfig}.
-	 */
-	preview?: PreviewConfig;
+	preview?: PreviewTuning<Slug>;
 }
 
-type BranchServiceConfig =
-	| { auth?: never; dataApi?: never }
-	| { auth: ServiceToggle; dataApi?: never }
-	| { auth?: never; dataApi: ServiceToggle }
-	| { auth: ServiceToggle; dataApi: ServiceToggle };
+/** Extract the declared function slugs from a {@link PreviewInput} for closure typing. */
+type FunctionSlugsOf<Preview extends PreviewInput | undefined> =
+	Preview extends {
+		functions: infer F;
+	}
+		? Extract<keyof F, string>
+		: string;
 
-export type BranchConfig = BranchConfigBase & BranchServiceConfig;
+/**
+ * Signature of the `branch` closure. Generic over the static {@link PreviewInput} so the
+ * `preview.functions` keys it may tune are constrained to the slugs actually declared.
+ */
+export type BranchTuningFn<
+	Preview extends PreviewInput | undefined = PreviewInput | undefined,
+> = (branch: BranchTarget) => BranchTuning<FunctionSlugsOf<Preview>>;
 
-export type Config = (branch: BranchTarget) => BranchConfig;
+/**
+ * A validated Neon branch policy — the value `defineConfig({ … })` returns and `neon.ts`
+ * default-exports.
+ *
+ * Split into a **static** existential set (top-level `auth` / `dataApi` GA toggles plus the
+ * beta `preview` block) and a **dynamic** per-branch `branch` closure for tuning. The
+ * static half is what makes the secret set — and therefore `NeonEnv<typeof config>` and
+ * `parseEnv` — exact; the closure can tune but never change what exists.
+ *
+ * Generic over the three static fields so the type system can read the exact toggle/slug
+ * literals; the defaults make the bare `Config` a usable "any policy" type for runtime
+ * function signatures.
+ */
+export interface Config<
+	Auth extends ServiceToggleInput | undefined =
+		| ServiceToggleInput
+		| undefined,
+	DataApi extends ServiceToggleInput | undefined =
+		| ServiceToggleInput
+		| undefined,
+	Preview extends PreviewInput | undefined = PreviewInput | undefined,
+> {
+	/** Neon Auth integration toggle (GA). Static — drives `NeonEnv.auth`. */
+	auth?: Auth;
+	/** Neon Data API integration toggle (GA). Static — drives `NeonEnv.dataApi`. */
+	dataApi?: DataApi;
+	/** Beta (Preview) feature set: AI Gateway, functions, buckets. Static. */
+	preview?: Preview;
+	/** Per-branch tuning closure. Cannot change the static existential set. */
+	branch?: BranchTuningFn<Preview>;
+}
 
 /**
  * A function with all deploy defaults applied. `resolveConfig` fills in `runtime` and

--- a/packages/config/src/v1.test.ts
+++ b/packages/config/src/v1.test.ts
@@ -9,10 +9,12 @@ import {
 
 describe("v1 surface", () => {
 	test("exports the authoring helpers, pure diff engine, adapter, and loader", () => {
-		const config = defineConfig((branch) => ({
-			parent: branch.name === "main" ? undefined : "main",
-		}));
-		expect(config({ name: "dev", exists: false })).toEqual({
+		const config = defineConfig({
+			branch: (branch) => ({
+				parent: branch.name === "main" ? undefined : "main",
+			}),
+		});
+		expect(config.branch?.({ name: "dev", exists: false })).toEqual({
 			parent: "main",
 		});
 		// Authoring + pure core stays in @neondatabase/config.

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -42,13 +42,15 @@ import {
 	PushConflictError,
 } from "./lib/errors.js";
 import {
-	branchConfigSchema,
-	bucketConfigSchema,
+	branchTuningSchema,
+	bucketDefSchema,
 	computeSettingsSchema,
-	configSchema,
-	functionConfigSchema,
+	configInputSchema,
+	functionDefSchema,
+	functionTuningSchema,
 	postgresConfigSchema,
-	previewConfigSchema,
+	previewInputSchema,
+	serviceToggleInputSchema,
 	serviceToggleSchema,
 } from "./lib/schema.js";
 
@@ -68,14 +70,16 @@ export const errors = {
 
 /** The zod schemas underlying `defineConfig`, grouped under product-friendly names. */
 export const schemas = {
-	branch: branchConfigSchema,
-	bucket: bucketConfigSchema,
+	config: configInputSchema,
+	branchTuning: branchTuningSchema,
+	bucket: bucketDefSchema,
 	computeSettings: computeSettingsSchema,
-	config: configSchema,
-	function: functionConfigSchema,
+	function: functionDefSchema,
+	functionTuning: functionTuningSchema,
 	postgres: postgresConfigSchema,
-	preview: previewConfigSchema,
+	preview: previewInputSchema,
 	service: serviceToggleSchema,
+	serviceInput: serviceToggleInputSchema,
 } as const;
 
 // ─── Lower-level adapters ──────────────────────────────────────────────────────
@@ -127,23 +131,27 @@ export { createRealNeonApi } from "./lib/neon-api-real.js";
 // ─── Config types (used in neon.ts and in operation return values) ────────────
 export type {
 	AppliedChange,
-	BranchConfig,
 	BranchTarget,
+	BranchTuning,
+	BranchTuningFn,
 	BucketAccessLevel,
-	BucketConfig,
+	BucketDef,
 	ComputeSettings,
 	Config,
 	ConflictReport,
-	FunctionConfig,
+	FunctionDef,
 	FunctionDevConfig,
 	FunctionMemoryMib,
 	FunctionRuntime,
+	FunctionTuning,
 	PostgresConfig,
-	PreviewConfig,
+	PreviewInput,
+	PreviewTuning,
 	PushResult,
 	ResolvedBranchConfig,
 	ResolvedBucketConfig,
 	ResolvedFunctionConfig,
 	ResolvedPreviewConfig,
 	ServiceToggle,
+	ServiceToggleInput,
 } from "./lib/types.js";

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -12,9 +12,9 @@ npm install @neondatabase/env
 
 ## Functions
 
-The library functions are **filesystem- and env-agnostic**: `fetchEnv` requires an explicit `projectId` + `branchId`, and `parseEnv` requires an explicit `branchName`. (The `neon-env` CLI does the `.neon`/`NEON_*` resolution and passes these in.)
+The library functions are **filesystem- and env-agnostic**: `fetchEnv` requires an explicit `projectId` + `branchId`. (The `neon-env` CLI does the `.neon`/`NEON_*` resolution and passes these in.)
 
-> `parseEnv` takes a branch **name**, not an id, because it makes no API call — it only needs the branch to evaluate your `neon.ts` policy, which switches on `branch.name`. The API-backed functions take a `branchId` (`br-…`) and read the name back from Neon.
+> `parseEnv` takes **no branch name**: the secret set is static (top-level `config.auth` / `config.dataApi`), so it reads those toggles directly without evaluating the per-branch closure. Its optional second argument is a **scope** — omit it for external (app/build) env, or pass a **function slug** when running inside that deployed function to also get a typed `function` namespace of its declared env keys.
 
 ```ts
 import config from "../neon";
@@ -26,7 +26,11 @@ const db = drizzle(neon(env.postgres.databaseUrl), { schema });
 
 // Sync — reads already-injected process.env and validates it (no network).
 // Use in app bootstrap where async isn't available.
-const env2 = parseEnv(config, process.env.NEON_BRANCH_NAME ?? "main");
+const env2 = parseEnv(config);
+
+// Inside a deployed function, pass its slug for the typed `function` namespace:
+const fnEnv = parseEnv(config, "hello");
+fnEnv.function.resendApiKey; // typed from hello's declared env keys
 ```
 
 Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `auth` and `dataApi` are included (and statically typed) when the evaluated branch policy enables them.
@@ -34,7 +38,7 @@ Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `
 | Function | Description |
 | --- | --- |
 | `fetchEnv(config, { projectId, branchId, ... })` | Async. Calls the Neon API for the given project + branch and returns live connection strings (and Auth/Data API values when enabled). `projectId` and `branchId` are required (`branchId` is a `br-…` id). |
-| `parseEnv(config, branchName)` | Sync. Reads/validates the Neon env vars already present in `process.env`, evaluating the policy for `branchName`. Throws `PlatformError(EnvNotInjected)` listing missing vars when the env isn't populated. |
+| `parseEnv(config)` / `parseEnv(config, slug)` | Sync. Reads/validates the Neon env vars already present in `process.env` against the static policy toggles. With a function `slug`, also returns a typed `function` namespace of that function's declared env keys. Throws `PlatformError(EnvNotInjected)` listing missing vars when the env isn't populated. |
 | `toEntries(env)` | Project a resolved `NeonEnv` into `{ KEY: value }` pairs for cross-process transport (named after the web `.entries()` convention; returns a `Record`). |
 
 ## CLI

--- a/packages/env/e2e/env.e2e.test.ts
+++ b/packages/env/e2e/env.e2e.test.ts
@@ -26,10 +26,11 @@ describe("e2e — fetchEnv against real Neon API", () => {
 			(b) => b.isDefault,
 		)?.id;
 		if (!branchId) throw new Error("missing default branch");
-		const env = await fetchEnv(
-			defineConfig(() => ({})),
-			{ api, projectId, branchId },
-		);
+		const env = await fetchEnv(defineConfig({}), {
+			api,
+			projectId,
+			branchId,
+		});
 		expect(env.postgres.databaseUrl).toContain("postgresql://");
 		expect(env.postgres.databaseUrlUnpooled).toContain("postgresql://");
 	});

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a single `env run -- <cmd>` CLI.",
 	"keywords": [
 		"neon",

--- a/packages/env/src/lib/cli/commands.test.ts
+++ b/packages/env/src/lib/cli/commands.test.ts
@@ -40,7 +40,7 @@ function seededFake() {
 
 function policy() {
 	return `import { defineConfig } from "${CONFIG_SRC}";
-export default defineConfig(() => ({}));`;
+export default defineConfig({});`;
 }
 
 describe("runEnvRun", () => {

--- a/packages/env/src/lib/cli/resolve-context.test.ts
+++ b/packages/env/src/lib/cli/resolve-context.test.ts
@@ -67,7 +67,6 @@ describe("resolveContext — precedence", () => {
 			".neon/project.json": JSON.stringify({
 				projectId: "proj-file",
 				branchId: "br-file",
-				branchName: "main",
 			}),
 		});
 		const result = resolveContext({ cwd: root, env: EMPTY_ENV });
@@ -76,26 +75,7 @@ describe("resolveContext — precedence", () => {
 			context: {
 				projectId: "proj-file",
 				branchId: "br-file",
-				branchName: "main",
 			},
-		});
-	});
-
-	test("NEON_BRANCH_NAME populates branchName", () => {
-		const root = setup({
-			"package.json": "{}",
-			".neon/project.json": JSON.stringify({
-				projectId: "p",
-				branchId: "br-1",
-			}),
-		});
-		const result = resolveContext({
-			cwd: root,
-			env: { NEON_BRANCH_NAME: "feature-x" },
-		});
-		expect(result).toMatchObject({
-			ok: true,
-			context: { branchName: "feature-x" },
 		});
 	});
 });

--- a/packages/env/src/lib/cli/resolve-context.ts
+++ b/packages/env/src/lib/cli/resolve-context.ts
@@ -10,8 +10,6 @@ import { dirname, resolve } from "node:path";
 export interface ResolvedContext {
 	projectId: string;
 	branchId: string;
-	/** Branch name for `parseEnv`-style policy evaluation, when known. */
-	branchName?: string;
 }
 
 export interface ResolveContextOptions {
@@ -44,8 +42,6 @@ export function resolveContext(
 		nonEmpty(env.NEON_BRANCH_ID) ??
 		file?.branchId;
 
-	const branchName = nonEmpty(env.NEON_BRANCH_NAME) ?? file?.branchName;
-
 	const missing: string[] = [];
 	if (!projectId) {
 		missing.push(
@@ -61,18 +57,13 @@ export function resolveContext(
 
 	return {
 		ok: true,
-		context: {
-			projectId,
-			branchId,
-			...(branchName ? { branchName } : {}),
-		},
+		context: { projectId, branchId },
 	};
 }
 
 interface NeonFile {
 	projectId?: string;
 	branchId?: string;
-	branchName?: string;
 }
 
 /**
@@ -122,8 +113,6 @@ function readNeonFileAt(path: string): NeonFile | null {
 		out.projectId = obj.projectId;
 	if (typeof obj.branchId === "string" && obj.branchId !== "")
 		out.branchId = obj.branchId;
-	if (typeof obj.branchName === "string" && obj.branchName !== "")
-		out.branchName = obj.branchName;
 	return out;
 }
 

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -187,6 +187,73 @@ describe("parseEnv", () => {
 			// @ts-expect-error "nope" is not a declared function slug.
 			expect(() => parseEnv(config, "nope")).toThrow();
 		});
+
+		test("passes through a deliberately empty function env value (present != non-empty)", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+			vi.stubEnv("resendApiKey", "");
+			const env = parseEnv(config, "hello");
+			expect(env.function.resendApiKey).toBe("");
+		});
+
+		test("returns an empty function namespace when the function declares no env keys", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+			const noEnvConfig = defineConfig({
+				preview: {
+					functions: { bare: { name: "Bare", source: "./bare.ts" } },
+				},
+			});
+			const env = parseEnv(noEnvConfig, "bare");
+			expect(env.function).toEqual({});
+		});
+
+		test("function scope still includes branch secrets (auth) when enabled", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+			vi.stubEnv("NEON_AUTH_BASE_URL", "https://auth.example.com");
+			vi.stubEnv("resendApiKey", "re_live_123");
+			const authConfig = defineConfig({
+				auth: true,
+				preview: {
+					functions: {
+						hello: {
+							name: "Hello",
+							source: "./hello.ts",
+							env: { resendApiKey: "" },
+						},
+					},
+				},
+			});
+			const env = parseEnv(authConfig, "hello");
+			expect(env.auth.baseUrl).toBe("https://auth.example.com");
+			expect(env.function.resendApiKey).toBe("re_live_123");
+		});
+	});
+
+	test("external scope has no function namespace (type-level)", () => {
+		vi.stubEnv("DATABASE_URL", "postgres://pooled");
+		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+		const env = parseEnv(defineConfig({}));
+		// @ts-expect-error external scope must not expose the function namespace.
+		env.function;
+		expect(env.postgres.databaseUrl).toBe("postgres://pooled");
+	});
+
+	test("a present-but-empty object toggle (`auth: {}`) enables the namespace", () => {
+		vi.stubEnv("DATABASE_URL", "postgres://pooled");
+		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+		vi.stubEnv("NEON_AUTH_BASE_URL", "https://auth.example.com");
+		const env = parseEnv(defineConfig({ auth: {} }));
+		expect(env.auth.baseUrl).toBe("https://auth.example.com");
+	});
+
+	test("`dataApi: { enabled: true }` enables the data API namespace", () => {
+		vi.stubEnv("DATABASE_URL", "postgres://pooled");
+		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+		vi.stubEnv("NEON_DATA_API_URL", "https://data.example.com");
+		const env = parseEnv(defineConfig({ dataApi: { enabled: true } }));
+		expect(env.dataApi.url).toBe("https://data.example.com");
 	});
 
 	test("projects env object to process env keys", () => {

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -1,8 +1,4 @@
-import {
-	type BranchConfig,
-	defineConfig,
-	ErrorCode,
-} from "@neondatabase/config/v1";
+import { defineConfig, ErrorCode } from "@neondatabase/config/v1";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import {
 	fetchEnv,
@@ -40,7 +36,7 @@ function seededFake() {
 describe("fetchEnv", () => {
 	test("fetches postgres env for selected branch", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({}));
+		const config = defineConfig({});
 		const env = await fetchEnv(config, {
 			api,
 			projectId,
@@ -50,9 +46,9 @@ describe("fetchEnv", () => {
 		expect(env.postgres.databaseUrl).toContain("-pooler");
 	});
 
-	test("requires auth integration when branch policy enables auth", async () => {
+	test("requires auth integration when policy enables auth", async () => {
 		const { api, projectId } = seededFake();
-		const config = defineConfig(() => ({ auth: {} }));
+		const config = defineConfig({ auth: true });
 		await expect(
 			fetchEnv(config, { api, projectId, branchId: "br-main" }),
 		).rejects.toMatchObject({ code: ErrorCode.NotFound });
@@ -61,7 +57,7 @@ describe("fetchEnv", () => {
 	test("returns the integration base URL from the live snapshot", async () => {
 		const { api, projectId } = seededFake();
 		await api.enableNeonAuth(projectId, "br-main");
-		const config = defineConfig(() => ({ auth: {} }));
+		const config = defineConfig({ auth: true });
 
 		const env = await fetchEnv(config, {
 			api,
@@ -80,7 +76,7 @@ describe("fetchEnv", () => {
 			projectId: "auth-br-main",
 			jwksUrl: "https://example.com/jwks.json",
 		});
-		const config = defineConfig(() => ({ auth: {} }));
+		const config = defineConfig({ auth: true });
 
 		const env = await fetchEnv(config, {
 			api,
@@ -94,57 +90,34 @@ describe("fetchEnv", () => {
 });
 
 describe("parseEnv", () => {
-	test("parses postgres env synchronously", () => {
+	test("parses postgres env synchronously (external scope)", () => {
 		vi.stubEnv("DATABASE_URL", "postgres://pooled");
 		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
-		const env = parseEnv(
-			defineConfig(() => ({})),
-			"main",
-		);
+		const env = parseEnv(defineConfig({}));
 		expect(env.postgres.databaseUrl).toBe("postgres://pooled");
 	});
 
-	test("requires service env when service namespaces are present", () => {
+	test("requires service env when service toggles are statically enabled", () => {
 		vi.stubEnv("DATABASE_URL", "postgres://pooled");
 		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
-		const config = defineConfig(() => ({
-			auth: {},
-			dataApi: {},
-		}));
+		const config = defineConfig({ auth: true, dataApi: true });
 
-		expect(() => parseEnv(config, "main")).toThrow(
+		expect(() => parseEnv(config)).toThrow(
 			expect.objectContaining({ code: ErrorCode.EnvNotInjected }),
 		);
 	});
 
-	test("types auth env when config spreads BranchConfig defaults", () => {
+	test("types auth env from the static toggle and excludes dataApi", () => {
 		vi.stubEnv("DATABASE_URL", "postgres://pooled");
 		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
 		vi.stubEnv("NEON_AUTH_BASE_URL", "https://auth.example.com");
-		const config = defineConfig((branch) => {
-			const defaults: BranchConfig = {
-				auth: {},
-			};
+		const config = defineConfig({ auth: true });
 
-			if (branch.name === "main") {
-				return {
-					...defaults,
-					protected: true,
-				};
-			}
-
-			return {
-				...defaults,
-				parent: "main",
-				ttl: "7d",
-			};
-		});
-
-		const env = parseEnv(config, "main");
+		const env = parseEnv(config);
 
 		expectType<NeonEnv<typeof config>>(env);
 		expectType<NeonAuthEnv>(env.auth);
-		// @ts-expect-error Auth defaults must not imply Data API env.
+		// @ts-expect-error auth: true must not imply Data API env.
 		env.dataApi;
 		expect(env.auth.baseUrl).toBe("https://auth.example.com");
 	});
@@ -154,12 +127,66 @@ describe("parseEnv", () => {
 		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
 		vi.stubEnv("NEON_AUTH_BASE_URL", "");
 
-		expect(() =>
-			parseEnv(
-				defineConfig(() => ({ auth: {} })),
-				"main",
-			),
-		).toThrow(expect.objectContaining({ code: ErrorCode.EnvNotInjected }));
+		expect(() => parseEnv(defineConfig({ auth: true }))).toThrow(
+			expect.objectContaining({ code: ErrorCode.EnvNotInjected }),
+		);
+	});
+
+	test("a boolean false / object false toggle yields just postgres", () => {
+		vi.stubEnv("DATABASE_URL", "postgres://pooled");
+		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+		const config = defineConfig({
+			auth: false,
+			dataApi: { enabled: false },
+		});
+		const env = parseEnv(config);
+		// @ts-expect-error disabled toggles must not add the namespace.
+		env.auth;
+		expect(env.postgres.databaseUrl).toBe("postgres://pooled");
+	});
+
+	describe("function scope", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					hello: {
+						name: "Hello",
+						source: "./hello.ts",
+						env: {
+							resendApiKey: process.env.NOT_SET ?? "placeholder",
+						},
+					},
+				},
+			},
+		});
+
+		test("returns the declared function env keys, typed", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+			vi.stubEnv("resendApiKey", "re_live_123");
+
+			const env = parseEnv(config, "hello");
+
+			expect(env.function.resendApiKey).toBe("re_live_123");
+			// @ts-expect-error only declared keys are present on the function namespace.
+			env.function.notDeclared;
+		});
+
+		test("throws EnvNotInjected when a declared function env key is missing", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+
+			expect(() => parseEnv(config, "hello")).toThrow(
+				expect.objectContaining({ code: ErrorCode.EnvNotInjected }),
+			);
+		});
+
+		test("rejects an unknown function slug at the type level", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+			// @ts-expect-error "nope" is not a declared function slug.
+			expect(() => parseEnv(config, "nope")).toThrow();
+		});
 	});
 
 	test("projects env object to process env keys", () => {

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -627,7 +627,10 @@ export function parseEnv(config: Config, scope?: string): unknown {
 		const envOut: Record<string, string> = {};
 		for (const key of Object.keys(fn.env ?? {})) {
 			const value = source[key];
-			if (value === undefined || value === "") {
+			// Only a truly *unset* var is "not injected". Function env values carry no
+			// non-empty constraint (unlike DATABASE_URL / NEON_AUTH_BASE_URL), so a
+			// deliberately empty value is a present, valid value and is passed through.
+			if (value === undefined) {
 				issues.push(`${key} is missing (function "${scope}")`);
 			} else {
 				envOut[key] = value;

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -1,5 +1,4 @@
 import {
-	type BranchConfig,
 	type Config,
 	createNeonApiFromOptions,
 	ErrorCode,
@@ -9,6 +8,7 @@ import {
 	type NeonRoleSnapshot,
 	PlatformError,
 	resolveConfig,
+	type ServiceToggleInput,
 } from "@neondatabase/config/v1";
 import { z } from "zod";
 
@@ -75,46 +75,82 @@ export interface NeonDataApiEnv {
  */
 type NoNamespace = Record<never, never>;
 
-type BranchConfigOf<C extends Config> = ReturnType<C> extends BranchConfig
-	? ReturnType<C>
-	: BranchConfig;
-
-type ServiceToggleOf<Cfg, Key extends "auth" | "dataApi"> = Cfg extends unknown
-	? Key extends keyof Cfg
-		? Cfg[Key]
-		: never
-	: never;
-
-type HasEnabledService<Cfg, Key extends "auth" | "dataApi"> = [
-	Exclude<ServiceToggleOf<Cfg, Key>, undefined | { enabled: false }>,
-] extends [never]
+/**
+ * Resolve a **static** service toggle (the value of `config.auth` / `config.dataApi`) to a
+ * type-level boolean. The whole-thing wrapping (`[T] extends […]`) turns off distribution
+ * so a union/`undefined` is checked as one unit:
+ *
+ * - `false` / `{ enabled: false }` / `undefined` → `false`
+ * - `true` / `{ enabled: true }` / any other object (`{}`, `{ enabled?: boolean }`) → `true`
+ *   (a present toggle defaults to enabled)
+ * - the bare `boolean | ServiceToggle | undefined` (the default `Config` param, no literal
+ *   info) → `false`, so an untyped policy yields just `{ postgres }`.
+ */
+type ServiceOn<T> = [T] extends [false]
 	? false
-	: true;
-
-type IsDefaultConfig<C extends Config> = Config extends C ? true : false;
+	: [T] extends [{ enabled: false }]
+		? false
+		: [T] extends [undefined]
+			? false
+			: [T] extends [true]
+				? true
+				: [T] extends [{ enabled: true }]
+					? true
+					: [T] extends [object]
+						? true
+						: false;
 
 /**
  * Static, namespaced shape of `fetchEnv` / `parseEnv`'s return value. Generic over the
  * {@link Config} so the type system knows which optional namespaces are present.
  *
+ * Because the secret-bearing toggles now live in the **static** top-level `config.auth` /
+ * `config.dataApi` (not inside a per-branch closure), the namespace presence is a direct
+ * read of those fields — no union-across-branches, no default-config escape hatch:
+ *
  * - `postgres` is always present.
- * - `auth` is added iff the config return type has an `auth` namespace that is not
- *   explicitly disabled.
- * - `dataApi` is added iff the config return type has a `dataApi` namespace that is not
- *   explicitly disabled.
+ * - `auth` is added iff `config.auth` is statically enabled.
+ * - `dataApi` is added iff `config.dataApi` is statically enabled.
  */
 export type NeonEnv<C extends Config = Config> = {
 	postgres: NeonPostgresEnv;
-} & (IsDefaultConfig<C> extends true
-	? NoNamespace
-	: HasEnabledService<BranchConfigOf<C>, "auth"> extends true
-		? { auth: NeonAuthEnv }
-		: NoNamespace) &
-	(IsDefaultConfig<C> extends true
-		? NoNamespace
-		: HasEnabledService<BranchConfigOf<C>, "dataApi"> extends true
-			? { dataApi: NeonDataApiEnv }
-			: NoNamespace);
+} & (ServiceOn<NonNullable<C["auth"]>> extends true
+	? { auth: NeonAuthEnv }
+	: NoNamespace) &
+	(ServiceOn<NonNullable<C["dataApi"]>> extends true
+		? { dataApi: NeonDataApiEnv }
+		: NoNamespace);
+
+/** The static `preview.functions` record of a config, or an empty record when absent. */
+type PreviewFunctionsOf<C extends Config> = NonNullable<C["preview"]> extends {
+	functions: infer F;
+}
+	? F
+	: Record<never, never>;
+
+/** The declared function slugs of a config (record keys), as a string union. */
+export type FunctionSlugOf<C extends Config> = Extract<
+	keyof PreviewFunctionsOf<C>,
+	string
+>;
+
+/** The declared env-var keys of one function `S`, as a string union. */
+type FunctionEnvKeysOf<
+	C extends Config,
+	S extends string,
+> = S extends keyof PreviewFunctionsOf<C>
+	? NonNullable<PreviewFunctionsOf<C>[S]> extends { env: infer E }
+		? Extract<keyof E, string>
+		: never
+	: never;
+
+/**
+ * The extra `function` namespace added to `parseEnv`'s result when called with a function
+ * slug scope: the declared env-var keys for that function, each resolved to a `string`.
+ */
+export type NeonFunctionEnv<C extends Config, S extends string> = {
+	function: Record<FunctionEnvKeysOf<C, S>, string>;
+};
 
 export interface FetchEnvOptions {
 	/**
@@ -479,47 +515,62 @@ const dataApiEnvSchema = z.object({
 		.min(1, "NEON_DATA_API_URL must not be empty"),
 });
 
+/** Static-toggle helper mirroring `config`'s `isServiceEnabled` for the env reader. */
+function isServiceEnabledInput(
+	toggle: ServiceToggleInput | undefined,
+): boolean {
+	if (toggle === undefined) return false;
+	if (typeof toggle === "boolean") return toggle;
+	return toggle.enabled !== false;
+}
+
 /**
- * Synchronous, network-free counterpart to {@link fetchEnv}. Reads `process.env` (or
- * `options.env`), validates the required Neon env vars with zod, and returns the same
- * {@link NeonEnv} shape — so the rest of your app touches `env.postgres.databaseUrl`
- * instead of stringly-typed `process.env.DATABASE_URL` lookups.
+ * Synchronous, network-free counterpart to {@link fetchEnv}. Reads `process.env`, validates
+ * the required Neon env vars with zod, and returns the same {@link NeonEnv} shape — so the
+ * rest of your app touches `env.postgres.databaseUrl` instead of stringly-typed
+ * `process.env.DATABASE_URL` lookups.
  *
  * Designed for the **"env-vars-already-injected"** path:
- * - You wrapped your dev command with `neon-env run -- <cmd>`.
+ * - You wrapped your dev command with `neon-env run -- <cmd>` or `neon dev`.
  * - Your platform (Vercel, Fly, Railway, …) injected the vars via its own integration.
+ * - You are **inside a deployed Neon Function**, whose env was uploaded at `config apply`.
  *
- * Takes a branch **name** (not an id like the API-backed `fetchEnv` / config operations):
- * `parseEnv` makes no Neon API call, so the only thing it needs the branch for is
- * evaluating your `neon.ts` policy, which switches on `branch.name`. With no network round
- * trip there's no way to turn a `br-…` id into a name, so the name is passed directly.
- * Pass it explicitly so the result is deterministic and not coupled to any `NEON_*` env
- * var. (The `neon-env` CLI injects `NEON_BRANCH_NAME`; pass that through, or default to
- * your main branch name.) Prefer `fetchEnv` when runtime code needs the exact live branch.
+ * Unlike the old API, `parseEnv` does **not** take a branch name: the secret set is now
+ * static (top-level `config.auth` / `config.dataApi`), so it reads those directly without
+ * evaluating the per-branch closure.
+ *
+ * The second argument is a **scope**:
+ * - omitted — *external* scope (app bootstrap, build scripts, your dev machine). Returns
+ *   `{ postgres, auth?, dataApi? }`.
+ * - a **function slug** (a key of `config.preview.functions`) — *function* scope: you are
+ *   running inside that function. Returns the same branch secrets **plus** a typed
+ *   `function` namespace with the function's declared env-var keys.
  *
  * Throws `PlatformError(EnvNotInjected)` listing every missing/invalid var when the env
- * isn't fully populated, with a fix hint pointing back at `neon-env run`.
+ * isn't fully populated, with a fix hint pointing back at `neon dev` / `neon-env run`.
  *
  * ```ts
  * import config from "../neon";
  * import { parseEnv } from "@neondatabase/env/v1";
  *
- * const env = parseEnv(config, process.env.NEON_BRANCH_NAME ?? "main");
+ * // External (app / build):
+ * const env = parseEnv(config);
  * const db = drizzle(neon(env.postgres.databaseUrl), { schema });
- * // env.auth is statically typed when the config return type has auth: {} or auth.enabled: true.
+ *
+ * // Inside the "hello" function:
+ * const env = parseEnv(config, "hello");
+ * env.function.resendApiKey; // typed from hello's declared env keys
  * ```
  */
-export function parseEnv<const C extends Config>(
-	config: C,
-	branchName: string,
-): NeonEnv<C> {
+export function parseEnv<const C extends Config>(config: C): NeonEnv<C>;
+export function parseEnv<
+	const C extends Config,
+	const S extends FunctionSlugOf<C>,
+>(config: C, scope: S): NeonEnv<C> & NeonFunctionEnv<C, S>;
+export function parseEnv(config: Config, scope?: string): unknown {
 	const source = process.env;
 	const issues: string[] = [];
 	const result: Record<string, unknown> = {};
-	const desired = resolveConfig(config, {
-		name: branchName,
-		exists: true,
-	});
 
 	const pg = postgresEnvSchema.safeParse({
 		DATABASE_URL: source.DATABASE_URL,
@@ -534,7 +585,7 @@ export function parseEnv<const C extends Config>(
 		for (const issue of pg.error.issues) issues.push(issue.message);
 	}
 
-	if (desired.authEnabled) {
+	if (isServiceEnabledInput(config.auth)) {
 		const auth = authEnvSchema.safeParse({
 			NEON_AUTH_BASE_URL: source.NEON_AUTH_BASE_URL,
 		});
@@ -547,7 +598,7 @@ export function parseEnv<const C extends Config>(
 		}
 	}
 
-	if (desired.dataApiEnabled) {
+	if (isServiceEnabledInput(config.dataApi)) {
 		const dataApi = dataApiEnvSchema.safeParse({
 			NEON_DATA_API_URL: source.NEON_DATA_API_URL,
 		});
@@ -561,6 +612,30 @@ export function parseEnv<const C extends Config>(
 		}
 	}
 
+	if (scope !== undefined) {
+		const fn = config.preview?.functions?.[scope];
+		if (!fn) {
+			throw new PlatformError(
+				ErrorCode.EnvNotInjected,
+				[
+					`parseEnv: no function "${scope}" is declared in this policy's preview.functions.`,
+					"Pass a declared function slug (or omit the scope to read external env).",
+				].join("\n"),
+				{ details: { scope } },
+			);
+		}
+		const envOut: Record<string, string> = {};
+		for (const key of Object.keys(fn.env ?? {})) {
+			const value = source[key];
+			if (value === undefined || value === "") {
+				issues.push(`${key} is missing (function "${scope}")`);
+			} else {
+				envOut[key] = value;
+			}
+		}
+		result.function = envOut;
+	}
+
 	if (issues.length > 0) {
 		throw new PlatformError(
 			ErrorCode.EnvNotInjected,
@@ -568,15 +643,16 @@ export function parseEnv<const C extends Config>(
 				"parseEnv: the required Neon env variables are not present in process.env.",
 				...issues.map((i) => `  - ${i}`),
 				"Inject them via one of:",
-				"  - `neon-env run -- <your dev command>` (wraps the command with the vars injected)",
+				"  - `neon dev` / `neon-env run -- <your dev command>` (wraps the command with the vars injected)",
 				"  - your hosting platform's Neon integration (Vercel, Fly, Railway, …)",
-				"Or switch the call to `await fetchEnv(config)` if you're in a context that can do async I/O.",
+				"  - for the `function` namespace: deploy the function (`neon deploy` / `config apply`) so its env is uploaded.",
+				"Or switch the call to `await fetchEnv(config, …)` if you're in a context that can do async I/O.",
 			].join("\n"),
 			{ details: { missing: issues } },
 		);
 	}
 
-	return result as NeonEnv<C>;
+	return result;
 }
 
 // ───────────────────────── env-var mapping helpers ─────────────────────────

--- a/packages/env/src/v1.ts
+++ b/packages/env/src/v1.ts
@@ -13,9 +13,11 @@
 
 export type {
 	FetchEnvOptions,
+	FunctionSlugOf,
 	NeonAuthEnv,
 	NeonDataApiEnv,
 	NeonEnv,
+	NeonFunctionEnv,
 	NeonPostgresEnv,
 } from "./lib/env.js";
 export {


### PR DESCRIPTION
## Summary

Reshape `defineConfig` from a `(branch) => BranchConfig` closure into a **static existential set** (top-level `auth`/`dataApi` GA toggles + a beta `preview` block with `aiGateway` and record-keyed `functions`/`buckets`) plus a **tuning-only `branch` closure**. Because the secret/function set is now static, it's known at the type level, so `NeonEnv` / `parseEnv` are exact.

**Breaking:** `@neondatabase/config@0.3.0`, `@neondatabase/config-runtime@0.3.0`, `@neondatabase/env@0.2.0` (changeset included).

```ts
export default defineConfig({
  auth: true,
  dataApi: false,
  preview: {
    aiGateway: false,
    functions: { hello: { name: "Hello", source: "./functions/hello.ts", dev: { port: 8787 } } },
    buckets: { uploads: { access: "public_read" } },
  },
  branch: (branch) => ({
    protected: branch.name === "main",
    preview: { functions: { hello: { memoryMib: 1024 } } },
  }),
});
```

- `resolveConfig` compiles static + branch tuning into the **unchanged** `ResolvedBranchConfig`, so diff/plan/apply are untouched at runtime.
- `pullConfig` reverses into the new shape; **fix:** it no longer copies `branch.expiresAt` (a timestamp) into the policy `ttl` (a duration), which crashed `fetchEnv`/`neon dev`/`neon env pull` on any TTL branch.
- `@neondatabase/env`: `parseEnv` drops `branchName`; optional scope arg (omit = external; a function slug adds a typed `function` namespace of its declared env keys). Empty function env values pass through (present != non-empty). Dead `branchName` CLI plumbing removed.

## Test plan

- [x] config 154 / config-runtime 34 / env 35 tests green; all typecheck
- [x] Compile-time constraint tests (branch closure can't tune an undeclared slug, add a service, or redeclare a function source)
- [x] Regression test: pulling a branch with an expiry resolves without a ttl parse crash
- [ ] Publish 0.3.0/0.3.0/0.2.0, then neonctl swaps link: -> published