### PR TITLE
feat(init): support NEON_API_HOST env var for staging environments

### DIFF
--- a/.changeset/neon-init-api-host.md
+++ b/.changeset/neon-init-api-host.md
@@ -1,0 +1,5 @@
+---
+"neon-init": patch
+---
+
+Support NEON_API_HOST env var for targeting staging environments. When set, all neonctl commands (including agent-issued ones) include --api-host and --oauth-host flags.

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -5,6 +5,7 @@ import { isAuthenticated } from "./lib/auth.js";
 import { detectAvailableEditors } from "./lib/editors.js";
 import { usesExtension } from "./lib/extension.js";
 import { installNeon } from "./lib/install.js";
+import { getNeonctlApiFlags, neonctlCmd } from "./lib/neonctl.js";
 import {
 	fetchSkillContent,
 	installAgentSkills,
@@ -48,48 +49,57 @@ export interface InitOptions {
 	json?: boolean;
 }
 
-const NEONCTL_COMMANDS = {
-	listOrgs: "npx neonctl orgs list --output json",
-	listProjects: "npx neonctl projects list --output json",
-	createProject:
-		"npx neonctl projects create --name <project-name> --output json",
-	getConnectionString:
-		"npx neonctl connection-string --project-id <project-id>",
-} as const;
+function getNeonctlCommands() {
+	const flags = getNeonctlApiFlags();
+	const base = flags ? `npx neonctl ${flags}` : "npx neonctl";
+	return {
+		listOrgs: `${base} orgs list --output json`,
+		listProjects: `${base} projects list --output json`,
+		createProject: `${base} projects create --name <project-name> --output json`,
+		getConnectionString: `${base} connection-string --project-id <project-id>`,
+	};
+}
 
-const AUTH_INSTRUCTIONS = [
-	"YOU (the agent) must handle authentication. Do NOT ask the user to run commands themselves.",
-	"Do NOT write wrapper scripts (Python, shell, etc.) — use simple shell commands only.",
-	"IMPORTANT: Unset the CI environment variable for all neonctl commands below,",
-	"otherwise neonctl will refuse to open the browser.",
-	"",
-	'Step 1: Ask the user: "Do you already have a Neon account, or do you need to create one?"',
-	"",
-	"=== NEW ACCOUNT (sign up) ===",
-	"Step 2a: Open the Neon sign-up page in the user's browser:",
-	"   On macOS: open https://console.neon.tech/signup",
-	"   On Linux: xdg-open https://console.neon.tech/signup",
-	"Step 3a: Tell the user: \"I've opened the Neon sign-up page in your browser.",
-	"   Create your account, then check your email for a verification link and click it.",
-	'   Let me know when you have finished signing up and verifying your email."',
-	"Step 4a: Once the user confirms, run the OAuth login:",
-	"   CI= npx -y neonctl auth",
-	"   This opens a second browser tab for OAuth authorization. The user approves access.",
-	"   If exit code 0: authentication succeeded.",
-	"   If exit code 2 (timeout): ask the user to confirm they finished sign-up and",
-	"   email verification, then retry the same command.",
-	"",
-	"=== EXISTING ACCOUNT (sign in) ===",
-	"Step 2b: Execute: CI= npx -y neonctl auth",
-	"   This opens the OAuth login page directly. Sign-in is fast (60-second timeout).",
-	"   If exit code 0: authentication succeeded.",
-	"   If exit code 2 (timeout): ask the user to confirm they completed sign-in, then retry.",
-	"",
-	"=== AFTER SUCCESSFUL AUTH ===",
-	"Step 5: Verify by running: CI= npx -y neonctl me",
-	"   This should print the user's account info and exit with code 0.",
-	"Step 6: Re-run neon-init with the same --agent and --json flags to complete setup.",
-].join("\n");
+function getAuthInstructions(): string {
+	const cmd = neonctlCmd();
+	const apiBase = process.env.NEON_API_HOST?.replace(/\/+$/, "");
+	const signupUrl = apiBase
+		? `${apiBase}/signup`
+		: "https://console.neon.tech/signup";
+	return [
+		"YOU (the agent) must handle authentication. Do NOT ask the user to run commands themselves.",
+		"Do NOT write wrapper scripts (Python, shell, etc.) — use simple shell commands only.",
+		"IMPORTANT: Unset the CI environment variable for all neonctl commands below,",
+		"otherwise neonctl will refuse to open the browser.",
+		"",
+		'Step 1: Ask the user: "Do you already have a Neon account, or do you need to create one?"',
+		"",
+		"=== NEW ACCOUNT (sign up) ===",
+		"Step 2a: Open the Neon sign-up page in the user's browser:",
+		`   On macOS: open ${signupUrl}`,
+		`   On Linux: xdg-open ${signupUrl}`,
+		"Step 3a: Tell the user: \"I've opened the Neon sign-up page in your browser.",
+		"   Create your account, then check your email for a verification link and click it.",
+		'   Let me know when you have finished signing up and verifying your email."',
+		"Step 4a: Once the user confirms, run the OAuth login:",
+		`   ${cmd} auth`,
+		"   This opens a second browser tab for OAuth authorization. The user approves access.",
+		"   If exit code 0: authentication succeeded.",
+		"   If exit code 2 (timeout): ask the user to confirm they finished sign-up and",
+		"   email verification, then retry the same command.",
+		"",
+		"=== EXISTING ACCOUNT (sign in) ===",
+		`Step 2b: Execute: ${cmd} auth`,
+		"   This opens the OAuth login page directly. Sign-in is fast (60-second timeout).",
+		"   If exit code 0: authentication succeeded.",
+		"   If exit code 2 (timeout): ask the user to confirm they completed sign-in, then retry.",
+		"",
+		"=== AFTER SUCCESSFUL AUTH ===",
+		`Step 5: Verify by running: ${cmd} me`,
+		"   This should print the user's account info and exit with code 0.",
+		"Step 6: Re-run neon-init with the same --agent and --json flags to complete setup.",
+	].join("\n");
+}
 
 function buildAgentInstructions(refs: Record<string, string>): string {
 	return [
@@ -102,14 +112,14 @@ function buildAgentInstructions(refs: Record<string, string>): string {
 		"documentation pages (e.g. /docs/guides/*) or guess at import paths — the skill",
 		"references are more accurate, complete, and agent-optimized.",
 		"",
-		`1. List organizations: ${NEONCTL_COMMANDS.listOrgs}`,
+		`1. List organizations: ${getNeonctlCommands().listOrgs}`,
 		"   - If one org, use it. If multiple, ask the user which to use.",
-		`2. List projects: ${NEONCTL_COMMANDS.listProjects} (add --org-id <org-id>)`,
+		`2. List projects: ${getNeonctlCommands().listProjects} (add --org-id <org-id>)`,
 		"   - No projects: ask if they want to create a new one.",
 		"   - One project: ask if they want to use it or create new.",
 		"   - Multiple: let the user choose.",
-		`3. Create project if needed: ${NEONCTL_COMMANDS.createProject} (add --org-id <org-id>)`,
-		`4. Get connection string: ${NEONCTL_COMMANDS.getConnectionString}`,
+		`3. Create project if needed: ${getNeonctlCommands().createProject} (add --org-id <org-id>)`,
+		`4. Get connection string: ${getNeonctlCommands().getConnectionString}`,
 		"5. Store in .env as DATABASE_URL (append, don't overwrite existing .env).",
 		"6. For apps with user login/auth: STOP. Before writing any auth code, fetch and",
 		`   read this skill reference: ${refs.neonAuth ?? ""}`,
@@ -139,7 +149,7 @@ export async function init(options?: InitOptions): Promise<InitResult> {
 		},
 		neonctl: {
 			authenticated: auth,
-			commands: { ...NEONCTL_COMMANDS },
+			commands: { ...getNeonctlCommands() },
 		},
 		mcpServer: {
 			configured: false,
@@ -226,7 +236,7 @@ export async function init(options?: InitOptions): Promise<InitResult> {
 				success: false,
 				auth: false,
 				authRequired: true,
-				authInstructions: AUTH_INSTRUCTIONS,
+				authInstructions: getAuthInstructions(),
 				editors: [],
 				skills: {
 					installed: false,
@@ -235,7 +245,7 @@ export async function init(options?: InitOptions): Promise<InitResult> {
 				},
 				neonctl: {
 					authenticated: false,
-					commands: { ...NEONCTL_COMMANDS },
+					commands: { ...getNeonctlCommands() },
 				},
 				mcpServer: {
 					configured: false,
@@ -296,7 +306,7 @@ export async function init(options?: InitOptions): Promise<InitResult> {
 			},
 			neonctl: {
 				authenticated: authSuccess,
-				commands: { ...NEONCTL_COMMANDS },
+				commands: { ...getNeonctlCommands() },
 			},
 			mcpServer: {
 				configured: mcpConfigured,
@@ -362,7 +372,7 @@ export async function init(options?: InitOptions): Promise<InitResult> {
 			skills: { installed: false, gettingStarted: null, references: {} },
 			neonctl: {
 				authenticated: authSuccess,
-				commands: { ...NEONCTL_COMMANDS },
+				commands: { ...getNeonctlCommands() },
 			},
 			mcpServer: { configured: false, requiresRestart: false },
 		};
@@ -400,7 +410,7 @@ export async function init(options?: InitOptions): Promise<InitResult> {
 		},
 		neonctl: {
 			authenticated: authSuccess,
-			commands: { ...NEONCTL_COMMANDS },
+			commands: { ...getNeonctlCommands() },
 		},
 		mcpServer: {
 			configured: mcpConfigured,

--- a/packages/init/src/lib/auth.ts
+++ b/packages/init/src/lib/auth.ts
@@ -98,20 +98,20 @@ export async function createApiKeyFromNeonctl(
 		const keyName = `neonctl-init-${timestamp}`;
 
 		// Call Neon API to create an API key
-		const response = await fetch(
-			"https://console.neon.tech/api/v2/api_keys",
-			{
-				method: "POST",
-				headers: {
-					Authorization: `Bearer ${accessToken}`,
-					"Content-Type": "application/json",
-				},
-				body: JSON.stringify({
-					key_name: keyName,
-				}),
-				signal: AbortSignal.timeout(30000),
+		const apiBase = process.env.NEON_API_HOST
+			? `${process.env.NEON_API_HOST.replace(/\/+$/, "")}/api/v2`
+			: "https://console.neon.tech/api/v2";
+		const response = await fetch(`${apiBase}/api_keys`, {
+			method: "POST",
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"Content-Type": "application/json",
 			},
-		);
+			body: JSON.stringify({
+				key_name: keyName,
+			}),
+			signal: AbortSignal.timeout(30000),
+		});
 
 		if (!response.ok) {
 			const errorText = await response.text();

--- a/packages/init/src/lib/neonctl.ts
+++ b/packages/init/src/lib/neonctl.ts
@@ -1,6 +1,49 @@
 import { execa } from "execa";
 
 /**
+ * Derives --api-host and --oauth-host flags from the NEON_API_HOST env var.
+ *
+ * When NEON_API_HOST is set (e.g. "https://console-stage.neon.build"), neonctl
+ * commands need explicit flags:
+ *   --api-host https://console-stage.neon.build/api/v2
+ *   --oauth-host https://oauth2-stage.neon.build
+ *
+ * The oauth host is derived by replacing the "console" prefix in the hostname
+ * with "oauth2" (e.g. console-stage.neon.build → oauth2-stage.neon.build).
+ */
+export function getNeonctlApiFlags(): string {
+	const apiHost = process.env.NEON_API_HOST;
+	if (!apiHost) return "";
+
+	const apiUrl = `${apiHost.replace(/\/+$/, "")}/api/v2`;
+
+	let oauthUrl = "";
+	try {
+		const url = new URL(apiHost);
+		url.hostname = url.hostname.replace(/^console/, "oauth2");
+		// OAuth host is just the origin (no path)
+		oauthUrl = url.origin;
+	} catch {
+		// If URL parsing fails, skip oauth-host
+	}
+
+	const flags = [`--api-host ${apiUrl}`];
+	if (oauthUrl) flags.push(`--oauth-host ${oauthUrl}`);
+	return flags.join(" ");
+}
+
+/**
+ * Returns the neonctl command prefix: "CI= npx -y neonctl" with any
+ * --api-host / --oauth-host flags appended when NEON_API_HOST is set.
+ *
+ * Usage: `${neonctlCmd()} orgs list --output json`
+ */
+export function neonctlCmd(): string {
+	const flags = getNeonctlApiFlags();
+	return flags ? `CI= npx -y neonctl ${flags}` : "CI= npx -y neonctl";
+}
+
+/**
  * Detects which package manager was used to invoke the current process.
  * Reads the `npm_config_user_agent` env var set by npm/pnpm/yarn/bun when
  * they spawn child processes (including via `npx`, `pnpx`, `bunx`, etc.).

--- a/packages/init/src/lib/phases/auth.ts
+++ b/packages/init/src/lib/phases/auth.ts
@@ -1,11 +1,20 @@
 import { isAuthenticated } from "../auth.js";
+import { neonctlCmd } from "../neonctl.js";
 import type { PhaseResponse } from "../types.js";
 
-const SIGNUP_COMMANDS: Record<string, string> = {
-	darwin: "open https://console.neon.tech/signup",
-	linux: "xdg-open https://console.neon.tech/signup",
-	win32: "start https://console.neon.tech/signup",
-};
+function getSignupUrl(): string {
+	const base = process.env.NEON_API_HOST?.replace(/\/+$/, "");
+	return base ? `${base}/signup` : "https://console.neon.tech/signup";
+}
+
+function getSignupCommands(): Record<string, string> {
+	const url = getSignupUrl();
+	return {
+		darwin: `open ${url}`,
+		linux: `xdg-open ${url}`,
+		win32: `start ${url}`,
+	};
+}
 
 export interface AuthPhaseOptions {
 	agent?: string;
@@ -61,7 +70,7 @@ export async function handleAuthPhase(
 	// --method new: guide through signup
 	if (options.method === "new") {
 		const openCmd =
-			SIGNUP_COMMANDS[process.platform] ?? SIGNUP_COMMANDS.linux;
+			getSignupCommands()[process.platform] ?? getSignupCommands().linux;
 		return {
 			phase: "auth",
 			status: "in_progress",
@@ -95,7 +104,7 @@ export async function handleAuthPhase(
 			status: "in_progress",
 			nextAction: {
 				type: "run_command",
-				command: "CI= npx -y neonctl auth",
+				command: `${neonctlCmd()} auth`,
 				description:
 					"This will open your browser for Neon OAuth sign-in.",
 				timeout: 120000,
@@ -134,7 +143,8 @@ export async function handleAuthPhase(
 
 	// No method specified: ask the user, then launch OAuth directly for
 	// "existing account" without an intermediate CLI round-trip.
-	const openCmd = SIGNUP_COMMANDS[process.platform] ?? SIGNUP_COMMANDS.linux;
+	const openCmd =
+		getSignupCommands()[process.platform] ?? getSignupCommands().linux;
 	return {
 		phase: "auth",
 		status: "required",
@@ -158,7 +168,7 @@ export async function handleAuthPhase(
 				existing_account: {
 					action: {
 						type: "run_command",
-						command: "CI= npx -y neonctl auth",
+						command: `${neonctlCmd()} auth`,
 						description:
 							"This will open your browser for Neon OAuth sign-in.",
 						timeout: 120000,

--- a/packages/init/src/lib/phases/db.ts
+++ b/packages/init/src/lib/phases/db.ts
@@ -1,3 +1,4 @@
+import { neonctlCmd } from "../neonctl.js";
 import { SKILL_REFERENCE_URLS } from "../skills.js";
 import type { PhaseResponse } from "../types.js";
 
@@ -69,7 +70,7 @@ export async function handleDbPhase(
 					{
 						id: "get_connection_string",
 						description: "Get the database connection string",
-						command: `CI= npx -y neonctl connection-string --project-id ${options.projectId}`,
+						command: `${neonctlCmd()} connection-string --project-id ${options.projectId}`,
 					},
 					{
 						id: "store_env",
@@ -121,7 +122,7 @@ export async function handleDbPhase(
 						},
 					],
 					context:
-						"The agent should ask the user for a project name, then run: CI= npx -y neonctl projects create --name <name> --output json" +
+						`The agent should ask the user for a project name, then run: ${neonctlCmd()} projects create --name <name> --output json` +
 						(options.orgId ? ` --org-id ${options.orgId}` : "") +
 						" and pass the result back.",
 					responseMapping: {
@@ -171,8 +172,7 @@ export async function handleDbPhase(
 				type: "ask_user",
 				question: "Which Neon project would you like to use?",
 				options: projectOptions,
-				context:
-					"If the user wants to create a new project, ask for a name then run: CI= npx -y neonctl projects create --name <name> --output json and use the returned project id.",
+				context: `If the user wants to create a new project, ask for a name then run: ${neonctlCmd()} projects create --name <name> --output json and use the returned project id.`,
 				responseMapping,
 			},
 		};
@@ -203,7 +203,7 @@ export async function handleDbPhase(
 				org: { id: orgId },
 				nextAction: {
 					type: "run_command",
-					command: `CI= npx -y neonctl projects list --org-id ${orgId} --output json`,
+					command: `${neonctlCmd()} projects list --org-id ${orgId} --output json`,
 					description: "Listing Neon projects.",
 					timeout: 30000,
 					onSuccess: {
@@ -264,7 +264,7 @@ export async function handleDbPhase(
 			org: { id: options.orgId },
 			nextAction: {
 				type: "run_command",
-				command: `CI= npx -y neonctl projects list --org-id ${options.orgId} --output json`,
+				command: `${neonctlCmd()} projects list --org-id ${options.orgId} --output json`,
 				description: "Listing Neon projects.",
 				timeout: 30000,
 				onSuccess: {
@@ -299,7 +299,7 @@ export async function handleDbPhase(
 		status: "ready",
 		nextAction: {
 			type: "run_command",
-			command: "CI= npx -y neonctl orgs list --output json",
+			command: `${neonctlCmd()} orgs list --output json`,
 			description: "Listing your Neon organizations.",
 			timeout: 30000,
 			onSuccess: {

--- a/packages/init/src/lib/phases/getting-started.ts
+++ b/packages/init/src/lib/phases/getting-started.ts
@@ -1,3 +1,4 @@
+import { neonctlCmd } from "../neonctl.js";
 import { ensureSkillsUpToDate, SKILL_REFERENCE_URLS } from "../skills.js";
 import type { PhaseResponse } from "../types.js";
 
@@ -42,7 +43,7 @@ export async function handleGettingStartedPhase(
 						"If multiple orgs exist, ask the user which one to use.",
 						"Remember the selected org ID for the next steps.",
 					].join(" "),
-					command: "CI= npx -y neonctl orgs list --output json",
+					command: `${neonctlCmd()} orgs list --output json`,
 				},
 				{
 					id: "select_or_create_project",
@@ -54,8 +55,7 @@ export async function handleGettingStartedPhase(
 						"If no eligible projects exist, tell the user and proceed directly to creating a new one.",
 						"IMPORTANT: Always include --org-id when creating a project to avoid interactive prompts.",
 					].join(" "),
-					command:
-						"CI= npx -y neonctl projects list --org-id <org-id> --output json",
+					command: `${neonctlCmd()} projects list --org-id <org-id> --output json`,
 				},
 				{
 					id: "create_project_if_needed",
@@ -64,8 +64,7 @@ export async function handleGettingStartedPhase(
 						"Ask the user for a project name (suggest the current directory name).",
 						"If the user chose an existing eligible project, skip this step.",
 					].join(" "),
-					command:
-						"CI= npx -y neonctl projects create --name <project-name> --org-id <org-id> --region-id aws-us-east-2 --output json",
+					command: `${neonctlCmd()} projects create --name <project-name> --org-id <org-id> --region-id aws-us-east-2 --output json`,
 				},
 			);
 		} else {
@@ -79,7 +78,7 @@ export async function handleGettingStartedPhase(
 						"If multiple orgs exist, ask the user which one to use.",
 						"Remember the selected org ID for the next steps.",
 					].join(" "),
-					command: "CI= npx -y neonctl orgs list --output json",
+					command: `${neonctlCmd()} orgs list --output json`,
 				},
 				{
 					id: "select_or_create_project",
@@ -89,8 +88,7 @@ export async function handleGettingStartedPhase(
 						"If creating new, ask the user for a project name (suggest the current directory name).",
 						"IMPORTANT: Always include --org-id when creating a project to avoid interactive prompts.",
 					].join(" "),
-					command:
-						"CI= npx -y neonctl projects list --org-id <org-id> --output json",
+					command: `${neonctlCmd()} projects list --org-id <org-id> --output json`,
 				},
 				{
 					id: "create_project_if_needed",
@@ -98,8 +96,7 @@ export async function handleGettingStartedPhase(
 						"If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>).",
 						"If the user chose an existing project, skip this step.",
 					].join(" "),
-					command:
-						"CI= npx -y neonctl projects create --name <project-name> --org-id <org-id> --output json",
+					command: `${neonctlCmd()} projects create --name <project-name> --org-id <org-id> --output json`,
 				},
 			);
 		}
@@ -136,7 +133,7 @@ export async function handleGettingStartedPhase(
 				"It reads the .neon context file to determine the project, and writes to the appropriate env file for the project.",
 				"Ensure the target env file is listed in .gitignore.",
 			].join(" "),
-			command: "CI= npx -y neonctl env pull",
+			command: `${neonctlCmd()} env pull`,
 		});
 
 		// Step 6: Install Neon serverless driver if needed

--- a/packages/init/src/lib/phases/neon-auth.ts
+++ b/packages/init/src/lib/phases/neon-auth.ts
@@ -1,3 +1,4 @@
+import { neonctlCmd } from "../neonctl.js";
 import { ensureSkillsUpToDate, SKILL_REFERENCE_URLS } from "../skills.js";
 import type { PhaseResponse } from "../types.js";
 
@@ -77,8 +78,8 @@ export async function handleNeonAuthPhase(
 						id: "provision",
 						description:
 							"Enable Neon Auth on the project using the neonctl CLI. " +
-							"Run: `CI= npx -y neonctl neon-auth enable --project-id <project-id> --output json`. " +
-							"You can check current status with: `CI= npx -y neonctl neon-auth status --project-id <project-id> --output json`." +
+							`Run: \`${neonctlCmd()} neon-auth enable --project-id <project-id> --output json\`. ` +
+							`You can check current status with: \`${neonctlCmd()} neon-auth status --project-id <project-id> --output json\`.` +
 							(options.projectId
 								? ` Project ID: ${options.projectId}.`
 								: " Determine the project ID from the .neon file in the project root, or from the DATABASE_URL in .env, or ask the user."),
@@ -95,9 +96,8 @@ export async function handleNeonAuthPhase(
 					},
 					{
 						id: "pull_env",
-						description:
-							"Run `neonctl env pull` to populate the NEON_AUTH_BASE_URL, NEON_AUTH_JWKS_URL, and other Neon Auth environment variables. This reads the .neon context file and writes the auth URLs to the project's env file.",
-						command: "CI= npx -y neonctl env pull",
+						description: `Run \`${neonctlCmd()} env pull\` to populate the NEON_AUTH_BASE_URL, NEON_AUTH_JWKS_URL, and other Neon Auth environment variables. This reads the .neon context file and writes the auth URLs to the project's env file.`,
+						command: `${neonctlCmd()} env pull`,
 					},
 				],
 				onComplete: {


### PR DESCRIPTION
## Summary
- When `NEON_API_HOST` is set (e.g. `https://console-stage.neon.build`), all neonctl command strings now include `--api-host` and `--oauth-host` flags
- This applies to both orchestrator-executed commands and agent instruction strings, so the agent also targets the correct environment
- Signup URLs and API key creation also respect the env var
- Includes a changeset for a patch release

## How it works
- `neonctlCmd()` helper in `neonctl.ts` builds the command prefix with flags when `NEON_API_HOST` is set
- `--api-host` is derived as `NEON_API_HOST/api/v2`
- `--oauth-host` is derived by replacing `console` with `oauth2` in the hostname

## Usage
```bash
NEON_API_HOST=https://console-stage.neon.build npx neonctl@latest init
```

## Test plan
- [x] All 106 existing tests pass
- [x] Lint passes
- [x] Type-check passes
- [ ] Manual test with `NEON_API_HOST=https://console-stage.neon.build neon-init --agent claude --json`

This pull request and its description were written by Isaac.