### PR TITLE
chore: bump package versions

### DIFF
--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.4.2",
+	"version": "0.5.0",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.4.2",
+	"version": "0.5.0",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.3.2",
+	"version": "0.4.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Why?

To get recent changes released. neondatabase/neonctl#532 is blocked on exactly these versions — its `package.json` already pins `@neondatabase/config` / `@neondatabase/config-runtime` `0.5.0` and `@neondatabase/env` `0.4.0`, so its CI stays red until they're published.

Minor (not patch) bumps: the pending changesets declare the changes below as `minor`, including two interface removals (`createBranchFunction` is gone from `NeonApi`; `dev.portless` is gone from the function `dev` block).

## What?

- @neondatabase/config — 0.5.0
  - Branch-scoped service credentials (Preview): `NeonApi` gains `createCredential` / `listCredentials` / `revokeCredential` (the beta `…/credentials` endpoints) and `getProjectBranchStorage` (the beta `…/storage` endpoint), plus the credential scope/principal types and `deriveCredentialScopes` / `credentialScopesSatisfied` helpers (#181).
  - Functions are created via their first deployment: `createBranchFunction` is removed from `NeonApi` (the API has no standalone create endpoint — pushing a policy with a new function failed with HTTP 405), and the `deploy-function` plan step carries a `functionExists` flag (#184).
  - Precise `neon.ts` config error messages: rejected record keys report the actual reason (e.g. the function-slug rule) instead of `Invalid key in record`, and a `PlatformError` thrown during evaluation surfaces verbatim instead of the generic "TypeScript syntax error" hint. Adds `isPlatformError` (#184).
  - Remove the `dev.portless` function option; the `dev` block now supports only `dev.port` (#184).

- @neondatabase/config-runtime — 0.5.0
  - `pushConfig` emits a single `deploy-function` step per function, reported as a `create` (first deploy) or `update` (re-deploy) (#184).
  - Surface each deployed function's `invocationUrl` in `plan` / `apply` change details, so callers (e.g. `neonctl deploy`) can show where to call a function right after deploying it (#184).
  - `pullConfig` / `inspect` report secret-free issued-credential metadata under `preview.credentials` (#181).
  - Trim noise from `plan` / `apply` change details: plain branch toggles (`auth` / `dataApi` / `aiGateway`) no longer carry a `details` blob, and `bucket` / `function` changes drop the redundant `branchName` (#184).

- @neondatabase/env — 0.4.0
  - Two new env namespaces mapped onto SDK-standard names, backed by a minted branch credential: `env.storage` (when `preview.buckets`) → `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_ENDPOINT_URL_S3` / `AWS_REGION`, and `env.aiGateway` (when `preview.aiGateway`) → `OPENAI_API_KEY` / `OPENAI_BASE_URL`. Secrets already present in the env source are reused instead of re-minting a credential (#181).
  - Fix `OPENAI_BASE_URL` to point at the branch-scoped AI Gateway host (the old value used the control-plane API origin, which doesn't serve the gateway), and emit `NEON_AI_GATEWAY_TOKEN` / `NEON_AI_GATEWAY_BASE_URL` alongside the OpenAI vars (#184).

This pull request and its description were written by Isaac, Databricks's AI assistant (an AI agent built on Claude Code).
