### PR TITLE
chore: bump patch versions for six packages

### DIFF
--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/ai-sdk-provider",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/functions",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Runtime helpers for Neon Functions. Currently provides a `waitUntil` primitive for deferring async work past a response.",
 	"keywords": [
 		"neon",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.16.0",
+	"version": "0.16.1",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Summary

Patch version bumps for six packages:

| Package | Version |
|---|---|
| `@neondatabase/ai-sdk-provider` | 0.1.0 → 0.1.1 |
| `@neondatabase/config-runtime` | 0.7.0 → 0.7.1 |
| `@neondatabase/config` | 0.7.0 → 0.7.1 |
| `@neondatabase/env` | 0.5.0 → 0.5.1 |
| `@neondatabase/functions` | 0.1.1 → 0.1.2 |
| `neon-init` | 0.16.0 → 0.16.1 |

This pull request and its description were written by Isaac, Databricks's AI assistant (an AI agent built on Claude Code).