### PR TITLE
feat(ai-sdk-provider): implement @neondatabase/ai-sdk-provider for the Neon AI Gateway

### DIFF
--- a/.changeset/ai-sdk-provider-impl.md
+++ b/.changeset/ai-sdk-provider-impl.md
@@ -1,0 +1,15 @@
+---
+"@neondatabase/ai-sdk-provider": minor
+---
+
+Implement the Neon AI Gateway provider (replaces the name-reservation placeholder).
+
+`createNeon()` / `neon` now return a working Vercel AI SDK provider that routes each model to the best branch-scoped gateway endpoint based on its id:
+
+- **Anthropic** (`databricks-claude-*`) → native Messages API (streaming structured output + native reasoning).
+- **OpenAI** (`databricks-gpt-*`, `*-codex`) → native Responses API (unlocks Codex, which is only served natively; native reasoning; the image-generation tool).
+- **Everything else** (Gemini, Llama, Qwen, gpt-oss, ...) → the unified, OpenAI-compatible MLflow endpoint. Gemini is routed here because its native gateway endpoint does not support streaming.
+
+Routing is transparent (same base URL + token). The implementation reuses the official `@ai-sdk/anthropic` and `@ai-sdk/openai` model classes, with gateway-compatibility shims (`forceReasoning` for `gpt-5` so reasoning handling works despite the `databricks-` prefix; `toolStreaming: false` for Anthropic so streaming tool calls aren't rejected) and a JSON Schema `$schema` strip for the unified endpoint. MLflow-routed models drop parameters a backend rejects (e.g. penalties/`seed` for Llama, `reasoningEffort` for Gemini) with an AI SDK warning instead of failing.
+
+Supports `generateText`, `streamText`, tool calling (single + multi-step + streaming), `generateObject`, `streamObject`, image (vision) input, and image generation via the OpenAI Responses `image_generation` tool (use `streamText`). Configure with `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN`, or pass `baseURL` / `apiKey` to `createNeon`.

--- a/.github/workflows/dist-typecheck.yml
+++ b/.github/workflows/dist-typecheck.yml
@@ -31,6 +31,8 @@ jobs:
                       dir: env
                     - name: "@neondatabase/functions"
                       dir: functions
+                    - name: "@neondatabase/ai-sdk-provider"
+                      dir: ai-sdk-provider
         steps:
             - name: Harden the runner (Audit all outbound calls)
               uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -1,0 +1,24 @@
+# @neondatabase/ai-sdk-provider
+
+Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://neon.com) AI Gateway.
+
+## Install
+
+```bash
+npm install @neondatabase/ai-sdk-provider
+```
+
+## Usage
+
+```ts
+import { createNeon } from "@neondatabase/ai-sdk-provider/v1";
+
+const neon = createNeon({
+	baseURL: process.env.NEON_AI_GATEWAY_BASE_URL,
+	apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+});
+```
+
+> **Status: not implemented yet.** This `0.0.0` release only reserves the
+> `@neondatabase/ai-sdk-provider` package name — `createNeon()` currently throws. The Neon AI
+> Gateway integration ships in a follow-up release.

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -2,23 +2,89 @@
 
 Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://neon.com) AI Gateway.
 
+The Neon AI Gateway is **branch-scoped**: each Neon project branch gets its own gateway host, and a platform token authorizes requests for that branch. This provider routes each model to the best gateway endpoint (Anthropic → native Messages, OpenAI → native Responses incl. **Codex**, everything else → unified OpenAI-compatible MLflow endpoint), so a single `neon('databricks-...')` call reaches the whole `databricks-*` catalog.
+
 ## Install
 
 ```bash
 npm install @neondatabase/ai-sdk-provider
 ```
 
+## Configuration
+
+The gateway URL is branch-scoped, so both values come from the Neon Console (your project → a branch → **AI Gateway** tab), or from `neonctl env pull` / `neon dev`:
+
+```bash
+NEON_AI_GATEWAY_BASE_URL="https://<branch-id>-api.ai.<region>.aws.neon.tech"
+NEON_AI_GATEWAY_TOKEN="nt_live_..."
+```
+
 ## Usage
+
+```ts
+import { neon } from "@neondatabase/ai-sdk-provider/v1";
+import { generateText } from "ai";
+
+// Reads NEON_AI_GATEWAY_BASE_URL + NEON_AI_GATEWAY_TOKEN from the environment.
+const { text } = await generateText({
+  model: neon("databricks-claude-haiku-4-5"), // or 'databricks-gpt-5-3-codex', etc.
+  prompt: "Summarize Postgres for me.",
+});
+```
+
+Or configure explicitly with `createNeon`:
 
 ```ts
 import { createNeon } from "@neondatabase/ai-sdk-provider/v1";
 
 const neon = createNeon({
-	baseURL: process.env.NEON_AI_GATEWAY_BASE_URL,
-	apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
+  baseURL: process.env.NEON_AI_GATEWAY_BASE_URL,
+  apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
 });
 ```
 
-> **Status: not implemented yet.** This `0.0.0` release only reserves the
-> `@neondatabase/ai-sdk-provider` package name — `createNeon()` currently throws. The Neon AI
-> Gateway integration ships in a follow-up release.
+## Routing
+
+| Model family | Endpoint | Why |
+| --- | --- | --- |
+| Anthropic (`databricks-claude-*`) | native Messages API | streaming structured output + native reasoning |
+| OpenAI (`databricks-gpt-*`, `*-codex`) | native Responses API | Codex (native-only), native reasoning, image-gen tool |
+| Everything else (Gemini, Llama, Qwen, gpt-oss, ...) | unified MLflow endpoint | broad coverage; Gemini is here because its native endpoint does not support streaming |
+
+## Capabilities
+
+Verified across Anthropic, OpenAI (incl. Codex), Google, and Meta models: `generateText` / `streamText` (text, system prompts, multi-turn), tool calling (single and multi-step, generate and stream), `generateObject` / `streamObject`, and image (vision) input.
+
+For MLflow-routed models, the provider detects the model family and drops parameters a backend rejects (e.g. penalties/`seed` for Llama, `reasoningEffort` for Gemini) with an AI SDK warning (`result.warnings`) instead of failing the request.
+
+## Image generation
+
+Available on OpenAI models via the Responses `image_generation` tool (there is no `generateImage()` image-model endpoint). Use `streamText` — streaming returns the image as a `tool-result` part and avoids the gateway's non-streaming response-size cap and read timeout:
+
+```ts
+import { streamText } from "ai";
+import { neon } from "@neondatabase/ai-sdk-provider/v1";
+import { imageGeneration } from "@ai-sdk/openai/internal";
+
+const result = streamText({
+  model: neon("databricks-gpt-5-mini"),
+  prompt: "Generate an image of a red apple on a wooden table",
+  tools: { image: imageGeneration({ partialImages: 3 }) },
+});
+
+for await (const part of result.fullStream) {
+  if (part.type === "tool-result" && "result" in part.output) {
+    const png = Buffer.from(part.output.result as string, "base64");
+    // save or use the image
+  }
+}
+```
+
+## Limitations
+
+- `generateImage()` and embeddings (`embed` / `embedMany`) are not offered by the gateway and throw `NoSuchModelError`.
+- `gpt-oss-*` models return a non-standard ("harmony") response shape on the unified endpoint and are not fully supported.
+
+## Versioning
+
+Import from `@neondatabase/ai-sdk-provider/v1` to pin to a specific major. The default entry re-exports the latest stable version.

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,0 +1,66 @@
+{
+	"name": "@neondatabase/ai-sdk-provider",
+	"version": "0.0.0",
+	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
+	"keywords": [
+		"neon",
+		"ai",
+		"ai-sdk",
+		"vercel-ai-sdk",
+		"provider",
+		"ai-gateway",
+		"llm",
+		"platform"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/neondatabase/neon-pkgs.git"
+	},
+	"license": "Apache-2.0",
+	"author": {
+		"name": "Neon",
+		"url": "https://neon.com"
+	},
+	"type": "module",
+	"main": "dist/index.js",
+	"types": "dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js",
+			"default": "./dist/index.js"
+		},
+		"./v1": {
+			"types": "./dist/v1.d.ts",
+			"import": "./dist/v1.js",
+			"default": "./dist/v1.js"
+		}
+	},
+	"files": [
+		"README.md",
+		"dist/",
+		"package.json"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsdown",
+		"prepare": "npm run build",
+		"test": "vitest --passWithNoTests",
+		"test:ci": "vitest run --passWithNoTests",
+		"tsc": "tsc"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"@vitest/coverage-v8": "3.0.9",
+		"console-fail-test": "0.5.0",
+		"tsdown": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"packageManager": "pnpm@10.4.0",
+	"engines": {
+		"node": ">=22"
+	},
+	"publishConfig": {
+		"provenance": false
+	}
+}

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -54,7 +54,8 @@
 		"console-fail-test": "0.5.0",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
