### PR TITLE
fix: add ability to pass API host to use

### DIFF
--- a/.changeset/honor-neon-api-host.md
+++ b/.changeset/honor-neon-api-host.md
@@ -1,0 +1,7 @@
+---
+"@neondatabase/config": patch
+"@neondatabase/config-runtime": patch
+"@neondatabase/env": patch
+---
+
+Honor `NEON_API_HOST` / the new `apiHost` option when building the default Neon API client. `createNeonApiFromOptions` now resolves the host (explicit `apiHost` option → `NEON_API_HOST` env → production default), and `pullConfig`, `pushConfig`, `inspect`/`plan`/`apply`, and `fetchEnv` accept and forward an optional `apiHost`.

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/src/lib/apihost-forwarding.test.ts
+++ b/packages/config-runtime/src/lib/apihost-forwarding.test.ts
@@ -26,12 +26,12 @@ describe("pullConfig — apiHost forwarding", () => {
 				projectId: "p",
 				branchId: "br-1",
 				apiKey: "napi_k",
-				apiHost: "https://stage.example/api/v2",
+				apiHost: HOST,
 			}),
 		).rejects.toThrow("STOP-AFTER-API-BUILD");
 		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pullConfig", {
 			apiKey: "napi_k",
-			apiHost: "https://stage.example/api/v2",
+			apiHost: HOST,
 		});
 	});
 });
@@ -43,12 +43,12 @@ describe("pushConfig — apiHost forwarding", () => {
 				projectId: "p",
 				branchId: "br-1",
 				apiKey: "napi_k",
-				apiHost: "https://stage.example/api/v2",
+				apiHost: HOST,
 			}),
 		).rejects.toThrow("STOP-AFTER-API-BUILD");
 		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pushConfig", {
 			apiKey: "napi_k",
-			apiHost: "https://stage.example/api/v2",
+			apiHost: HOST,
 		});
 	});
 });

--- a/packages/config-runtime/src/lib/apihost-forwarding.test.ts
+++ b/packages/config-runtime/src/lib/apihost-forwarding.test.ts
@@ -1,0 +1,35 @@
+import { createNeonApiFromOptions } from "@neondatabase/config";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { pullConfig } from "./pull-config.js";
+
+// Throw immediately after the API client would be built. Every runtime entry builds its
+// API as its first statement, so this asserts the forwarded options without any network.
+vi.mock("@neondatabase/config", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@neondatabase/config")>();
+	return {
+		...actual,
+		createNeonApiFromOptions: vi.fn(() => {
+			throw new Error("STOP-AFTER-API-BUILD");
+		}),
+	};
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("pullConfig — apiHost forwarding", () => {
+	test("forwards apiHost (and apiKey) to createNeonApiFromOptions", async () => {
+		await expect(
+			pullConfig({
+				projectId: "p",
+				branchId: "br-1",
+				apiKey: "napi_k",
+				apiHost: "https://stage.example/api/v2",
+			}),
+		).rejects.toThrow("STOP-AFTER-API-BUILD");
+		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pullConfig", {
+			apiKey: "napi_k",
+			apiHost: "https://stage.example/api/v2",
+		});
+	});
+});

--- a/packages/config-runtime/src/lib/apihost-forwarding.test.ts
+++ b/packages/config-runtime/src/lib/apihost-forwarding.test.ts
@@ -1,6 +1,7 @@
 import { createNeonApiFromOptions } from "@neondatabase/config";
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import { pullConfig } from "./pull-config.js";
+import { pushConfig } from "./push-config.js";
 
 // Throw immediately after the API client would be built. Every runtime entry builds its
 // API as its first statement, so this asserts the forwarded options without any network.
@@ -15,8 +16,6 @@ vi.mock("@neondatabase/config", async (importOriginal) => {
 	};
 });
 
