### PR TITLE
feat(ai-sdk-provider): align model catalog with models.dev neon provider

### DIFF
--- a/.changeset/ai-sdk-provider-models-dev-catalog.md
+++ b/.changeset/ai-sdk-provider-models-dev-catalog.md
@@ -1,0 +1,7 @@
+---
+"@neondatabase/ai-sdk-provider": patch
+---
+
+Align the model catalog with the models.dev `neon` provider. Model ids now use the canonical Neon (unprefixed) form — `claude-sonnet-4-6`, `gpt-5`, `gemini-2-5-flash` — instead of the `databricks-` prefix. This is backward compatible: routing and capability detection match on the id substring, and the legacy `databricks-` prefixed ids still resolve via the `(string & {})` fallback.
+
+`NeonChatModelId` now covers the full models.dev `neon` catalog (incl. the Gemini 3 family: `gemini-3-pro`, `gemini-3-flash`, `gemini-3-1-pro`) plus gateway-served extras that models.dev does not list yet (Codex `gpt-5-*-codex`, `gpt-5-5-pro`, `gemini-3-5-flash`, `gemma-3-12b`, Llama, Qwen). The catalog is exported as `NEON_MODELS_DEV_IDS` / `NEON_EXTRA_MODEL_IDS`, and a maintainer-only drift check (`test:drift`, run weekly via the `catalog-drift` workflow) fails if the pinned models.dev list diverges from the live one.

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -1,0 +1,28 @@
+name: Catalog Drift
+
+# Maintainer guard: fails when @neondatabase/ai-sdk-provider's pinned model
+# catalog (NEON_MODELS_DEV_IDS) drifts from the live models.dev `neon` provider.
+# Runs on a GitHub-hosted runner because it must reach the public internet
+# (models.dev); the protected runner group has no public egress.
+
+on:
+    schedule:
+        - cron: "0 9 * * 1" # Mondays 09:00 UTC
+    workflow_dispatch: ~
+
+permissions:
+    contents: read
+
+jobs:
+    drift:
+        name: models.dev catalog drift
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              with:
+                  cache: pnpm
+                  node-version-file: .node-version
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm --filter @neondatabase/ai-sdk-provider test:drift

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -2,7 +2,9 @@
 
 Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://neon.com) AI Gateway.
 
