### PR TITLE
feat(init): bootstrap templates, feature-driven setup, and preview mode

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -55,6 +55,7 @@
 		"add-mcp": "^1.5.1",
 		"execa": "^9.5.2",
 		"picocolors": "^1.1.1",
+		"yaml": "^2.9.0",
 		"yargs": "^18.0.0",
 		"yoctocolors": "^2.1.2"
 	},

--- a/packages/init/src/cli.ts
+++ b/packages/init/src/cli.ts
@@ -110,6 +110,12 @@ const cli = yargs(hideBin(process.argv))
 					type: "boolean",
 					default: false,
 					description: "Skip the migrations phase.",
+				})
+				.option("preview", {
+					type: "boolean",
+					default: false,
+					description:
+						"Enable preview features (e.g. project bootstrapping from templates).",
 				}),
 		async (argv) => {
 			const detectedAgent = detectAgentInvocation();
@@ -125,13 +131,14 @@ const cli = yargs(hideBin(process.argv))
 					agent,
 					skipNeonAuth: argv.skipNeonAuth,
 					skipMigrations: argv.skipMigrations,
+					preview: argv.preview,
 				});
 				outputJson(result);
 				process.exit(0);
 			}
 
 			// v2 interactive mode — same phase logic, driven by terminal prompts
-			await interactiveInit();
+			await interactiveInit({ preview: argv.preview });
 			process.exit(0);
 		},
 	)
@@ -608,6 +615,21 @@ const cli = yargs(hideBin(process.argv))
 				scaffold: argv.scaffold as "prisma" | "drizzle" | undefined,
 				apply: argv.apply,
 			});
