### PR TITLE
docs(config): use object-form defineConfig in neon.ts examples

### DIFF
--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -57,7 +57,7 @@ export interface PushConfigOptions {
 	api?: NeonApi;
 	/**
 	 * Whether to evaluate the policy as if the target branch **already exists** (the value of
-	 * `branch.exists` passed to the `defineConfig((branch) => …)` closure). Defaults to `true`.
+	 * `branch.exists` passed to the `defineConfig({ branch: (branch) => … })` closure). Defaults to `true`.
 	 *
 	 * Set to `false` to evaluate the policy as a **branch creation** — used by
 	 * {@link createBranch} right after it provisions a new branch, so creation-time tuning

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -103,7 +103,7 @@ export interface ComputeSettings {
 
 /**
  * Read-only descriptor of the branch a {@link Config} policy is being evaluated for — the
- * `branch` argument passed to your `defineConfig((branch) => …)` callback. It describes
+ * `branch` argument passed to your `defineConfig({ branch: (branch) => … })` closure. It describes
  * **which** branch this invocation decides for; it is not a live branch handle and must not
  * be mutated. Switch on its fields and return the desired {@link BranchConfig}.
  */

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -5,9 +5,14 @@
  * ```ts
  * import { defineConfig } from "@neondatabase/config/v1";
  *
- * export default defineConfig((branch) => {
- *   if (branch.name === "main") return { protected: true, auth: {} };
- *   return { parent: "main", ttl: "7d" };
+ * export default defineConfig({
+ *   // Static: what *exists* on every branch (drives the typed env).
+ *   auth: true,
+ *   // Dynamic: per-branch tuning only — cannot add/remove services.
+ *   branch: (branch) => ({
+ *     protected: branch.name === "main",
+ *     ...(branch.name === "main" ? {} : { parent: "main", ttl: "7d" }),
+ *   }),
  * });
  * ```
  *


### PR DESCRIPTION
## Summary
- `defineConfig` now expects an object (and explicitly throws on the old top-level function form), but the `@neondatabase/config/v1` doc comment still showed `defineConfig((branch) => …)`.
- Updated the `v1.ts` "Usage in `neon.ts`" example to the object form (static `auth` at top level + a dynamic `branch:` closure), matching the package README and the `define-config.ts` JSDoc.
- Fixed two prose references in `types.ts` and `push-config.ts` to point at the `defineConfig({ branch: (branch) => … })` closure.

Docs/comment-only — no runtime behavior change. (CHANGELOG entries with the old form are historical and left untouched.)

## Test plan
- [x] No code changes; JSDoc/comment edits only