-The Neon AI Gateway is **branch-scoped**: each Neon project branch gets its own gateway host, and a platform token authorizes requests for that branch. This provider routes each model to the best gateway endpoint (Anthropic → native Messages, OpenAI → native Responses incl. **Codex**, everything else → unified OpenAI-compatible MLflow endpoint), so a single `neon('databricks-...')` call reaches the whole `databricks-*` catalog.
+The Neon AI Gateway is **branch-scoped**: each Neon project branch gets its own gateway host, and a platform token authorizes requests for that branch. This provider routes each model to the best gateway endpoint (Anthropic → native Messages, OpenAI → native Responses incl. **Codex**, everything else → unified OpenAI-compatible MLflow endpoint), so a single `neon('claude-...')` call reaches the whole catalog.
+
+Model ids use the canonical Neon (unprefixed) form — `claude-sonnet-4-6`, `gpt-5`, `gemini-2-5-flash` — matching the [`neon` provider on models.dev](https://models.dev). The typed catalog mirrors that provider exactly (kept in sync by a scheduled drift check), plus a few extra gateway-served ids that models.dev doesn't list yet (e.g. Codex, Llama, Qwen). Any other id — including the legacy `databricks-` prefixed form (`databricks-claude-sonnet-4-6`) — is still accepted as a plain string, so existing code keeps working.
 
 ## Install
 
@@ -27,7 +29,7 @@ import { generateText } from "ai";
 
 // Reads NEON_AI_GATEWAY_BASE_URL + NEON_AI_GATEWAY_TOKEN from the environment.
 const { text } = await generateText({
-  model: neon("databricks-claude-haiku-4-5"), // or 'databricks-gpt-5-3-codex', etc.
+  model: neon("claude-haiku-4-5"), // or 'gpt-5-3-codex', etc.
   prompt: "Summarize Postgres for me.",
 });
 ```
@@ -47,9 +49,11 @@ const neon = createNeon({
 
 | Model family | Endpoint | Why |
 | --- | --- | --- |
-| Anthropic (`databricks-claude-*`) | native Messages API | streaming structured output + native reasoning |
-| OpenAI (`databricks-gpt-*`, `*-codex`) | native Responses API | Codex (native-only), native reasoning, image-gen tool |
+| Anthropic (`claude-*`) | native Messages API | streaming structured output + native reasoning |
+| OpenAI (`gpt-*`, `*-codex`) | native Responses API | Codex (native-only), native reasoning, image-gen tool |
 | Everything else (Gemini, Llama, Qwen, gpt-oss, ...) | unified MLflow endpoint | broad coverage; Gemini is here because its native endpoint does not support streaming |
+
+Routing matches on the model id, so both the canonical (`gpt-5`) and the legacy `databricks-`-prefixed (`databricks-gpt-5`) forms route identically.
 
 ## Capabilities
 
@@ -67,7 +71,7 @@ import { neon } from "@neondatabase/ai-sdk-provider/v1";
 import { imageGeneration } from "@ai-sdk/openai/internal";
 
 const result = streamText({
-  model: neon("databricks-gpt-5-mini"),
+  model: neon("gpt-5-mini"),
   prompt: "Generate an image of a red apple on a wooden table",
   tools: { image: imageGeneration({ partialImages: 3 }) },
 });

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -46,6 +46,7 @@
 		"prepare": "npm run build",
 		"test": "vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
+		"test:drift": "NEON_DRIFT_CHECK=1 vitest run neon-catalog-drift",
 		"tsc": "tsc"
 	},
 	"devDependencies": {

--- a/packages/ai-sdk-provider/src/lib/neon-catalog-drift.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-catalog-drift.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+	NEON_EXTRA_MODEL_IDS,
+	NEON_MODELS_DEV_IDS,
+} from "./neon-chat-options.js";
+
+/**
+ * Maintainer-only guard against models.dev drift. The `neon` provider on
+ * models.dev is the source of truth for the gateway's published catalog; this
+ * test fails when our `NEON_MODELS_DEV_IDS` no longer mirrors it, or when one of
+ * our `NEON_EXTRA_MODEL_IDS` has since been published (and should be promoted).
+ *
+ * It hits the network, so it is opt-in: it runs only when `NEON_DRIFT_CHECK=1`
+ * (see the `test:drift` script and the scheduled `catalog-drift` CI workflow),
+ * and is skipped by the normal unit-test run / PR CI to keep those offline and
+ * deterministic.
+ */
+const ENABLED = process.env.NEON_DRIFT_CHECK === "1";
+const MODELS_DEV_API = "https://models.dev/api.json";
+
+interface ModelsDevApi {
+	neon?: { models?: Record<string, unknown> };
+}
+
+async function fetchNeonCatalogIds(): Promise<Set<string>> {
+	const response = await fetch(MODELS_DEV_API);
+	if (!response.ok) {
+		throw new Error(
+			`models.dev returned ${response.status} ${response.statusText}`,
+		);
+	}
+	const data: ModelsDevApi = await response.json();
+	const models = data.neon?.models;
+	if (models == null) {
+		throw new Error("models.dev response has no `neon` provider models");
+	}
+	return new Set(Object.keys(models));
+}
+
+describe.skipIf(!ENABLED)("models.dev catalog drift", () => {
+	it("keeps NEON_MODELS_DEV_IDS in sync with the live neon catalog", async () => {
+		const live = await fetchNeonCatalogIds();
+		expect(live.size).toBeGreaterThan(0);
+
+		const declared = new Set<string>(NEON_MODELS_DEV_IDS);
+		const missingFromProvider = [...live]
+			.filter((id) => !declared.has(id))
+			.sort();
+		const removedUpstream = [...declared]
+			.filter((id) => !live.has(id))
+			.sort();
+
+		// `missingFromProvider`: add these to NEON_MODELS_DEV_IDS.
+		// `removedUpstream`: models.dev dropped these — remove or move to extras.
+		expect({ missingFromProvider, removedUpstream }).toEqual({
+			missingFromProvider: [],
+			removedUpstream: [],
+		});
+	});
+
+	it("keeps NEON_EXTRA_MODEL_IDS off the live catalog", async () => {
+		const live = await fetchNeonCatalogIds();
+
+		// If models.dev starts listing one of our extras, promote it into
+		// NEON_MODELS_DEV_IDS so the catalog stays the single source of truth.
+		const promotable = NEON_EXTRA_MODEL_IDS.filter((id) =>
+			live.has(id),
+		).sort();
+		expect(promotable).toEqual([]);
+	});
+});

--- a/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
@@ -2,47 +2,84 @@
 // to their provider-native endpoints; everything else uses the unified MLflow
 // (OpenAI-compatible) endpoint.
 //
-// The authoritative, always-current catalog is shown in the Neon Console under
-// the branch's "AI Gateway" tab. Any other id can be passed as a plain string
-// via the `(string & {})` fallback.
-export type NeonChatModelId =
+// Ids use the canonical Neon (unprefixed) form, matching the `neon` provider on
+// models.dev. The gateway also accepts the legacy `databricks-` prefixed form
+// (the `databricks` provider on models.dev), which still resolves via the
+// `(string & {})` fallback on `NeonChatModelId`.
+//
+// `NEON_MODELS_DEV_IDS` mirrors the models.dev `neon` catalog exactly — the
+// `neon-catalog-drift.test.ts` maintainer check fails if the two diverge.
+// `NEON_EXTRA_MODEL_IDS` are additional ids the gateway serves that models.dev
+// does not (yet) list; they are kept for autocomplete and verified to resolve
+// against the gateway. The authoritative, always-current catalog is shown in
+// the Neon Console under the branch's "AI Gateway" tab.
+
+/** The models.dev `neon` catalog (canonical, unprefixed ids). */
+export const NEON_MODELS_DEV_IDS = [
 	// Anthropic (native Messages API)
-	| "databricks-claude-opus-4-8"
-	| "databricks-claude-opus-4-7"
-	| "databricks-claude-opus-4-6"
-	| "databricks-claude-opus-4-5"
-	| "databricks-claude-opus-4-1"
-	| "databricks-claude-sonnet-4-6"
-	| "databricks-claude-sonnet-4-5"
-	| "databricks-claude-sonnet-4"
-	| "databricks-claude-haiku-4-5"
-	// OpenAI (native Responses API, incl. Codex)
-	| "databricks-gpt-5"
-	| "databricks-gpt-5-mini"
-	| "databricks-gpt-5-nano"
-	| "databricks-gpt-5-1"
-	| "databricks-gpt-5-2"
-	| "databricks-gpt-5-2-codex"
-	| "databricks-gpt-5-3-codex"
-	| "databricks-gpt-5-4"
-	| "databricks-gpt-5-4-mini"
-	| "databricks-gpt-5-4-nano"
-	| "databricks-gpt-5-5"
-	| "databricks-gpt-5-5-pro"
+	"claude-opus-4-7",
+	"claude-opus-4-6",
+	"claude-opus-4-5",
+	"claude-opus-4-1",
+	"claude-sonnet-4-6",
+	"claude-sonnet-4-5",
+	"claude-sonnet-4",
+	"claude-haiku-4-5",
+	// OpenAI (native Responses API)
+	"gpt-5",
+	"gpt-5-mini",
+	"gpt-5-nano",
+	"gpt-5-1",
+	"gpt-5-2",
+	"gpt-5-4",
+	"gpt-5-4-mini",
+	"gpt-5-4-nano",
+	"gpt-5-5",
 	// OpenAI open-weight (unified MLflow endpoint)
-	| "databricks-gpt-oss-120b"
-	| "databricks-gpt-oss-20b"
+	"gpt-oss-120b",
+	"gpt-oss-20b",
 	// Google (unified MLflow endpoint)
-	| "databricks-gemini-3-5-flash"
-	| "databricks-gemini-3-1-flash-lite"
-	| "databricks-gemini-2-5-pro"
-	| "databricks-gemini-2-5-flash"
-	| "databricks-gemma-3-12b"
+	"gemini-3-pro",
+	"gemini-3-flash",
+	"gemini-3-1-pro",
+	"gemini-3-1-flash-lite",
+	"gemini-2-5-pro",
+	"gemini-2-5-flash",
+] as const;
+
+/**
+ * Ids the gateway serves that the models.dev `neon` provider does not list.
+ * Verified to resolve against the gateway; retained for autocomplete. If
+ * models.dev later lists one of these, the drift check flags it for promotion
+ * into `NEON_MODELS_DEV_IDS`.
+ */
+export const NEON_EXTRA_MODEL_IDS = [
+	// Anthropic (native Messages API)
+	"claude-opus-4-8",
+	// OpenAI (native Responses API) — Codex is served only natively
+	"gpt-5-2-codex",
+	"gpt-5-3-codex",
+	"gpt-5-5-pro",
+	// Google (unified MLflow endpoint)
+	"gemini-3-5-flash",
+	"gemma-3-12b",
 	// Meta (unified MLflow endpoint)
-	| "databricks-llama-4-maverick"
-	| "databricks-meta-llama-3-3-70b-instruct"
-	| "databricks-meta-llama-3-1-8b-instruct"
+	"llama-4-maverick",
+	"meta-llama-3-3-70b-instruct",
+	"meta-llama-3-1-8b-instruct",
 	// Alibaba (unified MLflow endpoint)
-	| "databricks-qwen3-next-80b-a3b-instruct"
-	| "databricks-qwen35-122b-a10b"
-	| (string & {});
+	"qwen3-next-80b-a3b-instruct",
+	"qwen35-122b-a10b",
+] as const;
+
+/** A known Neon AI Gateway model id (models.dev catalog + gateway extras). */
+export type NeonKnownModelId =
+	| (typeof NEON_MODELS_DEV_IDS)[number]
+	| (typeof NEON_EXTRA_MODEL_IDS)[number];
+
+/**
+ * A Neon AI Gateway model id. Known ids are listed for autocomplete; any other
+ * id (e.g. a brand-new model, or the legacy `databricks-` prefixed form) is
+ * accepted via the `(string & {})` fallback.
+ */
+export type NeonChatModelId = NeonKnownModelId | (string & {});

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
@@ -6,30 +6,43 @@ import {
 
 describe("getNeonModelRoute", () => {
 	it("routes Anthropic and OpenAI models to their native endpoints", () => {
-		expect(getNeonModelRoute("databricks-claude-opus-4-8")).toBe(
-			"anthropic",
-		);
-		expect(getNeonModelRoute("databricks-claude-haiku-4-5")).toBe(
-			"anthropic",
-		);
-		expect(getNeonModelRoute("databricks-gpt-5")).toBe("openai");
-		expect(getNeonModelRoute("databricks-gpt-5-mini")).toBe("openai");
-		expect(getNeonModelRoute("databricks-gpt-5-3-codex")).toBe("openai");
+		expect(getNeonModelRoute("claude-opus-4-8")).toBe("anthropic");
+		expect(getNeonModelRoute("claude-haiku-4-5")).toBe("anthropic");
+		expect(getNeonModelRoute("gpt-5")).toBe("openai");
+		expect(getNeonModelRoute("gpt-5-mini")).toBe("openai");
+		expect(getNeonModelRoute("gpt-5-3-codex")).toBe("openai");
 	});
 
 	it("falls back to the unified MLflow endpoint for everything else", () => {
 		// Gemini is routed to MLflow because its native endpoint cannot stream.
-		expect(getNeonModelRoute("databricks-gemini-2-5-flash")).toBe("mlflow");
-		expect(getNeonModelRoute("databricks-llama-4-maverick")).toBe("mlflow");
-		expect(getNeonModelRoute("databricks-qwen35-122b-a10b")).toBe("mlflow");
+		expect(getNeonModelRoute("gemini-2-5-flash")).toBe("mlflow");
+		expect(getNeonModelRoute("llama-4-maverick")).toBe("mlflow");
+		expect(getNeonModelRoute("qwen35-122b-a10b")).toBe("mlflow");
 		// gpt-oss is open-weight and served on the unified endpoint, not Responses.
-		expect(getNeonModelRoute("databricks-gpt-oss-120b")).toBe("mlflow");
+		expect(getNeonModelRoute("gpt-oss-120b")).toBe("mlflow");
+	});
+
+	it("routes the legacy databricks- prefixed ids identically", () => {
+		// The gateway accepts both id forms; routing matches on the id substring,
+		// so the prefixed and canonical forms must resolve to the same endpoint.
+		const pairs: Array<[string, string]> = [
+			["claude-haiku-4-5", "databricks-claude-haiku-4-5"],
+			["gpt-5", "databricks-gpt-5"],
+			["gpt-5-3-codex", "databricks-gpt-5-3-codex"],
+			["gemini-2-5-flash", "databricks-gemini-2-5-flash"],
+			["gpt-oss-120b", "databricks-gpt-oss-120b"],
+		];
+		for (const [canonical, prefixed] of pairs) {
+			expect(getNeonModelRoute(prefixed)).toBe(
+				getNeonModelRoute(canonical),
+			);
+		}
 	});
 });
 
 describe("getNeonModelCapabilities", () => {
 	it("marks Anthropic models correctly", () => {
-		const caps = getNeonModelCapabilities("databricks-claude-haiku-4-5");
+		const caps = getNeonModelCapabilities("claude-haiku-4-5");
 		expect(caps.family).toBe("anthropic");
 		expect(caps.supportsPenalties).toBe(false);
 		expect(caps.supportsSeed).toBe(false);
@@ -38,29 +51,45 @@ describe("getNeonModelCapabilities", () => {
 	});
 
 	it("marks plain GPT-5 reasoning models without temperature/topP support", () => {
-		const caps = getNeonModelCapabilities("databricks-gpt-5-mini");
+		const caps = getNeonModelCapabilities("gpt-5-mini");
 		expect(caps.family).toBe("openai");
 		expect(caps.supportsTemperature).toBe(false);
 		expect(caps.supportsTopP).toBe(false);
 	});
 
 	it("keeps temperature for gpt-5.1+ models", () => {
-		const caps = getNeonModelCapabilities("databricks-gpt-5-1");
+		const caps = getNeonModelCapabilities("gpt-5-1");
 		expect(caps.supportsTemperature).toBe(true);
 		expect(caps.supportsTopP).toBe(true);
 	});
 
 	it("marks Meta models without penalties/seed support", () => {
-		const caps = getNeonModelCapabilities("databricks-llama-4-maverick");
+		const caps = getNeonModelCapabilities("llama-4-maverick");
 		expect(caps.family).toBe("meta");
 		expect(caps.supportsPenalties).toBe(false);
 		expect(caps.supportsSeed).toBe(false);
 	});
 
 	it("is permissive for unknown models", () => {
-		const caps = getNeonModelCapabilities("databricks-qwen35-122b-a10b");
+		const caps = getNeonModelCapabilities("qwen35-122b-a10b");
 		expect(caps.family).toBe("other");
 		expect(caps.supportsPenalties).toBe(true);
 		expect(caps.supportsReasoningEffort).toBe(true);
+	});
+
+	it("detects capabilities identically for legacy databricks- prefixed ids", () => {
+		const ids = [
+			"claude-haiku-4-5",
+			"gpt-5-mini",
+			"gpt-5-1",
+			"gemini-2-5-flash",
+			"llama-4-maverick",
+			"qwen35-122b-a10b",
+		];
+		for (const id of ids) {
+			expect(getNeonModelCapabilities(`databricks-${id}`)).toEqual(
+				getNeonModelCapabilities(id),
+			);
+		}
 	});
 });

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
@@ -101,10 +101,11 @@ export function getNeonModelCapabilities(
 	// OpenAI GPT-5 reasoning family (routed to the native Responses API). The
 	// Responses model strips parameters the Responses API doesn't accept
 	// (penalties, seed, stop), but its reasoning-model detection matches the bare
-	// model id (`gpt-5`), which the gateway's `databricks-` prefix defeats. So we
-	// only handle the temperature/topP restriction here: the original gpt-5 /
-	// gpt-5-mini / gpt-5-nano require the default temperature and reject topP,
-	// while gpt-5.1+ (a minor version digit follows) accept them again.
+	// model id (`gpt-5`), which the gateway's optional `databricks-` prefix can
+	// defeat. So we only handle the temperature/topP restriction here: the
+	// original gpt-5 / gpt-5-mini / gpt-5-nano require the default temperature and
+	// reject topP, while gpt-5.1+ (a minor version digit follows) accept them
+	// again. The regex matches both prefixed and unprefixed ids.
 	if (/gpt-5/.test(id)) {
 		const hasMinorVersion = /gpt-5[.-]\d/.test(id);
 		return {

--- a/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
@@ -13,10 +13,11 @@ import type {
  * reasoning and the image-generation tool.
  *
  * The shared OpenAI Responses model shapes a request based on whether the model
- * is a reasoning model, but it detects that from the bare model id (`gpt-5`),
- * which the gateway's required `databricks-` prefix defeats. For the GPT-5
- * reasoning family we set the model's own `forceReasoning` provider option so it
- * applies the correct reasoning behavior. Users can still override it.
+ * is a reasoning model, but its detection is brittle here: the gateway also
+ * accepts the legacy `databricks-` prefix, which defeats the upstream bare-id
+ * (`gpt-5`) match. For the GPT-5 reasoning family we set the model's own
+ * `forceReasoning` provider option so it applies the correct reasoning behavior
+ * for both id forms. Users can still override it.
  */
 export class NeonResponsesLanguageModel
 	extends OpenAIResponsesLanguageModel

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -4,8 +4,9 @@
  * `createNeon()` returns a provider that routes each model to the best gateway
  * endpoint based on its id (Anthropic → native Messages, OpenAI → native
  * Responses incl. Codex, everything else → unified MLflow), so a single
- * `neon('databricks-...')` call (same base URL + token) reaches the whole
- * catalog. Configure with the branch-scoped `NEON_AI_GATEWAY_BASE_URL` +
+ * `neon('claude-...')` call (same base URL + token) reaches the whole catalog.
+ * Ids use the canonical Neon (unprefixed) form; the legacy `databricks-` prefix
+ * is also accepted. Configure with the branch-scoped `NEON_AI_GATEWAY_BASE_URL` +
  * `NEON_AI_GATEWAY_TOKEN` emitted by `neonctl env pull` / `neon dev`, or pass
  * `baseURL` / `apiKey` explicitly.
  */

--- a/packages/ai-sdk-provider/src/v1.ts
+++ b/packages/ai-sdk-provider/src/v1.ts
@@ -8,7 +8,12 @@
  */
 export { NeonAnthropicLanguageModel } from "./lib/neon-anthropic-language-model.js";
 export { NeonChatLanguageModel } from "./lib/neon-chat-language-model.js";
-export type { NeonChatModelId } from "./lib/neon-chat-options.js";
+export {
+	NEON_EXTRA_MODEL_IDS,
+	NEON_MODELS_DEV_IDS,
+	type NeonChatModelId,
+	type NeonKnownModelId,
+} from "./lib/neon-chat-options.js";
 export {
 	getNeonModelCapabilities,
 	getNeonModelRoute,


### PR DESCRIPTION
## Summary

Aligns `@neondatabase/ai-sdk-provider`'s model catalog with the [`neon` provider on models.dev](https://models.dev), and adds a maintainer drift guard so it stays in sync.

- **Canonical ids are now unprefixed** (`claude-sonnet-4-6`, `gpt-5`, `gemini-2-5-flash`) matching the models.dev `neon` provider, instead of the `databricks-` prefix used by the `databricks` provider. Fully backward compatible — routing (`getNeonModelRoute`) and capability detection match on the id substring, and the legacy `databricks-` prefixed ids still resolve via the `(string & {})` fallback. Updated the now-inaccurate "prefix required" code comments.
- **Full catalog parity + marked extras.** `NeonChatModelId` is derived from two runtime arrays (single source of truth, exported for consumers):
  - `NEON_MODELS_DEV_IDS` — mirrors the models.dev `neon` catalog exactly (adds the Gemini 3 family: `gemini-3-pro`, `gemini-3-flash`, `gemini-3-1-pro`).
  - `NEON_EXTRA_MODEL_IDS` — gateway-served ids models.dev doesn't list yet, grouped per family with an "extra" comment: Codex (`gpt-5-2-codex`, `gpt-5-3-codex`), `gpt-5-5-pro`, `gemini-3-5-flash`, `gemma-3-12b`, Llama, Qwen, `claude-opus-4-8`.
- **Drift guard.** `neon-catalog-drift.test.ts` fetches the live models.dev catalog and fails if `NEON_MODELS_DEV_IDS` diverges, or if an extra has since been published (should be promoted). It's opt-in (`NEON_DRIFT_CHECK=1` / `pnpm test:drift`), so the normal unit run and PR CI stay offline/deterministic. A scheduled `catalog-drift` workflow runs it weekly on a GitHub-hosted runner (the protected runner group has no public egress to reach models.dev).

### Verification notes
- The `gemini-3-*` ids were probed against the staging gateway: `gemini-3-pro` / `gemini-3-1-pro` → `gemini-3.1-pro-preview`, and the extra `gemini-3-5-flash` → `gemini-3.5-flash` (confirmed real, not a typo). `gemini-3-flash` was rate-limited (TPM) but is on models.dev.

## Test plan
- [x] `pnpm --filter @neondatabase/ai-sdk-provider tsc` — clean
- [x] `pnpm --filter @neondatabase/ai-sdk-provider test:ci` — 9 pass, 2 drift tests skipped (offline)
- [x] `pnpm --filter @neondatabase/ai-sdk-provider test:drift` — 2 pass live against models.dev
- [x] `pnpm --filter @neondatabase/ai-sdk-provider build` — clean
- [x] `biome check` — clean
- [ ] Confirm the scheduled `catalog-drift` workflow runs (manual `workflow_dispatch` after merge)