### PR TITLE
chore: release packages

### DIFF
--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/ai-sdk-provider",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Cuts a release for the five packages with pending changes by bumping their `package.json` versions directly (per request — `changeset version` was intentionally **not** run).

| Package | Old | New |
| --- | --- | --- |
| `@neondatabase/config` | 0.5.0 | **0.6.0** |
| `@neondatabase/config-runtime` | 0.5.0 | **0.6.0** |
| `@neondatabase/env` | 0.4.0 | **0.5.0** |
| `@neondatabase/ai-sdk-provider` | 0.0.0 | **0.1.0** |
| `neon-init` | 0.14.0 | **0.15.0** |

Bump levels match what the existing pending changesets imply (highest level per package = minor). Internal deps use `workspace:*`, so no dependency ranges needed updating.

### How to merge (so the release actually tags)
`post-release.yml` gates on the squash-commit subject starting with `chore: release packages`. So **manually "Squash and merge"** in the UI (do **not** use auto-merge, and don't edit the PR title). On merge it tags each bumped package `name@version` and posts Stage 2 (npm publish) dispatch instructions.

### Heads-up: pending changesets are NOT consumed
Because versions were bumped by hand rather than via `changeset version`, the 18 `.changeset/*.md` files are still present and the per-package `CHANGELOG.md` files were not updated. The next `changeset version` / `prepare-release` run will therefore bump these packages **again** from those same changesets. Clear the now-released changesets in a follow-up (or let me know and I'll add a commit removing them) if you want to avoid a double bump.