-		"vitest": "catalog:"
+		"vitest": "catalog:",
+		"zod": "^4.4.3"
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
@@ -62,5 +63,15 @@
 	},
 	"publishConfig": {
 		"provenance": false
+	},
+	"dependencies": {
+		"@ai-sdk/anthropic": "4.0.0-beta.42",
+		"@ai-sdk/openai": "4.0.0-beta.44",
+		"@ai-sdk/openai-compatible": "3.0.0-beta.36",
+		"@ai-sdk/provider": "4.0.0-beta.14",
+		"@ai-sdk/provider-utils": "5.0.0-beta.30"
+	},
+	"peerDependencies": {
+		"zod": "^3.25.76 || ^4.1.8"
 	}
 }

--- a/packages/ai-sdk-provider/src/index.ts
+++ b/packages/ai-sdk-provider/src/index.ts
@@ -1,0 +1,5 @@
+/**
+ * The default entry point re-exports the latest stable version. New consumers should import
+ * directly from `@neondatabase/ai-sdk-provider/v1` to opt in to a specific major.
+ */
+export * from "./v1.js";

--- a/packages/ai-sdk-provider/src/lib/neon-anthropic-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-anthropic-language-model.ts
@@ -1,0 +1,51 @@
+import { AnthropicLanguageModel } from "@ai-sdk/anthropic/internal";
+import type {
+	LanguageModelV4,
+	LanguageModelV4CallOptions,
+	LanguageModelV4GenerateResult,
+	LanguageModelV4StreamResult,
+} from "@ai-sdk/provider";
+
+/**
+ * Language model for Anthropic models served via the Neon AI Gateway's native
+ * Messages API (`/ai-gateway/anthropic/v1/messages`). Unlocks streaming
+ * structured output and native reasoning for Claude.
+ *
+ * The shared Anthropic model defaults to fine-grained tool-input streaming
+ * (`eager_input_streaming: true`) on streaming tool calls, which the gateway
+ * rejects (`Extra inputs are not permitted`). We disable it via the model's own
+ * `toolStreaming` option so streaming tool calls work. Users can still override.
+ */
+export class NeonAnthropicLanguageModel
+	extends AnthropicLanguageModel
+	implements LanguageModelV4
+{
+	private withGatewayCompat(
+		options: LanguageModelV4CallOptions,
+	): LanguageModelV4CallOptions {
+		const anthropic = options.providerOptions?.anthropic;
+		// Respect an explicit user setting.
+		if (anthropic != null && "toolStreaming" in anthropic) {
+			return options;
+		}
+		return {
+			...options,
+			providerOptions: {
+				...options.providerOptions,
+				anthropic: { ...anthropic, toolStreaming: false },
+			},
+		};
+	}
+
+	override doGenerate(
+		options: LanguageModelV4CallOptions,
+	): Promise<LanguageModelV4GenerateResult> {
+		return super.doGenerate(this.withGatewayCompat(options));
+	}
+
+	override doStream(
+		options: LanguageModelV4CallOptions,
+	): Promise<LanguageModelV4StreamResult> {
+		return super.doStream(this.withGatewayCompat(options));
+	}
+}

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
@@ -1,0 +1,133 @@
+import type {
+	LanguageModelV4CallOptions,
+	LanguageModelV4StreamPart,
+	SharedV4ProviderOptions,
+	SharedV4Warning,
+} from "@ai-sdk/provider";
+import { isCustomReasoning } from "@ai-sdk/provider-utils";
+import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
+
+/**
+ * Drop call options the resolved model's upstream backend does not accept and
+ * collect a warning for each, so callers get a clear signal instead of a hard
+ * `400` from the gateway.
+ */
+export function applyNeonCapabilities(
+	modelId: string,
+	options: LanguageModelV4CallOptions,
+): { options: LanguageModelV4CallOptions; warnings: SharedV4Warning[] } {
+	const caps = getNeonModelCapabilities(modelId);
+	const warnings: SharedV4Warning[] = [];
+	const patch: Partial<LanguageModelV4CallOptions> = {};
+
+	const dropUnsupported = (feature: string) => {
+		warnings.push({
+			type: "unsupported",
+			feature,
+			details: `${feature} is not supported by the Neon AI Gateway for ${caps.family} model "${modelId}" and was dropped.`,
+		});
+	};
+
+	if (options.temperature != null && !caps.supportsTemperature) {
+		patch.temperature = undefined;
+		dropUnsupported("temperature");
+	}
+	if (options.topP != null && !caps.supportsTopP) {
+		patch.topP = undefined;
+		dropUnsupported("topP");
+	}
+
+	// Anthropic-style models accept only one of temperature / topP.
+	const effectiveTemperature =
+		"temperature" in patch ? patch.temperature : options.temperature;
+	const effectiveTopP = "topP" in patch ? patch.topP : options.topP;
+	if (
+		caps.temperatureTopPMutuallyExclusive &&
+		effectiveTemperature != null &&
+		effectiveTopP != null
+	) {
+		patch.topP = undefined;
+		warnings.push({
+			type: "compatibility",
+			feature: "topP",
+			details: `${caps.family} models accept only one of temperature or topP; topP was dropped.`,
+		});
+	}
+
+	if (options.frequencyPenalty != null && !caps.supportsPenalties) {
+		patch.frequencyPenalty = undefined;
+		dropUnsupported("frequencyPenalty");
+	}
+	if (options.presencePenalty != null && !caps.supportsPenalties) {
+		patch.presencePenalty = undefined;
+		dropUnsupported("presencePenalty");
+	}
+	if (options.seed != null && !caps.supportsSeed) {
+		patch.seed = undefined;
+		dropUnsupported("seed");
+	}
+	if (options.stopSequences != null && !caps.supportsStopSequences) {
+		patch.stopSequences = undefined;
+		dropUnsupported("stopSequences");
+	}
+
+	if (!caps.supportsReasoningEffort) {
+		const { providerOptions } = options;
+		const hasProviderEffort =
+			providerOptions != null &&
+			Object.values(providerOptions).some(
+				(group) =>
+					"reasoningEffort" in group && group.reasoningEffort != null,
+			);
+		const hasReasoningOption =
+			isCustomReasoning(options.reasoning) &&
+			options.reasoning !== "none";
+
+		if (hasProviderEffort || hasReasoningOption) {
+			dropUnsupported("reasoningEffort");
+			if (hasProviderEffort && providerOptions != null) {
+				const cleaned: SharedV4ProviderOptions = {};
+				for (const [key, group] of Object.entries(providerOptions)) {
+					if ("reasoningEffort" in group) {
+						const { reasoningEffort: _removed, ...rest } = group;
+						cleaned[key] = rest;
+					} else {
+						cleaned[key] = group;
+					}
+				}
+				patch.providerOptions = cleaned;
+			}
+			if (hasReasoningOption) {
+				patch.reasoning = undefined;
+			}
+		}
+	}
+
+	if (Object.keys(patch).length === 0) {
+		return { options, warnings };
+	}
+	return { options: { ...options, ...patch }, warnings };
+}
+
+/**
+ * Merge additional warnings into the `stream-start` part of a model stream.
+ */
+export function mergeStreamStartWarnings(extra: SharedV4Warning[]) {
+	let merged = false;
+	return new TransformStream<
+		LanguageModelV4StreamPart,
+		LanguageModelV4StreamPart
+	>({
+		transform(part, controller) {
+			if (!merged && part.type === "stream-start") {
+				merged = true;
+				controller.enqueue({
+					...part,
+					warnings: [...extra, ...part.warnings],
+				});
+			} else {
+				controller.enqueue(part);
+			}
+		},
+	});
+}

