### PR TITLE
fix(config,config-runtime): treat AI Gateway as always-on (no probe); status-aware preview errors

### DIFF
--- a/.changeset/ai-gateway-no-probe.md
+++ b/.changeset/ai-gateway-no-probe.md
@@ -1,0 +1,13 @@
+---
+"@neondatabase/config": minor
+"@neondatabase/config-runtime": minor
+---
+
+Stop treating the AI Gateway as a provisionable branch resource. The AI Gateway is always available on a branch — it is credential-gated, not per-branch provisioned, and has no control-plane enable/disable/status route. Declaring `preview.aiGateway` in a `neon.ts` only means "mint a branch credential scoped `ai_gateway:invoke` and surface the gateway env vars (`OPENAI_*` / `NEON_AI_GATEWAY_*`)", which `@neondatabase/env` already does without touching any AI Gateway endpoint.
+
+Previously `plan` / `apply` / `status` (and the policy-gated `env pull`) probed `GET /projects/{p}/branches/{b}/ai-gateway` to diff an `enable-ai-gateway` step. That endpoint isn't part of the platform, so the probe failed with a `PLATFORM_FEATURE_UNAVAILABLE` error and broke commands that otherwise only needed `DATABASE_URL` / auth. Removed end to end:
+
+- **`@neondatabase/config`** — `NeonApi` no longer declares `getAiGatewayEnabled` / `enableAiGateway` / `disableAiGateway`; the `enable-ai-gateway` `PlanStep` and `RemotePreviewState.aiGatewayEnabled` are gone, and `diffConfig` never emits an AI Gateway step. `ResolvedPreviewConfig.aiGatewayEnabled` stays — it still drives the credential scope and env vars.
+- **`@neondatabase/config-runtime`** — `pushConfig` no longer probes or applies AI Gateway state, and `PulledPreview.aiGatewayEnabled` is removed from `pullConfig` / `inspect` (the gateway is not per-branch state to report).
+
+Consumers reading `PulledPreview.aiGatewayEnabled` (e.g. a CLI `config status` view) should drop it; `preview.aiGateway` continues to work in `neon.ts` exactly as before for env resolution.