-afterEach(() => vi.clearAllMocks());
-
 describe("pullConfig — apiHost forwarding", () => {
 	test("forwards apiHost (and apiKey) to createNeonApiFromOptions", async () => {
 		await expect(
@@ -28,6 +27,23 @@ describe("pullConfig — apiHost forwarding", () => {
 			}),
 		).rejects.toThrow("STOP-AFTER-API-BUILD");
 		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pullConfig", {
+			apiKey: "napi_k",
+			apiHost: "https://stage.example/api/v2",
+		});
+	});
+});
+
+describe("pushConfig — apiHost forwarding", () => {
+	test("forwards apiHost (and apiKey) to createNeonApiFromOptions", async () => {
+		await expect(
+			pushConfig({} as never, {
+				projectId: "p",
+				branchId: "br-1",
+				apiKey: "napi_k",
+				apiHost: "https://stage.example/api/v2",
+			}),
+		).rejects.toThrow("STOP-AFTER-API-BUILD");
+		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pushConfig", {
 			apiKey: "napi_k",
 			apiHost: "https://stage.example/api/v2",
 		});

--- a/packages/config-runtime/src/lib/apihost-forwarding.test.ts
+++ b/packages/config-runtime/src/lib/apihost-forwarding.test.ts
@@ -1,7 +1,10 @@
 import { createNeonApiFromOptions } from "@neondatabase/config";
 import { describe, expect, test, vi } from "vitest";
+import { apply, inspect, plan } from "./operations.js";
 import { pullConfig } from "./pull-config.js";
 import { pushConfig } from "./push-config.js";
+
+const HOST = "https://stage.example/api/v2";
 
 // Throw immediately after the API client would be built. Every runtime entry builds its
 // API as its first statement, so this asserts the forwarded options without any network.
@@ -46,6 +49,53 @@ describe("pushConfig — apiHost forwarding", () => {
 		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pushConfig", {
 			apiKey: "napi_k",
 			apiHost: "https://stage.example/api/v2",
+		});
+	});
+});
+
+describe("operations — apiHost forwarding", () => {
+	test("inspect forwards apiHost down to pullConfig", async () => {
+		await expect(
+			inspect({
+				projectId: "p",
+				branchId: "br-1",
+				apiKey: "k",
+				apiHost: HOST,
+			}),
+		).rejects.toThrow("STOP-AFTER-API-BUILD");
+		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pullConfig", {
+			apiKey: "k",
+			apiHost: HOST,
+		});
+	});
+
+	test("plan forwards apiHost down to pushConfig", async () => {
+		await expect(
+			plan({} as never, {
+				projectId: "p",
+				branchId: "br-1",
+				apiKey: "k",
+				apiHost: HOST,
+			}),
+		).rejects.toThrow("STOP-AFTER-API-BUILD");
+		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pushConfig", {
+			apiKey: "k",
+			apiHost: HOST,
+		});
+	});
+
+	test("apply forwards apiHost down to pushConfig", async () => {
+		await expect(
+			apply({} as never, {
+				projectId: "p",
+				branchId: "br-1",
+				apiKey: "k",
+				apiHost: HOST,
+			}),
+		).rejects.toThrow("STOP-AFTER-API-BUILD");
+		expect(createNeonApiFromOptions).toHaveBeenCalledWith("pushConfig", {
+			apiKey: "k",
+			apiHost: HOST,
 		});
 	});
 });

--- a/packages/config-runtime/src/lib/operations.ts
+++ b/packages/config-runtime/src/lib/operations.ts
@@ -30,6 +30,8 @@ export interface ConfigOperationOptions {
 	branchId: string;
 	/** Neon API key. Falls back to `NEON_API_KEY` / neonctl credentials. */
 	apiKey?: string;
+	/** Neon API base URL. Falls back to `NEON_API_HOST`, then production. */
+	apiHost?: string;
 	/** Inject a custom NeonApi adapter (primarily for tests). */
 	api?: PushConfigOptions["api"];
 }
@@ -67,6 +69,7 @@ export async function inspect(
 		branchId: options.branchId,
 		...(options.api ? { api: options.api } : {}),
 		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+		...(options.apiHost ? { apiHost: options.apiHost } : {}),
 	});
 }
 
@@ -90,6 +93,7 @@ export async function plan(
 		updateExisting: true,
 		...(options.api ? { api: options.api } : {}),
 		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+		...(options.apiHost ? { apiHost: options.apiHost } : {}),
 	});
 }
 