--- a/packages/ai-sdk-provider/src/lib/neon-chat-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-chat-language-model.ts
@@ -1,0 +1,56 @@
+import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible";
+import type {
+	LanguageModelV4,
+	LanguageModelV4CallOptions,
+	LanguageModelV4GenerateResult,
+	LanguageModelV4StreamResult,
+} from "@ai-sdk/provider";
+import {
+	applyNeonCapabilities,
+	mergeStreamStartWarnings,
+} from "./neon-capabilities.js";
+
+/**
+ * Language model for the Neon AI Gateway unified (MLflow) endpoint.
+ *
+ * Used for every model that is not routed to a provider-native endpoint
+ * (Gemini, Llama, Qwen, gpt-oss, ...). It is a thin specialization of the shared
+ * OpenAI-compatible chat model that adds per-model capability handling:
+ * parameters an upstream backend is known to reject are dropped and reported as
+ * warnings instead of failing the request.
+ */
+export class NeonChatLanguageModel
+	extends OpenAICompatibleChatLanguageModel
+	implements LanguageModelV4
+{
+	override async doGenerate(
+		options: LanguageModelV4CallOptions,
+	): Promise<LanguageModelV4GenerateResult> {
+		const { options: adjusted, warnings } = applyNeonCapabilities(
+			this.modelId,
+			options,
+		);
+		const result = await super.doGenerate(adjusted);
+		return warnings.length > 0
+			? { ...result, warnings: [...warnings, ...result.warnings] }
+			: result;
+	}
+
+	override async doStream(
+		options: LanguageModelV4CallOptions,
+	): Promise<LanguageModelV4StreamResult> {
+		const { options: adjusted, warnings } = applyNeonCapabilities(
+			this.modelId,
+			options,
+		);
+		const result = await super.doStream(adjusted);
+		return warnings.length > 0
+			? {
+					...result,
+					stream: result.stream.pipeThrough(
+						mergeStreamStartWarnings(warnings),
+					),
+				}
+			: result;
+	}
+}

