### PR TITLE
fix(config): align function-deploy multipart body with the public API spec

### DIFF
--- a/packages/config/src/lib/neon-api-real.test.ts
+++ b/packages/config/src/lib/neon-api-real.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { ErrorCode, PlatformError } from "./errors.js";
 import {
+	buildFunctionDeployForm,
 	createNeonAuthRestInput,
 	isPreviewFeatureUnavailable,
 	previewUnavailableError,
@@ -60,6 +61,54 @@ describe("retryOnLocked", () => {
 			}, FAST_CONFIG),
 		).rejects.toMatchObject({ message: "still locked" });
 		expect(calls).toBe(FAST_CONFIG.maxAttempts);
+	});
+});
+
+describe("buildFunctionDeployForm", () => {
+	const bundle = new Uint8Array([0x50, 0x4b, 0x03, 0x04]); // "PK\x03\x04"
+
+	test("matches the FunctionDeployRequest spec fields (zip / runtime / environment)", () => {
+		const form = buildFunctionDeployForm({
+			bundle,
+			runtime: "nodejs24",
+			environment: { RESEND_API_KEY: "re_abc", STRIPE: "sk_x" },
+		});
+		// Exactly the three spec fields — no legacy `file` / `concurrency`.
+		expect([...form.keys()].sort()).toEqual([
+			"environment",
+			"runtime",
+			"zip",
+		]);
+		expect(form.has("file")).toBe(false);
+		expect(form.has("concurrency")).toBe(false);
+		expect(form.get("runtime")).toBe("nodejs24");
+		const zip = form.get("zip");
+		expect(zip).toBeInstanceOf(Blob);
+		expect((zip as Blob).type).toBe("application/zip");
+	});
+
+	test("encodes environment as a single JSON-encoded string map", () => {
+		const form = buildFunctionDeployForm({
+			bundle,
+			runtime: "nodejs24",
+			environment: { A: "1", B: "two" },
+		});
+		// Spec: `environment` is one JSON string, NOT bracketed `environment[A]` parts.
+		expect(form.has("environment[A]")).toBe(false);
+		expect(JSON.parse(form.get("environment") as string)).toEqual({
+			A: "1",
+			B: "two",
+		});
+	});
+
+	test("omits the environment field entirely when there are no vars", () => {
+		const form = buildFunctionDeployForm({
+			bundle,
+			runtime: "nodejs24",
+			environment: {},
+		});
+		expect(form.has("environment")).toBe(false);
+		expect([...form.keys()].sort()).toEqual(["runtime", "zip"]);
 	});
 });
 

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -580,29 +580,17 @@ class RealNeonApi implements NeonApi {
 	}
 
 	/**
-	 * Upload a built function bundle via `multipart/form-data` to the deploy endpoint.
-	 * Sends the bundle as the `file` field plus the deploy params Neon requires.
+	 * Upload a built function bundle via `multipart/form-data` to the deploy endpoint
+	 * (`POST .../functions/{slug}/deployments`). Body shape lives in the pure
+	 * {@link buildFunctionDeployForm} helper so it can be unit-tested against the spec.
 	 */
 	private async postMultipart(
 		path: string,
 		input: DeployFunctionInput,
 	): Promise<unknown> {
-		const form = new FormData();
-		form.set(
-			"file",
-			new Blob([input.bundle as BlobPart], {
-				type: "application/zip",
-			}),
-			"bundle.zip",
-		);
-		// Keep concurrency internal for now. The API requires it, but the public
-		// neon.ts config surface intentionally does not expose it yet.
-		form.set("concurrency", "1");
-		form.set("runtime", input.runtime);
-		for (const [key, value] of Object.entries(input.environment)) {
-			form.set(`environment[${key}]`, value);
-		}
-		return this.request("POST", path, { body: form });
+		return this.request("POST", path, {
+			body: buildFunctionDeployForm(input),
+		});
 	}
 
 	private async request(
@@ -1056,6 +1044,31 @@ export function createNeonAuthRestInput(input: {
 		auth_provider: "better_auth",
 		...(input.databaseName ? { database_name: input.databaseName } : {}),
 	};
+}
+
+/**
+ * Build the `multipart/form-data` body for a function deployment, matching the public
+ * `FunctionDeployRequest` schema (`POST .../functions/{slug}/deployments`):
+ *
+ * - `zip` — the bundle as a binary part (named `bundle.zip`).
+ * - `runtime` — the function runtime.
+ * - `environment` — a single JSON-encoded string→string map (multipart can't carry a typed
+ *   object part), omitted entirely when there are no env vars.
+ *
+ * Pure (no I/O) so it can be unit-tested against the spec without stubbing `fetch`.
+ */
+export function buildFunctionDeployForm(input: DeployFunctionInput): FormData {
+	const form = new FormData();
+	form.set(
+		"zip",
+		new Blob([input.bundle as BlobPart], { type: "application/zip" }),
+		"bundle.zip",
+	);
+	form.set("runtime", input.runtime);
+	if (Object.keys(input.environment).length > 0) {
+		form.set("environment", JSON.stringify(input.environment));
+	}
+	return form;
 }
 
 /**


### PR DESCRIPTION
## Summary

While reviewing our adapter against the current Preview API spec, I found the function-deploy multipart body had drifted.

The real NeonApi adapter (`postMultipart`) was sending:
- a `file` part (spec field is **`zip`**)
- a `concurrency` field (**not in the spec**)
- bracketed `environment[key]=value` parts (spec wants `environment` as **one JSON-encoded string map**)

The public `FunctionDeployRequest` schema for `POST .../functions/{slug}/deployments` defines exactly `zip` (binary), `runtime`, and `environment` (JSON string). neonctl's own `functions_api.ts` already matches the spec; the package adapter did not.

This sends exactly the spec fields, and extracts the body construction into a pure, exported `buildFunctionDeployForm` so it can be unit-tested against the spec without stubbing `fetch`.

> Stacked on #173 (which is stacked on #172). Merge order: #172 → #173 → this.

## Test plan

- [x] New unit tests assert the form has only `zip` / `runtime` / `environment`, no `file` / `concurrency`, and that `environment` is a single JSON string (omitted when empty).
- [x] `pnpm --filter @neondatabase/config tsc` + 157 config tests
- [x] `pnpm lint:ci`