### PR TITLE
fix(env): use full token id for S3 AWS_ACCESS_KEY_ID

### DIFF
--- a/.changeset/storage-access-key-full-token-id.md
+++ b/.changeset/storage-access-key-full-token-id.md
@@ -1,0 +1,7 @@
+---
+"@neondatabase/env": patch
+---
+
+Fix object-storage credentials: map `AWS_ACCESS_KEY_ID` to the credential's full token id.
+
+`fetchEnv` / `parseEnv` previously injected the credential's short token id (`token_id_short`, e.g. `805e248a8e54`) as `AWS_ACCESS_KEY_ID`. The storage gateway only accepts the full token id (`token_id`, e.g. `nak_live_805e248a8e54…`), so every S3 request failed with `InvalidAccessKeyId`. `env.storage.accessKeyId` (and `AWS_ACCESS_KEY_ID`) now carries the full token id, making the standard object-storage path usable.

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -428,8 +428,11 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect(callsTo(api, "createCredential")).toBe(1);
 		expect(callsTo(api, "getProjectBranchStorage")).toBe(1);
 		expect(env.storage.secretAccessKey).toHaveLength(64);
-		// The S3 access-key id is the credential's short token id (embedded in api_token).
-		expect(env.storage.accessKeyId).not.toBe("");
+		// The S3 access-key id must be the credential's FULL token id — the storage
+		// gateway rejects the short token id with InvalidAccessKeyId. The fake mints
+		// full ids as `<short>-fake-fake-fake-<seq>`, so the access key id must carry
+		// that suffix and not equal the bare short id.
+		expect(env.storage.accessKeyId).toContain("-fake-");
 		expect(env.storage.endpoint).toContain("storage");
 		expect(env.storage.region).toBe("us-east-1");
 		expect(env.storage.forcePathStyle).toBe(true);

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -128,7 +128,8 @@ export interface NeonDataApiEnv {
 /**
  * S3-compatible object-storage access for the branch (Preview). Present on `NeonEnv` only
  * when the policy declares `preview.buckets`. Combines a minted branch credential's access
- * keys (`accessKeyId` = the credential's short token id, `secretAccessKey` = its
+ * keys (`accessKeyId` = the credential's full token id, e.g. `nak_live_…`, which is what the
+ * storage gateway authenticates against; `secretAccessKey` = its
  * `s3_secret_access_key`) with the branch's non-secret connection details
  * (`endpoint`/`region`/`forcePathStyle`, from `GET .../storage`). Projects to the AWS SDK's
  * standard config env (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`,
@@ -588,7 +589,10 @@ async function resolveCredentialSecrets(args: {
 		},
 	);
 	return {
-		accessKeyId: minted.tokenIdShort,
+		// The storage gateway authenticates against the full token id (e.g.
+		// `nak_live_…`), not the short token id — using the short id yields
+		// `InvalidAccessKeyId` on every S3 request.
+		accessKeyId: minted.tokenId,
 		secretAccessKey: minted.s3SecretAccessKey,
 		apiToken: minted.apiToken,
 	};


### PR DESCRIPTION
## Summary

- The credential-injection path in `@neondatabase/env` (`fetchEnv` / `parseEnv`) mapped `AWS_ACCESS_KEY_ID` to the credential's **short** token id (`token_id_short`, e.g. `805e248a8e54`), but the storage gateway only authenticates against the **full** token id (`token_id`, e.g. `nak_live_805e248a8e54…`). Every S3 request therefore failed with `InvalidAccessKeyId`, making the standard object-storage path unusable.
- Fix: map `accessKeyId` to `minted.tokenId` (the full token id) in `resolveCredentialSecrets`. This flows through `env.storage.accessKeyId` → `AWS_ACCESS_KEY_ID`.
- Updated the `NeonStorageEnv` doc comment (which incorrectly described the short id) and strengthened the buckets test to assert the full token id is injected.
- Added a patch changeset for `@neondatabase/env`.

## Test plan

- [x] `vitest run packages/env/src/lib/env.test.ts` → 37/37 pass
- [x] `tsc --noEmit` for `@neondatabase/env` → clean
- [ ] CI green