--- a/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
@@ -1,0 +1,48 @@
+// Models served by the Neon AI Gateway. Anthropic and OpenAI models are routed
+// to their provider-native endpoints; everything else uses the unified MLflow
+// (OpenAI-compatible) endpoint.
+//
+// The authoritative, always-current catalog is shown in the Neon Console under
+// the branch's "AI Gateway" tab. Any other id can be passed as a plain string
+// via the `(string & {})` fallback.
+export type NeonChatModelId =
+	// Anthropic (native Messages API)
+	| "databricks-claude-opus-4-8"
+	| "databricks-claude-opus-4-7"
+	| "databricks-claude-opus-4-6"
+	| "databricks-claude-opus-4-5"
+	| "databricks-claude-opus-4-1"
+	| "databricks-claude-sonnet-4-6"
+	| "databricks-claude-sonnet-4-5"
+	| "databricks-claude-sonnet-4"
+	| "databricks-claude-haiku-4-5"
+	// OpenAI (native Responses API, incl. Codex)
+	| "databricks-gpt-5"
+	| "databricks-gpt-5-mini"
+	| "databricks-gpt-5-nano"
+	| "databricks-gpt-5-1"
+	| "databricks-gpt-5-2"
+	| "databricks-gpt-5-2-codex"
+	| "databricks-gpt-5-3-codex"
+	| "databricks-gpt-5-4"
+	| "databricks-gpt-5-4-mini"
+	| "databricks-gpt-5-4-nano"
+	| "databricks-gpt-5-5"
+	| "databricks-gpt-5-5-pro"
+	// OpenAI open-weight (unified MLflow endpoint)
+	| "databricks-gpt-oss-120b"
+	| "databricks-gpt-oss-20b"
+	// Google (unified MLflow endpoint)
+	| "databricks-gemini-3-5-flash"
+	| "databricks-gemini-3-1-flash-lite"
+	| "databricks-gemini-2-5-pro"
+	| "databricks-gemini-2-5-flash"
+	| "databricks-gemma-3-12b"
+	// Meta (unified MLflow endpoint)
+	| "databricks-llama-4-maverick"
+	| "databricks-meta-llama-3-3-70b-instruct"
+	| "databricks-meta-llama-3-1-8b-instruct"
+	// Alibaba (unified MLflow endpoint)
+	| "databricks-qwen3-next-80b-a3b-instruct"
+	| "databricks-qwen35-122b-a10b"
+	| (string & {});

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+	getNeonModelCapabilities,
+	getNeonModelRoute,
+} from "./neon-model-capabilities.js";
+
+describe("getNeonModelRoute", () => {
+	it("routes Anthropic and OpenAI models to their native endpoints", () => {
+		expect(getNeonModelRoute("databricks-claude-opus-4-8")).toBe(
+			"anthropic",
+		);
+		expect(getNeonModelRoute("databricks-claude-haiku-4-5")).toBe(
+			"anthropic",
+		);
+		expect(getNeonModelRoute("databricks-gpt-5")).toBe("openai");
+		expect(getNeonModelRoute("databricks-gpt-5-mini")).toBe("openai");
+		expect(getNeonModelRoute("databricks-gpt-5-3-codex")).toBe("openai");
+	});
+
+	it("falls back to the unified MLflow endpoint for everything else", () => {
+		// Gemini is routed to MLflow because its native endpoint cannot stream.
+		expect(getNeonModelRoute("databricks-gemini-2-5-flash")).toBe("mlflow");
+		expect(getNeonModelRoute("databricks-llama-4-maverick")).toBe("mlflow");
+		expect(getNeonModelRoute("databricks-qwen35-122b-a10b")).toBe("mlflow");
+		// gpt-oss is open-weight and served on the unified endpoint, not Responses.
+		expect(getNeonModelRoute("databricks-gpt-oss-120b")).toBe("mlflow");
+	});
+});
+
+describe("getNeonModelCapabilities", () => {
+	it("marks Anthropic models correctly", () => {
+		const caps = getNeonModelCapabilities("databricks-claude-haiku-4-5");
+		expect(caps.family).toBe("anthropic");
+		expect(caps.supportsPenalties).toBe(false);
+		expect(caps.supportsSeed).toBe(false);
+		expect(caps.temperatureTopPMutuallyExclusive).toBe(true);
+		expect(caps.supportsReasoningEffort).toBe(false);
+	});
+
+	it("marks plain GPT-5 reasoning models without temperature/topP support", () => {
+		const caps = getNeonModelCapabilities("databricks-gpt-5-mini");
+		expect(caps.family).toBe("openai");
+		expect(caps.supportsTemperature).toBe(false);
+		expect(caps.supportsTopP).toBe(false);
+	});
+
+	it("keeps temperature for gpt-5.1+ models", () => {
+		const caps = getNeonModelCapabilities("databricks-gpt-5-1");
+		expect(caps.supportsTemperature).toBe(true);
+		expect(caps.supportsTopP).toBe(true);
+	});
+
+	it("marks Meta models without penalties/seed support", () => {
+		const caps = getNeonModelCapabilities("databricks-llama-4-maverick");
+		expect(caps.family).toBe("meta");
+		expect(caps.supportsPenalties).toBe(false);
+		expect(caps.supportsSeed).toBe(false);
+	});
+
+	it("is permissive for unknown models", () => {
+		const caps = getNeonModelCapabilities("databricks-qwen35-122b-a10b");
+		expect(caps.family).toBe("other");
+		expect(caps.supportsPenalties).toBe(true);
+		expect(caps.supportsReasoningEffort).toBe(true);
+	});
+});

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
@@ -1,0 +1,137 @@
+export type NeonModelFamily =
+	| "anthropic"
+	| "google"
+	| "openai"
+	| "meta"
+	| "other";
+
+/**
+ * Which gateway endpoint a model should be routed to.
+ *
+ * - `anthropic`: native Messages API — streaming structured output + native reasoning.
+ * - `openai`: native Responses API — models served only natively (e.g. Codex),
+ *   native reasoning, and the image-generation tool.
+ * - `mlflow`: the unified, OpenAI-compatible endpoint (the fallback). Gemini is
+ *   routed here because the gateway's native Gemini endpoint does not support
+ *   streaming (`streamGenerateContent` is rejected).
+ */
+export type NeonModelRoute = "anthropic" | "openai" | "mlflow";
+
+export function getNeonModelRoute(modelId: string): NeonModelRoute {
+	const id = modelId.toLowerCase();
+	if (id.includes("claude")) {
+		return "anthropic";
+	}
+	// OpenAI proprietary models (gpt-4/gpt-5 families, Codex) are served only via
+	// the native Responses API. `gpt-oss` is open-weight and served on the
+	// unified chat endpoint, so it is intentionally excluded here.
+	if (
+		(id.includes("gpt-") && !id.includes("gpt-oss")) ||
+		id.includes("codex")
+	) {
+		return "openai";
+	}
+	return "mlflow";
+}
+
+export interface NeonModelCapabilities {
+	family: NeonModelFamily;
+	supportsTemperature: boolean;
+	supportsTopP: boolean;
+	/**
+	 * Whether `temperature` and `topP` may be sent together. Anthropic models
+	 * accept only one of the two.
+	 */
+	temperatureTopPMutuallyExclusive: boolean;
+	supportsPenalties: boolean;
+	supportsSeed: boolean;
+	supportsStopSequences: boolean;
+	supportsReasoningEffort: boolean;
+}
+
+const PERMISSIVE: Omit<NeonModelCapabilities, "family"> = {
+	supportsTemperature: true,
+	supportsTopP: true,
+	temperatureTopPMutuallyExclusive: false,
+	supportsPenalties: true,
+	supportsSeed: true,
+	supportsStopSequences: true,
+	supportsReasoningEffort: true,
+};
+
+/**
+ * Heuristic, prefix-based capability detection for MLflow-routed Neon models.
+ *
+ * The unified endpoint proxies to heterogeneous upstream providers, each of
+ * which accepts a different subset of the OpenAI-style parameters the AI SDK
+ * emits. Sending a parameter an upstream rejects results in a hard `400`, so we
+ * strip the parameters a family is known to reject and surface a warning
+ * instead. Unknown/untested models stay permissive (passed through unchanged).
+ */
+export function getNeonModelCapabilities(
+	modelId: string,
+): NeonModelCapabilities {
+	const id = modelId.toLowerCase();
+
+	// Anthropic (Claude): rejects penalties and seed, accepts only one of
+	// temperature/topP, and rejects the OpenAI `reasoning_effort` field.
+	if (id.includes("claude")) {
+		return {
+			family: "anthropic",
+			supportsTemperature: true,
+			supportsTopP: true,
+			temperatureTopPMutuallyExclusive: true,
+			supportsPenalties: false,
+			supportsSeed: false,
+			supportsStopSequences: true,
+			supportsReasoningEffort: false,
+		};
+	}
+
+	// Google (Gemini): accepts standard sampling params but rejects the OpenAI
+	// `reasoning_effort` field (not part of Gemini's generation config).
+	if (id.includes("gemini")) {
+		return {
+			family: "google",
+			...PERMISSIVE,
+			supportsReasoningEffort: false,
+		};
+	}
+
+	// OpenAI GPT-5 reasoning family (routed to the native Responses API). The
+	// Responses model strips parameters the Responses API doesn't accept
+	// (penalties, seed, stop), but its reasoning-model detection matches the bare
+	// model id (`gpt-5`), which the gateway's `databricks-` prefix defeats. So we
+	// only handle the temperature/topP restriction here: the original gpt-5 /
+	// gpt-5-mini / gpt-5-nano require the default temperature and reject topP,
+	// while gpt-5.1+ (a minor version digit follows) accept them again.
+	if (/gpt-5/.test(id)) {
+		const hasMinorVersion = /gpt-5[.-]\d/.test(id);
+		return {
+			family: "openai",
+			supportsTemperature: hasMinorVersion,
+			supportsTopP: hasMinorVersion,
+			temperatureTopPMutuallyExclusive: false,
+			supportsPenalties: true,
+			supportsSeed: true,
+			supportsStopSequences: true,
+			supportsReasoningEffort: true,
+		};
+	}
+
+	// Meta (Llama): rejects penalties and seed; accepts sampling params and stop.
+	if (id.includes("llama")) {
+		return {
+			family: "meta",
+			supportsTemperature: true,
+			supportsTopP: true,
+			temperatureTopPMutuallyExclusive: false,
+			supportsPenalties: false,
+			supportsSeed: false,
+			supportsStopSequences: true,
+			supportsReasoningEffort: true,
+		};
+	}
+
+	return { family: "other", ...PERMISSIVE };
+}

--- a/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
@@ -1,0 +1,60 @@
+import { OpenAIResponsesLanguageModel } from "@ai-sdk/openai/internal";
+import type {
+	LanguageModelV4,
+	LanguageModelV4CallOptions,
+	LanguageModelV4GenerateResult,
+	LanguageModelV4StreamResult,
+} from "@ai-sdk/provider";
+
+/**
+ * Language model for OpenAI models served via the Neon AI Gateway's native
+ * Responses API (`/ai-gateway/openai/v1/responses`). This route is required for
+ * models that are only served natively (e.g. Codex) and unlocks native
+ * reasoning and the image-generation tool.
+ *
+ * The shared OpenAI Responses model shapes a request based on whether the model
+ * is a reasoning model, but it detects that from the bare model id (`gpt-5`),
+ * which the gateway's required `databricks-` prefix defeats. For the GPT-5
+ * reasoning family we set the model's own `forceReasoning` provider option so it
+ * applies the correct reasoning behavior. Users can still override it.
+ */
+export class NeonResponsesLanguageModel
+	extends OpenAIResponsesLanguageModel
+	implements LanguageModelV4
+{
+	private get isReasoningFamily(): boolean {
+		return /gpt-5/.test(this.modelId.toLowerCase());
+	}
+
+	private withForcedReasoning(
+		options: LanguageModelV4CallOptions,
+	): LanguageModelV4CallOptions {
+		if (!this.isReasoningFamily) {
+			return options;
+		}
+		const openai = options.providerOptions?.openai;
+		// Respect an explicit user setting.
+		if (openai != null && "forceReasoning" in openai) {
+			return options;
+		}
+		return {
+			...options,
+			providerOptions: {
+				...options.providerOptions,
+				openai: { ...openai, forceReasoning: true },
+			},
+		};
+	}
+
+	override doGenerate(
+		options: LanguageModelV4CallOptions,
+	): Promise<LanguageModelV4GenerateResult> {
+		return super.doGenerate(this.withForcedReasoning(options));
+	}
+
+	override doStream(
+		options: LanguageModelV4CallOptions,
+	): Promise<LanguageModelV4StreamResult> {
+		return super.doStream(this.withForcedReasoning(options));
+	}
+}

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -1,36 +1,211 @@
 /**
  * Community Vercel AI SDK provider for the Neon AI Gateway.
  *
- * The surface mirrors other AI SDK providers — a `createNeon()` factory that returns a
- * provider object (see https://ai-sdk.dev/providers/community-providers). The real
- * implementation wraps the branch-scoped Neon AI Gateway (`NEON_AI_GATEWAY_BASE_URL` +
- * `NEON_AI_GATEWAY_TOKEN`) emitted by `neonctl env pull` / `neon dev`.
- *
- * NOT IMPLEMENTED YET: this `0.0.0` release only reserves the
- * `@neondatabase/ai-sdk-provider` package name. The integration ships in a follow-up release.
+ * `createNeon()` returns a provider that routes each model to the best gateway
+ * endpoint based on its id (Anthropic → native Messages, OpenAI → native
+ * Responses incl. Codex, everything else → unified MLflow), so a single
+ * `neon('databricks-...')` call (same base URL + token) reaches the whole
+ * catalog. Configure with the branch-scoped `NEON_AI_GATEWAY_BASE_URL` +
+ * `NEON_AI_GATEWAY_TOKEN` emitted by `neonctl env pull` / `neon dev`, or pass
+ * `baseURL` / `apiKey` explicitly.
  */
