### PR TITLE
fix(config-runtime): bundle function dependencies into the deploy archive

### DIFF
--- a/.changeset/bundle-function-dependencies.md
+++ b/.changeset/bundle-function-dependencies.md
@@ -1,0 +1,9 @@
+---
+"@neondatabase/config-runtime": patch
+---
+
+Bundle function dependencies into the deploy archive.
+
+The default function bundler (`buildFunctionBundle`) ran esbuild with `--packages=external`, so npm dependencies were left as bare imports and never shipped. Since the Functions runtime has no `node_modules`, any function importing a third-party package failed to load at runtime (`Cannot find package '…'`).
+
+It now bundles dependencies into `index.mjs` (Node built-ins stay external on `platform: "node"`) and prepends a `createRequire` banner so bundled CommonJS dependencies work inside the ESM output (avoids `Dynamic require of "fs" is not supported`).

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -49,6 +49,8 @@ describe("buildFunctionBundle", () => {
 		// The bundled output should have inlined the imported constant.
 		const js = new TextDecoder().decode(files["index.mjs"]);
 		expect(js).toContain("hello from neon");
+		// The ESM↔CJS interop banner is prepended so bundled CommonJS deps can `require(...)`.
+		expect(js).toContain("createRequire");
 	});
 
 	test("throws a PlatformError when the source cannot be resolved", async () => {

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -18,6 +18,16 @@ export type FunctionBundler = (
 ) => Promise<Uint8Array>;
 
 /**
+ * Prepended to the ESM bundle. Bundled dependencies are frequently CommonJS, but an ESM
+ * output (`format: "esm"`) has no `require` / `__filename` / `__dirname` in scope — so any
+ * bundled CJS code that calls `require(...)` would fail at load with
+ * `Dynamic require of "x" is not supported`. Re-create those globals via `createRequire`
+ * so CJS and ESM dependencies coexist in the single `index.mjs`.
+ */
+const ESM_CJS_INTEROP_BANNER =
+	"import{createRequire as ___cr}from'module';import{fileURLToPath as ___f}from'url';import{dirname as ___d}from'path';const require=___cr(import.meta.url);const __filename=___f(import.meta.url);const __dirname=___d(__filename);";
+
+/**
  * Build the deployable bundle (a ZIP archive of the esbuild-bundled source) for a function.
  *
  * This is the **imperative shell** step of function deploys, and the reason it lives in
@@ -31,8 +41,10 @@ export type FunctionBundler = (
  * that nothing in this package's static graph names esbuild until a deploy actually runs —
  * a second layer of protection on top of the package split.
  *
- * Mirrors: `esbuild <source> --bundle --outfile=index.mjs --sourcemap --minify`, then zips
- * the emitted files into the archive the Functions deploy endpoint expects.
+ * Mirrors: `esbuild <source> --bundle --outfile=index.mjs --sourcemap --minify --format=esm
+ * --platform=node --banner:js=<createRequire shim>`, then zips the emitted files into the
+ * archive the Functions deploy endpoint expects. Dependencies are bundled into the entry
+ * (Node built-ins stay external); see {@link ESM_CJS_INTEROP_BANNER} for why the banner.
  */
 export async function buildFunctionBundle(
 	fn: ResolvedFunctionConfig,
@@ -54,8 +66,11 @@ export async function buildFunctionBundle(
 			minify: true,
 			format: "esm",
 			platform: "node",
-			// The Functions runtime provides Node built-ins; don't try to bundle them.
-			packages: "external",
+			// Bundle dependencies into the entry so the deployed archive is self-contained
+			// (the Functions runtime has no node_modules). Node built-ins stay external on
+			// `platform: "node"`. The banner re-creates require/__filename/__dirname so
+			// bundled CommonJS deps work inside the ESM output.
+			banner: { js: ESM_CJS_INTEROP_BANNER },
 			logLevel: "silent",
 		});
 	} catch (cause) {


### PR DESCRIPTION
## Summary

The default function bundler (`buildFunctionBundle`) ran esbuild with `--packages=external`, which leaves every npm dependency as a bare import and ships **none** of them. The Functions runtime has no `node_modules`, so any function importing a third-party package fails to load at runtime with `Cannot find package '…'`.

This changes the bundler to produce a **self-contained** ESM bundle:

```diff
- packages: "external",
+ banner: { js: ESM_CJS_INTEROP_BANNER },
```

- **Bundle dependencies** into `index.mjs` (Node built-ins stay external automatically on `platform: "node"`).
- **Add a `createRequire` banner** so bundled CommonJS deps work inside the ESM output — without it, bundled CJS code that calls `require(...)` dies with `Dynamic require of "fs" is not supported`. The banner re-creates `require` / `__filename` / `__dirname`:

```
import{createRequire as ___cr}from'module';import{fileURLToPath as ___f}from'url';import{dirname as ___d}from'path';const require=___cr(import.meta.url);const __filename=___f(import.meta.url);const __dirname=___d(__filename);
```

(`--sourcemap` / `--minify` are kept as-is.)

## Test plan

- [x] `tsc` clean for `@neondatabase/config-runtime`
- [x] `config-runtime` tests pass (44), incl. a new assertion that the bundle carries the `createRequire` banner
- [x] Verified end-to-end against staging: a Hono app importing `dotenv`/`hono`/`drizzle-orm`/`pg`, bundled this way, loads and serves `HTTP 200` (previously `502 function_load_failed`).

## Notes

- Standalone fix — independent of the `create-function`/405 fix (#184).
- neonctl ships its own bundler (`src/utils/esbuild.ts`) and injects it into `pushConfig`, so it doesn't use this default path; the matching neonctl change is in a separate PR.
- Follow-up (separate, runtime-side): the Functions runtime only accepts a *bare function* default export; `export default { fetch }` (Hono/Workers style) is rejected. Tracked separately.