### PR TITLE
feat(config): rich dataApi config in neon.ts (auth provider + settings)

### DIFF
--- a/.changeset/data-api-config.md
+++ b/.changeset/data-api-config.md
@@ -1,0 +1,25 @@
+---
+"@neondatabase/config": minor
+"@neondatabase/config-runtime": minor
+---
+
+Add a rich `dataApi` config to `neon.ts`: auth provider selection + reconcilable runtime settings.
+
+`dataApi` still accepts the boolean/toggle forms (`true` / `{}` / `{ enabled: true }`), but now also takes an object describing the integration:
+
+```ts
+defineConfig({
+  auth: true,
+  dataApi: {
+    authProvider: "neon", // default; "external" verifies a third-party IdP
+    settings: { dbSchemas: ["public", "api"], dbMaxRows: 1000 },
+  },
+});
+```
+
+- **`authProvider`** is `"neon"` (default) or `"external"` (friendly values, mapped to the API's `neon_auth` / `external`). The external-IdP wiring (`jwksUrl`, `providerName`, `jwtAudience`) is only valid — and only typeable — on the `"external"` variant (the `"neon"` variant types those fields as `never`).
+- **`settings`** mirror the Neon API `DataAPISettings` in camelCase (`dbAggregatesEnabled`, `dbAnonRole`, `dbExtraSearchPath`, `dbMaxRows`, `dbSchemas`, `jwtRoleClaimKey`, `jwtCacheMaxLifetime`, `openapiMode`, `serverCorsAllowedOrigins`, `serverTimingEnabled`).
+- **A `"neon"` Data API requires Neon Auth.** Enforced both at author time (TypeScript makes `auth` required) and at runtime (zod cross-field check). An `"external"` Data API does not.
+- The auth wiring is set when the Data API is first **enabled** (carried on the create request) and is immutable afterward. Changing the runtime `settings` is reconciled as an **update** and requires `updateExisting` / `--update-existing`, like compute/TTL/`protected` drift.
+
+The `add_default_grants` / `skip_auth_schema` create-only flags are intentionally not exposed.

--- a/packages/config-runtime/src/lib/fake-neon-api.ts
+++ b/packages/config-runtime/src/lib/fake-neon-api.ts
@@ -4,7 +4,9 @@ import type {
 	CreateBucketInput,
 	CreateCredentialInput,
 	CreateProjectInput,
+	DataApiSettings,
 	DeployFunctionInput,
+	EnableDataApiInput,
 	GetConnectionUriInput,
 	NeonApi,
 	NeonAuthSnapshot,
@@ -478,10 +480,11 @@ export class FakeNeonApi implements NeonApi {
 		projectId: string,
 		branchId: string,
 		databaseName: string,
+		input?: EnableDataApiInput,
 	): Promise<NeonDataApiSnapshot> {
 		this.history.push({
 			method: "enableProjectBranchDataApi",
-			args: [projectId, branchId, databaseName],
+			args: [projectId, branchId, databaseName, input],
 		});
 		this.requireProject(projectId);
 		this.requireBranch(projectId, branchId);
@@ -490,9 +493,38 @@ export class FakeNeonApi implements NeonApi {
 		if (existing) return clone(existing);
 		const snapshot: NeonDataApiSnapshot = {
 			url: `https://${branchId}.fake.neon.tech/data-api/${databaseName}`,
+			status: "ready",
 		};
+		if (input?.settings) snapshot.settings = { ...input.settings };
 		this.neonDataApi.set(key, snapshot);
 		return clone(snapshot);
+	}
+
+	async updateProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		settings: DataApiSettings,
+	): Promise<NeonDataApiSnapshot> {
+		this.history.push({
+			method: "updateProjectBranchDataApi",
+			args: [projectId, branchId, databaseName, settings],
+		});
+		this.requireProject(projectId);
+		this.requireBranch(projectId, branchId);
+		const key = `${projectId}:${branchId}:${databaseName}`;
+		const existing = this.neonDataApi.get(key);
+		if (!existing) {
+			throw new Error(
+				`Fake Neon: Data API not enabled on ${branchId}/${databaseName}`,
+			);
+		}
+		const updated: NeonDataApiSnapshot = {
+			...existing,
+			settings: { ...(existing.settings ?? {}), ...settings },
+		};
+		this.neonDataApi.set(key, updated);
+		return clone(updated);
 	}
 
 	/** Test helper: attach a Neon Auth integration to a branch. */

--- a/packages/config-runtime/src/lib/push-config.test.ts
+++ b/packages/config-runtime/src/lib/push-config.test.ts
@@ -1,7 +1,11 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { defineConfig, ErrorCode } from "@neondatabase/config";
+import {
+	defineConfig,
+	ErrorCode,
+	PushConflictError,
+} from "@neondatabase/config";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { FakeNeonApi } from "./fake-neon-api.js";
 import { pushConfig } from "./push-config.js";
@@ -88,6 +92,89 @@ describe("pushConfig", () => {
 				(h) => h.method === "enableNeonAuth" && h.args[1] === "br-main",
 			),
 		).toBe(true);
+	});
+
+	test("enabling the Data API forwards the create-time auth wiring + settings", async () => {
+		const { api, projectId } = seededFake();
+		const config = defineConfig({
+			dataApi: {
+				authProvider: "external",
+				jwksUrl: "https://idp.example.com/.well-known/jwks.json",
+				providerName: "Clerk",
+				settings: { dbMaxRows: 1000, dbSchemas: ["public", "api"] },
+			},
+		});
+
+		await pushConfig(config, { api, projectId, branchId: "br-main" });
+
+		const enable = api.history.find(
+			(h) => h.method === "enableProjectBranchDataApi",
+		);
+		expect(enable?.args[3]).toEqual({
+			authProvider: "external",
+			jwksUrl: "https://idp.example.com/.well-known/jwks.json",
+			providerName: "Clerk",
+			settings: { dbMaxRows: 1000, dbSchemas: ["public", "api"] },
+		});
+	});
+
+	test("Data API settings drift needs --update-existing (conflict otherwise, update with it)", async () => {
+		const config = defineConfig({
+			auth: true,
+			dataApi: { settings: { dbMaxRows: 1000 } },
+		});
+
+		// Seed an already-enabled Data API with different settings.
+		const seedEnabled = () => {
+			const { api, projectId } = seededFake();
+			api.seedNeonAuth("proj-push", "br-main", {
+				projectId: "auth-br-main",
+				jwksUrl: "https://api.fake.neon.tech/auth/jwks.json",
+			});
+			api.seedNeonDataApi("proj-push", "br-main", "neondb", {
+				url: "https://br-main.fake.neon.tech/data-api/neondb",
+				status: "ready",
+				settings: { dbMaxRows: 100 },
+			});
+			return { api, projectId };
+		};
+
+		// Without updateExisting → conflict (no mutation).
+		const noFlag = seedEnabled();
+		await expect(
+			pushConfig(config, {
+				api: noFlag.api,
+				projectId: noFlag.projectId,
+				branchId: "br-main",
+			}),
+		).rejects.toBeInstanceOf(PushConflictError);
+		expect(
+			noFlag.api.history.some(
+				(h) => h.method === "updateProjectBranchDataApi",
+			),
+		).toBe(false);
+
+		// With updateExisting → settings update is applied.
+		const withFlag = seedEnabled();
+		const result = await pushConfig(config, {
+			api: withFlag.api,
+			projectId: withFlag.projectId,
+			branchId: "br-main",
+			updateExisting: true,
+		});
+		const update = withFlag.api.history.find(
+			(h) => h.method === "updateProjectBranchDataApi",
+		);
+		expect(update?.args[3]).toEqual({ dbMaxRows: 1000 });
+		expect(result.applied).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "service",
+					action: "update",
+					identifier: "dataApi",
+				}),
+			]),
+		);
 	});
 
 	test("auth/dataApi changes carry no redundant details (target branch / derived db)", async () => {

--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -298,7 +298,8 @@ function isOverrideStep(step: PlanStep): boolean {
 	return (
 		step.kind === "update-branch-ttl" ||
 		step.kind === "update-branch-protected" ||
-		step.kind === "update-endpoint"
+		step.kind === "update-endpoint" ||
+		step.kind === "update-data-api"
 	);
 }
 
@@ -342,6 +343,13 @@ function synthesizeAppliedChange(step: PlanStep): AppliedChange {
 			return { kind: "service", action: "create", identifier: "auth" };
 		case "enable-data-api":
 			return { kind: "service", action: "create", identifier: "dataApi" };
+		case "update-data-api":
+			return {
+				kind: "service",
+				action: "update",
+				identifier: "dataApi",
+				details: { field: "settings", settings: step.settings },
+			};
 		case "create-bucket":
 			return {
 				kind: "service",
@@ -424,11 +432,15 @@ async function resolveServiceState(args: {
 			? api.getNeonDataApi(projectId, branch.id, databaseName)
 			: Promise.resolve(null),
 	]);
-	return {
+	const result: RemoteServiceState = {
 		databaseName,
 		authEnabled: auth !== null,
 		dataApiEnabled: dataApi !== null,
 	};
+	// Carry the current Data API settings (when reported) so the diff can detect settings
+	// drift and plan an update. `null` distinguishes "enabled but not reported" from "absent".
+	if (dataApi) result.dataApiSettings = dataApi.settings ?? null;
+	return result;
 }
 
 /**
@@ -559,11 +571,26 @@ async function applyStep(
 				ctx.remoteProjectId,
 				step.branchId,
 				step.databaseName,
+				step.input,
 			);
 			return {
 				kind: "service",
 				action: "create",
 				identifier: "dataApi",
+			};
+		}
+		case "update-data-api": {
+			await ctx.api.updateProjectBranchDataApi(
+				ctx.remoteProjectId,
+				step.branchId,
+				step.databaseName,
+				step.settings,
+			);
+			return {
+				kind: "service",
+				action: "update",
+				identifier: "dataApi",
+				details: { field: "settings", settings: step.settings },
 			};
 		}
 		case "create-bucket": {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -41,6 +41,47 @@ A policy is split into a **static** existential set and a **dynamic** `branch` c
 
 Service toggles accept `true` / `{}` / `{ enabled: true }` (enabled) and `false` / `{ enabled: false }` (disabled). Function slugs (record keys) must match `^[a-z0-9]{1,20}$`.
 
+### Data API
+
+`dataApi` accepts the same boolean/toggle forms **or** an object that selects the auth provider and reusable runtime `settings`:
+
+```ts
+export default defineConfig({
+  auth: true, // required when the Data API verifies Neon Auth tokens
+  dataApi: {
+    // "neon" (default) verifies Neon Auth tokens; "external" verifies a third-party IdP.
+    authProvider: "neon",
+    settings: {
+      dbSchemas: ["public", "api"],
+      dbMaxRows: 1000,
+      // dbAnonRole, dbExtraSearchPath, jwtRoleClaimKey, jwtCacheMaxLifetime,
+      // openapiMode ("ignore-privileges" | "disabled"), serverCorsAllowedOrigins,
+      // serverTimingEnabled — all optional, camelCase mirrors of the Neon API.
+    },
+  },
+});
+```
+
+```ts
+// External IdP (Clerk / Stytch / Auth0 / …): you provide the JWKS wiring, and no Neon Auth is required.
+export default defineConfig({
+  dataApi: {
+    authProvider: "external",
+    jwksUrl: "https://your-idp.example.com/.well-known/jwks.json",
+    providerName: "Clerk", // optional label
+    jwtAudience: "my-api", // optional; only *rejects* tokens with a different `aud`
+    settings: { dbSchemas: ["public"] },
+  },
+});
+```
+
+Two invariants are enforced **both** at author time (TypeScript) and at runtime (zod):
+
+- **`authProvider: "neon"` requires Neon Auth.** A Neon-verified Data API needs `auth` enabled on the same branch (so the tokens it verifies exist). `jwksUrl` / `providerName` / `jwtAudience` are forbidden on this variant — Neon supplies them.
+- **`authProvider: "external"`** is where `jwksUrl` / `providerName` / `jwtAudience` live, and it does **not** require Neon Auth.
+
+The auth wiring (`authProvider`, `jwksUrl`, …) is set when the Data API is first **enabled** and is immutable afterwards. The runtime `settings` are reconcilable: changing them is treated as an **update** and requires `updateExisting: true` (`apply`) / `--update-existing` (CLI), like compute/TTL/`protected` drift.
+
 ## Functions
 
 The three operations mirror the Terraform mental model: **`inspect`** (read live state), **`plan`** (dry-run diff), **`apply`** (reconcile).

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -401,3 +401,113 @@ describe("defineConfig type constraints (compile-time)", () => {
 		});
 	});
 });
+
+describe("defineConfig — Data API config", () => {
+	test("resolves a bare `dataApi: true` to a neon-auth integration", () => {
+		const config = defineConfig({ auth: true, dataApi: true });
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.dataApiEnabled).toBe(true);
+		expect(resolved.dataApi).toEqual({ authProvider: "neon" });
+	});
+
+	test("resolves neon-auth settings (camelCase, undefined dropped)", () => {
+		const config = defineConfig({
+			auth: true,
+			dataApi: {
+				settings: {
+					dbMaxRows: 1000,
+					dbSchemas: ["public", "api"],
+					dbExtraSearchPath: undefined,
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.dataApi).toEqual({
+			authProvider: "neon",
+			settings: { dbMaxRows: 1000, dbSchemas: ["public", "api"] },
+		});
+	});
+
+	test("resolves external-auth wiring without requiring Neon Auth", () => {
+		const config = defineConfig({
+			dataApi: {
+				authProvider: "external",
+				jwksUrl: "https://idp.example.com/.well-known/jwks.json",
+				providerName: "Clerk",
+				jwtAudience: "my-api",
+				settings: { openapiMode: "ignore-privileges" },
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.dataApi).toEqual({
+			authProvider: "external",
+			jwksUrl: "https://idp.example.com/.well-known/jwks.json",
+			providerName: "Clerk",
+			jwtAudience: "my-api",
+			settings: { openapiMode: "ignore-privileges" },
+		});
+	});
+
+	test("omits the resolved dataApi block when disabled", () => {
+		const config = defineConfig({ dataApi: false });
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.dataApiEnabled).toBe(false);
+		expect(resolved.dataApi).toBeUndefined();
+	});
+
+	test("throws at runtime when a neon Data API is enabled without auth", () => {
+		// Bypass the static guard (as a non-typed / JS caller would) to exercise the zod check.
+		expect(() => defineConfig({ dataApi: true } as never)).toThrow(
+			ConfigValidationError,
+		);
+	});
+
+	test("throws at runtime when external-only fields are used with neon auth", () => {
+		expect(() =>
+			defineConfig({
+				auth: true,
+				dataApi: { jwksUrl: "https://x" } as never,
+			}),
+		).toThrow(ConfigValidationError);
+	});
+
+	// ─── Static (type-level) guarantees ─────────────────────────────────────────
+
+	test("static: external-only fields are forbidden with neon auth", () => {
+		// Type error (jwksUrl is `never` on the neon variant) AND a runtime rejection.
+		expect(() =>
+			defineConfig({
+				auth: true,
+				dataApi: {
+					authProvider: "neon",
+					// @ts-expect-error jwksUrl is only allowed with authProvider: "external".
+					jwksUrl: "https://idp.example.com/jwks.json",
+				},
+			}),
+		).toThrow(ConfigValidationError);
+	});
+
+	test("static: a neon Data API requires top-level auth", () => {
+		expect(() =>
+			// @ts-expect-error dataApi (neon) needs `auth` enabled — `auth` is now required.
+			defineConfig({ dataApi: true }),
+		).toThrow(ConfigValidationError);
+		expect(() =>
+			// @ts-expect-error same, with the object form.
+			defineConfig({ dataApi: { settings: { dbMaxRows: 10 } } }),
+		).toThrow(ConfigValidationError);
+		// These satisfy it and must type-check (and not throw):
+		defineConfig({ auth: true, dataApi: true });
+		defineConfig({ auth: {}, dataApi: { settings: { dbMaxRows: 10 } } });
+		// (An explicit `auth: false` is caught at runtime by the zod cross-field check.)
+	});
+
+	test("static: an external Data API does not require auth", () => {
+		defineConfig({
+			dataApi: {
+				authProvider: "external",
+				jwksUrl: "https://idp.example.com/jwks.json",
+			},
+		});
+	});
+});

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -10,12 +10,16 @@ import type {
 	BranchTuning,
 	BranchTuningFn,
 	Config,
+	DataApiInput,
+	DataApiSettings,
 	FunctionDef,
 	FunctionTuning,
 	PreviewInput,
 	ResolvedBranchConfig,
+	ResolvedDataApiConfig,
 	ResolvedFunctionConfig,
 	ResolvedPreviewConfig,
+	ServiceEnabled,
 	ServiceToggleInput,
 } from "./types.js";
 
@@ -23,6 +27,34 @@ import type {
 const DEFAULT_FUNCTION_RUNTIME = "nodejs24" as const;
 
 const REGION_PREFIX = /^(aws|azure|gcp)-/;
+
+/**
+ * Whether a `dataApi` toggle is **enabled and verified by Neon Auth** at the type level: it is
+ * on (see {@link ServiceEnabled}) and not the explicit `authProvider: "external"` variant
+ * (so the default / `"neon"` provider). This is the case that requires top-level Neon Auth.
+ */
+type DataApiUsesNeonAuth<DataApi> = ServiceEnabled<DataApi> extends true
+	? [DataApi] extends [{ authProvider: "external" }]
+		? false
+		: true
+	: false;
+
+/** An `auth` toggle value that is statically guaranteed enabled (`true` / `{}` / `{ enabled: true }`). */
+type EnabledAuthToggle = true | { enabled?: true };
+
+/**
+ * Static cross-field guard for {@link defineConfig}. When the policy enables a Neon-Auth
+ * Data API (`authProvider: "neon"`, the default) but does **not** enable top-level `auth`,
+ * this resolves to `{ auth: EnabledAuthToggle }` — intersected into the parameter type, it
+ * makes `auth` required and rejects `auth: false` / a missing `auth`, surfacing the rule at
+ * author time. Otherwise it is `unknown` (a no-op intersection). The runtime `superRefine`
+ * in {@link configInputSchema} enforces the same invariant for non-typed callers.
+ */
+type RequiresNeonAuth<Auth, DataApi> = DataApiUsesNeonAuth<DataApi> extends true
+	? ServiceEnabled<Auth> extends true
+		? unknown
+		: { auth: EnabledAuthToggle }
+	: unknown;
 
 /**
  * Validate and freeze a Neon Platform branch policy.
@@ -59,20 +91,22 @@ const REGION_PREFIX = /^(aws|azure|gcp)-/;
  */
 export function defineConfig<
 	const Auth extends ServiceToggleInput | undefined = undefined,
-	const DataApi extends ServiceToggleInput | undefined = undefined,
+	const DataApi extends DataApiInput | undefined = undefined,
 	const Preview extends PreviewInput | undefined = undefined,
->(input: {
-	// Each field is intersected with its concrete interface (not just typed as the bare
-	// generic). The generic alone — e.g. `preview?: Preview` — gives editors no members to
-	// complete against in the object-literal position (they see `{} | undefined`), so you
-	// lose hints for `aiGateway` / `functions` / `buckets`. `& PreviewInput` restores the
-	// full shape for autocomplete while still inferring the `const` literal that types the
-	// `branch` closure's slugs (BranchTuningFn<Preview>) and the returned Config.
-	auth?: Auth & ServiceToggleInput;
-	dataApi?: DataApi & ServiceToggleInput;
-	preview?: Preview & PreviewInput;
-	branch?: BranchTuningFn<Preview>;
-}): Config<Auth, DataApi, Preview> {
+>(
+	input: {
+		// Each field is intersected with its concrete interface (not just typed as the bare
+		// generic). The generic alone — e.g. `preview?: Preview` — gives editors no members to
+		// complete against in the object-literal position (they see `{} | undefined`), so you
+		// lose hints for `aiGateway` / `functions` / `buckets`. `& PreviewInput` restores the
+		// full shape for autocomplete while still inferring the `const` literal that types the
+		// `branch` closure's slugs (BranchTuningFn<Preview>) and the returned Config.
+		auth?: Auth & ServiceToggleInput;
+		dataApi?: DataApi & DataApiInput;
+		preview?: Preview & PreviewInput;
+		branch?: BranchTuningFn<Preview>;
+	} & RequiresNeonAuth<Auth, DataApi>,
+): Config<Auth, DataApi, Preview> {
 	if (typeof input === "function") {
 		throw new ConfigValidationError([
 			"defineConfig now expects an object, not a function: `export default defineConfig({ auth: true, preview: { … }, branch: (branch) => ({ … }) })`.",
@@ -108,8 +142,10 @@ export function resolveConfig(
 
 	const resolved: ResolvedBranchConfig = {
 		authEnabled: isServiceEnabled(config.auth),
-		dataApiEnabled: isServiceEnabled(config.dataApi),
+		dataApiEnabled: isDataApiEnabled(config.dataApi),
 	};
+	const dataApi = resolveDataApi(config.dataApi);
+	if (dataApi) resolved.dataApi = dataApi;
 	if (tuning.parent !== undefined) resolved.parent = tuning.parent;
 	if (tuning.ttl !== undefined) {
 		// `branchTuningSchema` already validated `ttl` with the same `parseBranchTtl`, so
@@ -159,6 +195,55 @@ function isServiceEnabled(toggle: ServiceToggleInput | undefined): boolean {
 	if (toggle === undefined) return false;
 	if (typeof toggle === "boolean") return toggle;
 	return toggle.enabled !== false;
+}
+
+/** Whether a {@link DataApiInput} is enabled (present object/`true` unless `enabled: false`). */
+function isDataApiEnabled(input: DataApiInput | undefined): boolean {
+	if (input === undefined) return false;
+	if (typeof input === "boolean") return input;
+	return input.enabled !== false;
+}
+
+/**
+ * Normalize a {@link DataApiInput} into a {@link ResolvedDataApiConfig}, or `undefined` when
+ * the Data API is not enabled. `authProvider` defaults to `"neon"`; the external-IdP wiring
+ * is carried through only for the `"external"` provider; `settings` is copied with its
+ * `undefined` entries dropped so diffing only considers fields the policy actually set.
+ */
+function resolveDataApi(
+	input: DataApiInput | undefined,
+): ResolvedDataApiConfig | undefined {
+	if (!isDataApiEnabled(input)) return undefined;
+	if (typeof input !== "object") {
+		// Bare `true`: enabled with Neon Auth and all-default settings.
+		return { authProvider: "neon" };
+	}
+	const authProvider = input.authProvider ?? "neon";
+	const resolved: ResolvedDataApiConfig = { authProvider };
+	if (authProvider === "external") {
+		if (input.jwksUrl !== undefined) resolved.jwksUrl = input.jwksUrl;
+		if (input.providerName !== undefined)
+			resolved.providerName = input.providerName;
+		if (input.jwtAudience !== undefined)
+			resolved.jwtAudience = input.jwtAudience;
+	}
+	const settings = normalizeDataApiSettings(input.settings);
+	if (settings) resolved.settings = settings;
+	return resolved;
+}
+
+/** Copy a {@link DataApiSettings}, dropping `undefined` entries; `undefined` when empty. */
+function normalizeDataApiSettings(
+	settings: DataApiSettings | undefined,
+): DataApiSettings | undefined {
+	if (!settings) return undefined;
+	const out: DataApiSettings = {};
+	for (const [key, value] of Object.entries(settings)) {
+		if (value !== undefined) {
+			(out as Record<string, unknown>)[key] = value;
+		}
+	}
+	return Object.keys(out).length > 0 ? out : undefined;
 }
 
 /**

--- a/packages/config/src/lib/diff.test.ts
+++ b/packages/config/src/lib/diff.test.ts
@@ -37,6 +37,119 @@ describe("diffConfig", () => {
 		]);
 	});
 
+	test("enable-data-api carries the resolved create input (auth wiring + settings)", () => {
+		const diff = diffConfig(
+			{
+				authEnabled: false,
+				dataApiEnabled: true,
+				dataApi: {
+					authProvider: "external",
+					jwksUrl: "https://idp.example.com/jwks.json",
+					settings: { dbMaxRows: 500 },
+				},
+			},
+			remote,
+			{ updateExisting: false },
+		);
+		expect(diff.plan).toEqual([
+			{
+				kind: "enable-data-api",
+				projectId: "proj",
+				branchId: "br-main",
+				branchName: "main",
+				databaseName: "neondb",
+				input: {
+					authProvider: "external",
+					jwksUrl: "https://idp.example.com/jwks.json",
+					settings: { dbMaxRows: 500 },
+				},
+			},
+		]);
+	});
+
+	test("Data API settings drift is a conflict unless updateExisting is set", () => {
+		const enabledRemote: RemoteState = {
+			...remote,
+			services: {
+				databaseName: "neondb",
+				authEnabled: false,
+				dataApiEnabled: true,
+				dataApiSettings: { dbMaxRows: 100 },
+			},
+		};
+		const desired = {
+			authEnabled: false,
+			dataApiEnabled: true,
+			dataApi: {
+				authProvider: "neon" as const,
+				settings: { dbMaxRows: 500 },
+			},
+		};
+		const conflictDiff = diffConfig(desired, enabledRemote, {
+			updateExisting: false,
+		});
+		expect(conflictDiff.plan).toEqual([]);
+		expect(conflictDiff.conflicts[0]).toMatchObject({
+			field: "dataApi.settings",
+			current: { dbMaxRows: 100 },
+			desired: { dbMaxRows: 500 },
+		});
+
+		const updateDiff = diffConfig(desired, enabledRemote, {
+			updateExisting: true,
+		});
+		expect(updateDiff.conflicts).toEqual([]);
+		expect(updateDiff.plan[0]).toMatchObject({
+			kind: "update-data-api",
+			databaseName: "neondb",
+			settings: { dbMaxRows: 500 },
+		});
+	});
+
+	test("no Data API update when settings match or are unreported", () => {
+		const desired = {
+			authEnabled: false,
+			dataApiEnabled: true,
+			dataApi: {
+				authProvider: "neon" as const,
+				settings: { dbMaxRows: 500 },
+			},
+		};
+		// Matching remote settings → no plan, no conflict.
+		const matched = diffConfig(
+			desired,
+			{
+				...remote,
+				services: {
+					databaseName: "neondb",
+					authEnabled: false,
+					dataApiEnabled: true,
+					dataApiSettings: { dbMaxRows: 500 },
+				},
+			},
+			{ updateExisting: true },
+		);
+		expect(matched.plan).toEqual([]);
+		expect(matched.conflicts).toEqual([]);
+
+		// Remote settings not reported (null) → cannot diff, so no update is planned.
+		const unreported = diffConfig(
+			desired,
+			{
+				...remote,
+				services: {
+					databaseName: "neondb",
+					authEnabled: false,
+					dataApiEnabled: true,
+					dataApiSettings: null,
+				},
+			},
+			{ updateExisting: true },
+		);
+		expect(unreported.plan).toEqual([]);
+		expect(unreported.conflicts).toEqual([]);
+	});
+
 	test("reports compute drift unless updateExisting is set", () => {
 		const diff = diffConfig(
 			{

--- a/packages/config/src/lib/diff.ts
+++ b/packages/config/src/lib/diff.ts
@@ -1,4 +1,5 @@
 import type {
+	EnableDataApiInput,
 	NeonBranchSnapshot,
 	NeonBucketSnapshot,
 	NeonEndpointSnapshot,
@@ -8,7 +9,9 @@ import type {
 	BucketAccessLevel,
 	ComputeSettings,
 	ConflictReport,
+	DataApiSettings,
 	ResolvedBranchConfig,
+	ResolvedDataApiConfig,
 	ResolvedFunctionConfig,
 } from "./types.js";
 
@@ -51,6 +54,21 @@ export type PlanStep =
 			branchId: string;
 			branchName: string;
 			databaseName: string;
+			/** Create-time auth wiring + initial settings from the policy. */
+			input?: EnableDataApiInput;
+	  }
+	| {
+			/**
+			 * Reconcile the runtime settings of an already-enabled Data API integration.
+			 * Only `settings` are mutable post-create, so this is the lone Data API
+			 * *update* step — and it is an override (requires `updateExisting`).
+			 */
+			kind: "update-data-api";
+			projectId: string;
+			branchId: string;
+			branchName: string;
+			databaseName: string;
+			settings: DataApiSettings;
 	  }
 	| {
 			kind: "create-bucket";
@@ -81,6 +99,12 @@ export interface RemoteServiceState {
 	databaseName: string;
 	authEnabled: boolean;
 	dataApiEnabled: boolean;
+	/**
+	 * Current Data API runtime settings, when the integration is enabled and the API reports
+	 * them (SubZero only). `null`/absent means "not reported" — settings drift can't be
+	 * computed, so no update step is planned.
+	 */
+	dataApiSettings?: DataApiSettings | null;
 }
 
 /**
@@ -124,7 +148,7 @@ export function diffConfig(
 	const conflicts: ConflictReport[] = [];
 	const plan: PlanStep[] = [];
 	diffBranchConfig({ config, remote, options, plan, conflicts });
-	diffServices({ config, remote, plan });
+	diffServices({ config, remote, options, plan, conflicts });
 	diffPreview({ config, remote, plan });
 	return { plan, conflicts };
 }
@@ -190,15 +214,20 @@ function diffPreview(args: {
 }
 
 /**
- * Plan additive branch-scoped integrations. Disabling remains explicit/manual because
- * teardown is destructive.
+ * Plan branch-scoped integrations. Enabling is additive (no existing resource to override).
+ * The Data API is the one integration that also has a reconcilable *update*: its runtime
+ * `settings` can drift once enabled, and reconciling them is an override (gated on
+ * `updateExisting`, like compute/TTL/protected). The auth provider / JWKS wiring is fixed at
+ * enable time, so it is never updated here. Disabling stays explicit/manual (destructive).
  */
 function diffServices(args: {
 	config: ResolvedBranchConfig;
 	remote: RemoteState;
+	options: DiffOptions;
 	plan: PlanStep[];
+	conflicts: ConflictReport[];
 }): void {
-	const { config, remote, plan } = args;
+	const { config, remote, options, plan, conflicts } = args;
 	const state = remote.services;
 	if (config.authEnabled && !state.authEnabled) {
 		const step: PlanStep = {
@@ -210,15 +239,114 @@ function diffServices(args: {
 		if (state.databaseName) step.databaseName = state.databaseName;
 		plan.push(step);
 	}
-	if (config.dataApiEnabled && !state.dataApiEnabled) {
-		plan.push({
+	if (config.dataApiEnabled) {
+		diffDataApi({ config, remote, options, plan, conflicts });
+	}
+}
+
+/**
+ * Plan the Data API: a first-time **enable** (carrying the create-time auth wiring +
+ * settings), or — when it already exists — a **settings update** if the policy's settings
+ * drift from the remote. The update is an override: applied as a plan step under
+ * `updateExisting`, otherwise reported as a conflict.
+ */
+function diffDataApi(args: {
+	config: ResolvedBranchConfig;
+	remote: RemoteState;
+	options: DiffOptions;
+	plan: PlanStep[];
+	conflicts: ConflictReport[];
+}): void {
+	const { config, remote, options, plan, conflicts } = args;
+	const state = remote.services;
+	const desired = config.dataApi;
+
+	if (!state.dataApiEnabled) {
+		const step: PlanStep = {
 			kind: "enable-data-api",
 			projectId: remote.projectId,
 			branchId: remote.branch.id,
 			branchName: remote.branch.name,
 			databaseName: state.databaseName,
+		};
+		const input = desired ? enableInputFromResolved(desired) : undefined;
+		if (input) step.input = input;
+		plan.push(step);
+		return;
+	}
+
+	// Already enabled: the only reconcilable change is its runtime settings.
+	const desiredSettings = desired?.settings;
+	if (!desiredSettings) return;
+	if (!dataApiSettingsDiffer(desiredSettings, state.dataApiSettings)) return;
+
+	if (options.updateExisting) {
+		plan.push({
+			kind: "update-data-api",
+			projectId: remote.projectId,
+			branchId: remote.branch.id,
+			branchName: remote.branch.name,
+			databaseName: state.databaseName,
+			settings: desiredSettings,
+		});
+	} else {
+		conflicts.push({
+			kind: "branch",
+			identifier: remote.branch.name,
+			field: "dataApi.settings",
+			current: state.dataApiSettings ?? undefined,
+			desired: desiredSettings,
+			reason: "Existing Data API has different settings. Pass `updateExisting: true` (SDK) or `--update-existing` (CLI) to apply.",
 		});
 	}
+}
+
+/** Build the create-time {@link EnableDataApiInput} from a resolved Data API config. */
+function enableInputFromResolved(
+	resolved: ResolvedDataApiConfig,
+): EnableDataApiInput {
+	const input: EnableDataApiInput = { authProvider: resolved.authProvider };
+	if (resolved.jwksUrl !== undefined) input.jwksUrl = resolved.jwksUrl;
+	if (resolved.providerName !== undefined)
+		input.providerName = resolved.providerName;
+	if (resolved.jwtAudience !== undefined)
+		input.jwtAudience = resolved.jwtAudience;
+	if (resolved.settings) input.settings = resolved.settings;
+	return input;
+}
+
+/** The camelCase keys of {@link DataApiSettings}, used to compare desired vs remote settings. */
+const DATA_API_SETTING_KEYS = [
+	"dbAggregatesEnabled",
+	"dbAnonRole",
+	"dbExtraSearchPath",
+	"dbMaxRows",
+	"dbSchemas",
+	"jwtRoleClaimKey",
+	"jwtCacheMaxLifetime",
+	"openapiMode",
+	"serverCorsAllowedOrigins",
+	"serverTimingEnabled",
+] as const satisfies ReadonlyArray<keyof DataApiSettings>;
+
+/**
+ * Whether the policy's Data API `settings` differ from the remote ones. Only the keys the
+ * policy actually set are compared (so unset fields never count as drift). When the remote
+ * settings are not reported (`null`/absent — non-SubZero), drift can't be computed and this
+ * returns `false` so no spurious update is planned.
+ */
+function dataApiSettingsDiffer(
+	desired: DataApiSettings,
+	current: DataApiSettings | null | undefined,
+): boolean {
+	if (!current) return false;
+	for (const key of DATA_API_SETTING_KEYS) {
+		if (desired[key] === undefined) continue;
+		if (JSON.stringify(desired[key]) !== JSON.stringify(current[key])) {
+			return true;
+		}
+	}
+	return false;
 }
 
 interface BranchConfigArgs {

--- a/packages/config/src/lib/fake-neon-api.ts
+++ b/packages/config/src/lib/fake-neon-api.ts
@@ -4,6 +4,7 @@ import type {
 	CreateCredentialInput,
 	CreateProjectInput,
 	DeployFunctionInput,
+	EnableDataApiInput,
 	GetConnectionUriInput,
 	NeonApi,
 	NeonAuthSnapshot,
@@ -21,7 +22,7 @@ import type {
 	NeonRoleSnapshot,
 	UpdateBranchInput,
 } from "./neon-api.js";
-import type { ComputeSettings } from "./types.js";
+import type { ComputeSettings, DataApiSettings } from "./types.js";
 
 /**
  * Test-only branch seed shape. Permits omitting `protected` (defaults to `false`) so the
@@ -478,10 +479,11 @@ export class FakeNeonApi implements NeonApi {
 		projectId: string,
 		branchId: string,
 		databaseName: string,
+		input?: EnableDataApiInput,
 	): Promise<NeonDataApiSnapshot> {
 		this.history.push({
 			method: "enableProjectBranchDataApi",
-			args: [projectId, branchId, databaseName],
+			args: [projectId, branchId, databaseName, input],
 		});
 		this.requireProject(projectId);
 		this.requireBranch(projectId, branchId);
@@ -490,9 +492,38 @@ export class FakeNeonApi implements NeonApi {
 		if (existing) return clone(existing);
 		const snapshot: NeonDataApiSnapshot = {
 			url: `https://${branchId}.fake.neon.tech/data-api/${databaseName}`,
+			status: "ready",
 		};
+		if (input?.settings) snapshot.settings = { ...input.settings };
 		this.neonDataApi.set(key, snapshot);
 		return clone(snapshot);
+	}
+
+	async updateProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		settings: DataApiSettings,
+	): Promise<NeonDataApiSnapshot> {
+		this.history.push({
+			method: "updateProjectBranchDataApi",
+			args: [projectId, branchId, databaseName, settings],
+		});
+		this.requireProject(projectId);
+		this.requireBranch(projectId, branchId);
+		const key = `${projectId}:${branchId}:${databaseName}`;
+		const existing = this.neonDataApi.get(key);
+		if (!existing) {
+			throw new Error(
+				`Fake Neon: Data API not enabled on ${branchId}/${databaseName}`,
+			);
+		}
+		const updated: NeonDataApiSnapshot = {
+			...existing,
+			settings: { ...(existing.settings ?? {}), ...settings },
+		};
+		this.neonDataApi.set(key, updated);
+		return clone(updated);
 	}
 
 	/** Test helper: attach a Neon Auth integration to a branch. */

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -4,6 +4,9 @@ import {
 	type BranchCreateRequestEndpointOptions,
 	type BranchUpdateRequest,
 	createApiClient,
+	type DataAPICreateRequest,
+	type DataAPIReponse,
+	type DataAPISettings,
 	type Database,
 	type DefaultEndpointSettings,
 	type Endpoint,
@@ -25,6 +28,7 @@ import type {
 	CreateCredentialInput,
 	CreateProjectInput,
 	DeployFunctionInput,
+	EnableDataApiInput,
 	GetConnectionUriInput,
 	NeonApi,
 	NeonAuthSnapshot,
@@ -42,7 +46,11 @@ import type {
 	NeonRoleSnapshot,
 	UpdateBranchInput,
 } from "./neon-api.js";
-import type { BucketAccessLevel, ComputeSettings } from "./types.js";
+import type {
+	BucketAccessLevel,
+	ComputeSettings,
+	DataApiSettings,
+} from "./types.js";
 import { wrapNeonError } from "./wrap-neon-error.js";
 
 type ApiClient = ReturnType<typeof createApiClient>;
@@ -55,6 +63,102 @@ const neonAuthResponseSchema = z.object({
 	jwks_url: z.string(),
 	base_url: z.string().optional(),
 });
+
+// ─── Data API mapping (camelCase neon.ts ↔ snake_case Neon API) ───────────────
+
+/** Map our camelCase {@link DataApiSettings} onto the Neon API's snake_case `DataAPISettings`. */
+function dataApiSettingsToApi(settings: DataApiSettings): DataAPISettings {
+	const out: DataAPISettings = {};
+	if (settings.dbAggregatesEnabled !== undefined)
+		out.db_aggregates_enabled = settings.dbAggregatesEnabled;
+	if (settings.dbAnonRole !== undefined)
+		out.db_anon_role = settings.dbAnonRole;
+	if (settings.dbExtraSearchPath !== undefined)
+		out.db_extra_search_path = settings.dbExtraSearchPath;
+	if (settings.dbMaxRows !== undefined) out.db_max_rows = settings.dbMaxRows;
+	if (settings.dbSchemas !== undefined) out.db_schemas = settings.dbSchemas;
+	if (settings.jwtRoleClaimKey !== undefined)
+		out.jwt_role_claim_key = settings.jwtRoleClaimKey;
+	if (settings.jwtCacheMaxLifetime !== undefined)
+		out.jwt_cache_max_lifetime = settings.jwtCacheMaxLifetime;
+	if (settings.openapiMode !== undefined)
+		out.openapi_mode = settings.openapiMode;
+	if (settings.serverCorsAllowedOrigins !== undefined)
+		out.server_cors_allowed_origins = settings.serverCorsAllowedOrigins;
+	if (settings.serverTimingEnabled !== undefined)
+		out.server_timing_enabled = settings.serverTimingEnabled;
+	return out;
+}
+
+/** Narrow the API's free-form `openapi_mode` string to our literal union (else drop it). */
+function normalizeOpenapiMode(
+	value: string,
+): DataApiSettings["openapiMode"] | undefined {
+	return value === "ignore-privileges" || value === "disabled"
+		? value
+		: undefined;
+}
+
+/** Map the Neon API's snake_case `DataAPISettings` back to our camelCase {@link DataApiSettings}. */
+function dataApiSettingsFromApi(
+	settings: DataAPISettings | null | undefined,
+): DataApiSettings | undefined {
+	if (!settings) return undefined;
+	const out: DataApiSettings = {};
+	if (settings.db_aggregates_enabled !== undefined)
+		out.dbAggregatesEnabled = settings.db_aggregates_enabled;
+	if (settings.db_anon_role !== undefined)
+		out.dbAnonRole = settings.db_anon_role;
+	if (settings.db_extra_search_path !== undefined)
+		out.dbExtraSearchPath = settings.db_extra_search_path;
+	if (settings.db_max_rows !== undefined)
+		out.dbMaxRows = settings.db_max_rows;
+	if (settings.db_schemas !== undefined) out.dbSchemas = settings.db_schemas;
+	if (settings.jwt_role_claim_key !== undefined)
+		out.jwtRoleClaimKey = settings.jwt_role_claim_key;
+	if (settings.jwt_cache_max_lifetime !== undefined)
+		out.jwtCacheMaxLifetime = settings.jwt_cache_max_lifetime;
+	if (settings.openapi_mode !== undefined) {
+		const mode = normalizeOpenapiMode(settings.openapi_mode);
+		if (mode !== undefined) out.openapiMode = mode;
+	}
+	if (settings.server_cors_allowed_origins !== undefined)
+		out.serverCorsAllowedOrigins = settings.server_cors_allowed_origins;
+	if (settings.server_timing_enabled !== undefined)
+		out.serverTimingEnabled = settings.server_timing_enabled;
+	return Object.keys(out).length > 0 ? out : undefined;
+}
+
+/** Build the Neon API `DataAPICreateRequest` from our {@link EnableDataApiInput}. */
+function dataApiCreateRequest(
+	input: EnableDataApiInput | undefined,
+): DataAPICreateRequest {
+	const req: DataAPICreateRequest = {};
+	if (!input) return req;
+	if (input.authProvider !== undefined)
+		req.auth_provider =
+			input.authProvider === "neon" ? "neon_auth" : "external";
+	if (input.jwksUrl !== undefined) req.jwks_url = input.jwksUrl;
+	if (input.providerName !== undefined)
+		req.provider_name = input.providerName;
+	if (input.jwtAudience !== undefined) req.jwt_audience = input.jwtAudience;
+	if (input.settings) {
+		const settings = dataApiSettingsToApi(input.settings);
+		if (Object.keys(settings).length > 0) req.settings = settings;
+	}
+	return req;
+}
+
+/** Map a `DataAPIReponse` (GET) onto our {@link NeonDataApiSnapshot}. */
+function dataApiSnapshotFromResponse(
+	data: DataAPIReponse,
+): NeonDataApiSnapshot {
+	const snapshot: NeonDataApiSnapshot = { url: data.url };
+	if (data.status !== undefined) snapshot.status = data.status;
+	const settings = dataApiSettingsFromApi(data.settings);
+	if (settings) snapshot.settings = settings;
+	return snapshot;
+}
 
 // ─── Preview: buckets ──────────────────────────────────────────────────────
 
@@ -674,14 +778,16 @@ class RealNeonApi implements NeonApi {
 		try {
 			return await this.call(
 				`getNeonDataApi(${projectId}/${branchId}/${databaseName})`,
-				async () => {
-					const res = await this.client.getProjectBranchDataApi(
-						projectId,
-						branchId,
-						databaseName,
-					);
-					return { url: res.data.url };
-				},
+				async () =>
+					dataApiSnapshotFromResponse(
+						await this.client
+							.getProjectBranchDataApi(
+								projectId,
+								branchId,
+								databaseName,
+							)
+							.then((res) => res.data),
+					),
 				{ projectId },
 			);
 		} catch (err) {
@@ -695,6 +801,7 @@ class RealNeonApi implements NeonApi {
 		projectId: string,
 		branchId: string,
 		databaseName: string,
+		input?: EnableDataApiInput,
 	): Promise<NeonDataApiSnapshot> {
 		// Idempotent in the same shape as `enableNeonAuth`: if an integration already
 		// exists, the POST returns 409 and we re-fetch the existing snapshot.
@@ -706,10 +813,10 @@ class RealNeonApi implements NeonApi {
 						projectId,
 						branchId,
 						databaseName,
-						// Empty body — pick up Neon defaults (auth_provider inferred from
-						// whether Neon Auth is also enabled; default schemas/grants).
-						{},
+						dataApiCreateRequest(input),
 					);
+					// The create response only carries `url`; settings/status come from a
+					// follow-up GET, which we leave to the caller when it needs them.
 					return { url: res.data.url };
 				},
 				{ projectId, mutating: true },
@@ -728,6 +835,34 @@ class RealNeonApi implements NeonApi {
 			}
 			throw err;
 		}
+	}
+
+	async updateProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		settings: DataApiSettings,
+	): Promise<NeonDataApiSnapshot> {
+		return await this.call(
+			`updateProjectBranchDataApi(${projectId}/${branchId}/${databaseName})`,
+			async () => {
+				await this.client.updateProjectBranchDataApi(
+					projectId,
+					branchId,
+					databaseName,
+					{ settings: dataApiSettingsToApi(settings) },
+				);
+				// The PATCH returns an empty body; re-fetch so the caller sees the
+				// post-update url/status/settings.
+				const res = await this.client.getProjectBranchDataApi(
+					projectId,
+					branchId,
+					databaseName,
+				);
+				return dataApiSnapshotFromResponse(res.data);
+			},
+			{ projectId, mutating: true },
+		);
 	}
 
 	// ─── Preview: buckets ──────────────────────────────────────────────────────

--- a/packages/config/src/lib/neon-api.ts
+++ b/packages/config/src/lib/neon-api.ts
@@ -3,6 +3,8 @@ import type {
 	ComputeSettings,
 	CredentialPrincipalType,
 	CredentialScope,
+	DataApiAuthProvider,
+	DataApiSettings,
 	FunctionRuntime,
 } from "./types.js";
 
@@ -108,11 +110,33 @@ export interface NeonAuthSnapshot {
 }
 
 /**
- * Public, fetchable bits of a Neon Data API integration on a specific branch.
+ * Public, fetchable bits of a Neon Data API integration on a specific branch — the subset of
+ * the Neon API `DataAPIReponse` we model. `settings` is only populated for SubZero-backed
+ * integrations (the API returns `null` otherwise), so it is used for settings-drift diffing
+ * when present and ignored when absent.
  */
 export interface NeonDataApiSnapshot {
 	/** REST endpoint URL. */
 	url: string;
+	/** Deployment status (e.g. `"ready"`), when reported. */
+	status?: string;
+	/** Current runtime settings (SubZero only); `null`/absent when not reported. */
+	settings?: DataApiSettings | null;
+}
+
+/**
+ * Input for {@link NeonApi.enableProjectBranchDataApi} — the create-time wiring for a Data
+ * API integration (the subset of the Neon API `DataAPICreateRequest` we expose; the
+ * `add_default_grants` / `skip_auth_schema` create flags are intentionally not modeled).
+ * `authProvider` is the friendly `"neon"` / `"external"` value (mapped to the API's
+ * `neon_auth` / `external` by the adapter).
+ */
+export interface EnableDataApiInput {
+	authProvider?: DataApiAuthProvider;
+	jwksUrl?: string;
+	providerName?: string;
+	jwtAudience?: string;
+	settings?: DataApiSettings;
 }
 
 /**
@@ -351,12 +375,28 @@ export interface NeonApi {
 	/**
 	 * Enable the Neon Data API integration on a specific branch + database. Idempotent:
 	 * if an integration is already enabled, the existing snapshot is returned unchanged.
-	 * Used by `pushConfig` and `branch` to honour branch policy `dataApi: {}` / `dataApi.enabled: true`.
+	 * Used by `pushConfig` to honour branch policy `dataApi: {}` / `dataApi: { … }`. The
+	 * optional {@link EnableDataApiInput} carries the create-time auth wiring + initial
+	 * settings; omit it for an all-defaults, Neon-Auth integration.
 	 */
 	enableProjectBranchDataApi(
 		projectId: string,
 		branchId: string,
 		databaseName: string,
+		input?: EnableDataApiInput,
+	): Promise<NeonDataApiSnapshot>;
+
+	/**
+	 * Update the runtime {@link DataApiSettings} of an already-enabled Data API integration
+	 * (the Neon API `PATCH .../data-api/{db}`; always refreshes the schema cache). Only
+	 * `settings` are mutable post-create — the auth provider / JWKS wiring is fixed at
+	 * enable time. Used by `pushConfig` to reconcile settings drift under `updateExisting`.
+	 */
+	updateProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		settings: DataApiSettings,
 	): Promise<NeonDataApiSnapshot>;
 
 	// ─── Preview: buckets ──────────────────────────────────────────────────────

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -3,6 +3,7 @@ import {
 	branchTuningSchema,
 	computeSettingsSchema,
 	configInputSchema,
+	dataApiConfigSchema,
 	formatZodIssues,
 } from "./schema.js";
 
@@ -138,6 +139,98 @@ describe("configInputSchema", () => {
 			},
 		});
 		expect(result.success).toBe(false);
+	});
+});
+
+describe("dataApiConfigSchema", () => {
+	test("accepts an empty object (defaults to neon auth)", () => {
+		expect(dataApiConfigSchema.safeParse({}).success).toBe(true);
+	});
+
+	test("accepts neon auth with settings", () => {
+		const result = dataApiConfigSchema.safeParse({
+			authProvider: "neon",
+			settings: { dbMaxRows: 1000, dbSchemas: ["public", "api"] },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts external auth with jwksUrl / providerName / jwtAudience", () => {
+		const result = dataApiConfigSchema.safeParse({
+			authProvider: "external",
+			jwksUrl: "https://idp.example.com/.well-known/jwks.json",
+			providerName: "Clerk",
+			jwtAudience: "my-api",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects external-only fields when authProvider is neon (default)", () => {
+		const result = dataApiConfigSchema.safeParse({
+			jwksUrl: "https://idp.example.com/jwks.json",
+		});
+		if (result.success) throw new Error("expected failure");
+		const formatted = formatZodIssues(result.error).join("\n");
+		expect(formatted).toContain("jwksUrl");
+		expect(formatted).toContain('authProvider: "external"');
+	});
+
+	test("rejects external-only fields with an explicit neon provider", () => {
+		const result = dataApiConfigSchema.safeParse({
+			authProvider: "neon",
+			providerName: "Clerk",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects an unknown settings key (camelCase only)", () => {
+		const result = dataApiConfigSchema.safeParse({
+			settings: { db_max_rows: 1000 },
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("configInputSchema — Data API requires Neon Auth", () => {
+	test("rejects a neon Data API without auth enabled", () => {
+		const result = configInputSchema.safeParse({ dataApi: true });
+		if (result.success) throw new Error("expected failure");
+		const formatted = formatZodIssues(result.error).join("\n");
+		expect(formatted).toContain("auth");
+		expect(formatted).toContain('authProvider "neon"');
+	});
+
+	test("rejects a neon Data API when auth is explicitly disabled", () => {
+		const result = configInputSchema.safeParse({
+			auth: false,
+			dataApi: { enabled: true },
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("accepts a neon Data API when auth is enabled", () => {
+		const result = configInputSchema.safeParse({
+			auth: true,
+			dataApi: { settings: { dbMaxRows: 500 } },
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts an external Data API without auth", () => {
+		const result = configInputSchema.safeParse({
+			dataApi: {
+				authProvider: "external",
+				jwksUrl: "https://idp.example.com/jwks.json",
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts a disabled Data API without auth", () => {
+		const result = configInputSchema.safeParse({
+			dataApi: { enabled: false },
+		});
+		expect(result.success).toBe(true);
 	});
 });
 

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -73,6 +73,66 @@ export const serviceToggleInputSchema = z.union([
 	serviceToggleSchema,
 ]);
 
+/**
+ * Reusable Data API runtime settings (camelCase mirror of the Neon API `DataAPISettings`).
+ * `strictObject` so a typo / snake_case key fails loudly instead of being silently dropped.
+ */
+export const dataApiSettingsSchema = z.strictObject({
+	dbAggregatesEnabled: z.boolean().optional(),
+	dbAnonRole: z.string().optional(),
+	dbExtraSearchPath: z.string().optional(),
+	dbMaxRows: z.number().int().optional(),
+	dbSchemas: z.array(z.string()).optional(),
+	jwtRoleClaimKey: z.string().optional(),
+	jwtCacheMaxLifetime: z.number().int().optional(),
+	openapiMode: z
+		.union([z.literal("ignore-privileges"), z.literal("disabled")])
+		.optional(),
+	serverCorsAllowedOrigins: z.string().optional(),
+	serverTimingEnabled: z.boolean().optional(),
+});
+
+/** Names of the external-IdP-only fields, forbidden when `authProvider` is `"neon"`. */
+const DATA_API_EXTERNAL_ONLY_KEYS = [
+	"jwksUrl",
+	"providerName",
+	"jwtAudience",
+] as const;
+
+/**
+ * Object form of the `dataApi` toggle. A single `strictObject` plus a `superRefine` (rather
+ * than a discriminated union) so the `"neon"` default works without the discriminator being
+ * present, and so the "external-only field with authProvider neon" error points at the exact
+ * offending key — mirroring the `?: never` type-level guard at runtime.
+ */
+export const dataApiConfigSchema = z
+	.strictObject({
+		enabled: z.boolean().optional(),
+		authProvider: z
+			.union([z.literal("neon"), z.literal("external")])
+			.optional(),
+		jwksUrl: z.string().optional(),
+		providerName: z.string().optional(),
+		jwtAudience: z.string().optional(),
+		settings: dataApiSettingsSchema.optional(),
+	})
+	.superRefine((cfg, ctx) => {
+		const provider = cfg.authProvider ?? "neon";
+		if (provider !== "neon") return;
+		for (const key of DATA_API_EXTERNAL_ONLY_KEYS) {
+			if (cfg[key] !== undefined) {
+				ctx.addIssue({
+					code: "custom",
+					path: [key],
+					message: `${key} is only allowed with authProvider: "external" — Neon supplies it for authProvider: "neon".`,
+				});
+			}
+		}
+	});
+
+/** A `dataApi` toggle as written in a policy: `boolean` or {@link dataApiConfigSchema}. */
+export const dataApiInputSchema = z.union([z.boolean(), dataApiConfigSchema]);
+
 export const postgresConfigSchema = z.strictObject({
 	computeSettings: computeSettingsSchema.optional(),
 });
@@ -187,20 +247,59 @@ export const branchTuningSchema = z
  * structurally as a function here; its returned tuning is validated per-evaluation by
  * {@link branchTuningSchema} inside `resolveConfig`.
  */
-export const configInputSchema = z.strictObject({
-	auth: serviceToggleInputSchema.optional(),
-	dataApi: serviceToggleInputSchema.optional(),
-	preview: previewInputSchema.optional(),
-	branch: z
-		.custom<(...args: unknown[]) => unknown>(
-			(value) => typeof value === "function",
-			{
+export const configInputSchema = z
+	.strictObject({
+		auth: serviceToggleInputSchema.optional(),
+		dataApi: dataApiInputSchema.optional(),
+		preview: previewInputSchema.optional(),
+		branch: z
+			.custom<(...args: unknown[]) => unknown>(
+				(value) => typeof value === "function",
+				{
+					message:
+						"branch must be a function: `branch: (branch) => ({ … })`",
+				},
+			)
+			.optional(),
+	})
+	.superRefine((cfg, ctx) => {
+		// A Data API verified by Neon Auth (`authProvider: "neon"`, the default) needs Neon
+		// Auth enabled on the same branch so the tokens it verifies actually exist. Enforce
+		// the same invariant the `defineConfig` type-level check expresses, at runtime.
+		if (!isToggleEnabledValue(cfg.dataApi)) return;
+		if (dataApiAuthProviderValue(cfg.dataApi) !== "neon") return;
+		if (!isToggleEnabledValue(cfg.auth)) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["auth"],
 				message:
-					"branch must be a function: `branch: (branch) => ({ … })`",
-			},
-		)
-		.optional(),
-});
+					'dataApi with authProvider "neon" requires Neon Auth — set `auth: true` (or `auth: { enabled: true }`), or use `dataApi.authProvider: "external"` with your own `jwksUrl`.',
+			});
+		}
+	});
+
+/**
+ * Whether a parsed `auth` / `dataApi` toggle value is enabled: a present object (or `true`)
+ * is on unless `enabled` is explicitly `false`. Mirrors `isServiceEnabled` in
+ * `define-config.ts`, operating on the already-validated runtime value.
+ */
+function isToggleEnabledValue(value: unknown): boolean {
+	if (value === undefined || value === null) return false;
+	if (typeof value === "boolean") return value;
+	if (typeof value === "object") {
+		return (value as { enabled?: unknown }).enabled !== false;
+	}
+	return false;
+}
+
+/** Read the (defaulted) `authProvider` from a parsed `dataApi` value. */
+function dataApiAuthProviderValue(value: unknown): "neon" | "external" {
+	if (value !== null && typeof value === "object") {
+		const provider = (value as { authProvider?: unknown }).authProvider;
+		if (provider === "external") return "external";
+	}
+	return "neon";
+}
 
 function validateParentReference(args: {
 	ctx: z.RefinementCtx;

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -146,9 +146,134 @@ export interface ServiceToggle {
  */
 export type ServiceToggleInput = boolean | ServiceToggle;
 
+/**
+ * Resolve a **static** service toggle (`true` / `false` / `{ enabled?: boolean }` / object /
+ * `undefined`) to a type-level boolean. The tuple wrapping (`[T] extends […]`) disables
+ * distribution so a union/`undefined` is judged as a single unit:
+ *
+ * - `false` / `{ enabled: false }` / `undefined` → `false`
+ * - `true` / `{ enabled: true }` / any other object (`{}`, `{ enabled?: boolean }`) → `true`
+ *   (a present toggle defaults to enabled)
+ * - the bare `boolean | … | undefined` (no literal info) → `false`
+ *
+ * Shared by the {@link Config} static cross-field checks and the `@neondatabase/env`
+ * `NeonEnv` namespace derivation, so both read "is this service on?" identically.
+ */
+export type ServiceEnabled<T> = [T] extends [false]
+	? false
+	: [T] extends [{ enabled: false }]
+		? false
+		: [T] extends [undefined]
+			? false
+			: [T] extends [true]
+				? true
+				: [T] extends [{ enabled: true }]
+					? true
+					: [T] extends [object]
+						? true
+						: false;
+
 export interface PostgresConfig {
 	computeSettings?: ComputeSettings;
 }
+
+/**
+ * Authentication providers a Data API integration can verify JWTs against, as written in
+ * `neon.ts`. Friendly authoring values (mapped to the Neon API's `neon_auth` / `external`
+ * at the API boundary):
+ *
+ * - `"neon"` — verify tokens minted by **Neon Auth** on the same branch. Neon supplies the
+ *   JWKS URL / provider wiring for you, so the `jwksUrl` / `providerName` / `jwtAudience`
+ *   fields are forbidden (a type error) on this variant — and the policy must also enable
+ *   top-level `auth` (Neon Auth) so the tokens exist.
+ * - `"external"` — verify tokens from a third-party IdP (Clerk, Stytch, Auth0, …). You
+ *   provide `jwksUrl` (and optionally `providerName` / `jwtAudience`).
+ */
+export const DATA_API_AUTH_PROVIDERS = ["neon", "external"] as const;
+export type DataApiAuthProvider = (typeof DATA_API_AUTH_PROVIDERS)[number];
+
+/**
+ * Reusable runtime settings for a Data API integration (the Neon API `DataAPISettings`,
+ * camelCased to match the rest of `neon.ts`). Every field is optional; omitted fields keep
+ * the Neon defaults shown below. These are the **only** Data API fields that can change on
+ * an already-enabled integration — drift here is reconciled as an *update* (requires
+ * `updateExisting` / `--update-existing`); the create-only auth wiring above cannot.
+ */
+export interface DataApiSettings {
+	/** Enable the aggregates feature (`db_aggregates_enabled`). Default `true`. */
+	dbAggregatesEnabled?: boolean;
+	/** Database role used for anonymous requests (`db_anon_role`). Default `"anonymous"`. */
+	dbAnonRole?: string;
+	/** Extra schemas appended to the search path (`db_extra_search_path`). */
+	dbExtraSearchPath?: string;
+	/** Maximum rows returned in a single request (`db_max_rows`). */
+	dbMaxRows?: number;
+	/** Schemas exposed via the API (`db_schemas`). Default `["public"]`. */
+	dbSchemas?: string[];
+	/** JWT claim key used for role extraction (`jwt_role_claim_key`). Default `".role"`. */
+	jwtRoleClaimKey?: string;
+	/** Maximum lifetime of the JWT cache, in seconds (`jwt_cache_max_lifetime`). */
+	jwtCacheMaxLifetime?: number;
+	/** OpenAPI spec mode (`openapi_mode`). Default `"disabled"`. */
+	openapiMode?: "ignore-privileges" | "disabled";
+	/** CORS allowed origins (`server_cors_allowed_origins`). */
+	serverCorsAllowedOrigins?: string;
+	/** Emit server-timing headers (`server_timing_enabled`). */
+	serverTimingEnabled?: boolean;
+}
+
+/** Fields shared by every {@link DataApiConfig} variant. */
+interface DataApiConfigBase {
+	/** Defaults to `true` when the `dataApi` namespace is present. Set `false` to opt out. */
+	enabled?: boolean;
+	/** Reusable runtime settings. Drift here is reconciled as an update. */
+	settings?: DataApiSettings;
+}
+
+/**
+ * Data API verified by **Neon Auth** (`authProvider: "neon"`, the default). The external
+ * IdP fields are statically forbidden (`?: never`) because Neon supplies them; declaring any
+ * of them is a type error directing you to `authProvider: "external"`.
+ */
+export interface DataApiNeonAuthConfig extends DataApiConfigBase {
+	authProvider?: "neon";
+	/** Forbidden with `authProvider: "neon"` — Neon provides the JWKS URL. */
+	jwksUrl?: never;
+	/** Forbidden with `authProvider: "neon"` — the provider is Neon Auth. */
+	providerName?: never;
+	/** Forbidden with `authProvider: "neon"` — Neon manages the audience. */
+	jwtAudience?: never;
+}
+
+/**
+ * Data API verified by an **external** IdP (`authProvider: "external"`). You provide the
+ * JWKS URL (and optionally a provider label / expected audience).
+ */
+export interface DataApiExternalAuthConfig extends DataApiConfigBase {
+	authProvider: "external";
+	/** URL that publishes the IdP's JWKS (JSON Web Key Set). */
+	jwksUrl?: string;
+	/** Human label for the IdP (e.g. "Clerk", "Stytch", "Auth0"). */
+	providerName?: string;
+	/**
+	 * Expected `aud` claim. ⚠️ This only **rejects** tokens carrying a *different* audience;
+	 * tokens with no `aud` claim are still accepted.
+	 */
+	jwtAudience?: string;
+}
+
+/**
+ * Object form of the `dataApi` toggle. A discriminated union on {@link DataApiAuthProvider}:
+ * the `"neon"` variant forbids the external-IdP fields, the `"external"` variant allows them.
+ */
+export type DataApiConfig = DataApiNeonAuthConfig | DataApiExternalAuthConfig;
+
+/**
+ * How the Data API is toggled in a policy: a bare boolean (like the other service toggles)
+ * or the richer {@link DataApiConfig} object. `true` / `{}` / `{ enabled: true }` enable it
+ * with Neon defaults; `false` / `{ enabled: false }` opt out.
+ */
+export type DataApiInput = boolean | DataApiConfig;
 
 /**
  * Supported function runtimes. Mirrors the Neon Functions deploy API `runtime` enum.
@@ -363,14 +488,17 @@ export interface Config<
 	Auth extends ServiceToggleInput | undefined =
 		| ServiceToggleInput
 		| undefined,
-	DataApi extends ServiceToggleInput | undefined =
-		| ServiceToggleInput
-		| undefined,
+	DataApi extends DataApiInput | undefined = DataApiInput | undefined,
 	Preview extends PreviewInput | undefined = PreviewInput | undefined,
 > {
 	/** Neon Auth integration toggle (GA). Static — drives `NeonEnv.auth`. */
 	auth?: Auth;
-	/** Neon Data API integration toggle (GA). Static — drives `NeonEnv.dataApi`. */
+	/**
+	 * Neon Data API integration (GA). Static — drives `NeonEnv.dataApi`. A boolean/toggle, or
+	 * a {@link DataApiConfig} object selecting the auth provider (`"neon"` / `"external"`) and
+	 * runtime {@link DataApiSettings}. With `authProvider: "neon"` the policy must also enable
+	 * top-level `auth`.
+	 */
 	dataApi?: DataApi;
 	/** Beta (Preview) feature set: AI Gateway, functions, buckets. Static. */
 	preview?: Preview;
@@ -412,6 +540,20 @@ export interface ResolvedPreviewConfig {
 	aiGatewayEnabled: boolean;
 }
 
+/**
+ * Normalized Data API integration. Present on {@link ResolvedBranchConfig} only when the
+ * policy enables `dataApi`. `authProvider` always resolves (defaults to `"neon"`); the
+ * external-IdP wiring is present only for `"external"`; `settings` carries the camelCase
+ * runtime settings (reconciled as an update when they drift).
+ */
+export interface ResolvedDataApiConfig {
+	authProvider: DataApiAuthProvider;
+	jwksUrl?: string;
+	providerName?: string;
+	jwtAudience?: string;
+	settings?: DataApiSettings;
+}
+
 export interface ResolvedBranchConfig {
 	parent?: string;
 	ttlSeconds?: number;
@@ -419,6 +561,11 @@ export interface ResolvedBranchConfig {
 	postgres?: PostgresConfig;
 	authEnabled: boolean;
 	dataApiEnabled: boolean;
+	/**
+	 * Resolved Data API integration. Present iff {@link dataApiEnabled} is `true`. Carries the
+	 * create-time auth wiring and the updatable {@link DataApiSettings}.
+	 */
+	dataApi?: ResolvedDataApiConfig;
 	preview?: ResolvedPreviewConfig;
 }
 

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -52,6 +52,9 @@ import {
 	bucketDefSchema,
 	computeSettingsSchema,
 	configInputSchema,
+	dataApiConfigSchema,
+	dataApiInputSchema,
+	dataApiSettingsSchema,
 	functionDefSchema,
 	functionTuningSchema,
 	postgresConfigSchema,
@@ -81,6 +84,9 @@ export const schemas = {
 	branchTuning: branchTuningSchema,
 	bucket: bucketDefSchema,
 	computeSettings: computeSettingsSchema,
+	dataApi: dataApiConfigSchema,
+	dataApiInput: dataApiInputSchema,
+	dataApiSettings: dataApiSettingsSchema,
 	function: functionDefSchema,
 	functionTuning: functionTuningSchema,
 	postgres: postgresConfigSchema,
@@ -128,6 +134,7 @@ export type {
 	CreateCredentialInput,
 	CreateProjectInput,
 	DeployFunctionInput,
+	EnableDataApiInput,
 	GetConnectionUriInput,
 	NeonApi,
 	NeonAuthSnapshot,
@@ -146,7 +153,6 @@ export type {
 	UpdateBranchInput,
 } from "./lib/neon-api.js";
 export { createRealNeonApi } from "./lib/neon-api-real.js";
-// ─── Config types (used in neon.ts and in operation return values) ────────────
 export type {
 	AppliedChange,
 	BranchTarget,
@@ -160,6 +166,12 @@ export type {
 	ConflictReport,
 	CredentialPrincipalType,
 	CredentialScope,
+	DataApiAuthProvider,
+	DataApiConfig,
+	DataApiExternalAuthConfig,
+	DataApiInput,
+	DataApiNeonAuthConfig,
+	DataApiSettings,
 	DurationString,
 	DurationUnit,
 	FunctionDef,
@@ -172,8 +184,12 @@ export type {
 	PushResult,
 	ResolvedBranchConfig,
 	ResolvedBucketConfig,
+	ResolvedDataApiConfig,
 	ResolvedFunctionConfig,
 	ResolvedPreviewConfig,
+	ServiceEnabled,
 	ServiceToggle,
 	ServiceToggleInput,
 } from "./lib/types.js";
+// ─── Config types (used in neon.ts and in operation return values) ────────────
+export { DATA_API_AUTH_PROVIDERS } from "./lib/types.js";

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -362,7 +362,17 @@ describe("parseEnv", () => {
 		vi.stubEnv("DATABASE_URL", "postgres://pooled");
 		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
 		vi.stubEnv("NEON_DATA_API_URL", "https://data.example.com");
-		const env = parseEnv(defineConfig({ dataApi: { enabled: true } }));
+		// `authProvider: "external"` so the toggle stands alone (a `"neon"` Data API
+		// requires Neon Auth — covered by the config package's validation tests).
+		const env = parseEnv(
+			defineConfig({
+				dataApi: {
+					enabled: true,
+					authProvider: "external",
+					jwksUrl: "https://idp.example.com/.well-known/jwks.json",
+				},
+			}),
+		);
 		expect(env.dataApi.url).toBe("https://data.example.com");
 	});
 

--- a/packages/env/src/lib/fake-neon-api.ts
+++ b/packages/env/src/lib/fake-neon-api.ts
@@ -4,7 +4,9 @@ import type {
 	CreateBucketInput,
 	CreateCredentialInput,
 	CreateProjectInput,
+	DataApiSettings,
 	DeployFunctionInput,
+	EnableDataApiInput,
 	GetConnectionUriInput,
 	NeonApi,
 	NeonAuthSnapshot,
@@ -478,10 +480,11 @@ export class FakeNeonApi implements NeonApi {
 		projectId: string,
 		branchId: string,
 		databaseName: string,
+		input?: EnableDataApiInput,
 	): Promise<NeonDataApiSnapshot> {
 		this.history.push({
 			method: "enableProjectBranchDataApi",
-			args: [projectId, branchId, databaseName],
+			args: [projectId, branchId, databaseName, input],
 		});
 		this.requireProject(projectId);
 		this.requireBranch(projectId, branchId);
@@ -490,9 +493,38 @@ export class FakeNeonApi implements NeonApi {
 		if (existing) return clone(existing);
 		const snapshot: NeonDataApiSnapshot = {
 			url: `https://${branchId}.fake.neon.tech/data-api/${databaseName}`,
+			status: "ready",
 		};
+		if (input?.settings) snapshot.settings = { ...input.settings };
 		this.neonDataApi.set(key, snapshot);
 		return clone(snapshot);
+	}
+
+	async updateProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		settings: DataApiSettings,
+	): Promise<NeonDataApiSnapshot> {
+		this.history.push({
+			method: "updateProjectBranchDataApi",
+			args: [projectId, branchId, databaseName, settings],
+		});
+		this.requireProject(projectId);
+		this.requireBranch(projectId, branchId);
+		const key = `${projectId}:${branchId}:${databaseName}`;
+		const existing = this.neonDataApi.get(key);
+		if (!existing) {
+			throw new Error(
+				`Fake Neon: Data API not enabled on ${branchId}/${databaseName}`,
+			);
+		}
+		const updated: NeonDataApiSnapshot = {
+			...existing,
+			settings: { ...(existing.settings ?? {}), ...settings },
+		};
+		this.neonDataApi.set(key, updated);
+		return clone(updated);
 	}
 
 	/** Test helper: attach a Neon Auth integration to a branch. */


### PR DESCRIPTION
## Summary
Expands the `dataApi` field in `neon.ts` from a bare service toggle into an object that selects the **auth provider** and reusable **runtime settings**, with matching static (TypeScript) and runtime (zod) guarantees, plus the create-vs-update wiring in the runtime.

```ts
defineConfig({
  auth: true,
  dataApi: {
    authProvider: "neon",            // default; or "external"
    settings: { dbSchemas: ["public", "api"], dbMaxRows: 1000 },
  },
});
```

`dataApi: true` / `{}` / `{ enabled: true }` still work unchanged.

### Behavior
- **`authProvider: "neon" | "external"`** — friendly authoring values, mapped to the Neon API's `neon_auth` / `external` at the adapter boundary (`DATA_API_AUTH_PROVIDERS`).
- **External-only fields** (`jwksUrl`, `providerName`, `jwtAudience`) are valid only on the `"external"` variant — typed `never` on `"neon"` (compile error) and rejected by zod at runtime.
- **A `"neon"` Data API requires Neon Auth** — `defineConfig` makes `auth` required at author time, and a zod cross-field check enforces it at runtime (covers `auth: false` and non-typed callers). `"external"` requires neither.
- **`settings`** are the camelCase mirror of the Neon API `DataAPISettings` (`dbAggregatesEnabled`, `dbAnonRole`, `dbExtraSearchPath`, `dbMaxRows`, `dbSchemas`, `jwtRoleClaimKey`, `jwtCacheMaxLifetime`, `openapiMode`, `serverCorsAllowedOrigins`, `serverTimingEnabled`).
- **Create vs update** — the auth wiring is set when the Data API is first enabled (carried on the create request) and is immutable afterward. Changing `settings` is reconciled as an **update** gated behind `updateExisting` / `--update-existing`, exactly like compute/TTL/`protected` drift (a `PushConflictError` otherwise).
- `add_default_grants` / `skip_auth_schema` create-only flags are intentionally not exposed.

### Surfaces touched
- `@neondatabase/config`: types (`DataApiConfig`, `DataApiSettings`, `ResolvedDataApiConfig`, `ServiceEnabled`, `DATA_API_AUTH_PROVIDERS`), zod schema + cross-field check, `defineConfig` static guard + `resolveConfig`, the `NeonApi` interface (`enableProjectBranchDataApi(input)`, new `updateProjectBranchDataApi`, richer `NeonDataApiSnapshot`), the real adapter (camelCase ⇄ snake_case mapping), the diff engine (create-with-input + `update-data-api`), README, and the in-memory fake.
- `@neondatabase/config-runtime`: service-state fetch carries current settings; `enable`/`update` apply steps + override classification; fake.
- `@neondatabase/env`: no behavioral change (structurally compatible); fake + one test updated to satisfy the new auth requirement.

## Test plan
- [x] `@neondatabase/config` (212), `@neondatabase/config-runtime` (49), `@neondatabase/env` (57) — all green
- [x] New unit tests: schema (external-only forbidden, neon-requires-auth), `resolveConfig` resolution, diff settings-drift (conflict vs update vs unreported), runtime update path, and static `@ts-expect-error` type guarantees
- [x] `biome ci` clean; all three packages typecheck/build
- [x] **Live e2e** against the real Neon API (org `andrelandgraf`): create Auth + Data API → re-plan no-op (settings round-trip) → `dbMaxRows` 1000→500 planned/applied as an update → direct read confirmed `dbMaxRows: 500`; throwaway project deleted
- [x] Changeset added (`minor` for config + config-runtime)