### PR TITLE
feat(env): add `neon-env export` to print branch env to stdout

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -1,6 +1,6 @@
 # @neondatabase/env
 
-Resolve and inject Neon connection strings for the branch selected by your `neon.ts` policy. Exposes `fetchEnv` / `parseEnv` functions plus a single CLI command: `neon-env run -- <cmd>`.
+Resolve and inject Neon connection strings for the branch selected by your `neon.ts` policy. Exposes `fetchEnv` / `parseEnv` functions plus a `neon-env` CLI with `run` (inject env into a command) and `export` (print env to stdout).
 
 Builds on [`@neondatabase/config`](../config) — it reuses the `Config` policy type and the Neon API client.
 
@@ -43,7 +43,9 @@ Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `
 
 ## CLI
 
-One command — inject the env vars for your `neon.ts` branch into a dev command:
+### `run` — inject env into a command
+
+Inject the env vars for your `neon.ts` branch into a dev command:
 
 ```bash
 neon-env run -- npm run dev
@@ -52,7 +54,23 @@ neon-env run -- pnpm dev
 
 `run` loads `neon.ts`, resolves the branch (via `--branch`, `NEON_BRANCH_ID`, or `.neon[/project.json]`), fetches the connection strings from Neon, and spawns the command with `DATABASE_URL` / `DATABASE_URL_UNPOOLED` (and `NEON_AUTH_BASE_URL` / `NEON_DATA_API_URL` when the policy enables them) injected on top of the inherited environment. Stdio is inherited so interactive dev servers keep working, and the parent exits with the child's exit code.
 
