### PR TITLE
chore: release packages

### DIFF
--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.15.0",
+	"version": "0.16.0",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
bump `neon-init` to `0.16.0`