### PR TITLE
fix(config): restore preview/auth/dataApi autocomplete in defineConfig

### DIFF
--- a/.changeset/define-config-preview-autocomplete.md
+++ b/.changeset/define-config-preview-autocomplete.md
@@ -1,0 +1,13 @@
+---
+"@neondatabase/config": patch
+---
+
+Fix `defineConfig` autocomplete for the nested `preview` (and `auth`/`dataApi`) fields.
+
+Each field was typed as the bare generic type parameter (e.g. `preview?: Preview`), so editors
+had no concrete shape to complete against in the object-literal position and showed
+`{} | undefined` with no hints for `aiGateway` / `functions` / `buckets`. The fields are now
+intersected with their concrete interfaces (`Preview & PreviewInput`, `Auth & ServiceToggleInput`,
+`DataApi & ServiceToggleInput`), restoring full member autocomplete and inline docs while keeping
+the `const` literal inference that types the `branch` closure's function slugs. Type-only change —
+no runtime behavior change.

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -350,4 +350,55 @@ describe("defineConfig type constraints (compile-time)", () => {
 			}),
 		});
 	});
+
+	test("the preview block accepts all of its declared members (aiGateway/functions/buckets)", () => {
+		// Regression: when `preview` was typed as the bare generic `Preview`, editors saw
+		// `{} | undefined` and offered no member hints. Intersecting with `PreviewInput` keeps
+		// the field's full shape, so every declared member type-checks in place.
+		defineConfig({
+			preview: {
+				aiGateway: { enabled: true },
+				functions: { hello: { name: "H", source: "./h.ts" } },
+				buckets: { uploads: { access: "public_read" } },
+			},
+		});
+	});
+
+	test("the preview block rejects an unknown member (type + runtime)", () => {
+		expect(() =>
+			defineConfig({
+				// @ts-expect-error `gateway` is not a PreviewInput member (it's `aiGateway`).
+				preview: { gateway: { enabled: true } },
+			}),
+		).toThrow(ConfigValidationError);
+	});
+
+	test("a bucket access level is constrained to the known literals (type + runtime)", () => {
+		expect(() =>
+			defineConfig({
+				preview: {
+					// @ts-expect-error access is "private" | "public_read", not an arbitrary string.
+					buckets: { uploads: { access: "world_readable" } },
+				},
+			}),
+		).toThrow(ConfigValidationError);
+	});
+
+	test("intersecting the generics still infers function slugs for the branch closure", () => {
+		// The autocomplete fix (Preview & PreviewInput) must not weaken slug inference: the
+		// closure can tune a declared slug but not an undeclared one.
+		defineConfig({
+			preview: { functions: { hello: { name: "H", source: "./h.ts" } } },
+			branch: () => ({
+				preview: { functions: { hello: { runtime: "nodejs24" } } },
+			}),
+		});
+		defineConfig({
+			preview: { functions: { hello: { name: "H", source: "./h.ts" } } },
+			// @ts-expect-error "bye" is not a declared function slug.
+			branch: () => ({
+				preview: { functions: { bye: { runtime: "nodejs24" } } },
+			}),
+		});
+	});
 });

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -62,9 +62,15 @@ export function defineConfig<
 	const DataApi extends ServiceToggleInput | undefined = undefined,
 	const Preview extends PreviewInput | undefined = undefined,
 >(input: {
-	auth?: Auth;
-	dataApi?: DataApi;
-	preview?: Preview;
+	// Each field is intersected with its concrete interface (not just typed as the bare
+	// generic). The generic alone — e.g. `preview?: Preview` — gives editors no members to
+	// complete against in the object-literal position (they see `{} | undefined`), so you
+	// lose hints for `aiGateway` / `functions` / `buckets`. `& PreviewInput` restores the
+	// full shape for autocomplete while still inferring the `const` literal that types the
+	// `branch` closure's slugs (BranchTuningFn<Preview>) and the returned Config.
+	auth?: Auth & ServiceToggleInput;
+	dataApi?: DataApi & ServiceToggleInput;
+	preview?: Preview & PreviewInput;
 	branch?: BranchTuningFn<Preview>;
 }): Config<Auth, DataApi, Preview> {
 	if (typeof input === "function") {


### PR DESCRIPTION
## Problem

In `neon.ts`, typing the nested `preview` object inside `defineConfig({ ... })` gives no autocomplete — the editor shows the type as `{} | undefined` and offers no hints for `aiGateway`, `functions`, or `buckets`. Same for `auth` / `dataApi`.

### Root cause

`defineConfig`'s parameter typed each field as the **bare generic type parameter**:

```ts
export function defineConfig<
  const Auth extends ServiceToggleInput | undefined = undefined,
  const DataApi extends ServiceToggleInput | undefined = undefined,
  const Preview extends PreviewInput | undefined = undefined,
>(input: {
  auth?: Auth;
  dataApi?: DataApi;
  preview?: Preview;        // ← bare generic, default `undefined`
  branch?: BranchTuningFn<Preview>;
}): Config<Auth, DataApi, Preview>
```

When you type `preview: { ` the editor's contextual type is the type parameter `Preview` (default `undefined`, constraint `PreviewInput | undefined`). TS doesn't expand the constraint's members for completion in that position, so you get `{} | undefined` and lose all member hints. (Type-checking still rejected wrong shapes — only IntelliSense was degraded.)

## Fix

Intersect each field with its concrete interface so the editor has the full member shape to complete against, while still inferring the `const` literal that types the `branch` closure's function slugs (`BranchTuningFn<Preview>`) and the returned `Config`:

```ts
auth?: Auth & ServiceToggleInput;
dataApi?: DataApi & ServiceToggleInput;
preview?: Preview & PreviewInput;
```

Type-only change — **no runtime behavior change**. The intersection doesn't block inference, so slug constraints in the `branch` closure are preserved (verified by the existing + new compile-time tests).

## Tests

Added compile-time (`@ts-expect-error`) + runtime tests in `define-config.test.ts`:
- `preview` accepts all declared members (`aiGateway`/`functions`/`buckets`)
- unknown `preview` member is rejected (type + runtime)
- bucket `access` constrained to `"private" | "public_read"` (type + runtime)
- intersecting the generics still infers function slugs (declared slug OK; undeclared slug is a type error)

- [x] `tsc --noEmit` clean (proves the `const` inference + `@ts-expect-error` assertions hold)
- [x] `pnpm test:ci` — config package: 163 passed
- [x] `pnpm build` (tsdown) succeeds; emitted `define-config.d.ts` carries the intersected types

## Versioning

Changeset: **patch** to `@neondatabase/config` (DX/typing fix, no API change). `config-runtime` / `env` pick up the internal-dependency patch automatically per `.changeset/config.json` (`updateInternalDependencies: "patch"`).

## Downstream

Once released, `neonctl` picks this up on its next `@neondatabase/config` bump — fixing the `preview: {} | undefined` hint reported there.