@@ -113,6 +117,7 @@ export async function apply(
 		branchId: options.branchId,
 		...(options.api ? { api: options.api } : {}),
 		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+		...(options.apiHost ? { apiHost: options.apiHost } : {}),
 		...(options.updateExisting ? { updateExisting: true } : {}),
 		...(options.allowProtectedBranch ? { allowProtectedBranch: true } : {}),
 		...(options.bundleFunction

--- a/packages/config-runtime/src/lib/pull-config.ts
+++ b/packages/config-runtime/src/lib/pull-config.ts
@@ -22,6 +22,8 @@ export interface PullConfigOptions {
 	branchId: string;
 	/** Neon API key. Falls back to `NEON_API_KEY` / neonctl credentials. */
 	apiKey?: string;
+	/** Neon API base URL. Falls back to `NEON_API_HOST`, then production. */
+	apiHost?: string;
 	/** Inject a custom NeonApi adapter (primarily for tests). */
 	api?: NeonApi;
 }
@@ -162,6 +164,7 @@ async function degradeUnavailable<T>(
 function createApiFromOptions(options: PullConfigOptions): NeonApi {
 	return createNeonApiFromOptions("pullConfig", {
 		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+		...(options.apiHost ? { apiHost: options.apiHost } : {}),
 	});
 }
 

--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -48,6 +48,8 @@ export interface PushConfigOptions {
 	branchId: string;
 	/** Neon API key. Falls back to `NEON_API_KEY` / neonctl credentials. Ignored when `api` is supplied. */
 	apiKey?: string;
+	/** Neon API base URL. Falls back to `NEON_API_HOST`, then production. */
+	apiHost?: string;
 	/**
 	 * Inject a custom NeonApi adapter. Primarily used by tests; production callers can rely
 	 * on the default real adapter built from `apiKey`.
@@ -390,6 +392,7 @@ function synthesizeAppliedChange(step: PlanStep): AppliedChange {
 function createApiFromOptions(options: PushConfigOptions): NeonApi {
 	return createNeonApiFromOptions("pushConfig", {
 		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+		...(options.apiHost ? { apiHost: options.apiHost } : {}),
 	});
 }
 

--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -148,7 +148,7 @@ export interface PushConfirmContext {
  *
  * Filesystem- and env-agnostic: the caller supplies an already-validated `Config` object
  * (from `defineConfig` / `loadConfigFromFile`) and explicit `projectId` + `branch` in
- * `options`. `pushConfig` performs no `.neon` lookups and reads no `NEON_*` env vars.
+ * `options`. `pushConfig` performs no `.neon` lookups and reads no `NEON_*` env vars except the API credential/host resolution documented on `apiKey`/`apiHost`.
  *
  * It will **not** create a project or branch — both must already exist on Neon.
  */

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/config/src/lib/auth.test.ts
+++ b/packages/config/src/lib/auth.test.ts
@@ -1,6 +1,16 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { readNeonctlCredentials, resolveApiKey } from "./auth.js";
+import {
+	createNeonApiFromOptions,
+	readNeonctlCredentials,
+	resolveApiKey,
+} from "./auth.js";
+import { createRealNeonApi } from "./neon-api-real.js";
 import { makeTempRepo, stubCleanNeonEnv } from "./test-utils.js";
+
+vi.mock("./neon-api-real.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("./neon-api-real.js")>();
+	return { ...actual, createRealNeonApi: vi.fn(() => ({}) as never) };
+});
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
@@ -161,6 +171,56 @@ describe("resolveApiKey — priority chain", () => {
 		expect(resolveApiKey({ apiKey: "  napi_x  " })).toEqual({
 			token: "napi_x",
 			source: "option",
+		});
+	});
+});
+
+describe("createNeonApiFromOptions — host resolution", () => {
+	const created = createRealNeonApi as unknown as ReturnType<typeof vi.fn>;
+
+	test("explicit apiHost option wins over NEON_API_HOST", () => {
+		vi.stubEnv("NEON_API_HOST", "https://env.example/api/v2");
+		createNeonApiFromOptions("op", {
+			apiKey: "napi_k",
+			apiHost: "https://opt.example/api/v2",
+		});
+		expect(created).toHaveBeenCalledWith({
+			apiKey: "napi_k",
+			baseUrl: "https://opt.example/api/v2",
+		});
+	});
+
+	test("falls back to NEON_API_HOST when no option is given", () => {
+		vi.stubEnv("NEON_API_HOST", "https://env.example/api/v2");
+		createNeonApiFromOptions("op", { apiKey: "napi_k" });
+		expect(created).toHaveBeenCalledWith({
+			apiKey: "napi_k",
+			baseUrl: "https://env.example/api/v2",
+		});
+	});
+
+	test("passes no baseUrl when neither option nor env is set (prod default)", () => {
+		createNeonApiFromOptions("op", { apiKey: "napi_k" });
+		expect(created).toHaveBeenCalledWith({ apiKey: "napi_k" });
+	});
+
+	test("normalizes trailing slashes and surrounding whitespace", () => {
+		createNeonApiFromOptions("op", {
+			apiKey: "napi_k",
+			apiHost: "  https://opt.example/api/v2/  ",
+		});
+		expect(created).toHaveBeenCalledWith({
+			apiKey: "napi_k",
+			baseUrl: "https://opt.example/api/v2",
+		});
+	});
+
+	test("treats an empty / whitespace apiHost as unset, falling through to env", () => {
+		vi.stubEnv("NEON_API_HOST", "https://env.example/api/v2");
+		createNeonApiFromOptions("op", { apiKey: "napi_k", apiHost: "   " });
+		expect(created).toHaveBeenCalledWith({
+			apiKey: "napi_k",
+			baseUrl: "https://env.example/api/v2",
 		});
 	});
 });

--- a/packages/config/src/lib/auth.ts
+++ b/packages/config/src/lib/auth.ts
@@ -92,10 +92,19 @@ export function resolveApiKey(
 	return null;
 }
 
+/** Trim trailing slashes and surrounding whitespace; treat empty as unset. */
+function normalizeApiHost(url: string | undefined): string | undefined {
+	const trimmed = url?.trim().replace(/\/+$/, "");
+	return trimmed ? trimmed : undefined;
+}
+
 /**
  * Resolve the Neon API key via the standard chain (option → `NEON_API_KEY` env →
  * `~/.config/neonctl/credentials.json`) and construct a real {@link NeonApi} adapter from
  * it, or throw a uniform `PLATFORM_MISSING_API_KEY` error if no key can be found.
+ *
+ * The API host is resolved via: `options.apiHost` → `NEON_API_HOST` env → production
+ * default (`https://console.neon.tech/api/v2`).
  *
  * Used by `pullConfig`, `pushConfig`, `fetchEnv`, and `branch` to build their default
  * `NeonApi` when the caller doesn't inject one. `operation` is the calling function's
@@ -106,12 +115,21 @@ export function createNeonApiFromOptions(
 	operation: string,
 	options: {
 		apiKey?: string;
+		apiHost?: string;
 	} = {},
 ): NeonApi {
 	const resolved = resolveApiKey(
 		options.apiKey ? { apiKey: options.apiKey } : {},
 	);
-	if (resolved) return createRealNeonApi({ apiKey: resolved.token });
+	if (resolved) {
+		const baseUrl =
+			normalizeApiHost(options.apiHost) ??
+			normalizeApiHost(process.env.NEON_API_HOST);
+		return createRealNeonApi({
+			apiKey: resolved.token,
+			...(baseUrl ? { baseUrl } : {}),
+		});
+	}
 	throw new PlatformError(
 		ErrorCode.MissingApiKey,
 		[

--- a/packages/config/src/lib/test-utils.ts
+++ b/packages/config/src/lib/test-utils.ts
@@ -11,6 +11,7 @@ import { vi } from "vitest";
  */
 const NEON_AND_RELATED_ENV_KEYS = [
 	"NEON_API_KEY",
+	"NEON_API_HOST",
 	"NEON_PROJECT_ID",
 	"NEON_BRANCH_ID",
 	"NEON_ORG_ID",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/env/src/lib/env.apihost.test.ts
+++ b/packages/env/src/lib/env.apihost.test.ts
@@ -1,0 +1,33 @@
+import { createNeonApiFromOptions } from "@neondatabase/config/v1";
+import { describe, expect, test, vi } from "vitest";
+import { fetchEnv } from "./env.js";
+
+// Throw immediately after the API client would be built: fetchEnv builds its API before
+// any other work, so this asserts the forwarded options without any network.
+vi.mock("@neondatabase/config/v1", async (importOriginal) => {
+	const actual =
+		await importOriginal<typeof import("@neondatabase/config/v1")>();
+	return {
+		...actual,
+		createNeonApiFromOptions: vi.fn(() => {
+			throw new Error("STOP-AFTER-API-BUILD");
+		}),
+	};
+});
+
+describe("fetchEnv — apiHost forwarding", () => {
+	test("forwards apiHost (and apiKey) to createNeonApiFromOptions", async () => {
+		await expect(
+			fetchEnv({} as never, {
+				projectId: "p",
+				branchId: "br-1",
+				apiKey: "napi_k",
+				apiHost: "https://stage.example/api/v2",
+			}),
+		).rejects.toThrow("STOP-AFTER-API-BUILD");
+		expect(createNeonApiFromOptions).toHaveBeenCalledWith("fetchEnv", {
+			apiKey: "napi_k",
+			apiHost: "https://stage.example/api/v2",
+		});
+	});
+});

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -189,6 +189,11 @@ export interface FetchEnvOptions {
 	 */
 	apiKey?: string;
 	/**
+	 * Neon **management** API base URL (not the Auth base URL). Falls back to
+	 * `NEON_API_HOST`, then production. Ignored when a custom `api` is supplied.
+	 */
+	apiHost?: string;
+	/**
 	 * Inject a custom NeonApi adapter. Primarily used by tests; production callers can rely
 	 * on the default real adapter built from `apiKey`.
 	 */
@@ -387,10 +392,10 @@ function resolveAuthJwksUrl(
 }
 
 function createApiFromOptions(options: FetchEnvOptions): NeonApi {
-	return createNeonApiFromOptions(
-		"fetchEnv",
-		options.apiKey ? { apiKey: options.apiKey } : {},
-	);
+	return createNeonApiFromOptions("fetchEnv", {
+		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+		...(options.apiHost ? { apiHost: options.apiHost } : {}),
+	});
 }
 
 function resolveBranch(


### PR DESCRIPTION
## Why?

`neonctl config status` / `config plan` / `config apply` / `deploy`, `neonctl env`, `neon dev`, and the checkout/link env-pull always talk to the **hardcoded production API host**, even when the user points neonctl at another environment via `NEON_API_HOST` or `--api-host`. Against staging this fails with:

```
ERROR: getProject(...) failed: the Bearer token sent to the Neon API was rejected.
Neon API said: "supplied credentials do not pass authentication"
```

The root cause: every runtime entry funnels into `createNeonApiFromOptions` (`packages/config/src/lib/auth.ts`), which resolves the *credential* from the environment (option → `NEON_API_KEY` → credentials file) but resolves **no host**, so `createRealNeonApi` falls back to `DEFAULT_NEON_API_BASE_URL = https://console.neon.tech/api/v2`. `createRealNeonApi` already accepts `baseUrl` — nothing fills it.

This PR gives the host the same treatment as the credential, at the same single choke point. A follow-up neonctl PR threads `props.apiHost` (the resolved `--api-host` flag) into these options; the env-var path works for all consumers with this PR alone.

## What?

### `@neondatabase/config`
- `createNeonApiFromOptions(operation, { apiKey?, apiHost? })` now resolves the API host: explicit `apiHost` option → `NEON_API_HOST` env → production default. Resolution happens at call time (not module load). Each source is normalized independently, so a blank/whitespace option falls through to the env var — symmetric with the existing `apiKey` chain.
- New module-private `normalizeApiHost`: trims surrounding whitespace and trailing slashes, treats empty as unset (guards `NEON_API_HOST=https://.../api/v2/` from producing a subtly different base URL).
- `createRealNeonApi` is untouched — it stays the explicit low-level constructor taking `baseUrl`.
- `NEON_API_HOST` added to the test clean-env list (`test-utils.ts`).
- Tests (`auth.test.ts`): option wins over env; env fallback; neither set → prod default (regression guard); trailing-slash/whitespace normalization; blank option falls through to env.

### `@neondatabase/config-runtime`
- `PullConfigOptions`, `PushConfigOptions`, and `ConfigOperationOptions` gain optional `apiHost` (doc: "Neon API base URL. Falls back to `NEON_API_HOST`, then production."), forwarded to `createNeonApiFromOptions` by `pullConfig`, `pushConfig`, and the `inspect`/`plan`/`apply` wrappers.
- New shared test `apihost-forwarding.test.ts`: sentinel-mock pattern asserting each entry forwards `{ apiKey, apiHost }` to the right callee (`inspect`→`pullConfig`, `plan`/`apply`→`pushConfig`).
- `pushConfig` header TSDoc corrected: it no longer claims to read no `NEON_*` env vars (the API credential/host resolution documented on `apiKey`/`apiHost` does).
- `createBranch`/`CreateBranchOptions` deliberately untouched: neonctl's callers use their own host-correct client; programmatic users are covered by the `NEON_API_HOST` env fallback.

### `@neondatabase/env`
- `FetchEnvOptions` gains optional `apiHost`, forwarded by `fetchEnv`. The field is named `apiHost` (not `baseUrl`) because this package already uses `baseUrl` for the Neon Auth publishable URL — the doc comment disambiguates ("Neon **management** API base URL (not the Auth base URL)").
- Its private `createApiFromOptions` normalized to the same spread style as config-runtime (behavior-identical for existing callers).
- New test `env.apihost.test.ts` (mocks `@neondatabase/config/v1`, the actual import specifier).