### PR TITLE
fix(env): use full credential token_id for AWS_ACCESS_KEY_ID (object storage broken)

### DIFF
--- a/.changeset/env-storage-access-key-id.md
+++ b/.changeset/env-storage-access-key-id.md
@@ -1,0 +1,5 @@
+---
+"@neondatabase/env": patch
+---
+
+Fix object storage being unusable from a pulled `.env`. `fetchEnv` (and therefore `neon env pull` / `neon dev`) set `AWS_ACCESS_KEY_ID` to the credential's display-only short id (`token_id_short`) instead of its full `token_id` (e.g. `nak_live_…`). The S3-compatible storage endpoint authenticates with the **full** token id, so every request failed with `InvalidAccessKeyId` ("The AWS Access Key Id you provided does not exist in our records") even though the `.env` looked complete and the bucket existed. Now emits the full `token_id`, so the AWS SDKs work from the pulled env out of the box. `AWS_SECRET_ACCESS_KEY` and the AI Gateway / Postgres vars are unchanged.

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -588,7 +588,12 @@ async function resolveCredentialSecrets(args: {
 		},
 	);
 	return {
-		accessKeyId: minted.tokenIdShort,
+		// The S3-compatible storage endpoint authenticates with the credential's full token
+		// id (`token_id`, e.g. `nak_live_…`), NOT the display-only `token_id_short`. Using the
+		// short form makes every S3 request fail with `InvalidAccessKeyId` ("The AWS Access Key
+		// Id you provided does not exist in our records"), so a pulled `.env` looks complete but
+		// object storage is unusable.
+		accessKeyId: minted.tokenId,
 		secretAccessKey: minted.s3SecretAccessKey,
 		apiToken: minted.apiToken,
 	};


### PR DESCRIPTION
## Summary

`neon env pull` / `neon dev` write an `AWS_ACCESS_KEY_ID` that the S3-compatible storage endpoint **rejects**, so object storage is unusable from a pulled `.env` even though the bucket exists and the file looks complete.

`fetchEnv`'s `resolveCredentialSecrets` set `accessKeyId` to the credential's display-only short id (`token_id_short`, 12 chars) instead of its full `token_id` (`nak_live_…`, 41 chars). The storage endpoint authenticates with the **full** token id, so every request fails:

```
InvalidAccessKeyId: The AWS Access Key Id you provided does not exist in our records.
```

Fix: emit `minted.tokenId`. `AWS_SECRET_ACCESS_KEY` and the AI Gateway / Postgres / Auth vars are unchanged.

## Reproduced + verified on staging (us-east-2)
Full flow `bootstrap → link → config apply → env pull` against a real project with `preview.buckets`:

- **Before:** `AWS_ACCESS_KEY_ID` = `79feadb0c832` (len 12) → S3 `PutObject`/`ListObjectsV2` fail with `InvalidAccessKeyId`.
- **After:** `AWS_ACCESS_KEY_ID` = `nak_live_…` (len 41) → S3 `PutObject` + `ListObjectsV2` **succeed**.

(Confirmed independently by retrying S3 with the full `token_id` from the credentials API — it works; the short id does not.)

## Release
- Bumps `@neondatabase/env` `0.5.0 → 0.5.1` and adds a changeset (patch), so a release can be cut on merge.

## Test plan
- [x] `@neondatabase/env` unit suite (57 tests) + `tsc --noEmit` clean
- [x] e2e on staging: re-pulled env after the fix → S3 PUT/LIST succeed