+import type { ProviderErrorStructure } from "@ai-sdk/openai-compatible";
+import {
+	type LanguageModelV4,
+	NoSuchModelError,
+	type ProviderV4,
+} from "@ai-sdk/provider";
+import {
+	type FetchFunction,
+	generateId,
+	loadApiKey,
+	loadSetting,
+	withoutTrailingSlash,
+	withUserAgentSuffix,
+} from "@ai-sdk/provider-utils";
+import { z } from "zod/v4";
+import { NeonAnthropicLanguageModel } from "./neon-anthropic-language-model.js";
+import { NeonChatLanguageModel } from "./neon-chat-language-model.js";
+import type { NeonChatModelId } from "./neon-chat-options.js";
+import { getNeonModelRoute } from "./neon-model-capabilities.js";
+import { NeonResponsesLanguageModel } from "./neon-responses-language-model.js";
+import { VERSION } from "./version.js";
 
-/** Configuration for {@link createNeon}. */
-export type NeonProviderSettings = {
-	/** Neon AI Gateway base URL, e.g. the branch-scoped `NEON_AI_GATEWAY_BASE_URL`. */
-	baseURL?: string;
-	/** Neon AI Gateway token, e.g. `NEON_AI_GATEWAY_TOKEN`. */
-	apiKey?: string;
-};
+const neonErrorSchema = z.object({
+	error: z.object({
+		message: z.string(),
+		type: z.string().nullish(),
+		param: z.unknown().nullish(),
+		code: z.unknown().nullish(),
+	}),
+});
 
