### PR TITLE
docs: list config / config-runtime / env packages in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@
 | `neon-init`                          | Set up your project with Neon's MCP Server for AI-powered database operations | active     |
 | `neon-new`                           | A CLI tool and SDK for creating claimable Neon databases instantly.           | active     |
 | `vite-plugin-neon-new`               | A Vite plugin that automatically provisions databases during development.     | active     |
+| `@neondatabase/config`               | Config-as-Code for Neon: `defineConfig` types + the pure diff engine and Neon API adapter behind a `neon.ts` policy. | active     |
+| `@neondatabase/config-runtime`       | Runtime for `neon.ts` policies — `inspect` / `plan` / `apply` (push/pull) plus function bundling and deploy. | active     |
+| `@neondatabase/env`                  | Resolve and inject a branch's Neon env (`fetchEnv` / `parseEnv`, `neon-env run`) from a `neon.ts` policy. | active     |
 | `get-db`                             | alias for `neon-new`                                                          | deprecated |
 | `vite-plugin-db`                     | alias for `vite-plugin-neon-new`                                              | deprecated |
 | `neondb`                             | alias for `neon-new`                                                          | deprecated |


### PR DESCRIPTION
## Summary

The top-level README package table didn't mention the Config-as-Code packages. Adds three rows so the repo's published `@neondatabase/*` packages are all discoverable from the README:

- `@neondatabase/config` — Config-as-Code authoring surface (`defineConfig`, types, pure diff engine, Neon API adapter) for a `neon.ts` policy.
- `@neondatabase/config-runtime` — imperative runtime for `neon.ts` policies (`inspect` / `plan` / `apply`, push/pull) plus function bundling & deploy.
- `@neondatabase/env` — resolve/inject a branch's Neon env (`fetchEnv` / `parseEnv`, `neon-env run`) from a `neon.ts` policy.

Docs-only; no code changes.

## Test plan

- [x] `biome ci` clean.