### PR TITLE
chore: add changeset for neon-init v2 minor release

### DIFF
--- a/.changeset/neon-init-v2.md
+++ b/.changeset/neon-init-v2.md
@@ -1,0 +1,5 @@
+---
+"neon-init": minor
+---
+
+Add agent-driven v2 orchestrator, interactive init mode, bootstrap templates, feature-driven setup, and preview mode


### PR DESCRIPTION
## Summary
- Adds a missing changeset for the `neon-init` package to trigger a minor version bump
- Covers the v2 orchestrator, interactive init, bootstrap templates, feature-driven setup, and preview mode added in PR #151

## Context
PR #151 merged without a changeset for `neon-init`. This is needed so the `Prepare Release` workflow can bump the version and publish to npm, unblocking the downstream neonctl wrapper PR.

This pull request and its description were written by Isaac.