-/** The Neon AI SDK provider. The model surface is added in the first real release. */
-export type NeonProvider = {
-	readonly providerId: "neon";
+export type NeonErrorData = z.infer<typeof neonErrorSchema>;
+
+const neonErrorStructure: ProviderErrorStructure<NeonErrorData> = {
+	errorSchema: neonErrorSchema,
+	errorToMessage: (data) => data.error.message,
 };
 
 /**
- * Creates a Neon AI SDK provider.
- *
- * NOT IMPLEMENTED YET: calling this throws. The `0.0.0` release is a name-reservation
- * placeholder; the Neon AI Gateway integration ships in a follow-up release.
+ * Recursively remove the JSON Schema `$schema` marker, which some gateway
+ * backends (notably Gemini) reject in tool/structured-output schemas. Other
+ * backends ignore its absence, so stripping it everywhere is safe.
  */
-export function createNeon(_settings: NeonProviderSettings = {}): NeonProvider {
-	throw new Error(
-		"@neondatabase/ai-sdk-provider is not implemented yet (0.0.0 name-reservation release).",
-	);
+function stripJsonSchemaMarker(value: unknown): unknown {
+	if (Array.isArray(value)) {
+		return value.map(stripJsonSchemaMarker);
+	}
+	if (value !== null && typeof value === "object") {
+		const result: Record<string, unknown> = {};
+		for (const [key, entry] of Object.entries(value)) {
+			if (key === "$schema") {
+				continue;
+			}
+			result[key] = stripJsonSchemaMarker(entry);
+		}
+		return result;
+	}
+	return value;
 }
+
+function transformNeonRequestBody(
+	args: Record<string, unknown>,
+): Record<string, unknown> {
+	const transformed = { ...args };
+	if (transformed.tools != null) {
+		transformed.tools = stripJsonSchemaMarker(transformed.tools);
+	}
+	if (transformed.response_format != null) {
+		transformed.response_format = stripJsonSchemaMarker(
+			transformed.response_format,
+		);
+	}
+	return transformed;
+}
+
+export interface NeonProviderSettings {
+	/**
+	 * Neon AI Gateway base URL — the branch-scoped host root, e.g.
+	 * `https://<branch-id>-api.ai.<region>.aws.neon.tech`. The gateway paths are
+	 * appended internally. Falls back to the `NEON_AI_GATEWAY_BASE_URL` env var.
+	 */
+	baseURL?: string;
+
+	/**
+	 * Neon AI Gateway platform token (the `nt_live_...` value). Falls back to the
+	 * `NEON_AI_GATEWAY_TOKEN` env var.
+	 */
+	apiKey?: string;
+
+	/** Custom headers to include in the requests. */
+	headers?: Record<string, string>;
+
+	/** Custom fetch implementation (e.g. for testing or middleware). */
+	fetch?: FetchFunction;
+}
+
+export interface NeonProvider extends ProviderV4 {
+	/** Creates a Neon AI Gateway model for text generation. */
+	(modelId: NeonChatModelId): LanguageModelV4;
+
+	/** Creates a Neon AI Gateway model for text generation. */
+	languageModel(modelId: NeonChatModelId): LanguageModelV4;
+
+	/** Creates a Neon AI Gateway chat model for text generation. */
+	chat(modelId: NeonChatModelId): LanguageModelV4;
+
+	/** @deprecated Use `embeddingModel` instead. */
+	textEmbeddingModel(modelId: string): never;
+}
+
+export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
+	// Resolved lazily so that `createNeon()` and the default `neon` instance do
+	// not throw at import time when configuration comes from the environment.
+	const getHost = () =>
+		withoutTrailingSlash(
+			loadSetting({
+				settingValue: options.baseURL,
+				environmentVariableName: "NEON_AI_GATEWAY_BASE_URL",
+				settingName: "baseURL",
+				description: "Neon AI Gateway base URL",
+			}),
+		);
+
+	const getHeaders = (extra?: Record<string, string>) =>
+		withUserAgentSuffix(
+			{
+				Authorization: `Bearer ${loadApiKey({
+					apiKey: options.apiKey,
+					environmentVariableName: "NEON_AI_GATEWAY_TOKEN",
+					description: "Neon AI Gateway token",
+				})}`,
+				...extra,
+				...options.headers,
+			},
+			`neondatabase/ai-sdk-provider/${VERSION}`,
+		);
+
+	// Anthropic models -> native Messages API.
+	const createAnthropicModel = (modelId: NeonChatModelId) =>
+		new NeonAnthropicLanguageModel(modelId, {
+			provider: "neon.anthropic",
+			baseURL: `${getHost()}/ai-gateway/anthropic/v1`,
+			headers: () => getHeaders({ "anthropic-version": "2023-06-01" }),
+			fetch: options.fetch,
+			generateId,
+		});
+
+	// OpenAI models (incl. Codex, only served natively) -> Responses API.
+	const createOpenAIModel = (modelId: NeonChatModelId) =>
+		new NeonResponsesLanguageModel(modelId, {
+			provider: "neon.openai.responses",
+			url: ({ path }) => `${getHost()}/ai-gateway/openai/v1${path}`,
+			headers: getHeaders,
+			fetch: options.fetch,
+			fileIdPrefixes: ["file-"],
+		});
+
+	// Everything else (Gemini, Llama, Qwen, gpt-oss, ...) -> unified MLflow
+	// endpoint. Gemini is here because its native endpoint can't stream.
+	const createChatModel = (modelId: NeonChatModelId) =>
+		new NeonChatLanguageModel(modelId, {
+			provider: "neon.chat",
+			url: ({ path }) => `${getHost()}/ai-gateway/mlflow/v1${path}`,
+			headers: getHeaders,
+			fetch: options.fetch,
+			errorStructure: neonErrorStructure,
+			transformRequestBody: transformNeonRequestBody,
+			supportsStructuredOutputs: true,
+		});
+
+	const createLanguageModel = (modelId: NeonChatModelId): LanguageModelV4 => {
+		switch (getNeonModelRoute(modelId)) {
+			case "anthropic":
+				return createAnthropicModel(modelId);
+			case "openai":
+				return createOpenAIModel(modelId);
+			default:
+				return createChatModel(modelId);
+		}
+	};
+
+	const provider = (modelId: NeonChatModelId) => createLanguageModel(modelId);
+
+	provider.specificationVersion = "v4" as const;
+	provider.languageModel = createLanguageModel;
+	provider.chat = createLanguageModel;
+
+	provider.embeddingModel = (modelId: string) => {
+		throw new NoSuchModelError({ modelId, modelType: "embeddingModel" });
+	};
+	provider.textEmbeddingModel = provider.embeddingModel;
+	provider.imageModel = (modelId: string) => {
+		throw new NoSuchModelError({ modelId, modelType: "imageModel" });
+	};
+
+	return provider;
+}
+
+/** Default Neon provider instance (reads `NEON_AI_GATEWAY_*` env vars). */
+export const neon = createNeon();

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -1,0 +1,36 @@
+/**
+ * Community Vercel AI SDK provider for the Neon AI Gateway.
+ *
+ * The surface mirrors other AI SDK providers — a `createNeon()` factory that returns a
+ * provider object (see https://ai-sdk.dev/providers/community-providers). The real
+ * implementation wraps the branch-scoped Neon AI Gateway (`NEON_AI_GATEWAY_BASE_URL` +
+ * `NEON_AI_GATEWAY_TOKEN`) emitted by `neonctl env pull` / `neon dev`.
+ *
+ * NOT IMPLEMENTED YET: this `0.0.0` release only reserves the
+ * `@neondatabase/ai-sdk-provider` package name. The integration ships in a follow-up release.
+ */
+
+/** Configuration for {@link createNeon}. */
+export type NeonProviderSettings = {
+	/** Neon AI Gateway base URL, e.g. the branch-scoped `NEON_AI_GATEWAY_BASE_URL`. */
+	baseURL?: string;
+	/** Neon AI Gateway token, e.g. `NEON_AI_GATEWAY_TOKEN`. */
+	apiKey?: string;
+};
+
+/** The Neon AI SDK provider. The model surface is added in the first real release. */
+export type NeonProvider = {
+	readonly providerId: "neon";
+};
+
+/**
+ * Creates a Neon AI SDK provider.
+ *
+ * NOT IMPLEMENTED YET: calling this throws. The `0.0.0` release is a name-reservation
+ * placeholder; the Neon AI Gateway integration ships in a follow-up release.
+ */
+export function createNeon(_settings: NeonProviderSettings = {}): NeonProvider {
+	throw new Error(
+		"@neondatabase/ai-sdk-provider is not implemented yet (0.0.0 name-reservation release).",
+	);
+}

--- a/packages/ai-sdk-provider/src/lib/version.ts
+++ b/packages/ai-sdk-provider/src/lib/version.ts
@@ -1,0 +1,2 @@
+// Package version, used in the User-Agent suffix sent to the gateway.
+export const VERSION = "0.0.0";

--- a/packages/ai-sdk-provider/src/lib/version.ts
+++ b/packages/ai-sdk-provider/src/lib/version.ts
@@ -1,2 +1,5 @@
-// Package version, used in the User-Agent suffix sent to the gateway.
-export const VERSION = "0.0.0";
+import pkg from "../../package.json" with { type: "json" };
+
+// Package version, used in the User-Agent suffix sent to the gateway. Derived
+// from package.json so it stays in sync with the changeset version bump flow.
+export const VERSION: string = pkg.version;

--- a/packages/ai-sdk-provider/src/v1.ts
+++ b/packages/ai-sdk-provider/src/v1.ts
@@ -1,0 +1,9 @@
+/**
+ * `@neondatabase/ai-sdk-provider/v1` — community Vercel AI SDK provider for the Neon AI Gateway.
+ *
+ * - `createNeon()` — factory for the Neon provider.
+ *   Not implemented yet; this `0.0.0` release reserves the package name.
+ */
+
+export type { NeonProvider, NeonProviderSettings } from "./lib/provider.js";
+export { createNeon } from "./lib/provider.js";

--- a/packages/ai-sdk-provider/src/v1.ts
+++ b/packages/ai-sdk-provider/src/v1.ts
@@ -1,9 +1,26 @@
 /**
- * `@neondatabase/ai-sdk-provider/v1` — community Vercel AI SDK provider for the Neon AI Gateway.
+ * `@neondatabase/ai-sdk-provider/v1` — community Vercel AI SDK provider for the
+ * Neon AI Gateway.
  *
- * - `createNeon()` — factory for the Neon provider.
- *   Not implemented yet; this `0.0.0` release reserves the package name.
+ * - `createNeon()` / `neon` — the provider. Routes each model to the best
+ *   gateway endpoint (Anthropic → native Messages, OpenAI → native Responses
+ *   incl. Codex, everything else → unified MLflow).
  */
-
-export type { NeonProvider, NeonProviderSettings } from "./lib/provider.js";
-export { createNeon } from "./lib/provider.js";
+export { NeonAnthropicLanguageModel } from "./lib/neon-anthropic-language-model.js";
+export { NeonChatLanguageModel } from "./lib/neon-chat-language-model.js";
+export type { NeonChatModelId } from "./lib/neon-chat-options.js";
+export {
+	getNeonModelCapabilities,
+	getNeonModelRoute,
+	type NeonModelCapabilities,
+	type NeonModelFamily,
+	type NeonModelRoute,
+} from "./lib/neon-model-capabilities.js";
+export { NeonResponsesLanguageModel } from "./lib/neon-responses-language-model.js";
+export {
+	createNeon,
+	type NeonErrorData,
+	type NeonProvider,
+	type NeonProviderSettings,
+	neon,
+} from "./lib/provider.js";

--- a/packages/ai-sdk-provider/tsconfig.json
+++ b/packages/ai-sdk-provider/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["src", "vitest.config.ts", "tsdown.config.ts"]
+}

--- a/packages/ai-sdk-provider/tsdown.config.ts
+++ b/packages/ai-sdk-provider/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	name: "@neondatabase/ai-sdk-provider",
+	bundle: false,
+	clean: true,
+	dts: true,
+	entry: ["src/index.ts", "src/v1.ts", "src/lib/**/*.ts", "!src/**/*.test.*"],
+	format: "esm",
+	outDir: "dist",
+	treeshake: true,
+});