-Flags: `--config <path>`, `--project-id`, `--branch`, `--api-key`, `--debug`.
+### `export` — print env to stdout
+
+Resolve the same branch env, but print it instead of spawning a process — for piping into other env tools:
+
+```bash
+neon-env export                 # dotenv KEY=value lines (default)
+neon-env export --format json   # JSON object
+```
+
+For example, [varlock](https://varlock.dev) can bulk-load Neon's branch env via its `exec()` resolver:
+
+```bash
+# .env.schema
+# @setValuesBulk(exec(`neon-env export --format json`), format=json)
+```
+
+Flags (both commands): `--config <path>`, `--project-id`, `--branch`, `--api-key`, `--debug`. `export` also takes `--format dotenv|json`.
 
 ## Env vars produced
 

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@neondatabase/env",
 	"version": "0.3.0",
-	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a single `env run -- <cmd>` CLI.",
+	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",
 		"database",

--- a/packages/env/src/cli.ts
+++ b/packages/env/src/cli.ts
@@ -4,13 +4,17 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
-import { type CommandResult, runEnvRun } from "./lib/cli/commands.js";
+import {
+	type CommandResult,
+	runEnvExport,
+	runEnvRun,
+} from "./lib/cli/commands.js";
 
 const pkgVersion = readPackageVersion();
 
 const argv = yargs(hideBin(process.argv))
 	.scriptName("neon-env")
-	.usage("$0 run -- <command> [options]")
+	.usage("$0 <command> [options]")
 	.parserConfiguration({ "populate--": true })
 	.option("debug", {
 		type: "boolean",
@@ -23,6 +27,35 @@ const argv = yargs(hideBin(process.argv))
 		"Run a command with Neon env vars (from your neon.ts policy) injected into its environment. Use `--` to separate the command: `neon-env run -- npm run dev`.",
 		(y) =>
 			y
+				.option("config", {
+					type: "string",
+					describe:
+						"Path to neon.ts (defaults to walking up from cwd)",
+				})
+				.option("project-id", {
+					type: "string",
+					describe: "Override the .neon/project.json projectId",
+				})
+				.option("branch", {
+					type: "string",
+					describe:
+						"Override the .neon/project.json branchId / NEON_BRANCH_ID",
+				})
+				.option("api-key", {
+					type: "string",
+					describe: "Neon API key (defaults to NEON_API_KEY)",
+				}),
+	)
+	.command(
+		"export",
+		"Print the branch's Neon env vars (from your neon.ts policy) to stdout, as dotenv lines or JSON. Useful for piping into other env tools, e.g. `neon-env export --format json`.",
+		(y) =>
+			y
+				.option("format", {
+					choices: ["dotenv", "json"] as const,
+					default: "dotenv",
+					describe: "Output format: dotenv (KEY=value lines) or json",
+				})
 				.option("config", {
 					type: "string",
 					describe:
@@ -60,6 +93,27 @@ switch (command) {
 		result = await runEnvRun(
 			{
 				command: passthrough,
+				...(typeof argv.config === "string"
+					? { configPath: argv.config }
+					: {}),
+				...(typeof argv["project-id"] === "string"
+					? { projectId: argv["project-id"] }
+					: {}),
+				...(typeof argv.branch === "string"
+					? { branch: argv.branch }
+					: {}),
+				...(typeof argv["api-key"] === "string"
+					? { apiKey: argv["api-key"] }
+					: {}),
+			},
+			{ cwd },
+		);
+		break;
+	}
+	case "export": {
+		result = await runEnvExport(
+			{
+				format: argv.format === "json" ? "json" : "dotenv",
 				...(typeof argv.config === "string"
 					? { configPath: argv.config }
 					: {}),

--- a/packages/env/src/lib/cli/commands.test.ts
+++ b/packages/env/src/lib/cli/commands.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { FakeNeonApi } from "../fake-neon-api.js";
 import { makeTempRepo, stubCleanNeonEnv } from "../test-utils.js";
-import { runEnvRun } from "./commands.js";
+import { runEnvExport, runEnvRun } from "./commands.js";
 
 const CONFIG_SRC = new URL("../../../../config/src/v1.ts", import.meta.url)
 	.pathname;
@@ -97,5 +97,63 @@ describe("runEnvRun", () => {
 			{ cwd: root, api },
 		);
 		expect(result.exitCode).toBe(3);
+	});
+});
+
+describe("runEnvExport", () => {
+	test("prints the branch env as dotenv lines by default", async () => {
+		const { api, projectId } = seededFake();
+		const root = setup({
+			"package.json": "{}",
+			".neon/project.json": JSON.stringify({
+				projectId,
+				branchId: "br-main",
+			}),
+			"neon.ts": policy(),
+		});
+
+		const result = await runEnvExport(
+			{ format: "dotenv" },
+			{ cwd: root, api },
+		);
+
+		expect(result.exitCode).toBe(0);
+		// The connection string contains `=` (e.g. ?sslmode=require), so the value is quoted.
+		expect(result.stdout).toMatch(/^DATABASE_URL="postgresql:\/\//m);
+		expect(result.stdout.endsWith("\n")).toBe(true);
+	});
+
+	test("prints valid JSON with --format json", async () => {
+		const { api, projectId } = seededFake();
+		const root = setup({
+			"package.json": "{}",
+			".neon/project.json": JSON.stringify({
+				projectId,
+				branchId: "br-main",
+			}),
+			"neon.ts": policy(),
+		});
+
+		const result = await runEnvExport(
+			{ format: "json" },
+			{ cwd: root, api },
+		);
+
+		expect(result.exitCode).toBe(0);
+		const parsed = JSON.parse(result.stdout) as Record<string, string>;
+		expect(parsed.DATABASE_URL).toMatch(/^postgresql:\/\//);
+	});
+
+	test("fails with a non-zero exit code when no project/branch can be resolved", async () => {
+		const { api } = seededFake();
+		const root = setup({ "package.json": "{}" });
+
+		const result = await runEnvExport(
+			{ format: "json" },
+			{ cwd: root, api },
+		);
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("could not resolve");
 	});
 });

--- a/packages/env/src/lib/cli/commands.ts
+++ b/packages/env/src/lib/cli/commands.ts
@@ -40,13 +40,21 @@ export interface CommandResult {
 	debugInfo?: string;
 }
 
-export interface EnvRunCommandOptions {
-	/** The user command to spawn (after `--`). The first element is the executable. */
-	command: string[];
+/**
+ * Inputs needed to resolve a branch and fetch its env, shared by `run` and `export`: an
+ * optional explicit `neon.ts` path, project/branch overrides, and an API key (otherwise
+ * resolved from `.neon` / `NEON_*` env by the CLI and `NEON_API_KEY` by `fetchEnv`).
+ */
+export interface EnvResolveOptions {
 	configPath?: string;
 	projectId?: string;
 	branch?: string;
 	apiKey?: string;
+}
+
+export interface EnvRunCommandOptions extends EnvResolveOptions {
+	/** The user command to spawn (after `--`). The first element is the executable. */
+	command: string[];
 }
 
 /**
@@ -102,6 +110,69 @@ export async function runEnvRun(
 	return { exitCode, stdout: "", stderr: "" };
 }
 
+export interface EnvExportCommandOptions extends EnvResolveOptions {
+	/** Output format. `dotenv` (KEY=value lines) by default; `json` for tooling / bulk loaders. */
+	format?: "dotenv" | "json";
+}
+
+/**
+ * Implementation of `neon-env export`. Resolves the branch's Neon env the same way `run`
+ * does (neon.ts policy + linked branch), then writes it to stdout — as dotenv lines or JSON —
+ * instead of spawning a process, so other env tools can consume it. For example, varlock can
+ * bulk-load it with `@setValuesBulk(exec("neon-env export --format json"), format=json)`.
+ */
+export async function runEnvExport(
+	options: EnvExportCommandOptions,
+	ctx: CommandEnv,
+): Promise<CommandResult> {
+	const resolved = resolveContext({
+		cwd: ctx.cwd,
+		...(options.projectId ? { projectId: options.projectId } : {}),
+		...(options.branch ? { branch: options.branch } : {}),
+	});
+	if (!resolved.ok) {
+		return failure(
+			[
+				"`env export` could not resolve the Neon project and branch:",
+				...resolved.missing.map((m) => `  - ${m}`),
+			].join("\n"),
+			3,
+		);
+	}
+
+	let entries: Record<string, string>;
+	try {
+		const env = await loadConfigAndFetchEnv(options, ctx, resolved.context);
+		entries = toEntries(env);
+	} catch (err) {
+		return handleError(err);
+	}
+
+	const stdout =
+		options.format === "json"
+			? `${JSON.stringify(entries, null, 2)}\n`
+			: toDotenv(entries);
+	return { exitCode: 0, stdout, stderr: "" };
+}
+
+/** Render an env map as dotenv `KEY=value` lines, quoting values that need it. */
+function toDotenv(entries: Record<string, string>): string {
+	const lines = Object.entries(entries).map(([key, value]) =>
+		formatDotenvLine(key, value),
+	);
+	return lines.length > 0 ? `${lines.join("\n")}\n` : "";
+}
+
+/**
+ * Render a single `KEY=value` dotenv line, double-quoting (and escaping) values that contain
+ * whitespace, `#`, quotes, or `=` so connection strings round-trip through dotenv parsers.
+ */
+function formatDotenvLine(key: string, value: string): string {
+	if (!/[\s#"'=]/.test(value)) return `${key}=${value}`;
+	const escaped = value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+	return `${key}="${escaped}"`;
+}
+
 /**
  * Load `neon.ts`, then call `fetchEnv` with the explicitly-resolved project + branch.
  * Layers any one-time Auth keys from `.env.local` (next to the config file) into the env
@@ -109,7 +180,7 @@ export async function runEnvRun(
  * integration-creation time.
  */
 async function loadConfigAndFetchEnv(
-	options: EnvRunCommandOptions,
+	options: EnvResolveOptions,
 	ctx: CommandEnv,
 	resolved: { projectId: string; branchId: string },
 ): Promise<Awaited<ReturnType<typeof fetchEnv>>> {


### PR DESCRIPTION
## Summary

Adds an `export` command to the `neon-env` CLI (`@neondatabase/env`) that resolves a branch's Neon env the same way `run` does (`neon.ts` policy + linked branch), but **prints it to stdout instead of spawning a process** — as dotenv `KEY=value` lines (default) or JSON.

```bash
neon-env export                 # dotenv lines (default)
neon-env export --format json   # JSON object
```

## Why

`run` injects env into a child process and `env pull` (neonctl) writes a file, but neither emits the resolved env to stdout — so other env tools can't consume Neon's branch env. `export` fills that gap. The motivating case is [varlock](https://varlock.dev), whose `exec()` / `@setValuesBulk` resolvers can now bulk-load Neon vars from a `.env.schema`:

```bash
# @setValuesBulk(exec(`neon-env export --format json`), format=json)
```

(Layering: Neon supplies branch-scoped values; varlock adds schema/validation/redaction on top.)

## Changes

- `commands.ts`: new `runEnvExport`; extracted a shared `EnvResolveOptions` from `EnvRunCommandOptions` and reused the existing `loadConfigAndFetchEnv` (same policy load + `.env.local` auth-key layering as `run`). dotenv values containing `=` / whitespace / quotes / `#` are quoted so connection strings round-trip.
- `cli.ts`: `export` command with `--format dotenv|json` plus the same `--config` / `--project-id` / `--branch` / `--api-key` flags as `run`.
- README + package description updated.

## Test plan

- [x] `tsc` clean; `biome check` clean
- [x] `vitest run` green (42 passed) — new tests cover dotenv output, `--format json`, and the unresolved-context error (exit 3)
- [ ] Manual: `neon-env export` / `--format json` in a linked repo; `varlock load` consuming `@setValuesBulk(exec("neon-env export --format json"), format=json)`