+			outputJson(result);
+			process.exit(0);
+		},
+	)
+
+	// -----------------------------------------------------------------------
+	// finalize (internal — called at the end of feature chains)
+	// -----------------------------------------------------------------------
+	.command(
+		"finalize",
+		false, // hidden from help
+		(y) => y.options(jsonOption).options(agentOption),
+		async () => {
+			const { handleCleanup } = await import("./lib/phases/cleanup.js");
+			const result = handleCleanup();
 			outputJson(result);
 			process.exit(0);
 		},

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -12,6 +12,8 @@ import {
 } from "./lib/skills.js";
 import type { Editor, InitResult } from "./lib/types.js";
 
+export type { InteractiveInitOptions } from "./interactive.js";
+export { interactiveInit } from "./interactive.js";
 export { handleAuthPhase } from "./lib/phases/auth.js";
 export { handleDbPhase } from "./lib/phases/db.js";
 export { handleMcpPhase } from "./lib/phases/mcp.js";

--- a/packages/init/src/interactive.ts
+++ b/packages/init/src/interactive.ts
@@ -4,7 +4,7 @@
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { resolve } from "node:path";
 import {
 	confirm,
 	isCancel,
@@ -13,12 +13,17 @@ import {
 	outro,
 	select,
 	spinner,
-	text,
 } from "@clack/prompts";
 import { execa } from "execa";
 import { bold, dim } from "yoctocolors";
 import { ALL_CONFIGURABLE_AGENTS, getAddMcpAgentId } from "./lib/agents.js";
 import { ensureNeonctlAuth, isAuthenticated } from "./lib/auth.js";
+import {
+	type BootstrapTemplate,
+	FALLBACK_TEMPLATES,
+	fetchTemplates,
+	type NeonFeature,
+} from "./lib/bootstrap.js";
 import { detectAgent } from "./lib/detect-agent.js";
 import { detectAvailableEditors } from "./lib/editors.js";
 import {
@@ -74,16 +79,24 @@ function patchClackColors(): () => void {
 	};
 }
 
-export async function interactiveInit(): Promise<void> {
+export interface InteractiveInitOptions {
+	preview?: boolean;
+}
+
+export async function interactiveInit(
+	options: InteractiveInitOptions = {},
+): Promise<void> {
 	const restoreColors = patchClackColors();
 	try {
-		await interactiveInitInner();
+		await interactiveInitInner(options);
 	} finally {
 		restoreColors();
 	}
 }
 
-async function interactiveInitInner(): Promise<void> {
+async function interactiveInitInner(
+	options: InteractiveInitOptions,
+): Promise<void> {
 	console.log();
 	console.log(
 		"\x1b[38;2;75;181;120m" +
@@ -118,6 +131,7 @@ async function interactiveInitInner(): Promise<void> {
 	const inspectSpinner = spinner();
 	inspectSpinner.start("Checking existing configuration...");
 	const inspection = await inspectProject([
+		{ id: "has_app", description: "", lookFor: [] },
 		{ id: "mcp_server", description: "", lookFor: [] },
 		{ id: "skills", description: "", lookFor: [] },
 		{ id: "connection_string", description: "", lookFor: [] },
@@ -127,8 +141,116 @@ async function interactiveInitInner(): Promise<void> {
 	]);
 	inspectSpinner.stop(dim("Configuration checked ✓"));
 
+	const hasApp = inspection.hasApp === true;
+	let selectedFeatures: NeonFeature[] = [];
+	let selectedTemplate: BootstrapTemplate | null = null;
+
+	// Preview mode: bootstrap from template if no app detected
+	if (options.preview && !hasApp) {
+		let templates = FALLBACK_TEMPLATES;
+		try {
+			const fetched = await fetchTemplates();
+			if (fetched && fetched.length > 0) templates = fetched;
+		} catch {}
+
+		const templateResult = await select({
+			message:
+				"No application detected. Would you like to scaffold a new project from a template?",
+			options: [
+				...templates.map((t) => ({
+					value: t.id,
+					label: `${t.title} — ${t.description}`,
+				})),
+				{
+					value: "none",
+					label: "No thanks — continue without scaffolding",
+				},
+			],
+			initialValue: "none",
+		});
+		if (isCancel(templateResult)) {
+			outro("Setup cancelled.");
+			return;
+		}
+		if (templateResult !== "none") {
+			selectedTemplate =
+				templates.find((t) => t.id === templateResult) ?? null;
+			if (selectedTemplate) {
+				selectedFeatures = selectedTemplate.requires;
+				const bootstrapS = spinner();
+				bootstrapS.start(
+					`Scaffolding project from template "${selectedTemplate.title}"...`,
+				);
+				try {
+					await execa(
+						"npx",
+						[
+							"neonctl",
+							"bootstrap",
+							".",
+							"--template",
+							selectedTemplate.id,
+							"--force",
+						],
+						{ stdio: "pipe", timeout: 120000 },
+					);
+					bootstrapS.stop(
+						dim(
+							`Scaffolded project from "${selectedTemplate.title}" ✓`,
+						),
+					);
+				} catch (err) {
+					const msg =
+						err instanceof Error ? err.message : "Unknown error";
+					bootstrapS.stop("Failed to scaffold project");
+					log.error(msg);
+					outro("Setup failed.");
+					return;
+				}
+			}
+		}
+	}
+
+	// For brownfield flows (existing app), ask which features to enable
+	if (!selectedTemplate && hasApp) {
+		const featuresResult = await select({
+			message:
+				"Which Neon features would you like to enable for this project?",
+			options: [
+				{ value: "database", label: "Database" },
+				{
+					value: "database,auth",
+					label: "Database + Neon Auth (adds authentication via Neon)",
+				},
+			],
+			initialValue: "database",
+		});
+		if (isCancel(featuresResult)) {
+			outro("Setup cancelled.");
+			return;
+		}
+		selectedFeatures = (featuresResult as string).split(
+			",",
+		) as NeonFeature[];
+	}
+
+	// Write _init metadata to .neon
+	if (selectedFeatures.length > 0) {
+		const neonPath = resolve(process.cwd(), ".neon");
+		let existing: Record<string, unknown> = {};
+		if (existsSync(neonPath)) {
+			try {
+				existing = JSON.parse(readFileSync(neonPath, "utf-8"));
+			} catch {}
+		}
+		existing._init = { features: selectedFeatures };
+		writeFileSync(neonPath, `${JSON.stringify(existing, null, 2)}\n`);
+	}
+
 	const mcpAlready = inspection.mcpConfigured === true;
-	const skillsAlready = inspection.skillsInstalled === true;
+	// If we bootstrapped, skills come from the template
+	const skillsAlready =
+		inspection.skillsInstalled === true || selectedTemplate !== null;
 	const hasNeonConnection = inspection.connectionString === true;
 	const needsMcp = !mcpAlready;
 	const needsSkills = !skillsAlready;
@@ -505,80 +627,39 @@ async function interactiveInitInner(): Promise<void> {
 	}
 
 	// -----------------------------------------------------------------------
-	// Auth check (needed even if tooling is already installed)
-	// -----------------------------------------------------------------------
-	const authed = await isAuthenticated();
-	if (!authed) {
-		const authS = spinner();
-		authS.start("Authenticating with Neon...");
-		const authSuccess = await ensureNeonctlAuth();
-		if (!authSuccess) {
-			authS.stop("Authentication failed.");
-			outro("Run neon-init again after signing in.");
-			return;
-		}
-		authS.stop("Authenticated.");
-	}
-
-	// -----------------------------------------------------------------------
-	// Step 6: Collect org/project context for the get-started prompt
-	// -----------------------------------------------------------------------
-	let orgName: string | null = null;
-	let orgId: string | null = null;
-	let projectName: string | null = null;
-	let projectId: string | null = null;
-
-	const collected = await collectProjectContext();
-	if (collected === "cancelled") {
-		outro(dim("Setup cancelled."));
-		return;
-	}
-	if (collected === "no_orgs") {
-		outro(dim("Run neon-init again after creating an organization."));
-		return;
-	}
-	if (collected) {
-		orgName = collected.orgName;
-		orgId = collected.orgId;
-		projectName = collected.projectName;
-		projectId = collected.projectId;
-	}
-
-	// Write .neon context file if we have org/project info
-	if (orgId || projectId) {
-		writeNeonContext({ orgId, projectId });
-	}
-
-	// -----------------------------------------------------------------------
-	// Step 7: Done — build enhanced get-started prompt
+	// Step 6: Done — build prompt for the agent to continue
 	// -----------------------------------------------------------------------
 
-	// Build multi-line prompt for the user to paste
-	const promptLines: string[] = ["Get started with Neon."];
-	if (projectId && orgName && orgId) {
+	// Build the getting-started data payload (same as agent mode)
+	const gettingStartedData: Record<string, unknown> = {};
+	if (hasNeonConnection) gettingStartedData.hasConnectionString = true;
+	if (inspection.framework && inspection.framework !== "none")
+		gettingStartedData.framework = inspection.framework;
+	if (inspection.orm && inspection.orm !== "none")
+		gettingStartedData.orm = inspection.orm;
+	if (inspection.migrationTool && inspection.migrationTool !== "none")
+		gettingStartedData.migrationTool = inspection.migrationTool;
+	if (inspection.migrationDir && inspection.migrationDir !== "none")
+		gettingStartedData.migrationDir = inspection.migrationDir;
+	if (selectedFeatures.length > 0)
+		gettingStartedData.features = selectedFeatures;
+	if (options.preview) gettingStartedData.preview = true;
+
+	const dataJson = JSON.stringify(gettingStartedData);
+
+	// Build a natural-language prompt for the user to paste into their agent
+	const promptLines: string[] = [
+		"Continue setting up Neon for this project.",
+		`Run this command to proceed: neon-init getting-started --json --data '${dataJson}'`,
+		"Follow the steps it returns to connect a Neon database, pull environment variables, and verify the connection.",
+	];
+	if (selectedFeatures.includes("auth")) {
 		promptLines.push(
-			`Use project "${projectName}" (${projectId}) in org ${orgName} (${orgId}).`,
+			"After the database is connected, it will automatically set up Neon Auth.",
 		);
-	} else if (orgId && orgName) {
-		promptLines.push(`Use org ${orgName} (${orgId}).`);
-	}
-	const stackParts: string[] = [];
-	if (inspection.framework && inspection.framework !== "none") {
-		stackParts.push(inspection.framework as string);
-	}
-	if (inspection.orm && inspection.orm !== "none") {
-		if (stackParts.length > 0) {
-			promptLines.push(
-				`This is a ${stackParts[0]} app that uses ${inspection.orm}.`,
-			);
-		} else {
-			promptLines.push(`This app uses ${inspection.orm}.`);
-		}
-	} else if (stackParts.length > 0) {
-		promptLines.push(`This is a ${stackParts[0]} app.`);
 	}
 
-	log.step(`Next steps`);
+	log.step("Next steps");
 	log.message(
 		dim(
 			`Restart ${editorList} to load the Neon MCP server, then copy the following into your agent chat:`,
@@ -586,210 +667,6 @@ async function interactiveInitInner(): Promise<void> {
 	);
 	log.message(promptLines.map((line) => bold(neonGreenFn(line))).join("\n"));
 	outro(dim("Have feedback? Email us at feedback@neon.tech"));
-}
-
-// ---------------------------------------------------------------------------
-// Collect org/project context to enhance the get-started prompt
-// ---------------------------------------------------------------------------
-
-interface ProjectContext {
-	orgId: string;
-	orgName: string;
-	projectId: string | null;
-	projectName: string | null;
-}
-
-async function collectProjectContext(): Promise<
-	ProjectContext | "cancelled" | "no_orgs" | null
-> {
-	let orgs: { id: string; name: string }[];
-	const orgSpinner = spinner();
-	orgSpinner.start("Loading organizations...");
-	try {
-		const result = await execa(
-			"npx",
-			["-y", "neonctl", "orgs", "list", "--output", "json"],
-			{
-				stdio: "pipe",
-				timeout: 60000,
-				env: { ...process.env, CI: undefined },
-			},
-		);
-		orgs = JSON.parse(result.stdout);
-		orgSpinner.stop(dim("Organizations loaded ✓"));
-	} catch {
-		orgSpinner.stop("Failed to load organizations.");
-		return null;
-	}
-
-	if (orgs.length === 0) {
-		log.warn(
-			"No Neon organizations found for this account. Visit https://console.neon.tech to create an organization, then run neon-init again.",
-		);
-		return "no_orgs";
-	}
-
-	// Select org
-	let orgId: string;
-	let orgName: string;
-	if (orgs.length === 1) {
-		orgId = orgs[0].id;
-		orgName = orgs[0].name;
-	} else {
-		const orgResult = await select({
-			message: "Which organization?",
-			options: orgs.map((o) => ({ value: o.id, label: o.name })),
-		});
-		if (isCancel(orgResult)) return "cancelled";
-		orgId = orgResult as string;
-		orgName = orgs.find((o) => o.id === orgId)?.name ?? orgId;
-	}
-
-	// List existing projects
-	let projects: { id: string; name: string }[];
-	const projSpinner = spinner();
-	projSpinner.start("Loading projects...");
-	try {
-		const result = await execa(
-			"npx",
-			[
-				"-y",
-				"neonctl",
-				"projects",
-				"list",
-				"--org-id",
-				orgId,
-				"--output",
-				"json",
-			],
-			{
-				stdio: "pipe",
-				timeout: 60000,
-				env: { ...process.env, CI: undefined },
-			},
-		);
-		projects = JSON.parse(result.stdout);
-		projSpinner.stop(dim("Projects loaded ✓"));
-	} catch {
-		projSpinner.stop("Failed to load projects.");
-		return { orgId, orgName, projectId: null, projectName: null };
-	}
-
-	// Choose existing or create new
-	const projectOptions: { value: string; label: string; hint?: string }[] = [
-		{
-			value: "__new__",
-			label: "Create a new project",
-			hint: "the agent will create it",
-		},
-		...projects.map((p) => ({ value: p.id, label: p.name, hint: p.id })),
-	];
-
-	const projectResult = await select({
-		message: "Which Neon project should the agent use?",
-		options: projectOptions,
-	});
-	if (isCancel(projectResult)) return "cancelled";
-
-	if (projectResult === "__new__") {
-		const dirName = basename(process.cwd());
-		const nameResult = await text({
-			message: "What should the new project be called?",
-			defaultValue: dirName,
-			placeholder: dirName,
-		});
-		if (isCancel(nameResult)) return "cancelled";
-
-		const projectName = nameResult as string;
-
-		// Create the project now so we have the ID for .neon
-		const cs = spinner();
-		cs.start(`Creating project "${projectName}"...`);
-		try {
-			const result = await execa(
-				"npx",
-				[
-					"-y",
-					"neonctl",
-					"projects",
-					"create",
-					"--name",
-					projectName,
-					"--org-id",
-					orgId,
-					"--output",
-					"json",
-				],
-				{
-					stdio: "pipe",
-					timeout: 30000,
-					env: { ...process.env, CI: undefined },
-				},
-			);
-			const created = JSON.parse(result.stdout);
-			const projectId = created.project?.id ?? created.id;
-			cs.stop(dim(`Project "${projectName}" created (${projectId}) ✓`));
-			return { orgId, orgName, projectId, projectName };
-		} catch (err) {
-			const msg = err instanceof Error ? err.message : "Unknown error";
-			cs.stop(`Failed to create project`);
-			log.error(msg);
-			return { orgId, orgName, projectId: null, projectName };
-		}
-	}
-
-	const selectedProject = projects.find((p) => p.id === projectResult);
-	return {
-		orgId,
-		orgName,
-		projectId: projectResult as string,
-		projectName: selectedProject?.name ?? null,
-	};
-}
-
-// ---------------------------------------------------------------------------
-// Maps detectAgent() IDs to Editor types
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// .neon context file
-// ---------------------------------------------------------------------------
-
-function writeNeonContext(context: {
-	orgId: string | null;
-	projectId: string | null;
-}): void {
-	const neonPath = resolve(process.cwd(), ".neon");
-
-	let existing: Record<string, unknown> = {};
-	if (existsSync(neonPath)) {
-		try {
-			existing = JSON.parse(readFileSync(neonPath, "utf-8"));
-		} catch {
-			// Malformed file — we'll overwrite it
-		}
-	}
-
-	// Only set fields we have values for; preserve existing fields (e.g. branch)
-	const updated = { ...existing };
-	if (context.orgId) updated.orgId = context.orgId;
-	if (context.projectId) updated.projectId = context.projectId;
-
-	// Check if anything actually changed
-	const existingJson = JSON.stringify(existing, null, 2);
-	const updatedJson = JSON.stringify(updated, null, 2);
-	if (existingJson === updatedJson) {
-		return;
-	}
-
-	writeFileSync(neonPath, `${updatedJson}\n`);
-	if (Object.keys(existing).length > 0) {
-		log.step(dim("Updated .neon context file ✓"));
-	} else {
-		log.step(
-			dim("Created .neon context file (safe to commit — no secrets) ✓"),
-		);
-	}
 }
 
 function agentIdToEditor(agentId: string): Editor | null {

--- a/packages/init/src/interactive.ts
+++ b/packages/init/src/interactive.ts
@@ -159,14 +159,15 @@ async function interactiveInitInner(
 			options: [
 				...templates.map((t) => ({
 					value: t.id,
-					label: `${t.title} — ${t.description}`,
+					label: t.title,
+					hint: t.description,
 				})),
 				{
 					value: "none",
 					label: "No thanks — continue without scaffolding",
 				},
 			],
-			initialValue: "none",
+			initialValue: templates[0]?.id ?? "none",
 		});
 		if (isCancel(templateResult)) {
 			outro("Setup cancelled.");

--- a/packages/init/src/lib/bootstrap.test.ts
+++ b/packages/init/src/lib/bootstrap.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+import { FALLBACK_TEMPLATES, parseManifest } from "./bootstrap.js";
+
+describe("parseManifest", () => {
+	test("parses a valid manifest with requires", () => {
+		const yaml = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    requires:
+      - database
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+  - id: next-auth
+    title: Next.js with Auth
+    description: A Next.js template with auth.
+    requires:
+      - database
+      - auth
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-next-auth
+`;
+		const templates = parseManifest(yaml);
+		expect(templates).toHaveLength(2);
+		expect(templates[0].requires).toEqual(["database"]);
+		expect(templates[1].requires).toEqual(["database", "auth"]);
+	});
+
+	test("defaults requires to ['database'] when not specified", () => {
+		const yaml = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+		const templates = parseManifest(yaml);
+		expect(templates).toHaveLength(1);
+		expect(templates[0].requires).toEqual(["database"]);
+	});
+
+	test("skips malformed entries and keeps valid ones", () => {
+		const yaml = `templates:
+  - id: good
+    title: Good
+    description: A good template.
+    source:
+      owner: org
+      repo: repo
+      ref: main
+      subdir: good
+  - id: bad-no-source
+    title: Bad
+    description: Missing source field.
+  - not-even-an-object
+`;
+		const templates = parseManifest(yaml);
+		expect(templates).toHaveLength(1);
+		expect(templates[0].id).toBe("good");
+	});
+
+	test("returns empty array when all entries are malformed", () => {
+		const yaml = `templates:
+  - id: 123
+    title: numeric id
+`;
+		expect(parseManifest(yaml)).toEqual([]);
+	});
+
+	test("throws when the top-level structure is invalid", () => {
+		expect(() => parseManifest("not-yaml: []")).toThrow(
+			'missing "templates" array',
+		);
+		expect(() => parseManifest("templates: not-an-array")).toThrow(
+			'missing "templates" array',
+		);
+	});
+
+	test("handles an empty templates array", () => {
+		expect(parseManifest("templates: []")).toEqual([]);
+	});
+});
+
+describe("FALLBACK_TEMPLATES", () => {
+	test("contains at least one template", () => {
+		expect(FALLBACK_TEMPLATES.length).toBeGreaterThan(0);
+	});
+
+	test("each template has required fields", () => {
+		for (const t of FALLBACK_TEMPLATES) {
+			expect(typeof t.id).toBe("string");
+			expect(typeof t.title).toBe("string");
+			expect(typeof t.description).toBe("string");
+			expect(Array.isArray(t.requires)).toBe(true);
+			expect(t.requires.length).toBeGreaterThan(0);
+			expect(typeof t.source.owner).toBe("string");
+			expect(typeof t.source.repo).toBe("string");
+			expect(typeof t.source.ref).toBe("string");
+			expect(typeof t.source.subdir).toBe("string");
+		}
+	});
+});

--- a/packages/init/src/lib/bootstrap.ts
+++ b/packages/init/src/lib/bootstrap.ts
@@ -1,0 +1,117 @@
+import YAML from "yaml";
+
+/**
+ * Neon features that a template or project may require.
+ * Each feature maps to a setup phase that the orchestrator can run.
+ */
+export type NeonFeature =
+	| "database"
+	| "auth"
+	| "functions"
+	| "ai-gateway"
+	| "object-storage";
+
+/** Default features when a template doesn't specify `requires`. */
+const DEFAULT_REQUIRES: NeonFeature[] = ["database"];
+
+export interface BootstrapTemplate {
+	id: string;
+	title: string;
+	description: string;
+	/** Neon features this template needs (defaults to ["database"]) */
+	requires: NeonFeature[];
+	source: {
+		owner: string;
+		repo: string;
+		ref: string;
+		subdir: string;
+	};
+}
+
+/** Hardcoded fallback used when the remote manifest cannot be fetched. */
+export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
+	{
+		id: "hono",
+		title: "Hono API (Drizzle, Neon Postgres) on Neon Functions",
+		description:
+			"A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function.",
+		requires: ["database", "functions"],
+		source: {
+			owner: "neondatabase",
+			repo: "examples",
+			ref: "main",
+			subdir: "with-hono",
+		},
+	},
+];
+
+const MANIFEST_URL =
+	"https://raw.githubusercontent.com/neondatabase/examples/main/bootstrap.yaml";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+export function parseManifest(text: string): BootstrapTemplate[] {
+	const data: unknown = YAML.parse(text);
+	if (!isRecord(data) || !Array.isArray(data.templates)) {
+		throw new Error(
+			'Invalid bootstrap manifest: missing "templates" array.',
+		);
+	}
+	const templates: BootstrapTemplate[] = [];
+	for (const item of data.templates) {
+		if (
+			!isRecord(item) ||
+			typeof item.id !== "string" ||
+			typeof item.title !== "string" ||
+			typeof item.description !== "string" ||
+			!isRecord(item.source) ||
+			typeof item.source.owner !== "string" ||
+			typeof item.source.repo !== "string" ||
+			typeof item.source.ref !== "string" ||
+			typeof item.source.subdir !== "string"
+		) {
+			continue;
+		}
+		// Parse requires — accept string array, default to ["database"]
+		const requires: NeonFeature[] =
+			Array.isArray(item.requires) &&
+			item.requires.every((r: unknown) => typeof r === "string")
+				? (item.requires as NeonFeature[])
+				: DEFAULT_REQUIRES;
+
+		templates.push({
+			id: item.id,
+			title: item.title,
+			description: item.description,
+			requires,
+			source: {
+				owner: item.source.owner,
+				repo: item.source.repo,
+				ref: item.source.ref,
+				subdir: item.source.subdir,
+			},
+		});
+	}
+	return templates;
+}
+
+/**
+ * Fetch the template manifest from the remote bootstrap.yaml in the
+ * neondatabase/examples repo. Falls back to the hardcoded list on any error.
+ */
+export async function fetchTemplates(): Promise<BootstrapTemplate[]> {
+	const url = process.env.NEON_BOOTSTRAP_MANIFEST_URL ?? MANIFEST_URL;
+	try {
+		const res = await fetch(url, {
+			signal: AbortSignal.timeout(10_000),
+		});
+		if (!res.ok) throw new Error(`HTTP ${res.status}`);
+		const text = await res.text();
+		const templates = parseManifest(text);
+		if (templates.length === 0) return FALLBACK_TEMPLATES;
+		return templates;
+	} catch {
+		return FALLBACK_TEMPLATES;
+	}
+}

--- a/packages/init/src/lib/inspect.ts
+++ b/packages/init/src/lib/inspect.ts
@@ -21,6 +21,8 @@ export interface InspectionResults {
 	migrationDir?: string;
 	isVscodeIde?: boolean;
 	agent?: string;
+	/** True if the directory contains an application (package.json with deps, or source files) */
+	hasApp?: boolean;
 }
 
 /**
@@ -61,6 +63,9 @@ export async function inspectProject(
 				break;
 			case "ide_type":
 				results.isVscodeIde = checkVscodeIde();
+				break;
+			case "has_app":
+				results.hasApp = checkHasApp(cwd);
 				break;
 			case "agent_type":
 				// Handled by the interactive runner (prompt or env detection)
@@ -280,4 +285,37 @@ function checkVscodeIde(): boolean {
 		env.VSCODE_PID ||
 		env.VSCODE_CWD
 	);
+}
+
+/**
+ * Detects whether the current directory contains an application.
+ * Returns true if package.json has dependencies or common source directories exist.
+ */
+function checkHasApp(cwd: string): boolean {
+	const pkgPath = resolve(cwd, "package.json");
+	if (existsSync(pkgPath)) {
+		try {
+			const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+			const deps = Object.keys(pkg.dependencies ?? {});
+			const devDeps = Object.keys(pkg.devDependencies ?? {});
+			if (deps.length > 0 || devDeps.length > 0) return true;
+		} catch {}
+	}
+
+	// Check for common source directories / entry files
+	const indicators = [
+		"src",
+		"app",
+		"pages",
+		"lib",
+		"index.ts",
+		"index.js",
+		"main.ts",
+		"main.js",
+	];
+	for (const indicator of indicators) {
+		if (existsSync(resolve(cwd, indicator))) return true;
+	}
+
+	return false;
 }

--- a/packages/init/src/lib/phases/cleanup.ts
+++ b/packages/init/src/lib/phases/cleanup.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { PhaseResponse } from "../types.js";
+
+/**
+ * Terminal phase: cleans up ephemeral _init state from .neon and
+ * returns a complete message. All feature chains should end here.
+ */
+export function handleCleanup(): PhaseResponse {
+	const neonContextPath = resolve(process.cwd(), ".neon");
+	if (existsSync(neonContextPath)) {
+		try {
+			const context = JSON.parse(readFileSync(neonContextPath, "utf-8"));
+			if (context._init !== undefined) {
+				delete context._init;
+				writeFileSync(
+					neonContextPath,
+					`${JSON.stringify(context, null, 2)}\n`,
+				);
+			}
+		} catch {}
+	}
+
+	return {
+		phase: "setup",
+		status: "complete",
+		nextAction: {
+			type: "complete",
+			message:
+				"Neon setup is complete! Your database is connected and your agent has the Neon MCP server and skills available.",
+		},
+	};
+}

--- a/packages/init/src/lib/phases/getting-started.test.ts
+++ b/packages/init/src/lib/phases/getting-started.test.ts
@@ -34,13 +34,13 @@ describe("getting-started phase", () => {
 			expect(stepIds).toContain("select_org");
 			expect(stepIds).toContain("select_or_create_project");
 			expect(stepIds).toContain("create_project_if_needed");
-			expect(stepIds).toContain("set_connection_string");
+			expect(stepIds).toContain("pull_env");
 			// Org step should list orgs first
 			const orgStep = result.nextAction.steps.find(
 				(s) => s.id === "select_org",
 			);
 			expect(orgStep?.command).toContain("neonctl orgs list");
-			expect(orgStep?.description).toContain("MCP tool");
+			expect(orgStep?.description).toContain("CLI");
 			// Create step should include --org-id
 			const createStep = result.nextAction.steps.find(
 				(s) => s.id === "create_project_if_needed",
@@ -59,7 +59,7 @@ describe("getting-started phase", () => {
 			const stepIds = result.nextAction.steps.map((s) => s.id);
 			expect(stepIds).not.toContain("select_org");
 			expect(stepIds).not.toContain("select_or_create_project");
-			expect(stepIds).not.toContain("set_connection_string");
+			expect(stepIds).not.toContain("pull_env");
 		}
 	});
 
@@ -141,9 +141,8 @@ describe("getting-started phase", () => {
 			const verifyStep = result.nextAction.steps.find(
 				(s) => s.id === "verify_connection",
 			);
-			expect(verifyStep?.description).toContain("MCP tool");
 			expect(verifyStep?.description).toContain(
-				"Do NOT use the neonctl CLI",
+				"direct database connection",
 			);
 		}
 	});

--- a/packages/init/src/lib/phases/getting-started.ts
+++ b/packages/init/src/lib/phases/getting-started.ts
@@ -8,14 +8,18 @@ export interface GettingStartedPhaseOptions {
 	orm?: string;
 	migrationTool?: string;
 	migrationDir?: string;
+	/** Neon features required by the project (from .neon or template) */
+	features?: string[];
+	/** Preview mode — restricts project creation to new projects in AWS us-east */
+	preview?: boolean;
 }
 
 /**
  * Initiates the "Get started with Neon" workflow.
  *
- * Steps are concrete and executable — each has either an MCP tool to call,
- * a CLI command to run, or a specific file operation. The agent should
- * attempt each step in order and actually perform the action.
+ * Steps are concrete and executable — each has a CLI command to run
+ * or a specific file operation. The agent should attempt each step
+ * in order and actually perform the action using the neonctl CLI.
  */
 export async function handleGettingStartedPhase(
 	options: GettingStartedPhaseOptions,
@@ -27,72 +31,112 @@ export async function handleGettingStartedPhase(
 	const steps: { id: string; description: string; command?: string }[] = [];
 
 	if (!options.hasConnectionString) {
-		// Step 1: List organizations and let user choose
-		steps.push({
-			id: "select_org",
-			description: [
-				"List the user's Neon organizations.",
-				"Try using the Neon MCP tool `list_organizations` first.",
-				"If MCP is not available, use the CLI command below.",
-				"If only one org exists, use it automatically.",
-				"If multiple orgs exist, ask the user which one to use.",
-				"Remember the selected org ID for the next steps.",
-			].join(" "),
-			command: "CI= npx -y neonctl orgs list --output json",
-		});
+		if (options.preview) {
+			// Preview mode: new project in AWS us-east-2, or existing eligible project
+			steps.push(
+				{
+					id: "select_org",
+					description: [
+						"List the user's Neon organizations using the CLI command below.",
+						"If only one org exists, use it automatically.",
+						"If multiple orgs exist, ask the user which one to use.",
+						"Remember the selected org ID for the next steps.",
+					].join(" "),
+					command: "CI= npx -y neonctl orgs list --output json",
+				},
+				{
+					id: "select_or_create_project",
+					description: [
+						"List existing Neon projects in the selected organization using the CLI command below (replace <org-id> with the selected org ID).",
+						"IMPORTANT: Preview features require a project in the AWS us-east-2 region created on or after 2026-06-11.",
+						"Filter the project list to ONLY show projects where region_id is 'aws-us-east-2' AND created_at is on or after '2026-06-11'.",
+						"If eligible projects exist, present them alongside a 'Create new project' option.",
+						"If no eligible projects exist, tell the user and proceed directly to creating a new one.",
+						"IMPORTANT: Always include --org-id when creating a project to avoid interactive prompts.",
+					].join(" "),
+					command:
+						"CI= npx -y neonctl projects list --org-id <org-id> --output json",
+				},
+				{
+					id: "create_project_if_needed",
+					description: [
+						"If the user chose to create a new project, create it in the AWS us-east-2 region using the CLI command below (replace <org-id> and <project-name>).",
+						"Ask the user for a project name (suggest the current directory name).",
+						"If the user chose an existing eligible project, skip this step.",
+					].join(" "),
+					command:
+						"CI= npx -y neonctl projects create --name <project-name> --org-id <org-id> --region-id aws-us-east-2 --output json",
+				},
+			);
+		} else {
+			// Standard mode: let user choose existing or create new
+			steps.push(
+				{
+					id: "select_org",
+					description: [
+						"List the user's Neon organizations using the CLI command below.",
+						"If only one org exists, use it automatically.",
+						"If multiple orgs exist, ask the user which one to use.",
+						"Remember the selected org ID for the next steps.",
+					].join(" "),
+					command: "CI= npx -y neonctl orgs list --output json",
+				},
+				{
+					id: "select_or_create_project",
+					description: [
+						"List existing Neon projects in the selected organization using the CLI command below (replace <org-id> with the selected org ID).",
+						"Ask the user whether they want to use an existing project or create a new one.",
+						"If creating new, ask the user for a project name (suggest the current directory name).",
+						"IMPORTANT: Always include --org-id when creating a project to avoid interactive prompts.",
+					].join(" "),
+					command:
+						"CI= npx -y neonctl projects list --org-id <org-id> --output json",
+				},
+				{
+					id: "create_project_if_needed",
+					description: [
+						"If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>).",
+						"If the user chose an existing project, skip this step.",
+					].join(" "),
+					command:
+						"CI= npx -y neonctl projects create --name <project-name> --org-id <org-id> --output json",
+				},
+			);
+		}
 
-		// Step 2: List projects and let user choose or create new
-		steps.push({
-			id: "select_or_create_project",
-			description: [
-				"List existing Neon projects in the selected organization.",
-				"Try using the Neon MCP tool `list_projects` first.",
-				"If MCP is not available, use the CLI command below (replace <org-id> with the selected org ID).",
-				"Ask the user whether they want to use an existing project or create a new one.",
-				"If creating new, ask the user for a project name (suggest the current directory name).",
-				"IMPORTANT: Always include --org-id when creating a project to avoid interactive prompts.",
-			].join(" "),
-			command:
-				"CI= npx -y neonctl projects list --org-id <org-id> --output json",
-		});
-
-		// Step 3: Create project if needed (only if user chose to create new)
-		steps.push({
-			id: "create_project_if_needed",
-			description: [
-				"If the user chose to create a new project, create it now.",
-				"Try using the Neon MCP tool `create_project` first.",
-				"If MCP is not available, use the CLI command below (replace <org-id> and <project-name>).",
-				"If the user chose an existing project, skip this step.",
-			].join(" "),
-			command:
-				"CI= npx -y neonctl projects create --name <project-name> --org-id <org-id> --output json",
-		});
-
-		// Step 4: Create .neon context file
+		// Create/update .neon context file
 		steps.push({
 			id: "create_neon_context",
 			description: [
-				"Create a .neon context file in the project root with the selected org and project IDs.",
-				'The file is JSON with this format: {"orgId": "<org-id>", "projectId": "<project-id>"}',
-				"If a .neon file already exists, update only the fields that are missing or different. Do NOT overwrite fields the user may have customized (e.g. branch).",
+				"Update the .neon context file in the project root with the selected org and project IDs.",
+				"IMPORTANT: If a .neon file already exists, you MUST read it first, then merge the new orgId and projectId into the existing content. Do NOT overwrite the file — other fields (like _init, branch, etc.) must be preserved.",
+				"If no .neon file exists, create one.",
+				'The file is JSON. Add/update only the orgId and projectId fields: {"orgId": "<org-id>", "projectId": "<project-id>", ...existing fields}.',
 				"This file is safe to commit — it contains no secrets.",
 			].join(" "),
 		});
 
-		// Step 5: Get connection string and write to .env
+		// Install project dependencies (required before env pull — config files may import packages)
 		steps.push({
-			id: "set_connection_string",
+			id: "install_dependencies",
 			description: [
-				"Get the database connection string for the selected or newly created project.",
-				"Try using the Neon MCP tool `get_connection_string` first.",
-				"If MCP is not available, use the CLI command below.",
-				"Then write DATABASE_URL=<connection_string> to the .env file.",
-				"Create .env if it doesn't exist. Do NOT overwrite existing entries.",
-				"Ensure .env is listed in .gitignore.",
+				"Check if node_modules exists in the project root.",
+				"If not, install project dependencies using the appropriate package manager (check for pnpm-lock.yaml, yarn.lock, bun.lockb, or default to npm).",
+				"This must be done before `neonctl env pull` because the project's Neon config file may import packages that need to be installed first.",
 			].join(" "),
-			command:
-				"CI= npx -y neonctl connection-string --project-id <project-id>",
+			command: "npm install",
+		});
+
+		// Pull environment variables (connection string, etc.) from Neon
+		steps.push({
+			id: "pull_env",
+			description: [
+				"Now that the .neon context file is in place and dependencies are installed, run `neonctl env pull` to populate the project's environment variables.",
+				"This automatically writes the database connection string (and any other Neon-managed env vars) to the correct env file.",
+				"It reads the .neon context file to determine the project, and writes to the appropriate env file for the project.",
+				"Ensure the target env file is listed in .gitignore.",
+			].join(" "),
+			command: "CI= npx -y neonctl env pull",
 		});
 
 		// Step 6: Install Neon serverless driver if needed
@@ -124,19 +168,56 @@ export async function handleGettingStartedPhase(
 
 	// Run migrations if applicable
 	if (options.migrationTool && options.migrationTool !== "none") {
-		const migrationCommands: Record<string, string> = {
-			prisma: "npx prisma migrate deploy",
-			drizzle: "npx drizzle-kit migrate",
-			knex: "npx knex migrate:latest",
-		};
-		const cmd = migrationCommands[options.migrationTool.toLowerCase()];
-		if (cmd) {
+		const tool = options.migrationTool.toLowerCase();
+		const migrationDir = options.migrationDir;
+		const hasMigrationDir = migrationDir && migrationDir !== "none";
+
+		if (tool === "drizzle") {
 			steps.push({
 				id: "run_migrations",
-				description: `Apply existing ${options.migrationTool} migrations to the Neon database.`,
-				command: cmd,
+				description: [
+					hasMigrationDir
+						? `Check if the ${migrationDir} directory contains .sql migration files.`
+						: "Check if a drizzle migrations directory exists with .sql files.",
+					"If .sql files exist, apply them with `npx drizzle-kit migrate`.",
+					"If the directory is empty or missing but a drizzle schema file exists (e.g. src/db/schema.ts, drizzle/schema.ts), run `npx drizzle-kit generate` first to create migrations, then `npx drizzle-kit migrate` to apply them.",
+					"If neither schema nor migrations exist, skip this step.",
+				].join(" "),
+				command: "npx drizzle-kit migrate",
+			});
+		} else if (tool === "prisma") {
+			steps.push({
+				id: "run_migrations",
+				description: [
+					hasMigrationDir
+						? `Check if the ${migrationDir} directory contains migration folders.`
+						: "Check if prisma/migrations contains migration folders.",
+					"If migrations exist, apply them with `npx prisma migrate deploy`.",
+					"If the migrations directory is empty or missing but prisma/schema.prisma has models defined, run `npx prisma migrate dev --name init` to create and apply the initial migration.",
+					"If no models are defined, skip this step.",
+				].join(" "),
+				command: "npx prisma migrate deploy",
+			});
+		} else if (tool === "knex") {
+			steps.push({
+				id: "run_migrations",
+				description: `Apply existing knex migrations to the Neon database.`,
+				command: "npx knex migrate:latest",
 			});
 		}
+	} else if (options.preview) {
+		// Bootstrap flow: migration tool wasn't detected because the project was
+		// inspected before scaffolding. Detect and run migrations from the scaffolded template.
+		steps.push({
+			id: "run_migrations",
+			description: [
+				"Check the scaffolded project for a migration tool and schema.",
+				"Look for: drizzle.config.ts/js (Drizzle), prisma/schema.prisma (Prisma), or knexfile.ts/js (Knex).",
+				"If Drizzle is found: check if a drizzle migrations directory exists with .sql files. If .sql files exist, run `npx drizzle-kit migrate`. If the directory is empty or missing but a schema file exists, run `npx drizzle-kit generate` first, then `npx drizzle-kit migrate`.",
+				"If Prisma is found: check if prisma/migrations contains migration folders. If yes, run `npx prisma migrate deploy`. If not but models exist, run `npx prisma migrate dev --name init`.",
+				"If no migration tool is found, skip this step.",
+			].join(" "),
+		});
 	}
 
 	// Verify the connection
@@ -144,9 +225,8 @@ export async function handleGettingStartedPhase(
 		id: "verify_connection",
 		description: [
 			"Verify the database connection works by running a SQL query against the Neon database.",
-			"Use the Neon MCP tool `run_sql` to query a table from the migration (if migrations were run), or run `SELECT 1` as a basic connectivity check.",
-			"If MCP is not available, write and run a short script that connects using DATABASE_URL from .env and executes the query.",
-			"Do NOT use the neonctl CLI for queries.",
+			"Write and run a short script that connects using DATABASE_URL from the project's env file and executes `SELECT 1` (or queries a table from the migration if migrations were run).",
+			"Do NOT use the neonctl CLI or MCP tools for this — use a direct database connection to verify end-to-end connectivity.",
 		].join(" "),
 	});
 
@@ -157,14 +237,31 @@ export async function handleGettingStartedPhase(
 			type: "agent_action",
 			prerequisite: SKILL_REFERENCE_URLS.gettingStarted,
 			steps,
-			onComplete: {
-				type: "run_neon_init",
-				args: [
-					"neon-auth",
-					"--json",
-					...(options.agent ? ["--agent", options.agent] : []),
-				],
-			},
+			onComplete: buildOnComplete(options),
 		},
+	};
+}
+
+function buildOnComplete(
+	options: GettingStartedPhaseOptions,
+): import("../types.js").RunNeonInitAction {
+	const agentArgs = options.agent ? ["--agent", options.agent] : [];
+	const features = options.features ?? [];
+	const hasFeatureRequirements = features.length > 0;
+
+	// If features are specified and auth is not required, go to finalize
+	if (hasFeatureRequirements && !features.includes("auth")) {
+		return {
+			type: "run_neon_init",
+			args: ["finalize", "--json", ...agentArgs],
+		};
+	}
+
+	// Chain to neon-auth — if user already selected auth via features, go straight to setup
+	const authSetup =
+		hasFeatureRequirements && features.includes("auth") ? ["--setup"] : [];
+	return {
+		type: "run_neon_init",
+		args: ["neon-auth", "--json", ...agentArgs, ...authSetup],
 	};
 }

--- a/packages/init/src/lib/phases/neon-auth.ts
+++ b/packages/init/src/lib/phases/neon-auth.ts
@@ -51,11 +51,13 @@ export async function handleNeonAuthPhase(
 						],
 					},
 					no: {
-						action: {
-							type: "complete",
-							message:
-								"Neon setup is complete. You can set up Neon Auth later by having your agent run: neon-init neon-auth",
-						},
+						args: [
+							"finalize",
+							"--json",
+							...(options.agent
+								? ["--agent", options.agent]
+								: []),
+						],
 					},
 				},
 			},
@@ -74,12 +76,9 @@ export async function handleNeonAuthPhase(
 					{
 						id: "provision",
 						description:
-							"Enable Neon Auth on the project. " +
-							"Try using the Neon MCP server's provision_neon_auth tool first. " +
-							"If the MCP server is not available or the tool call fails, fall back to the neonctl CLI: " +
-							"`CI= npx -y neonctl neon-auth enable --project-id <project-id> --output json`. " +
-							"You can also check current status with: " +
-							"`CI= npx -y neonctl neon-auth status --project-id <project-id> --output json`." +
+							"Enable Neon Auth on the project using the neonctl CLI. " +
+							"Run: `CI= npx -y neonctl neon-auth enable --project-id <project-id> --output json`. " +
+							"You can check current status with: `CI= npx -y neonctl neon-auth status --project-id <project-id> --output json`." +
 							(options.projectId
 								? ` Project ID: ${options.projectId}.`
 								: " Determine the project ID from the .neon file in the project root, or from the DATABASE_URL in .env, or ask the user."),
@@ -95,16 +94,19 @@ export async function handleNeonAuthPhase(
 							"Create auth components per the skill reference. Follow the exact patterns and imports specified.",
 					},
 					{
-						id: "wire_env",
+						id: "pull_env",
 						description:
-							"Add the NEON_AUTH_* environment variables to .env as specified in the skill reference.",
+							"Run `neonctl env pull` to populate the NEON_AUTH_BASE_URL, NEON_AUTH_JWKS_URL, and other Neon Auth environment variables. This reads the .neon context file and writes the auth URLs to the project's env file.",
+						command: "CI= npx -y neonctl env pull",
 					},
 				],
 				onComplete: {
-					type: "complete",
-					message:
-						"Neon Auth has been configured successfully. Neon setup is complete! " +
-						"Your database is connected, agent tooling is installed, and authentication is ready.",
+					type: "run_neon_init",
+					args: [
+						"finalize",
+						"--json",
+						...(options.agent ? ["--agent", options.agent] : []),
+					],
 				},
 			},
 		};
@@ -135,11 +137,11 @@ export async function handleNeonAuthPhase(
 					],
 				},
 				no: {
-					action: {
-						type: "complete",
-						message:
-							"Neon setup is complete. You can set up Neon Auth later by having your agent run: neon-init neon-auth",
-					},
+					args: [
+						"finalize",
+						"--json",
+						...(options.agent ? ["--agent", options.agent] : []),
+					],
 				},
 				info: {
 					args: [

--- a/packages/init/src/lib/phases/setup.test.ts
+++ b/packages/init/src/lib/phases/setup.test.ts
@@ -48,6 +48,27 @@ vi.mock("node:fs/promises", () => ({
 	unlink: vi.fn().mockReturnValue(Promise.resolve()),
 }));
 
+vi.mock("../bootstrap.js", () => {
+	const templates = [
+		{
+			id: "hono",
+			title: "Hono API",
+			description: "A Hono template.",
+			requires: ["database"],
+			source: {
+				owner: "neondatabase",
+				repo: "examples",
+				ref: "main",
+				subdir: "with-hono",
+			},
+		},
+	];
+	return {
+		fetchTemplates: vi.fn().mockResolvedValue(templates),
+		FALLBACK_TEMPLATES: templates,
+	};
+});
+
 // Mock global fetch for Open VSX VSIX download
 const mockFetch = vi.fn();
 vi.stubGlobal("fetch", mockFetch);

--- a/packages/init/src/lib/phases/setup.ts
+++ b/packages/init/src/lib/phases/setup.ts
@@ -1,6 +1,13 @@
+import { writeFileSync } from "node:fs";
 import { unlink } from "node:fs/promises";
+import { resolve } from "node:path";
 import { execa } from "execa";
 import { resolveAddMcpAgentId } from "../agents.js";
+import {
+	FALLBACK_TEMPLATES,
+	fetchTemplates,
+	type NeonFeature,
+} from "../bootstrap.js";
 import {
 	detectIde,
 	isCursorInstalled,
@@ -17,6 +24,14 @@ export interface SetupPhaseOptions {
 	agent?: string;
 	/** The IDE/editor the user is running in (e.g. "cursor", "vscode") — reported by agent */
 	ide?: string;
+	/** Whether the directory already contains an application */
+	hasApp?: boolean;
+	/** Template ID to scaffold (when bootstrapping a new project) */
+	template?: string;
+	/** Neon features required by the selected template */
+	templateRequires?: NeonFeature[];
+	/** Neon features selected by the user (brownfield flows) */
+	features?: NeonFeature[];
 	// Inspection results — pre-filled by orchestrator or reported by agent
 	mcpConfigured?: boolean | null;
 	connectionString?: boolean | null;
@@ -45,6 +60,27 @@ export interface SetupPhaseOptions {
 export async function handleSetupPhase(
 	options: SetupPhaseOptions,
 ): Promise<PhaseResponse> {
+	// Parse features from comma-separated string (e.g. "database,auth" from agent --data)
+	if (typeof options.features === "string") {
+		options.features = (options.features as unknown as string)
+			.split(",")
+			.map((f) => f.trim()) as NeonFeature[];
+	}
+
+	// Treat "none" as no template selected
+	if (options.template === "none") {
+		options.template = undefined;
+	}
+
+	// Resolve template requirements if a template was selected but requires not yet populated
+	if (options.template && !options.templateRequires) {
+		const templates = await fetchTemplates();
+		const selected = templates.find((t) => t.id === options.template);
+		if (selected) {
+			options.templateRequires = selected.requires;
+		}
+	}
+
 	// --execute: run the batched installation (legacy path)
 	if (options.execute) {
 		return executeBatchedInstallation(await mergeCliInspection(options));
@@ -94,7 +130,34 @@ export async function handleSetupPhase(
 	return buildBulkInspection(options);
 }
 
-function buildBulkInspection(_options: SetupPhaseOptions): PhaseResponse {
+function buildTemplatePreference(
+	templates: { id: string; title: string; description: string }[],
+) {
+	return [
+		{
+			id: "template",
+			question:
+				"No application was detected in this directory. Would you like to scaffold a new project from a template?",
+			phase: "before_checks" as const,
+			options: [
+				...templates.map((t) => ({
+					value: t.id,
+					label: `${t.title} — ${t.description}`,
+				})),
+				{
+					value: "none",
+					label: "No thanks — continue without scaffolding",
+				},
+			],
+			default: "none",
+		},
+	];
+}
+
+async function buildBulkInspection(
+	options: SetupPhaseOptions,
+): Promise<PhaseResponse> {
+	const hasApp = options.hasApp !== false;
 	const detectedIde = detectIde();
 
 	// If no IDE detected (e.g. standalone terminal), check what's installed
@@ -104,15 +167,30 @@ function buildBulkInspection(_options: SetupPhaseOptions): PhaseResponse {
 		if (isVSCodeInstalled()) installedEditors.push("vscode");
 	}
 
+	// Fetch available templates when no app is detected
+	let templatePreferences: ReturnType<typeof buildTemplatePreference> = [];
+	if (!hasApp) {
+		let templates = FALLBACK_TEMPLATES;
+		try {
+			const fetched = await fetchTemplates();
+			if (fetched && fetched.length > 0) templates = fetched;
+		} catch {}
+		templatePreferences = buildTemplatePreference(templates);
+	}
+
 	return {
 		phase: "setup",
-		status: "pending",
+		status: hasApp ? "pending" : "bootstrap_needed",
 		detectedIde: detectedIde?.toLowerCase() ?? null,
 		installedEditors: installedEditors.length > 0 ? installedEditors : null,
 		nextAction: {
 			type: "agent_check",
 			instructions: [
-				"Perform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the `condition` field — only show a question if its condition is met.",
+				"IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.",
+				"",
+				hasApp
+					? "Perform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the `condition` field — only show a question if its condition is met."
+					: "No application was detected in this directory. Ask the user if they'd like to scaffold a new project from a template (the `template` preference). Present ALL template options and the 'No thanks' option — do NOT auto-select even if there is only one template. If the user selects a template, the scaffolded template includes agent skills so skills installation will be skipped. If the user chooses 'none', continue with the remaining setup preferences normally. Then perform the agent checks and present the remaining preferences ONE AT A TIME.",
 				"",
 				"If the MCP server is already configured, tell the user and note that it will be kept up to date. IMPORTANT: If you find neon-postgres in skills-lock.json, you MUST verify the actual SKILL.md file exists on disk (e.g. .agents/skills/neon-postgres/SKILL.md or .cursor/skills/neon-postgres/SKILL.md). If the lock file references it but the file is missing, report skills as NOT installed. Only ask about scope/options for components that are NOT already configured.",
 				"",
@@ -167,6 +245,31 @@ function buildBulkInspection(_options: SetupPhaseOptions): PhaseResponse {
 					: []),
 			],
 			userPreferences: [
+				...templatePreferences,
+				// For brownfield flows, ask which Neon features to enable
+				...(hasApp
+					? [
+							{
+								id: "features",
+								question:
+									"Which Neon features would you like to enable for this project?",
+								phase: "after_checks" as const,
+								options: [
+									{
+										value: "database",
+										label: "Database (always included)",
+									},
+									{
+										value: "database,auth",
+										label: "Database + Neon Auth (adds authentication via Neon)",
+									},
+								],
+								default: "database",
+								context:
+									"Database connectivity is always set up. Neon Auth adds user authentication powered by Neon. More features (Functions, AI Gateway, Object Storage) will be available soon.",
+							},
+						]
+					: []),
 				{
 					id: "mode",
 					question: "Use default settings or customize?",
@@ -174,7 +277,9 @@ function buildBulkInspection(_options: SetupPhaseOptions): PhaseResponse {
 					options: [
 						{
 							value: "defaults",
-							label: "Use defaults (neonctl CLI, MCP: global, skills: project-level, extension if applicable — already-configured components will be skipped)",
+							label: hasApp
+								? "Use defaults (neonctl CLI, MCP: global, skills: project-level, extension if applicable — already-configured components will be skipped)"
+								: "Use defaults (neonctl CLI, MCP: global, extension if applicable — skills included in template)",
 						},
 						{
 							value: "customize",
@@ -207,26 +312,35 @@ function buildBulkInspection(_options: SetupPhaseOptions): PhaseResponse {
 					condition: { preferenceId: "mode", equals: "customize" },
 					group: "customize",
 				},
-				{
-					id: "skillsScope",
-					question: "Where should Neon agent skills be installed?",
-					context:
-						"Always ask this question — the CLI handles skill detection and freshness automatically.",
-					phase: "after_checks",
-					options: [
-						{
-							value: "global",
-							label: "Global (available in all projects)",
-						},
-						{
-							value: "project",
-							label: "Project-level (scoped to this project only)",
-						},
-					],
-					default: "project",
-					condition: { preferenceId: "mode", equals: "customize" },
-					group: "customize",
-				},
+				// Only show skills scope when there's an existing app (templates bundle skills)
+				...(hasApp
+					? [
+							{
+								id: "skillsScope",
+								question:
+									"Where should Neon agent skills be installed?",
+								context:
+									"Always ask this question — the CLI handles skill detection and freshness automatically.",
+								phase: "after_checks" as const,
+								options: [
+									{
+										value: "global",
+										label: "Global (available in all projects)",
+									},
+									{
+										value: "project",
+										label: "Project-level (scoped to this project only)",
+									},
+								],
+								default: "project",
+								condition: {
+									preferenceId: "mode",
+									equals: "customize",
+								},
+								group: "customize",
+							},
+						]
+					: []),
 				{
 					id: "installExtension",
 					question:
@@ -249,7 +363,7 @@ function buildBulkInspection(_options: SetupPhaseOptions): PhaseResponse {
 					"setup",
 					"--json",
 					"--data",
-					"<json: { agent: string, ide: string, mcpConfigured: bool, mode: string, mcpScope?: 'global'|'project'|'none', skillsScope?: string, installExtension?: bool }>",
+					`<json: { agent: string, ide: string, mcpConfigured: bool, mode: string, mcpScope?: 'global'|'project'|'none', skillsScope?: string, installExtension?: bool${hasApp ? ", features?: string" : ", template: string"} }>`,
 				],
 			},
 		},
@@ -455,6 +569,49 @@ async function executeBatchedInstallation(
 	const installExt = options.installExtension === true;
 
 	const results: InstallResult[] = [];
+	const isBootstrap = !!options.template;
+
+	// Step 0: Bootstrap project from template if specified
+	if (isBootstrap && options.template) {
+		try {
+			await execa(
+				"npx",
+				[
+					"neonctl",
+					"bootstrap",
+					".",
+					"--template",
+					options.template,
+					"--force",
+				],
+				{ stdio: "pipe", timeout: 120000 },
+			);
+			results.push({
+				id: "bootstrap",
+				description: `Scaffolded project from template "${options.template}"`,
+				status: "success",
+			});
+
+			// Write template features to .neon under _init (ephemeral, cleaned up when init completes)
+			if (options.templateRequires) {
+				const neonContextPath = resolve(process.cwd(), ".neon");
+				const context: Record<string, unknown> = {
+					_init: { features: options.templateRequires },
+				};
+				writeFileSync(
+					neonContextPath,
+					`${JSON.stringify(context, null, 2)}\n`,
+				);
+			}
+		} catch (err) {
+			results.push({
+				id: "bootstrap",
+				description: `Failed to scaffold project from template "${options.template}"`,
+				status: "failed",
+				error: err instanceof Error ? err.message : "Unknown error",
+			});
+		}
+	}
 
 	// Step 1: Ensure neonctl CLI is installed and up to date
 	const neonctlResult = await ensureNeonctl();
@@ -562,16 +719,24 @@ async function executeBatchedInstallation(
 		}
 	}
 
-	// Step 3: Install/update skills (ensureSkillsUpToDate handles freshness checks)
-	const skillsScope = options.skillsScope ?? "project";
-	const skillsOk = await ensureSkillsUpToDate(agentId, skillsScope);
-	results.push({
-		id: "install_skills",
-		description: skillsOk
-			? "Neon agent skills installed"
-			: "Failed to install Neon agent skills",
-		status: skillsOk ? "success" : "failed",
-	});
+	// Step 3: Install/update skills (skip when bootstrapping — templates bundle skills)
+	if (isBootstrap) {
+		results.push({
+			id: "install_skills",
+			description: "Neon agent skills included in template",
+			status: "success",
+		});
+	} else {
+		const skillsScope = options.skillsScope ?? "project";
+		const skillsOk = await ensureSkillsUpToDate(agentId, skillsScope);
+		results.push({
+			id: "install_skills",
+			description: skillsOk
+				? "Neon agent skills installed"
+				: "Failed to install Neon agent skills",
+			status: skillsOk ? "success" : "failed",
+		});
+	}
 
 	// Step 4: Install editor extension if requested
 	// Use the agent-reported IDE (not agent identity) — e.g. Claude Code running in
@@ -579,6 +744,16 @@ async function executeBatchedInstallation(
 	if (installExt) {
 		const extResult = await installExtensionForIde(options.ide ?? agentId);
 		results.push(extResult);
+	}
+
+	// Step 5: Write selected features to .neon under _init for brownfield flows
+	// (Bootstrap flows already wrote _init in step 0)
+	if (!isBootstrap && options.features && options.features.length > 0) {
+		const neonContextPath = resolve(process.cwd(), ".neon");
+		const context: Record<string, unknown> = {
+			_init: { features: options.features },
+		};
+		writeFileSync(neonContextPath, `${JSON.stringify(context, null, 2)}\n`);
 	}
 
 	const allSucceeded = results.every((r) => r.status === "success");
@@ -594,6 +769,12 @@ async function executeBatchedInstallation(
 		gettingStartedData.migrationTool = options.migrationTool;
 	if (options.migrationDir)
 		gettingStartedData.migrationDir = options.migrationDir;
+	// Pass features so getting-started knows which phases to chain to
+	const resolvedFeatures = options.templateRequires ?? options.features;
+	if (resolvedFeatures && resolvedFeatures.length > 0)
+		gettingStartedData.features = resolvedFeatures;
+	// Bootstrap implies preview mode (new project in us-east required)
+	if (isBootstrap) gettingStartedData.preview = true;
 	const gettingStartedArgs = [
 		"getting-started",
 		"--json",

--- a/packages/init/src/lib/route-command.ts
+++ b/packages/init/src/lib/route-command.ts
@@ -75,6 +75,11 @@ export async function routeCommand(args: string[]): Promise<PhaseResponse> {
 	const agent = resolveAgent(parsed.agent as string | undefined);
 
 	switch (command) {
+		case "finalize": {
+			const { handleCleanup } = await import("./phases/cleanup.js");
+			return handleCleanup();
+		}
+
 		case "auth": {
 			const { handleAuthPhase } = await import("./phases/auth.js");
 			return handleAuthPhase({
@@ -229,6 +234,7 @@ export async function routeCommand(args: string[]): Promise<PhaseResponse> {
 				agent,
 				skipNeonAuth: parsed.skipNeonAuth === true,
 				skipMigrations: parsed.skipMigrations === true,
+				preview: parsed.preview === true,
 			});
 		}
 	}

--- a/packages/init/src/v2.test.ts
+++ b/packages/init/src/v2.test.ts
@@ -27,6 +27,27 @@ vi.mock("./lib/resolve-context.js", () => ({
 	resolveNeonContext: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("./lib/bootstrap.js", () => {
+	const templates = [
+		{
+			id: "hono",
+			title: "Hono API",
+			description: "A Hono template.",
+			requires: ["database"],
+			source: {
+				owner: "neondatabase",
+				repo: "examples",
+				ref: "main",
+				subdir: "with-hono",
+			},
+		},
+	];
+	return {
+		fetchTemplates: vi.fn().mockResolvedValue(templates),
+		FALLBACK_TEMPLATES: templates,
+	};
+});
+
 import { isAuthenticated } from "./lib/auth.js";
 import { orchestrate } from "./v2.js";
 
@@ -49,9 +70,19 @@ function mockFs(files: Record<string, string>) {
 	});
 }
 
+const APP_PKG_JSON = JSON.stringify({
+	dependencies: { next: "14.0.0" },
+});
+
+/** Simulate an app existing (package.json with deps) plus optional extra files */
+function mockAppExists(extraFiles: Record<string, string> = {}) {
+	mockFs({ "package.json": APP_PKG_JSON, ...extraFiles });
+}
+
 /** Simulate MCP + skills installed (Cursor config with neon, neon-postgres skill dir) */
 function mockToolingInstalled(extraFiles: Record<string, string> = {}) {
 	const files: Record<string, string> = {
+		"package.json": APP_PKG_JSON,
 		".cursor/mcp.json":
 			'{"mcpServers":{"Neon":{"url":"https://mcp.neon.tech/mcp"}}}',
 		// skills directory exists and contains neon-postgres skill with SKILL.md
@@ -85,8 +116,39 @@ describe("v2 orchestrator", () => {
 		}
 	});
 
+	test("enters setup with bootstrap when no app is detected and --preview", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+
+		const result = await orchestrate({ agent: "claude", preview: true });
+
+		expect(result.phase).toBe("setup");
+		expect(result.status).toBe("bootstrap_needed");
+		expect(result.nextAction.type).toBe("agent_check");
+		if (result.nextAction.type === "agent_check") {
+			// Should include template preference before mode
+			const prefs = result.nextAction.userPreferences ?? [];
+			expect(prefs[0]?.id).toBe("template");
+			// Should NOT include skillsScope (template bundles skills)
+			expect(prefs.find((p) => p.id === "skillsScope")).toBeUndefined();
+		}
+	});
+
+	test("skips bootstrap without --preview even when no app detected", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+
+		const result = await orchestrate({ agent: "claude" });
+
+		expect(result.phase).toBe("setup");
+		expect(result.status).toBe("pending");
+		if (result.nextAction.type === "agent_check") {
+			const prefs = result.nextAction.userPreferences ?? [];
+			expect(prefs.find((p) => p.id === "template")).toBeUndefined();
+		}
+	});
+
 	test("enters setup phase when no tooling is installed", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
+		mockAppExists();
 
 		const result = await orchestrate({ agent: "claude" });
 
@@ -94,7 +156,10 @@ describe("v2 orchestrator", () => {
 		expect(result.status).toBe("pending");
 		expect(result.nextAction.type).toBe("agent_check");
 		if (result.nextAction.type === "agent_check") {
-			expect(result.nextAction.userPreferences?.[0]?.id).toBe("mode");
+			const prefs = result.nextAction.userPreferences ?? [];
+			// Brownfield: features question first, then mode
+			expect(prefs[0]?.id).toBe("features");
+			expect(prefs[1]?.id).toBe("mode");
 		}
 	});
 
@@ -155,9 +220,36 @@ describe("v2 orchestrator", () => {
 		}
 	});
 
+	test("skips neon_auth when .neon _init features don't include auth", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockToolingInstalled({
+			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb",
+			".neon":
+				'{"projectId":"proj-123","_init":{"features":["database"]}}',
+		});
+
+		const result = await orchestrate({ agent: "claude" });
+
+		// Should skip neon_auth and go to migrations
+		expect(result.phase).toBe("migrations");
+	});
+
+	test("runs neon_auth when .neon _init features include auth", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockToolingInstalled({
+			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb",
+			".neon":
+				'{"projectId":"proj-123","_init":{"features":["database","auth"]}}',
+		});
+
+		const result = await orchestrate({ agent: "claude" });
+
+		expect(result.phase).toBe("neon_auth");
+	});
+
 	test("enters setup even with DATABASE_URL if MCP not configured", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
-		mockFs({
+		mockAppExists({
 			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb",
 		});
 

--- a/packages/init/src/v2.ts
+++ b/packages/init/src/v2.ts
@@ -14,6 +14,8 @@ export interface OrchestratorOptions {
 	agent?: string;
 	skipNeonAuth?: boolean;
 	skipMigrations?: boolean;
+	/** Enable preview features (e.g. project bootstrapping from templates) */
+	preview?: boolean;
 }
 
 /**
@@ -28,6 +30,7 @@ export interface OrchestratorOptions {
  * Each call is stateless — it re-checks everything from the file system and credentials.
  *
  * The orchestrator uses filesystem inspection to decide what to do:
+ * - No app detected → bootstrap phase (scaffold from template)
  * - MCP not configured → full setup flow (inspect → install → getting-started)
  * - MCP configured, no connection string → skip install, go to getting-started
  * - MCP configured + connection string → fall through to neon-auth/migrations/complete
@@ -45,6 +48,7 @@ export async function orchestrate(
 
 	// Phase 2: Inspect what's already in place
 	const inspection = await inspectProject([
+		{ id: "has_app", description: "", lookFor: [] },
 		{ id: "mcp_server", description: "", lookFor: [] },
 		{ id: "skills", description: "", lookFor: [] },
 		{ id: "connection_string", description: "", lookFor: [] },
@@ -52,16 +56,30 @@ export async function orchestrate(
 		{ id: "migrations", description: "", lookFor: [] },
 	]);
 
+	// Only detect empty projects when --preview is enabled
+	const hasApp = options.preview ? inspection.hasApp === true : true;
 	const toolingInstalled =
 		inspection.mcpConfigured && inspection.skillsInstalled;
 	const hasNeonConnection = inspection.connectionString === true;
 
-	// Phase 3a: Tooling not installed → full setup flow
-	// Don't pre-fill inspection results — the setup phase asks the agent to
-	// check and report back.
-	if (!toolingInstalled) {
-		return handleSetupPhase({ agent: options.agent });
+	// Phase 3a: No app or tooling not installed → setup flow
+	// When !hasApp (preview mode), setup will offer template selection before asking about tooling.
+	// Clean up any stale _init state from a previous run.
+	if (!hasApp || !toolingInstalled) {
+		cleanupInitState(resolve(cwd, ".neon"));
+		return handleSetupPhase({ agent: options.agent, hasApp });
 	}
+
+	// Read .neon context early — needed for feature-based routing
+	const neonContextPath = resolve(cwd, ".neon");
+	const neonContext = readNeonContext(neonContextPath);
+	const initState =
+		typeof neonContext._init === "object" && neonContext._init !== null
+			? (neonContext._init as Record<string, unknown>)
+			: {};
+	const features: string[] = Array.isArray(initState.features)
+		? initState.features
+		: [];
 
 	// Phase 3b: Tooling installed but no Neon connection string → getting-started
 	if (!hasNeonConnection) {
@@ -72,36 +90,24 @@ export async function orchestrate(
 			orm: inspection.orm as string | undefined,
 			migrationTool: inspection.migrationTool as string | undefined,
 			migrationDir: inspection.migrationDir as string | undefined,
+			features,
+			preview: options.preview,
 		});
 	}
 
 	// Phase 3c: Neon connection exists but no .neon context file → resolve project
-	const neonContextPath = resolve(cwd, ".neon");
-	const hasNeonContext =
-		existsSync(neonContextPath) &&
-		(() => {
-			try {
-				const content = JSON.parse(
-					readFileSync(neonContextPath, "utf-8"),
-				);
-				return !!content.projectId;
-			} catch {
-				return false;
-			}
-		})();
 
-	if (!hasNeonContext) {
-		// Resolve the project from the connection string and write .neon
+	if (!neonContext.projectId) {
+		// Resolve the project from the connection string and merge into .neon
 		try {
 			const resolved = await resolveNeonContext(cwd);
 			if (resolved) {
-				const contextData: Record<string, string> = {};
-				if (resolved.orgId) contextData.orgId = resolved.orgId;
-				if (resolved.projectId)
-					contextData.projectId = resolved.projectId;
+				const merged = { ...neonContext };
+				if (resolved.orgId) merged.orgId = resolved.orgId;
+				if (resolved.projectId) merged.projectId = resolved.projectId;
 				writeFileSync(
 					neonContextPath,
-					`${JSON.stringify(contextData, null, 2)}\n`,
+					`${JSON.stringify(merged, null, 2)}\n`,
 				);
 			}
 		} catch {
@@ -109,11 +115,20 @@ export async function orchestrate(
 		}
 	}
 
-	// Phase 4: Neon Auth (optional)
-	if (!options.skipNeonAuth) {
+	// Phase 4: Neon Auth — skip if template/user doesn't require it
+	const hasFeatureRequirements = features.length > 0;
+	const needsAuth = hasFeatureRequirements
+		? features.includes("auth")
+		: !options.skipNeonAuth;
+	if (needsAuth) {
 		const hasNeonAuth = checkNeonAuth(cwd);
 		if (!hasNeonAuth) {
-			return handleNeonAuthPhase({ agent: options.agent });
+			// If auth was already selected via features, go straight to setup
+			// (don't re-ask the user)
+			return handleNeonAuthPhase({
+				agent: options.agent,
+				setup: hasFeatureRequirements,
+			});
 		}
 	}
 
@@ -122,7 +137,9 @@ export async function orchestrate(
 		return handleMigrationsPhase({ agent: options.agent });
 	}
 
-	// All done
+	// All done — clean up ephemeral _init state from .neon
+	cleanupInitState(neonContextPath);
+
 	return {
 		phase: "setup",
 		status: "complete",
@@ -132,6 +149,30 @@ export async function orchestrate(
 				"Neon setup is complete. Your database is configured and your agent has the Neon MCP server and skills available.",
 		},
 	};
+}
+
+/** Remove the ephemeral _init key from .neon, preserving other fields. */
+function cleanupInitState(neonContextPath: string): void {
+	if (!existsSync(neonContextPath)) return;
+	try {
+		const context = JSON.parse(readFileSync(neonContextPath, "utf-8"));
+		if (context._init !== undefined) {
+			delete context._init;
+			writeFileSync(
+				neonContextPath,
+				`${JSON.stringify(context, null, 2)}\n`,
+			);
+		}
+	} catch {}
+}
+
+function readNeonContext(neonContextPath: string): Record<string, unknown> {
+	if (!existsSync(neonContextPath)) return {};
+	try {
+		return JSON.parse(readFileSync(neonContextPath, "utf-8"));
+	} catch {
+		return {};
+	}
 }
 
 function checkNeonAuth(cwd: string): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^4
-        version: 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       globals:
         specifier: ^16.4.0
         version: 16.4.0
@@ -80,7 +80,7 @@ importers:
         version: 5.8.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       vite-plugin-neon-new:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-neon-new
@@ -92,7 +92,7 @@ importers:
         version: 1.0.1
       '@tailwindcss/vite':
         specifier: ^4.1.13
-        version: 4.1.13(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 4.1.13(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/react-router':
         specifier: ^1.131.37
         version: 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -104,10 +104,10 @@ importers:
         version: 1.130.17(@tanstack/react-query@5.81.4(react@19.1.1))(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@tanstack/router-core@1.131.37)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-start':
         specifier: ^1.131.37
-        version: 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.131.37
-        version: 1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -119,7 +119,7 @@ importers:
         version: 4.1.13
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.2)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 5.1.4(typescript@5.8.2)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
     devDependencies:
       '@testing-library/dom':
         specifier: ^10.4.1
@@ -138,7 +138,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
@@ -147,13 +147,13 @@ importers:
         version: 5.8.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       vite-plugin-neon-new:
         specifier: workspace:*
         version: link:../../packages/vite-plugin-neon-new
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       web-vitals:
         specifier: ^4.2.4
         version: 4.2.4
@@ -175,7 +175,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -187,7 +187,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/config-runtime:
     dependencies:
@@ -209,7 +209,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -221,7 +221,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/env:
     dependencies:
@@ -246,7 +246,7 @@ importers:
         version: 17.0.35
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -258,7 +258,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/functions:
     devDependencies:
@@ -267,7 +267,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -279,7 +279,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/get-db:
     dependencies:
@@ -292,7 +292,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       tsdown:
         specifier: 'catalog:'
         version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
@@ -301,7 +301,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/init:
     dependencies:
@@ -317,6 +317,9 @@ importers:
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
@@ -332,7 +335,7 @@ importers:
         version: 17.0.35
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -344,7 +347,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/neon-new:
     dependencies:
@@ -384,7 +387,7 @@ importers:
         version: 17.0.35
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -402,7 +405,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/neondb:
     dependencies:
@@ -415,7 +418,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       tsdown:
         specifier: 'catalog:'
         version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
@@ -424,7 +427,7 @@ importers:
         version: 5.8.2
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/vite-plugin-db:
     dependencies:
@@ -437,7 +440,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       tsdown:
         specifier: 'catalog:'
         version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
@@ -446,10 +449,10 @@ importers:
         version: 5.8.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/vite-plugin-neon-new:
     dependencies:
@@ -465,7 +468,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       tsdown:
         specifier: 'catalog:'
         version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
@@ -474,10 +477,10 @@ importers:
         version: 5.8.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/vite-plugin-postgres:
     dependencies:
@@ -490,7 +493,7 @@ importers:
         version: 20.19.17
       '@vitest/coverage-v8':
         specifier: 3.0.9
-        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+        version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       tsdown:
         specifier: 'catalog:'
         version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
@@ -499,10 +502,10 @@ importers:
         version: 5.8.2
       vite:
         specifier: 'catalog:'
-        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
 packages:
 
@@ -1130,8 +1133,8 @@ packages:
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
 
-  '@oxc-project/types@0.133.0':
-    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+  '@oxc-project/types@0.134.0':
+    resolution: {integrity: sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -1243,97 +1246,97 @@ packages:
   '@quansync/fs@0.1.4':
     resolution: {integrity: sha512-vy/41FCdnIalPTQCb2Wl0ic1caMdzGus4ktDp+gpZesQNydXcx8nhh8qB3qMPbGkictOTaXgXEUUfQEm8DQYoA==}
 
-  '@rolldown/binding-android-arm64@1.0.3':
-    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+  '@rolldown/binding-android-arm64@1.1.0':
+    resolution: {integrity: sha512-gCYzGOSkYY6Z034suzd20euvds7lPzMEEla62DJGE/ZAlR4OMBnNbvnBSsIGUCAr52gaWMsloGxP4tVGtN5aCA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
-    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+  '@rolldown/binding-darwin-arm64@1.1.0':
+    resolution: {integrity: sha512-JQBD77MNgu+4Z6RAyg69acugdrhhVoWesr3l47zohYZ2YV2fwkWMArkN/2p4l6Ei+Sno7W5q+UsKdVWq5Ens0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.3':
-    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+  '@rolldown/binding-darwin-x64@1.1.0':
+    resolution: {integrity: sha512-p/8cXUTK4Sob604e+xxPhVSbDFf29E6J0l/xESM9rdCfn3aDai3nEs6TnMHUsdD5aNlFz0+gDbiGlozLKGa2YA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
-    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+  '@rolldown/binding-freebsd-x64@1.1.0':
+    resolution: {integrity: sha512-KbtOSlVv6fElujiZWMcC3aQYhEwLVVf073RcwlSmpGQvIsKZFUqc0ef4sjUuurRwfbiI6JJXji9DQn+86hawmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
-    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
+    resolution: {integrity: sha512-9fZ9i0o0/MQaw7om6Z6TsT7tfCk0jtbEFtC+aPqZL5RNsGWNcHvn6EHgL3dAprjq+AZzPTAQjg2JtpJaMt+6pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
-    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.0':
+    resolution: {integrity: sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
-    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+  '@rolldown/binding-linux-arm64-musl@1.1.0':
+    resolution: {integrity: sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
-    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
+    resolution: {integrity: sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
-    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.0':
+    resolution: {integrity: sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
-    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.0':
+    resolution: {integrity: sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
-    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+  '@rolldown/binding-linux-x64-musl@1.1.0':
+    resolution: {integrity: sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
-    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+  '@rolldown/binding-openharmony-arm64@1.1.0':
+    resolution: {integrity: sha512-4+fexHayrLCWpriPh4c6dNvL4an34DEZCG7zOM/FD5QNF6h8DT+bDXzyB/kfC8lDJbaFb7jKShtnjDQFXVQEjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
-    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+  '@rolldown/binding-wasm32-wasi@1.1.0':
+    resolution: {integrity: sha512-SbL++MNmOw6QamrwIGDMSSfM4ceTzFr+RjbOExJSLLBinScU4WI5OdA413h1qwPw2yH7lVF1+H4svQ+6mSXKTQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
-    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.0':
+    resolution: {integrity: sha512-+xTE6XC7wBgk0VKRXGG+QAnyW5S9b8vfsFpiMjf0waQTmSQSU8onsH/beyZ8X4aXVveJnotiy7VDjLOaW8bTrg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
-    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.0':
+    resolution: {integrity: sha512-Ogji1TQNqH3ACLnYr+1Ns1nyrJ0CO2P585u9Hsh02pXvtFiFpgtgT2b3P4PnCOU86VVCvqtAeCN4OftMT8KU4w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3851,8 +3854,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.0.3:
-    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+  rolldown@1.1.0:
+    resolution: {integrity: sha512-zpMvlJhs5PkXRTtKc0CaLBVI9AR/VDiJFpM+kx//hgToEca7FgMlGjaRIisXBcb19T76LswgmKECSQ96hjWr5A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4635,6 +4638,11 @@ packages:
   yaml@2.7.1:
     resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
     engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yargs-parser@20.2.9:
@@ -5422,7 +5430,7 @@ snapshots:
 
   '@oozcitak/util@8.3.8': {}
 
-  '@oxc-project/types@0.133.0': {}
+  '@oxc-project/types@0.134.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -5508,53 +5516,53 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rolldown/binding-android-arm64@1.0.3':
+  '@rolldown/binding-android-arm64@1.1.0':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.3':
+  '@rolldown/binding-darwin-arm64@1.1.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.3':
+  '@rolldown/binding-darwin-x64@1.1.0':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.3':
+  '@rolldown/binding-freebsd-x64@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+  '@rolldown/binding-linux-arm64-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.3':
+  '@rolldown/binding-linux-arm64-musl@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+  '@rolldown/binding-linux-s390x-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.3':
+  '@rolldown/binding-linux-x64-gnu@1.1.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.3':
+  '@rolldown/binding-linux-x64-musl@1.1.0':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.3':
+  '@rolldown/binding-openharmony-arm64@1.1.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.3':
+  '@rolldown/binding-wasm32-wasi@1.1.0':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+  '@rolldown/binding-win32-arm64-msvc@1.1.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.3':
+  '@rolldown/binding-win32-x64-msvc@1.1.0':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -5763,14 +5771,14 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.13
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tailwindcss/vite@4.1.13(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.1.13
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
-  '@tanstack/directive-functions-plugin@1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/directive-functions-plugin@1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.28.5
@@ -5779,7 +5787,7 @@ snapshots:
       '@tanstack/router-utils': 1.131.2
       babel-dead-code-elimination: 1.0.10
       tiny-invariant: 1.3.3
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5834,12 +5842,12 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-plugin@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/react-start-plugin@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
-      '@tanstack/start-plugin-core': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
-      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/start-plugin-core': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -5886,17 +5894,17 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/react-start@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/react-start@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-start-client': 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/react-start-plugin': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/react-start-plugin': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/start-server-functions-client': 1.131.37(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
-      '@tanstack/start-server-functions-server': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
-      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/start-server-functions-client': 1.131.37(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@tanstack/start-server-functions-server': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -5970,7 +5978,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/router-plugin@1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
@@ -5988,8 +5996,8 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       '@tanstack/react-router': 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
-      vite-plugin-solid: 2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
+      vite-plugin-solid: 2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -6004,7 +6012,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/server-functions-plugin@1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/server-functions-plugin@1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.28.5
@@ -6013,7 +6021,7 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
-      '@tanstack/directive-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/directive-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       babel-dead-code-elimination: 1.0.10
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
@@ -6028,27 +6036,27 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-plugin-core@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.0.3)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/start-plugin-core@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.5
       '@babel/types': 7.28.5
       '@tanstack/router-core': 1.131.37
       '@tanstack/router-generator': 1.131.37
-      '@tanstack/router-plugin': 1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/router-plugin': 1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/router-utils': 1.131.2
-      '@tanstack/server-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/server-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/start-server-core': 1.131.37
       '@types/babel__code-frame': 7.0.6
       '@types/babel__core': 7.20.5
       babel-dead-code-elimination: 1.0.10
       cheerio: 1.1.2
       h3: 1.13.0
-      nitropack: 2.12.5(@netlify/blobs@9.1.2)(rolldown@1.0.3)
+      nitropack: 2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.0)
       pathe: 2.0.3
       ufo: 1.6.1
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       xmlbuilder2: 3.1.1
       zod: 3.25.76
     transitivePeerDependencies:
@@ -6096,9 +6104,9 @@ snapshots:
       tiny-warning: 1.0.3
       unctx: 2.4.1
 
-  '@tanstack/start-server-functions-client@1.131.37(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/start-server-functions-client@1.131.37(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
-      '@tanstack/server-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/server-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/start-server-functions-fetcher': 1.131.37
     transitivePeerDependencies:
       - supports-color
@@ -6109,9 +6117,9 @@ snapshots:
       '@tanstack/router-core': 1.131.37
       '@tanstack/start-client-core': 1.131.37
 
-  '@tanstack/start-server-functions-server@1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@tanstack/start-server-functions-server@1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
-      '@tanstack/server-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@tanstack/server-functions-plugin': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - supports-color
@@ -6237,7 +6245,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -6245,11 +6253,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6263,7 +6271,7 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vitest: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6274,13 +6282,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.9(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))':
+  '@vitest/mocker@3.0.9(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.0.9
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.0.9':
     dependencies:
@@ -7753,7 +7761,7 @@ snapshots:
       qs: 6.14.1
     optional: true
 
-  nitropack@2.12.5(@netlify/blobs@9.1.2)(rolldown@1.0.3):
+  nitropack@2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.0):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@rollup/plugin-alias': 5.1.1(rollup@4.50.1)
@@ -7806,7 +7814,7 @@ snapshots:
       pretty-bytes: 7.0.1
       radix3: 1.1.2
       rollup: 4.50.1
-      rollup-plugin-visualizer: 6.0.3(rolldown@1.0.3)(rollup@4.50.1)
+      rollup-plugin-visualizer: 6.0.3(rolldown@1.1.0)(rollup@4.50.1)
       scule: 1.3.0
       semver: 7.7.2
       serve-placeholder: 2.0.2
@@ -8242,7 +8250,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.6(rolldown@1.0.3)(typescript@5.8.2):
+  rolldown-plugin-dts@0.15.6(rolldown@1.1.0)(typescript@5.8.2):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -8252,42 +8260,42 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
-      rolldown: 1.0.3
+      rolldown: 1.1.0
     optionalDependencies:
       typescript: 5.8.2
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.0.3:
+  rolldown@1.1.0:
     dependencies:
-      '@oxc-project/types': 0.133.0
+      '@oxc-project/types': 0.134.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.3
-      '@rolldown/binding-darwin-arm64': 1.0.3
-      '@rolldown/binding-darwin-x64': 1.0.3
-      '@rolldown/binding-freebsd-x64': 1.0.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
-      '@rolldown/binding-linux-arm64-gnu': 1.0.3
-      '@rolldown/binding-linux-arm64-musl': 1.0.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
-      '@rolldown/binding-linux-s390x-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-gnu': 1.0.3
-      '@rolldown/binding-linux-x64-musl': 1.0.3
-      '@rolldown/binding-openharmony-arm64': 1.0.3
-      '@rolldown/binding-wasm32-wasi': 1.0.3
-      '@rolldown/binding-win32-arm64-msvc': 1.0.3
-      '@rolldown/binding-win32-x64-msvc': 1.0.3
+      '@rolldown/binding-android-arm64': 1.1.0
+      '@rolldown/binding-darwin-arm64': 1.1.0
+      '@rolldown/binding-darwin-x64': 1.1.0
+      '@rolldown/binding-freebsd-x64': 1.1.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.0
+      '@rolldown/binding-linux-arm64-gnu': 1.1.0
+      '@rolldown/binding-linux-arm64-musl': 1.1.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.0
+      '@rolldown/binding-linux-s390x-gnu': 1.1.0
+      '@rolldown/binding-linux-x64-gnu': 1.1.0
+      '@rolldown/binding-linux-x64-musl': 1.1.0
+      '@rolldown/binding-openharmony-arm64': 1.1.0
+      '@rolldown/binding-wasm32-wasi': 1.1.0
+      '@rolldown/binding-win32-arm64-msvc': 1.1.0
+      '@rolldown/binding-win32-x64-msvc': 1.1.0
 
-  rollup-plugin-visualizer@6.0.3(rolldown@1.0.3)(rollup@4.50.1):
+  rollup-plugin-visualizer@6.0.3(rolldown@1.1.0)(rollup@4.50.1):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
-      rolldown: 1.0.3
+      rolldown: 1.1.0
       rollup: 4.50.1
 
   rollup@4.50.1:
@@ -8671,8 +8679,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.0.3
-      rolldown-plugin-dts: 0.15.6(rolldown@1.0.3)(typescript@5.8.2)
+      rolldown: 1.1.0
+      rolldown-plugin-dts: 0.15.6(rolldown@1.1.0)(typescript@5.8.2)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
@@ -8847,13 +8855,13 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  vite-node@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1):
+  vite-node@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8868,7 +8876,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)):
+  vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.28.5
       '@types/babel__core': 7.20.5
@@ -8876,24 +8884,24 @@ snapshots:
       merge-anything: 5.1.7
       solid-js: 1.9.6
       solid-refresh: 0.6.3(solid-js@1.9.6)
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.2)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.2)
     optionalDependencies:
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1):
+  vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8908,16 +8916,16 @@ snapshots:
       lightningcss: 1.30.1
       terser: 5.39.0
       tsx: 4.20.5
-      yaml: 2.7.1
+      yaml: 2.9.0
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
-  vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1):
+  vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 3.0.9
-      '@vitest/mocker': 3.0.9(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1))
+      '@vitest/mocker': 3.0.9(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.0.9
       '@vitest/snapshot': 3.0.9
@@ -8933,8 +8941,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
-      vite-node: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
+      vite-node: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.17
@@ -9041,6 +9049,8 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.7.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 


### PR DESCRIPTION
## Summary

Adds project bootstrapping from templates, feature-based phase routing, and a `--preview` flag to gate new functionality.

### Bootstrap & templates
- Fetches template manifest from `neondatabase/examples/bootstrap.yaml` (with hardcoded fallback)
- Templates declare `requires` (e.g. `["database", "functions"]`) to drive which post-bootstrap phases run
- Empty project detection via `hasApp` check (package.json with deps, or common source dirs)
- Template selection integrated into setup phase — user can pick a template or skip
- Skills installation automatically skipped when template bundles them

### Feature-driven orchestration
- `NeonFeature` type: `database | auth | functions | ai-gateway | object-storage`
- Brownfield flows ask which features to enable (Database, Database + Neon Auth)
- Features stored in `.neon` under ephemeral `_init` key
- Orchestrator uses features to skip/include phases (e.g. skip neon-auth when not required, go straight to `--setup` when pre-selected)
- All flows terminate through `neon-init finalize` which cleans up `_init` and returns a complete message

### Preview mode (`--preview` flag)
- Gates bootstrap flow and empty-project detection
- Restricts project creation to AWS us-east-2 region
- Filters existing projects to eligible ones (region + creation date)

### Other improvements
- Uses `neonctl env pull` instead of manual connection string writing (respects project's env config)
- Uses neonctl CLI exclusively during init flow (no MCP tools)
- Migration step checks for actual SQL files before offering to apply; generates if schema exists but no migrations
- Getting-started instructs agent to merge `.neon` content (preserving `_init` and other fields)
- Installs project dependencies before `env pull` (config files may import packages)
- Interactive mode updated with same bootstrap/features/preview support; builds agent prompt with getting-started data payload

## Test plan
- [x] All 106 tests pass
- [x] Lint clean (biome ci --error-on-warnings)
- [x] Tested `--preview` with Hono template: bootstrap → setup → getting-started → finalize
- [x] Tested brownfield flow with Database + Auth features
- [x] Tested non-preview flow (bootstrap gated, works as before)
- [x] Verified `_init` cleanup on completion and fresh runs

This pull request and its description were written by Isaac.