--- a/packages/ai-sdk-provider/vitest.config.ts
+++ b/packages/ai-sdk-provider/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		clearMocks: true,
+		mockReset: true,
+		unstubEnvs: true,
+		coverage: {
+			all: true,
+			include: ["src"],
+			exclude: ["src/**/*.test.ts"],
+			reporter: ["html", "lcov"],
+		},
+		exclude: ["lib", "node_modules", "dist"],
+		setupFiles: ["console-fail-test/setup"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         version: 1.130.17(@tanstack/react-query@5.81.4(react@19.1.1))(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@tanstack/router-core@1.131.37)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-start':
         specifier: ^1.131.37
-        version: 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       '@tanstack/router-plugin':
         specifier: ^1.131.37
         version: 1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
@@ -157,6 +157,27 @@ importers:
       web-vitals:
         specifier: ^4.2.4
         version: 4.2.4
+
+  packages/ai-sdk-provider:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.17
+      '@vitest/coverage-v8':
+        specifier: 3.0.9
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      console-fail-test:
+        specifier: 0.5.0
+        version: 0.5.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
 
   packages/config:
     dependencies:
@@ -1127,8 +1148,8 @@ packages:
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
 
-  '@oxc-project/types@0.133.0':
-    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+  '@oxc-project/types@0.134.0':
+    resolution: {integrity: sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -1240,97 +1261,97 @@ packages:
   '@quansync/fs@0.1.4':
     resolution: {integrity: sha512-vy/41FCdnIalPTQCb2Wl0ic1caMdzGus4ktDp+gpZesQNydXcx8nhh8qB3qMPbGkictOTaXgXEUUfQEm8DQYoA==}
 
-  '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+  '@rolldown/binding-android-arm64@1.1.0':
+    resolution: {integrity: sha512-gCYzGOSkYY6Z034suzd20euvds7lPzMEEla62DJGE/ZAlR4OMBnNbvnBSsIGUCAr52gaWMsloGxP4tVGtN5aCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+  '@rolldown/binding-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-JQBD77MNgu+4Z6RAyg69acugdrhhVoWesr3l47zohYZ2YV2fwkWMArkN/2p4l6Ei+Sno7W5q+UsKdVWq5Ens0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+  '@rolldown/binding-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-p/8cXUTK4Sob604e+xxPhVSbDFf29E6J0l/xESM9rdCfn3aDai3nEs6TnMHUsdD5aNlFz0+gDbiGlozLKGa2YA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+  '@rolldown/binding-freebsd-x64@1.1.0':
+    resolution: {integrity: sha512-KbtOSlVv6fElujiZWMcC3aQYhEwLVVf073RcwlSmpGQvIsKZFUqc0ef4sjUuurRwfbiI6JJXji9DQn+86hawmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
+    resolution: {integrity: sha512-9fZ9i0o0/MQaw7om6Z6TsT7tfCk0jtbEFtC+aPqZL5RNsGWNcHvn6EHgL3dAprjq+AZzPTAQjg2JtpJaMt+6pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.0':
+    resolution: {integrity: sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+  '@rolldown/binding-linux-arm64-musl@1.1.0':
+    resolution: {integrity: sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
+    resolution: {integrity: sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.0':
+    resolution: {integrity: sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.0':
+    resolution: {integrity: sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+  '@rolldown/binding-linux-x64-musl@1.1.0':
+    resolution: {integrity: sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+  '@rolldown/binding-openharmony-arm64@1.1.0':
+    resolution: {integrity: sha512-4+fexHayrLCWpriPh4c6dNvL4an34DEZCG7zOM/FD5QNF6h8DT+bDXzyB/kfC8lDJbaFb7jKShtnjDQFXVQEjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+  '@rolldown/binding-wasm32-wasi@1.1.0':
+    resolution: {integrity: sha512-SbL++MNmOw6QamrwIGDMSSfM4ceTzFr+RjbOExJSLLBinScU4WI5OdA413h1qwPw2yH7lVF1+H4svQ+6mSXKTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.0':
+    resolution: {integrity: sha512-+xTE6XC7wBgk0VKRXGG+QAnyW5S9b8vfsFpiMjf0waQTmSQSU8onsH/beyZ8X4aXVveJnotiy7VDjLOaW8bTrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.0':
+    resolution: {integrity: sha512-Ogji1TQNqH3ACLnYr+1Ns1nyrJ0CO2P585u9Hsh02pXvtFiFpgtgT2b3P4PnCOU86VVCvqtAeCN4OftMT8KU4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3848,8 +3869,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.3:
-    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+  rolldown@1.1.0:
+    resolution: {integrity: sha512-zpMvlJhs5PkXRTtKc0CaLBVI9AR/VDiJFpM+kx//hgToEca7FgMlGjaRIisXBcb19T76LswgmKECSQ96hjWr5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5419,7 +5440,7 @@ snapshots:
 
   '@oozcitak/util@8.3.8': {}
 
-  '@oxc-project/types@0.133.0': {}
+  '@oxc-project/types@0.134.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -5505,53 +5526,53 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rolldown/binding-android-arm64@1.0.3':
+  '@rolldown/binding-android-arm64@1.1.0':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
+  '@rolldown/binding-darwin-arm64@1.1.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.3':
+  '@rolldown/binding-darwin-x64@1.1.0':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
+  '@rolldown/binding-freebsd-x64@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+  '@rolldown/binding-linux-arm64-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
+  '@rolldown/binding-linux-arm64-musl@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+  '@rolldown/binding-linux-s390x-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
+  '@rolldown/binding-linux-x64-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
+  '@rolldown/binding-linux-x64-musl@1.1.0':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
+  '@rolldown/binding-openharmony-arm64@1.1.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
+  '@rolldown/binding-wasm32-wasi@1.1.0':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+  '@rolldown/binding-win32-arm64-msvc@1.1.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
+  '@rolldown/binding-win32-x64-msvc@1.1.0':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -5831,9 +5852,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-plugin@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/react-start-plugin@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
     dependencies:
-      '@tanstack/start-plugin-core': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/start-plugin-core': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       pathe: 2.0.3
       vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
@@ -5883,10 +5904,10 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/react-start@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/react-start@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
     dependencies:
       '@tanstack/react-start-client': 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/react-start-plugin': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/react-start-plugin': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       '@tanstack/react-start-server': 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/start-server-functions-client': 1.131.37(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
       '@tanstack/start-server-functions-server': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
@@ -6025,7 +6046,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-plugin-core@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/start-plugin-core@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.5
@@ -6041,7 +6062,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.10
       cheerio: 1.1.2
       h3: 1.13.0
-      nitropack: 2.12.5(@netlify/blobs@9.1.2)(rolldown@1.0.3)
+      nitropack: 2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.0)
       pathe: 2.0.3
       ufo: 1.6.1
       vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
@@ -7750,7 +7771,7 @@ snapshots:
       qs: 6.14.1
     optional: true
 
-  nitropack@2.12.5(@netlify/blobs@9.1.2)(rolldown@1.0.3):
+  nitropack@2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@rollup/plugin-alias': 5.1.1(rollup@4.50.1)
@@ -7803,7 +7824,7 @@ snapshots:
       pretty-bytes: 7.0.1
       radix3: 1.1.2
       rollup: 4.50.1
-      rollup-plugin-visualizer: 6.0.3(rolldown@1.0.3)(rollup@4.50.1)
+      rollup-plugin-visualizer: 6.0.3(rolldown@1.1.0)(rollup@4.50.1)
       scule: 1.3.0
       semver: 7.7.2
       serve-placeholder: 2.0.2
@@ -8239,7 +8260,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.6(rolldown@1.0.3)(typescript@5.8.2):
+  rolldown-plugin-dts@0.15.6(rolldown@1.1.0)(typescript@5.8.2):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -8249,42 +8270,42 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
-      rolldown: 1.0.3
+      rolldown: 1.1.0
     optionalDependencies:
       typescript: 5.8.2
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.0.3:
+  rolldown@1.1.0:
     dependencies:
-      '@oxc-project/types': 0.133.0
+      '@oxc-project/types': 0.134.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.3
-      '@rolldown/binding-darwin-arm64': 1.0.3
-      '@rolldown/binding-darwin-x64': 1.0.3
-      '@rolldown/binding-freebsd-x64': 1.0.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-      '@rolldown/binding-linux-arm64-gnu': 1.0.3
-      '@rolldown/binding-linux-arm64-musl': 1.0.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-      '@rolldown/binding-linux-s390x-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-musl': 1.0.3
-      '@rolldown/binding-openharmony-arm64': 1.0.3
-      '@rolldown/binding-wasm32-wasi': 1.0.3
-      '@rolldown/binding-win32-arm64-msvc': 1.0.3
-      '@rolldown/binding-win32-x64-msvc': 1.0.3
+      '@rolldown/binding-android-arm64': 1.1.0
+      '@rolldown/binding-darwin-arm64': 1.1.0
+      '@rolldown/binding-darwin-x64': 1.1.0
+      '@rolldown/binding-freebsd-x64': 1.1.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.0
+      '@rolldown/binding-linux-arm64-gnu': 1.1.0
+      '@rolldown/binding-linux-arm64-musl': 1.1.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.0
+      '@rolldown/binding-linux-s390x-gnu': 1.1.0
+      '@rolldown/binding-linux-x64-gnu': 1.1.0
+      '@rolldown/binding-linux-x64-musl': 1.1.0
+      '@rolldown/binding-openharmony-arm64': 1.1.0
+      '@rolldown/binding-wasm32-wasi': 1.1.0
+      '@rolldown/binding-win32-arm64-msvc': 1.1.0
+      '@rolldown/binding-win32-x64-msvc': 1.1.0
 
-  rollup-plugin-visualizer@6.0.3(rolldown@1.0.3)(rollup@4.50.1):
+  rollup-plugin-visualizer@6.0.3(rolldown@1.1.0)(rollup@4.50.1):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
-      rolldown: 1.0.3
+      rolldown: 1.1.0
       rollup: 4.50.1
 
   rollup@4.50.1:
@@ -8668,8 +8689,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.3
-      rolldown-plugin-dts: 0.15.6(rolldown@1.0.3)(typescript@5.8.2)
+      rolldown: 1.1.0
+      rolldown-plugin-dts: 0.15.6(rolldown@1.1.0)(typescript@5.8.2)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,22 @@ importers:
         version: 4.2.4
 
   packages/ai-sdk-provider:
+    dependencies:
+      '@ai-sdk/anthropic':
+        specifier: 4.0.0-beta.42
+        version: 4.0.0-beta.42(zod@4.4.3)
+      '@ai-sdk/openai':
+        specifier: 4.0.0-beta.44
+        version: 4.0.0-beta.44(zod@4.4.3)
+      '@ai-sdk/openai-compatible':
+        specifier: 3.0.0-beta.36
+        version: 3.0.0-beta.36(zod@4.4.3)
+      '@ai-sdk/provider':
+        specifier: 4.0.0-beta.14
+        version: 4.0.0-beta.14
+      '@ai-sdk/provider-utils':
+        specifier: 5.0.0-beta.30
+        version: 5.0.0-beta.30(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -178,6 +194,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
 
   packages/config:
     dependencies:
@@ -523,6 +542,34 @@ importers:
         version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
 
 packages:
+
+  '@ai-sdk/anthropic@4.0.0-beta.42':
+    resolution: {integrity: sha512-FdfNFc6ScMEMSXP2pjfpbCdFEKhznSzKgrAluNLZN4x+XAK4yoU2jhWUp8pHW085OyMA9Kg53HK1paIi3gED9g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai-compatible@3.0.0-beta.36':
+    resolution: {integrity: sha512-aYCyXlIgOonStbme/ZvPMntVZWiPcHrvn+HX/awO3SO+leoXv3ZwtAviFRk+2LuX57s+SQrPpMGlU+ZCEIQTHg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@4.0.0-beta.44':
+    resolution: {integrity: sha512-kXdGA6vyh9SwL/B11UhODjbw0koFkDA/yD7hacBxMHSZx6l3T9hZLECEwOkn6OZDrQR+vno5Ka/pUyXrG82BkQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.0-beta.30':
+    resolution: {integrity: sha512-X3AxTsFJZr9Mw32SncWJA4/ShU8NA/XjhoallCYdcdQZ2gZZ/cIDyJJ6pNh1aBhicRNHv2ndgI6w/H2NGNIjOA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.0-beta.14':
+    resolution: {integrity: sha512-SMijtjVHs38n0dMkTcNuGrnStiF76OhAqS0R+ZX4iXUnuPPyTxQoVcF8Xuf2AoBB5rqndTId5FVT05bgqD5KsA==}
+    engines: {node: '>=18'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -1572,6 +1619,9 @@ packages:
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.1.13':
     resolution: {integrity: sha512-eq3ouolC1oEFOAvOMOBAmfCIqZBJuvWvvYWh5h5iOYfe1HFC6+GZ6EIL0JdM3/niGRJmnrOc+8gl9/HGUaaptw==}
 
@@ -1983,6 +2033,9 @@ packages:
   '@whatwg-node/server@0.9.71':
     resolution: {integrity: sha512-ueFCcIPaMgtuYDS9u0qlUoEvj6GiSsKrwnOLPp9SshqjtcRaR1IEHRjoReq3sXNydsF5i0ZnmuYgXq9dV53t0g==}
     engines: {node: '>=18.0.0'}
+
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -2665,6 +2718,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
@@ -3121,6 +3178,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -4706,6 +4766,36 @@ packages:
 
 snapshots:
 
+  '@ai-sdk/anthropic@4.0.0-beta.42(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.14
+      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai-compatible@3.0.0-beta.36(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.14
+      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/openai@4.0.0-beta.44(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.14
+      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.0-beta.30(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.14
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.0-beta.14':
+    dependencies:
+      json-schema: 0.4.0
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -5717,6 +5807,8 @@ snapshots:
 
   '@speed-highlight/core@1.2.7': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.1.13':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -6362,6 +6454,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@workflow/serde@4.1.0': {}
+
   abbrev@3.0.1: {}
 
   abort-controller@3.0.0:
@@ -7006,6 +7100,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@3.1.0: {}
+
   execa@8.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -7500,6 +7596,8 @@ snapshots:
       - utf-8-validate
 
   jsesc@3.1.0: {}
+
+  json-schema@0.4.0: {}
 
   json5@2.2.3: {}
 


### PR DESCRIPTION
## Summary

Implements `@neondatabase/ai-sdk-provider` (replacing the `0.0.0` name-reservation placeholder) — a community Vercel AI SDK provider for the branch-scoped **Neon AI Gateway**.

`createNeon()` / `neon` route each model to the best gateway endpoint based on its id, so one `neon('databricks-...')` call (same base URL + token) reaches the whole `databricks-*` catalog:

| Model family | Endpoint | Why |
| --- | --- | --- |
| Anthropic (`databricks-claude-*`) | native Messages API | streaming structured output + native reasoning |
| OpenAI (`databricks-gpt-*`, `*-codex`) | native Responses API | **Codex** (native-only), native reasoning, image-gen tool |
| Everything else (Gemini, Llama, Qwen, gpt-oss, ...) | unified MLflow endpoint | broad coverage; Gemini is here because its native endpoint can't stream |

Reuses the official `@ai-sdk/anthropic` + `@ai-sdk/openai` model classes (pinned to the v6/v7 beta line) with thin gateway-compat shims:
- OpenAI: `forceReasoning` for `gpt-5` so reasoning handling works despite the required `databricks-` prefix.
- Anthropic: `toolStreaming: false` so the gateway doesn't reject `eager_input_streaming` on streaming tool calls.
- Unified endpoint: strips the JSON Schema `$schema` marker (Gemini rejects it) and drops backend-rejected params (penalties/`seed` for Llama, `reasoningEffort` for Gemini) with an AI SDK warning.

Behind the existing `./v1` versioned export. Configure with `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` (or pass `baseURL`/`apiKey`).

This is the **same implementation** proposed upstream as `@ai-sdk/neon` in [vercel/ai#15997](https://github.com/vercel/ai/pull/15997), kept in sync.

## Capabilities (verified live)

`generateText`, `streamText`, system prompts, multi-turn, tool calling (single + multi-step + streaming), `generateObject`, `streamObject`, image (vision) input, and image generation via the Responses `image_generation` tool (`streamText`).

## Limitations (gateway-side)

- `generateImage()` / embeddings: no gateway endpoint → `NoSuchModelError`.
- `gpt-oss-*`: returns a non-standard "harmony" response shape on the unified endpoint.

## Test plan

- [x] `pnpm --filter @neondatabase/ai-sdk-provider build` (tsc --noEmit + tsdown)
- [x] `pnpm --filter @neondatabase/ai-sdk-provider test:ci` (vitest)
- [x] Biome clean
- [x] Routing smoke test against the built package + beta deps
- [x] Changeset added (minor)