--- a/.changeset/preview-unavailable-message.md
+++ b/.changeset/preview-unavailable-message.md
@@ -1,0 +1,11 @@
+---
+"@neondatabase/config": patch
+---
+
+Make the "Preview feature unavailable" error status-aware and actionable instead of a misleading catch-all. When a `neon.ts` declares a Preview feature (Functions, object-storage buckets, branch credentials) that the project/region hasn't been granted, the reads behind `plan` / `apply` / `status` / `env pull` surfaced `"… is a Preview feature that is not available for this project or region … Enable it for your Neon account/project first"` — which read like the user had misconfigured something they could simply "enable".
+
+`previewUnavailableError` now:
+
+- Names the failing feature and summarizes the response in one short `HTTP <status> <reason>` line (e.g. `HTTP 404 Not Found`) — never a stack trace — and keeps the raw Neon API message + request id inline, which is valuable signal while these features are in preview.
+- Tailors the guidance to the HTTP status: a 404/501 points at region availability / private-preview access ("create a project in a region where the preview is enabled, and make sure your account has access"); a 503 distinguishes "still rolling out" from a transient incident and points at https://neonstatus.com / Neon support; everything else falls back to a generic account/region message.
+- Offers removing the feature from the `preview` block of your `neon.ts` as an escape hatch, and carries `status` / `requestId` on `error.details` for programmatic consumers.

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/src/lib/fake-neon-api.ts
+++ b/packages/config-runtime/src/lib/fake-neon-api.ts
@@ -68,8 +68,6 @@ export class FakeNeonApi implements NeonApi {
 	private readonly functions = new Map<string, NeonFunctionSnapshot[]>();
 	/** Monotonic per-function deployment counter, keyed by `${projectId}:${branchId}:${slug}`. */
 	private readonly functionDeployments = new Map<string, number>();
-	/** AI Gateway enabled set, keyed by `${projectId}:${branchId}`. */
-	private readonly aiGateway = new Set<string>();
 	/** Issued credentials (incl. secrets), keyed by `${projectId}:${branchId}`. */
 	private readonly credentials = new Map<
 		string,
@@ -675,39 +673,11 @@ export class FakeNeonApi implements NeonApi {
 	}
 
 	// ─── Preview: AI Gateway ───────────────────────────────────────────────────
-
-	async getAiGatewayEnabled(
-		projectId: string,
-		branchId: string,
-	): Promise<boolean> {
-		this.history.push({
-			method: "getAiGatewayEnabled",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		return this.aiGateway.has(`${projectId}:${branchId}`);
-	}
-
-	async enableAiGateway(projectId: string, branchId: string): Promise<void> {
-		this.history.push({
-			method: "enableAiGateway",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		this.aiGateway.add(`${projectId}:${branchId}`);
-	}
-
-	async disableAiGateway(projectId: string, branchId: string): Promise<void> {
-		this.history.push({
-			method: "disableAiGateway",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		this.aiGateway.delete(`${projectId}:${branchId}`);
-	}
+	//
+	// No methods: the AI Gateway is always available on a branch (credential-gated, not
+	// per-branch provisioned), so the real adapter exposes no enable/disable/status route and
+	// neither does this fake. `preview.aiGateway` only drives the branch credential's
+	// `ai_gateway:invoke` scope (see `createCredential`).
 
 	// ─── Preview: branch-scoped credentials ──────────────────────────────────
 
@@ -832,11 +802,6 @@ export class FakeNeonApi implements NeonApi {
 		const list = this.functions.get(key) ?? [];
 		list.push({ ...snapshot });
 		this.functions.set(key, list);
-	}
-
-	/** Test helper: mark the AI Gateway enabled on a branch. */
-	seedAiGateway(projectId: string, branchId: string): void {
-		this.aiGateway.add(`${projectId}:${branchId}`);
 	}
 
 	private requireProject(projectId: string): void {

--- a/packages/config-runtime/src/lib/pull-config.test.ts
+++ b/packages/config-runtime/src/lib/pull-config.test.ts
@@ -251,18 +251,19 @@ describe("pullConfig", () => {
 	});
 
 	test("degrades when a Preview feature is unavailable, still pulling auth/dataApi", async () => {
-		// A branch whose AI Gateway endpoint is unavailable for the project/region. pullConfig
-		// mirrors the branch for env resolution (`neon dev` / `neon env pull`) and inspect, so
-		// it must not abort on an unrelated Preview capability — env comes from auth/dataApi.
-		class UnavailableAiGatewayApi extends FakeNeonApi {
-			override async getAiGatewayEnabled(): Promise<boolean> {
+		// A branch whose object-storage endpoint is unavailable for the project/region.
+		// pullConfig mirrors the branch for env resolution (`neon dev` / `neon env pull`) and
+		// inspect, so it must not abort on an unrelated Preview capability — env comes from
+		// auth/dataApi.
+		class UnavailableBucketsApi extends FakeNeonApi {
+			override async listBranchBuckets(): Promise<never> {
 				throw new PlatformError(
 					ErrorCode.FeatureUnavailable,
-					"AI Gateway is a Preview feature that is not available for this project or region.",
+					"Object storage is a Preview feature that is not available for this project or region.",
 				);
 			}
 		}
-		const api = new UnavailableAiGatewayApi();
+		const api = new UnavailableBucketsApi();
 		const projectId = "proj-degrade";
 		api.seedProject({
 			project: {
@@ -287,8 +288,9 @@ describe("pullConfig", () => {
 			branchId: "br-main",
 		});
 
-		// Auth still pulled; the unavailable AI Gateway degrades to "off" rather than throwing.
+		// Auth still pulled; the unavailable buckets endpoint degrades to "none" rather than
+		// throwing.
 		expect(pulled.config.auth).toBe(true);
-		expect(pulled.preview?.aiGatewayEnabled ?? false).toBe(false);
+		expect(pulled.preview?.buckets ?? []).toEqual([]);
 	});
 });

--- a/packages/config-runtime/src/lib/pull-config.ts
+++ b/packages/config-runtime/src/lib/pull-config.ts
@@ -38,7 +38,6 @@ export interface PullConfigOptions {
 export interface PulledPreview {
 	buckets: Array<{ name: string; access: BucketAccessLevel }>;
 	functions: Array<{ slug: string; name: string }>;
-	aiGatewayEnabled: boolean;
 	/**
 	 * Secret-free metadata for the credentials issued on the branch (Preview). Surfaced so
 	 * `config status` can show issued credentials (id, scopes, last used) without ever
@@ -72,8 +71,9 @@ export interface PulledBranchConfig {
 	 */
 	config: Config;
 	/**
-	 * Live Preview-feature state, when the branch has any buckets/functions or an enabled
-	 * AI Gateway. Omitted entirely when there is nothing to report.
+	 * Live Preview-feature state, when the branch has any buckets/functions or issued
+	 * credentials. Omitted entirely when there is nothing to report. The AI Gateway is not
+	 * included: it is always available (credential-gated), not per-branch state.
 	 */
 	preview?: PulledPreview;
 }
@@ -102,34 +102,25 @@ export async function pullConfig(
 	// `neon env pull`) and `inspect` — an unavailable Preview feature should not break those
 	// (env comes from auth/dataApi/postgres). `pushConfig` is the place that fails on an
 	// unavailable feature, and only when the policy declares it.
-	const [buckets, functions, aiGatewayEnabled, credentials, auth, dataApi] =
-		await Promise.all([
-			degradeUnavailable(
-				() => api.listBranchBuckets(projectId, branch.id),
-				[],
-			),
-			degradeUnavailable(
-				() => api.listBranchFunctions(projectId, branch.id),
-				[],
-			),
-			degradeUnavailable(
-				() => api.getAiGatewayEnabled(projectId, branch.id),
-				false,
-			),
-			degradeUnavailable(
-				() => api.listCredentials(projectId, branch.id),
-				[],
-			),
-			api.getNeonAuth(projectId, branch.id),
-			probeDatabase
-				? api.getNeonDataApi(projectId, branch.id, probeDatabase)
-				: Promise.resolve(null),
-		]);
+	const [buckets, functions, credentials, auth, dataApi] = await Promise.all([
+		degradeUnavailable(
+			() => api.listBranchBuckets(projectId, branch.id),
+			[],
+		),
+		degradeUnavailable(
+			() => api.listBranchFunctions(projectId, branch.id),
+			[],
+		),
+		degradeUnavailable(() => api.listCredentials(projectId, branch.id), []),
+		api.getNeonAuth(projectId, branch.id),
+		probeDatabase
+			? api.getNeonDataApi(projectId, branch.id, probeDatabase)
+			: Promise.resolve(null),
+	]);
 
 	return buildPulledBranchConfig(project, branch, branches, endpoint, {
 		buckets,
 		functions,
-		aiGatewayEnabled,
 		credentials,
 		authEnabled: auth !== null,
 		dataApiEnabled: dataApi !== null,
@@ -189,7 +180,6 @@ export function buildPulledBranchConfig(
 	previewState?: {
 		buckets: NeonBucketSnapshot[];
 		functions: NeonFunctionSnapshot[];
-		aiGatewayEnabled: boolean;
 		credentials?: NeonCredentialMeta[];
 		/** Whether a Neon Auth integration is enabled on the branch. */
 		authEnabled?: boolean;
@@ -251,14 +241,12 @@ export function buildPulledBranchConfig(
 function buildPulledPreview(state: {
 	buckets: NeonBucketSnapshot[];
 	functions: NeonFunctionSnapshot[];
-	aiGatewayEnabled: boolean;
 	credentials?: NeonCredentialMeta[];
 }): PulledPreview | undefined {
 	const credentials = state.credentials ?? [];
 	if (
 		state.buckets.length === 0 &&
 		state.functions.length === 0 &&
-		!state.aiGatewayEnabled &&
 		credentials.length === 0
 	) {
 		return undefined;
@@ -272,7 +260,6 @@ function buildPulledPreview(state: {
 			slug: f.slug,
 			name: f.name,
 		})),
-		aiGatewayEnabled: state.aiGatewayEnabled,
 		credentials,
 	};
 }

--- a/packages/config-runtime/src/lib/push-config.test.ts
+++ b/packages/config-runtime/src/lib/push-config.test.ts
@@ -308,7 +308,7 @@ describe("pushConfig", () => {
 		expect(result.dryRun).toBe(true);
 	});
 
-	test("creates buckets, creates + deploys functions, and enables AI Gateway", async () => {
+	test("creates buckets and deploys functions; aiGateway needs no provisioning step", async () => {
 		const { api, projectId } = seededFake();
 		const config = defineConfig({
 			preview: {
@@ -342,12 +342,12 @@ describe("pushConfig", () => {
 					action: "create",
 					identifier: "function:fn1",
 				}),
-				expect.objectContaining({
-					kind: "service",
-					action: "create",
-					identifier: "aiGateway",
-				}),
 			]),
+		);
+		// The AI Gateway is always available (credential-gated), so enabling it in the
+		// policy produces no provisioning step — only a credential scope + env vars.
+		expect(result.applied.some((c) => c.identifier === "aiGateway")).toBe(
+			false,
 		);
 		// The function exists and now has an active deployment on the branch.
 		const functions = await api.listBranchFunctions(projectId, "br-main");
@@ -357,7 +357,6 @@ describe("pushConfig", () => {
 				activeDeploymentId: 1,
 			}),
 		]);
-		expect(await api.getAiGatewayEnabled(projectId, "br-main")).toBe(true);
 		expect(
 			(await api.listBranchBuckets(projectId, "br-main")).map(
 				(b) => b.name,
@@ -378,10 +377,10 @@ describe("pushConfig", () => {
 
 		const methods = api.history.map((h) => h.method);
 		expect(methods).toContain("listBranchFunctions");
-		// AI Gateway / buckets are not in the policy, so they are never read — this is
-		// what keeps `plan`/`apply` from failing on a Preview feature the user didn't ask
-		// for when it's unavailable in the project/region.
-		expect(methods).not.toContain("getAiGatewayEnabled");
+		// Buckets are not in the policy, so they are never read — this is what keeps
+		// `plan`/`apply` from failing on a Preview feature the user didn't ask for when it's
+		// unavailable in the project/region. (The AI Gateway is never probed at all — it is
+		// always available and credential-gated, not a per-branch resource.)
 		expect(methods).not.toContain("listBranchBuckets");
 	});
 
@@ -524,13 +523,13 @@ describe("pushConfig", () => {
 		expect(result.applied).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ identifier: "bucket:uploads" }),
-				expect.objectContaining({ identifier: "aiGateway" }),
 			]),
 		);
-		expect(api.history.some((h) => h.method === "createBranchBucket")).toBe(
+		// aiGateway is always available (credential-gated), so it never produces a plan step.
+		expect(result.applied.some((c) => c.identifier === "aiGateway")).toBe(
 			false,
 		);
-		expect(api.history.some((h) => h.method === "enableAiGateway")).toBe(
+		expect(api.history.some((h) => h.method === "createBranchBucket")).toBe(
 			false,
 		);
 	});

--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -364,12 +364,6 @@ function synthesizeAppliedChange(step: PlanStep): AppliedChange {
 					runtime: step.fn.runtime,
 				},
 			};
-		case "enable-ai-gateway":
-			return {
-				kind: "service",
-				action: "create",
-				identifier: "aiGateway",
-			};
 	}
 }
 
@@ -438,9 +432,12 @@ async function resolveServiceState(args: {
 }
 
 /**
- * Pre-fetch the current state of branch-scoped Preview features (buckets, functions, AI
- * Gateway) so the diff can be computed additively. Only called when the policy has a
- * `preview` block.
+ * Pre-fetch the current state of branch-scoped Preview features (buckets, functions) so the
+ * diff can be computed additively. Only called when the policy has a `preview` block.
+ *
+ * The AI Gateway is not probed: it is always available (credential-gated, not per-branch
+ * provisioned), so `preview.aiGateway` produces no plan step — it only drives the branch
+ * credential's `ai_gateway:invoke` scope and the gateway env vars (`@neondatabase/env`).
  */
 async function resolvePreviewState(args: {
 	api: NeonApi;
@@ -454,18 +451,15 @@ async function resolvePreviewState(args: {
 	// `plan`/`apply` fail on a feature the user didn't ask for if it's unavailable in the
 	// project/region. A declared-but-unavailable feature still throws (failing the push),
 	// which is the intended signal to enable it first.
-	const [buckets, functions, aiGatewayEnabled] = await Promise.all([
+	const [buckets, functions] = await Promise.all([
 		desired.buckets.length > 0
 			? api.listBranchBuckets(projectId, branchId)
 			: Promise.resolve([]),
 		desired.functions.length > 0
 			? api.listBranchFunctions(projectId, branchId)
 			: Promise.resolve([]),
-		desired.aiGatewayEnabled
-			? api.getAiGatewayEnabled(projectId, branchId)
-			: Promise.resolve(false),
 	]);
-	return { buckets, functions, aiGatewayEnabled };
+	return { buckets, functions };
 }
 
 /**
@@ -612,14 +606,6 @@ async function applyStep(
 					runtime: step.fn.runtime,
 					deploymentId: deployment.id,
 				},
-			};
-		}
-		case "enable-ai-gateway": {
-			await ctx.api.enableAiGateway(ctx.remoteProjectId, step.branchId);
-			return {
-				kind: "service",
-				action: "create",
-				identifier: "aiGateway",
 			};
 		}
 	}

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/config/src/lib/diff.test.ts
+++ b/packages/config/src/lib/diff.test.ts
@@ -62,7 +62,7 @@ describe("diffConfig", () => {
 		});
 	});
 
-	test("plans preview deploy + bucket + ai-gateway when nothing exists", () => {
+	test("plans preview deploy + bucket when nothing exists (aiGateway is never provisioned)", () => {
 		const diff = diffConfig(
 			{
 				authEnabled: false,
@@ -78,6 +78,8 @@ describe("diffConfig", () => {
 						},
 					],
 					buckets: [{ name: "uploads", access: "private" }],
+					// aiGateway is always available (credential-gated), so even when the
+					// policy enables it the diff emits no provisioning step for it.
 					aiGatewayEnabled: true,
 				},
 			},
@@ -86,7 +88,6 @@ describe("diffConfig", () => {
 				preview: {
 					buckets: [],
 					functions: [],
-					aiGatewayEnabled: false,
 				},
 			},
 			{ updateExisting: false },
@@ -94,7 +95,6 @@ describe("diffConfig", () => {
 		expect(diff.plan.map((p) => p.kind)).toEqual([
 			"create-bucket",
 			"deploy-function",
-			"enable-ai-gateway",
 		]);
 		// A brand-new function is created by its first deployment, so the single
 		// deploy-function step is flagged as not-yet-existing.
@@ -102,7 +102,7 @@ describe("diffConfig", () => {
 		expect(deploy).toMatchObject({ functionExists: false });
 	});
 
-	test("skips enable-ai-gateway when already present, but still re-deploys an existing function", () => {
+	test("re-deploys an existing function and never plans an aiGateway step", () => {
 		const diff = diffConfig(
 			{
 				authEnabled: false,
@@ -133,7 +133,6 @@ describe("diffConfig", () => {
 							invocationUrl: "https://x/functions/fn1",
 						},
 					],
-					aiGatewayEnabled: true,
 				},
 			},
 			{ updateExisting: false },

--- a/packages/config/src/lib/diff.ts
+++ b/packages/config/src/lib/diff.ts
@@ -75,12 +75,6 @@ export type PlanStep =
 			fn: ResolvedFunctionConfig;
 			/** Whether the function already existed remotely when the plan was computed. */
 			functionExists: boolean;
-	  }
-	| {
-			kind: "enable-ai-gateway";
-			projectId: string;
-			branchId: string;
-			branchName: string;
 	  };
 
 export interface RemoteServiceState {
@@ -96,7 +90,6 @@ export interface RemoteServiceState {
 export interface RemotePreviewState {
 	buckets: NeonBucketSnapshot[];
 	functions: NeonFunctionSnapshot[];
-	aiGatewayEnabled: boolean;
 }
 
 export interface RemoteState {
@@ -137,10 +130,15 @@ export function diffConfig(
 }
 
 /**
- * Plan Preview features (functions, buckets, AI Gateway). Like {@link diffServices}, this
- * is **additive**: it creates desired buckets/functions and enables the AI Gateway, but
- * never deletes buckets/functions or disables the gateway. Teardown is destructive, so it
- * stays explicit/manual — matching the existing auth / dataApi behaviour.
+ * Plan Preview features (functions, buckets). Like {@link diffServices}, this is
+ * **additive**: it creates desired buckets and (re-)deploys functions, but never deletes
+ * them. Teardown is destructive, so it stays explicit/manual — matching the existing
+ * auth / dataApi behaviour.
+ *
+ * The AI Gateway is intentionally NOT planned here: it is always available on a branch
+ * (credential-gated, not per-branch provisioned), so `preview.aiGateway` produces no plan
+ * step — it only drives the branch credential's `ai_gateway:invoke` scope and the gateway
+ * env vars (`@neondatabase/env`). There is nothing to create, and nothing to probe.
  *
  * Functions are always (re-)deployed: deployments are versioned and the newest becomes
  * active, so each push ships the current source. There is no separate create step — Neon
@@ -161,7 +159,6 @@ function diffPreview(args: {
 	const state: RemotePreviewState = remote.preview ?? {
 		buckets: [],
 		functions: [],
-		aiGatewayEnabled: false,
 	};
 
 	for (const bucket of preview.buckets) {
@@ -188,15 +185,6 @@ function diffPreview(args: {
 			branchName: remote.branch.name,
 			fn,
 			functionExists: exists,
-		});
-	}
-
-	if (preview.aiGatewayEnabled && !state.aiGatewayEnabled) {
-		plan.push({
-			kind: "enable-ai-gateway",
-			projectId: remote.projectId,
-			branchId: remote.branch.id,
-			branchName: remote.branch.name,
 		});
 	}
 }

--- a/packages/config/src/lib/fake-neon-api.ts
+++ b/packages/config/src/lib/fake-neon-api.ts
@@ -68,8 +68,6 @@ export class FakeNeonApi implements NeonApi {
 	private readonly functions = new Map<string, NeonFunctionSnapshot[]>();
 	/** Monotonic per-function deployment counter, keyed by `${projectId}:${branchId}:${slug}`. */
 	private readonly functionDeployments = new Map<string, number>();
-	/** AI Gateway enabled set, keyed by `${projectId}:${branchId}`. */
-	private readonly aiGateway = new Set<string>();
 	/** Issued credentials (incl. secrets), keyed by `${projectId}:${branchId}`. */
 	private readonly credentials = new Map<
 		string,
@@ -675,39 +673,11 @@ export class FakeNeonApi implements NeonApi {
 	}
 
 	// ─── Preview: AI Gateway ───────────────────────────────────────────────────
-
-	async getAiGatewayEnabled(
-		projectId: string,
-		branchId: string,
-	): Promise<boolean> {
-		this.history.push({
-			method: "getAiGatewayEnabled",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		return this.aiGateway.has(`${projectId}:${branchId}`);
-	}
-
-	async enableAiGateway(projectId: string, branchId: string): Promise<void> {
-		this.history.push({
-			method: "enableAiGateway",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		this.aiGateway.add(`${projectId}:${branchId}`);
-	}
-
-	async disableAiGateway(projectId: string, branchId: string): Promise<void> {
-		this.history.push({
-			method: "disableAiGateway",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		this.aiGateway.delete(`${projectId}:${branchId}`);
-	}
+	//
+	// No methods: the AI Gateway is always available on a branch (credential-gated, not
+	// per-branch provisioned), so the real adapter exposes no enable/disable/status route and
+	// neither does this fake. `preview.aiGateway` only drives the branch credential's
+	// `ai_gateway:invoke` scope (see `createCredential`).
 
 	// ─── Preview: branch-scoped credentials ──────────────────────────────────
 
@@ -832,11 +802,6 @@ export class FakeNeonApi implements NeonApi {
 		const list = this.functions.get(key) ?? [];
 		list.push({ ...snapshot });
 		this.functions.set(key, list);
-	}
-
-	/** Test helper: mark the AI Gateway enabled on a branch. */
-	seedAiGateway(projectId: string, branchId: string): void {
-		this.aiGateway.add(`${projectId}:${branchId}`);
 	}
 
 	private requireProject(projectId: string): void {

--- a/packages/config/src/lib/neon-api-real.test.ts
+++ b/packages/config/src/lib/neon-api-real.test.ts
@@ -205,12 +205,13 @@ describe("isPreviewFeatureUnavailable", () => {
 });
 
 describe("previewUnavailableError", () => {
-	test("wraps an unavailable error with a clear FeatureUnavailable message", () => {
+	test("503: FeatureUnavailable with status line, API message, request id, and incident guidance", () => {
 		const original = new PlatformError(ErrorCode.ServerError, "boom", {
 			details: {
 				status: 503,
 				neonMessage:
 					"platform functions not available for this project",
+				requestId: "req-503",
 			},
 		});
 		const wrapped = previewUnavailableError(original, "Functions");
@@ -218,7 +219,41 @@ describe("previewUnavailableError", () => {
 		if (!(wrapped instanceof PlatformError)) throw new Error("not wrapped");
 		expect(wrapped.code).toBe(ErrorCode.FeatureUnavailable);
 		expect(wrapped.message).toMatch(/Functions is a Preview feature/);
-		expect(wrapped.message).toMatch(/not available for this project/);
+		expect(wrapped.message).toMatch(
+			/isn't available for this Neon project/,
+		);
+		// One short status line + the raw API message + request id (never a stack trace).
+		expect(wrapped.message).toMatch(/HTTP 503 Service Unavailable/);
+		expect(wrapped.message).toMatch(
+			/platform functions not available for this project/,
+		);
+		expect(wrapped.message).toMatch(/request id req-503/);
+		// 503 → still coming up, or a transient incident: retry / status page / support.
+		expect(wrapped.message).toMatch(/incident/);
+		expect(wrapped.message).toMatch(/neonstatus\.com/);
+		// Escape hatch + structured details for programmatic consumers.
+		expect(wrapped.message).toMatch(
+			/remove the corresponding feature from the `preview`/,
+		);
+		expect(wrapped.details.status).toBe(503);
+		expect(wrapped.details.requestId).toBe("req-503");
+	});
+
+	test("404: points at region availability / private-preview access", () => {
+		const original = new PlatformError(ErrorCode.NotFound, "boom", {
+			details: { status: 404, neonMessage: "this route does not exist" },
+		});
+		const wrapped = previewUnavailableError(
+			original,
+			"Object storage (buckets)",
+		);
+		if (!(wrapped instanceof PlatformError)) throw new Error("not wrapped");
+		expect(wrapped.code).toBe(ErrorCode.FeatureUnavailable);
+		expect(wrapped.message).toMatch(/HTTP 404 Not Found/);
+		expect(wrapped.message).toMatch(/region/);
+		expect(wrapped.message).toMatch(/access to the preview/);
+		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
+		expect(wrapped.details.status).toBe(404);
 	});
 
 	test("passes a non-unavailable error through unchanged", () => {

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -883,66 +883,12 @@ class RealNeonApi implements NeonApi {
 
 	// ─── Preview: AI Gateway ───────────────────────────────────────────────────
 	//
-	// TODO(neon-deploy): the AI Gateway routes are not yet in the public API spec we wired
-	// the rest of this adapter against. The paths below follow the established branch-scoped
-	// convention (`/projects/{p}/branches/{b}/ai-gateway`); confirm them against the real
-	// API (and the exact enable/disable verb + response shape) before relying on this in
-	// production, and swap to the typed `@neondatabase/api-client` method once it exists.
-
-	async getAiGatewayEnabled(
-		projectId: string,
-		branchId: string,
-	): Promise<boolean> {
-		try {
-			return await this.call(
-				`getAiGatewayEnabled(${projectId}/${branchId})`,
-				async () => {
-					const data = await this.getJson(
-						aiGatewayPath(projectId, branchId),
-					);
-					return aiGatewayEnabledFromResponse(data);
-				},
-				{ projectId },
-			);
-		} catch (err) {
-			// A "feature unavailable" signal (route not deployed / "not available")
-			// is a hard error — surface it rather than reporting "disabled". A plain
-			// NotFound *without* that signal means the route exists but AI Gateway is
-			// simply not enabled on this branch, which is `false`.
-			if (isPreviewFeatureUnavailable(err)) {
-				throw previewUnavailableError(err, "AI Gateway");
-			}
-			if (
-				err instanceof PlatformError &&
-				err.code === ErrorCode.NotFound
-			) {
-				return false;
-			}
-			throw err;
-		}
-	}
-
-	async enableAiGateway(projectId: string, branchId: string): Promise<void> {
-		await this.call(
-			`enableAiGateway(${projectId}/${branchId})`,
-			async () => {
-				await this.postJson(aiGatewayPath(projectId, branchId), {
-					enabled: true,
-				});
-			},
-			{ projectId, mutating: true },
-		);
-	}
-
-	async disableAiGateway(projectId: string, branchId: string): Promise<void> {
-		await this.call(
-			`disableAiGateway(${projectId}/${branchId})`,
-			async () => {
-				await this.deleteJson(aiGatewayPath(projectId, branchId));
-			},
-			{ projectId, mutating: true },
-		);
-	}
+	// No methods: the AI Gateway is always available on a branch (credential-gated, not
+	// per-branch provisioned). There is no control-plane enable/disable/status route — the
+	// gateway is reached at the branch host with a credential carrying `ai_gateway:invoke`.
+	// `preview.aiGateway` only drives that credential scope and the `OPENAI_*` /
+	// `NEON_AI_GATEWAY_*` env vars (see `@neondatabase/env`); nothing is provisioned here, so
+	// `plan` / `apply` never touch an AI Gateway route and can't fail on its availability.
 
 	// ─── Preview: branch-scoped credentials ──────────────────────────────────
 
@@ -1020,10 +966,6 @@ function branchPreviewPath(
 	resource: "buckets" | "functions",
 ): string {
 	return `/projects/${encodeURIComponent(projectId)}/branches/${encodeURIComponent(branchId)}/${resource}`;
-}
-
-function aiGatewayPath(projectId: string, branchId: string): string {
-	return `/projects/${encodeURIComponent(projectId)}/branches/${encodeURIComponent(branchId)}/ai-gateway`;
 }
 
 function credentialsPath(projectId: string, branchId: string): string {
@@ -1127,13 +1069,6 @@ function normalizeDeploymentStatus(
 	}
 }
 
-function aiGatewayEnabledFromResponse(data: unknown): boolean {
-	if (data !== null && typeof data === "object" && "enabled" in data) {
-		return (data as { enabled?: unknown }).enabled === true;
-	}
-	return false;
-}
-
 /**
  * Whether an error from a Preview-feature read means the feature simply isn't available
  * for this project/branch/region (as opposed to a real, transient failure). Neon signals
@@ -1163,25 +1098,110 @@ export function isPreviewFeatureUnavailable(err: unknown): boolean {
 }
 
 /**
+ * Reason phrase for the handful of HTTP statuses a Preview-feature read can surface as
+ * "unavailable". Used to print a short `HTTP <status> <reason>` line (not a stack trace),
+ * so the message reads like the API response the user would see in a tool like curl.
+ */
+const HTTP_STATUS_TEXT: Record<number, string> = {
+	401: "Unauthorized",
+	403: "Forbidden",
+	404: "Not Found",
+	500: "Internal Server Error",
+	501: "Not Implemented",
+	503: "Service Unavailable",
+};
+
+/**
+ * Per-status guidance for a Preview feature that came back "unavailable". A preview can be
+ * gated several different ways and the HTTP status is the best signal for which, so we tailor
+ * the next step instead of emitting one catch-all — valuable while these features are in
+ * preview and rolling out region by region:
+ *
+ * - 404 / 501 — the route isn't deployed for this project's region (or the account isn't in
+ *   the private preview): create a project in a region where the preview is enabled, and
+ *   confirm your account has preview access.
+ * - 503 — the route exists but is refusing right now: either the preview is still coming up,
+ *   or Neon is having a transient incident. Retry; if it persists it's likely an incident.
+ * - anything else — generic "not enabled for your account/region; request access".
+ *
+ * Only statuses {@link isPreviewFeatureUnavailable} accepts (404/501/503) actually reach
+ * this, so there is intentionally no 401/403 branch — those never classify as "unavailable".
+ */
+function previewUnavailableHint(status: number | undefined): string {
+	switch (status) {
+		case 404:
+		case 501:
+			return (
+				"This usually means the preview isn't available in your project's region yet, or " +
+				"your Neon account isn't in the private preview: create a project in a region where " +
+				"the preview is enabled, and make sure your account has access to the preview."
+			);
+		case 503:
+			return (
+				"The endpoint is reachable but refused the request — the preview may still be " +
+				"coming up, or Neon may be having a transient incident. Retry shortly; if it keeps " +
+				"failing, check https://neonstatus.com and report it to Neon support."
+			);
+		default:
+			return (
+				"This usually means the preview isn't enabled for your Neon account or the project's " +
+				"region. Request access to the preview, or use a project in a region where it's available."
+			);
+	}
+}
+
+/**
  * Convert a Preview-feature error into a clear {@link PlatformError} when the feature is
  * unavailable for the project; otherwise pass the original error through unchanged so a
  * genuine failure (auth, transient 5xx, …) keeps its specific code and message.
+ *
+ * The message names the failing feature, summarizes the response in one short
+ * `HTTP <status> <reason>` line, includes the raw Neon API message + request id (valuable
+ * signal while the feature is in preview), gives status-specific guidance (see
+ * {@link previewUnavailableHint}), and offers removing the feature from the policy as an
+ * escape hatch. `status`/`requestId` are also kept on `details` for programmatic consumers.
  */
 export function previewUnavailableError(
 	err: unknown,
 	featureLabel: string,
 ): unknown {
 	if (!isPreviewFeatureUnavailable(err)) return err;
+	const details = err instanceof PlatformError ? err.details : {};
+	const status =
+		typeof details.status === "number" ? details.status : undefined;
 	const neonMessage =
-		err instanceof PlatformError &&
-		typeof err.details.neonMessage === "string"
-			? ` (Neon API said: "${err.details.neonMessage}")`
-			: "";
+		typeof details.neonMessage === "string"
+			? details.neonMessage
+			: undefined;
+	const requestId =
+		typeof details.requestId === "string" ? details.requestId : undefined;
+
+	// One short status line + the raw API message + request id — never a stack trace.
+	const statusText = status ? HTTP_STATUS_TEXT[status] : undefined;
+	const apiParts = [
+		status
+			? `HTTP ${status}${statusText ? ` ${statusText}` : ""}`
+			: undefined,
+		neonMessage ? `Neon API said: "${neonMessage}"` : undefined,
+		requestId ? `request id ${requestId}` : undefined,
+	].filter((part): part is string => part !== undefined);
+	const apiContext = apiParts.length > 0 ? ` (${apiParts.join("; ")})` : "";
+
 	return new PlatformError(
 		ErrorCode.FeatureUnavailable,
-		`${featureLabel} is a Preview feature that is not available for this project or region${neonMessage}. ` +
-			"Enable it for your Neon account/project first, then re-run.",
-		{ cause: err, details: { feature: featureLabel } },
+		[
+			`${featureLabel} is a Preview feature and isn't available for this Neon project${apiContext}.`,
+			previewUnavailableHint(status),
+			"If you don't need it, remove the corresponding feature from the `preview` block of your neon.ts and re-run.",
+		].join(" "),
+		{
+			cause: err,
+			details: {
+				feature: featureLabel,
+				...(status !== undefined ? { status } : {}),
+				...(requestId !== undefined ? { requestId } : {}),
+			},
+		},
 	);
 }
 

--- a/packages/config/src/lib/neon-api.ts
+++ b/packages/config/src/lib/neon-api.ts
@@ -421,18 +421,13 @@ export interface NeonApi {
 	): Promise<NeonFunctionDeploymentSnapshot>;
 
 	// ─── Preview: AI Gateway ───────────────────────────────────────────────────
-
-	/**
-	 * Whether the AI Gateway is enabled on a branch. Toggle-style, like Neon Auth / Data
-	 * API: used by both `fetchEnv` (to decide visibility) and `pushConfig` (to diff intent).
-	 */
-	getAiGatewayEnabled(projectId: string, branchId: string): Promise<boolean>;
-
-	/** Enable the AI Gateway on a branch. Idempotent. */
-	enableAiGateway(projectId: string, branchId: string): Promise<void>;
-
-	/** Disable the AI Gateway on a branch. Idempotent. */
-	disableAiGateway(projectId: string, branchId: string): Promise<void>;
+	//
+	// The AI Gateway is always available on a branch (credential-gated, not per-branch
+	// provisioned): there is no control-plane enable/disable/status route. Declaring
+	// `preview.aiGateway` in a policy therefore provisions nothing — it only adds the
+	// `ai_gateway:invoke` scope to the branch credential and surfaces the gateway env vars
+	// (`OPENAI_*` / `NEON_AI_GATEWAY_*`) on `fetchEnv` / `env pull`. So this interface
+	// intentionally exposes no AI Gateway methods.
 
 	// ─── Preview: branch-scoped credentials ──────────────────────────────────
 

--- a/packages/env/src/lib/fake-neon-api.ts
+++ b/packages/env/src/lib/fake-neon-api.ts
@@ -68,8 +68,6 @@ export class FakeNeonApi implements NeonApi {
 	private readonly functions = new Map<string, NeonFunctionSnapshot[]>();
 	/** Monotonic per-function deployment counter, keyed by `${projectId}:${branchId}:${slug}`. */
 	private readonly functionDeployments = new Map<string, number>();
-	/** AI Gateway enabled set, keyed by `${projectId}:${branchId}`. */
-	private readonly aiGateway = new Set<string>();
 	/** Issued credentials (incl. secrets), keyed by `${projectId}:${branchId}`. */
 	private readonly credentials = new Map<
 		string,
@@ -675,39 +673,11 @@ export class FakeNeonApi implements NeonApi {
 	}
 
 	// ─── Preview: AI Gateway ───────────────────────────────────────────────────
-
-	async getAiGatewayEnabled(
-		projectId: string,
-		branchId: string,
-	): Promise<boolean> {
-		this.history.push({
-			method: "getAiGatewayEnabled",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		return this.aiGateway.has(`${projectId}:${branchId}`);
-	}
-
-	async enableAiGateway(projectId: string, branchId: string): Promise<void> {
-		this.history.push({
-			method: "enableAiGateway",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		this.aiGateway.add(`${projectId}:${branchId}`);
-	}
-
-	async disableAiGateway(projectId: string, branchId: string): Promise<void> {
-		this.history.push({
-			method: "disableAiGateway",
-			args: [projectId, branchId],
-		});
-		this.requireProject(projectId);
-		this.requireBranch(projectId, branchId);
-		this.aiGateway.delete(`${projectId}:${branchId}`);
-	}
+	//
+	// No methods: the AI Gateway is always available on a branch (credential-gated, not
+	// per-branch provisioned), so the real adapter exposes no enable/disable/status route and
+	// neither does this fake. `preview.aiGateway` only drives the branch credential's
+	// `ai_gateway:invoke` scope (see `createCredential`).
 
 	// ─── Preview: branch-scoped credentials ──────────────────────────────────
 
@@ -832,11 +802,6 @@ export class FakeNeonApi implements NeonApi {
 		const list = this.functions.get(key) ?? [];
 		list.push({ ...snapshot });
 		this.functions.set(key, list);
-	}
-
-	/** Test helper: mark the AI Gateway enabled on a branch. */
-	seedAiGateway(projectId: string, branchId: string): void {
-		this.aiGateway.add(`${projectId}:${branchId}`);
 	}
 
 	private requireProject(projectId: string): void {


### PR DESCRIPTION
## Summary

Two related fixes for the Preview-feature surface (`config`, `config-runtime`), each with a changeset so a release is cut on merge.

### 1. AI Gateway is always-on — stop probing it (`minor`)
The AI Gateway is **always available** on a branch: it's credential-gated, not per-branch provisioned, and has **no** control-plane enable/disable/status route. Declaring `preview.aiGateway` should only mean "mint a branch credential scoped `ai_gateway:invoke` and surface the gateway env vars (`OPENAI_*` / `NEON_AI_GATEWAY_*`)" — which `@neondatabase/env` already does without touching any AI Gateway endpoint.

Previously `plan` / `apply` / `status` (and the policy-gated `env pull`) probed `GET /projects/{p}/branches/{b}/ai-gateway` to diff an `enable-ai-gateway` step. That route isn't part of the platform, so the probe failed with `PLATFORM_FEATURE_UNAVAILABLE` and broke commands that otherwise only needed `DATABASE_URL` / auth. Removed end-to-end:

- **`@neondatabase/config`**: dropped `getAiGatewayEnabled` / `enableAiGateway` / `disableAiGateway` from `NeonApi`, the `enable-ai-gateway` `PlanStep`, and `RemotePreviewState.aiGatewayEnabled`; `diffConfig` emits no AI Gateway step. `ResolvedPreviewConfig.aiGatewayEnabled` stays (it still drives the credential scope + env vars).
- **`@neondatabase/config-runtime`**: `pushConfig` no longer probes/applies AI Gateway state; `PulledPreview.aiGatewayEnabled` removed from `pullConfig` / `inspect`.

### 2. Status-aware "Preview feature unavailable" errors (`patch`)
For the features that *do* legitimately probe (Functions, object-storage buckets, branch credentials), `previewUnavailableError` now:
- names the failing feature and summarizes the response in one short `HTTP <status> <reason>` line (never a stack trace), keeping the raw Neon API message + request id inline (valuable while these are in preview);
- tailors guidance by status — **404/501** → region availability / private-preview access; **503** → rollout vs transient incident (retry, neonstatus.com, support); generic otherwise;
- offers removing the feature from `neon.ts` as an escape hatch, and carries `status` / `requestId` on `error.details`.

## Test plan
- [x] `@neondatabase/config`: 189 tests pass; `tsc --noEmit` clean
- [x] `@neondatabase/config-runtime`: 47 tests pass; `tsc --noEmit` clean
- [x] `@neondatabase/env`: 57 tests pass; `tsc --noEmit` clean
- [ ] End-to-end against staging (`neonctl-staging`) — deferred

## Notes
Consumers reading `PulledPreview.aiGatewayEnabled` (e.g. a CLI `config status` view) should drop it after adopting the new `config-runtime`. `preview.aiGateway` continues to work in `neon.ts` exactly as before for env resolution. The matching neonctl change is in neondatabase/neonctl (Utilized-services summary + auto env-pull).