### PR TITLE
fix(init): make project bootstrapping resilient to GitHub rate limits

### DIFF
--- a/.changeset/bootstrap-no-rate-limit.md
+++ b/.changeset/bootstrap-no-rate-limit.md
@@ -1,0 +1,9 @@
+---
+"neon-init": patch
+---
+
+Make project bootstrapping resilient to GitHub rate limits.
+
+- `neon init` now delegates scaffolding to `npx -y neonctl@latest bootstrap`, so a stale globally-installed `neonctl` can't be picked up — users always get the version of the CLI that downloads templates via the codeload tarball (no `api.github.com` rate limit) rather than the old REST tree-walk that failed with "GitHub API rate limit exceeded".
+- The template manifest is now fetched from neon.com first (CDN-backed, no GitHub rate limiting), falling back to the raw GitHub copy and then a built-in list.
+- The built-in fallback list now includes all starters (hono, ai-sdk, mastra), so the picker stays complete even when every manifest source is unreachable.

--- a/packages/init/src/interactive.ts
+++ b/packages/init/src/interactive.ts
@@ -183,10 +183,14 @@ async function interactiveInitInner(
 					`Scaffolding project from template "${selectedTemplate.title}"...`,
 				);
 				try {
+					// Pin @latest (and -y) so a stale globally-installed neonctl
+					// can't be picked up by npx — bootstrap's rate-limit fix lives
+					// in recent neonctl.
 					await execa(
 						"npx",
 						[
-							"neonctl",
+							"-y",
+							"neonctl@latest",
 							"bootstrap",
 							".",
 							"--template",

--- a/packages/init/src/lib/bootstrap.test.ts
+++ b/packages/init/src/lib/bootstrap.test.ts
@@ -95,6 +95,14 @@ describe("FALLBACK_TEMPLATES", () => {
 		expect(FALLBACK_TEMPLATES.length).toBeGreaterThan(0);
 	});
 
+	test("offers the full starter set, not just one template", () => {
+		expect(FALLBACK_TEMPLATES.map((t) => t.id)).toEqual([
+			"hono",
+			"ai-sdk",
+			"mastra",
+		]);
+	});
+
 	test("each template has required fields", () => {
 		for (const t of FALLBACK_TEMPLATES) {
 			expect(typeof t.id).toBe("string");

--- a/packages/init/src/lib/bootstrap.ts
+++ b/packages/init/src/lib/bootstrap.ts
@@ -28,7 +28,12 @@ export interface BootstrapTemplate {
 	};
 }
 
-/** Hardcoded fallback used when the remote manifest cannot be fetched. */
+/**
+ * Hardcoded fallback used when every remote manifest source is unreachable.
+ * Kept in sync with `neondatabase/examples/bootstrap.yaml` (the source of
+ * truth) so that, even fully offline from the manifest, the picker still offers
+ * the full set of starters rather than a single template.
+ */
 export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 	{
 		id: "hono",
@@ -43,10 +48,46 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 			subdir: "with-hono",
 		},
 	},
+	{
+		id: "ai-sdk",
+		title: "AI SDK agent (AI Gateway, object storage, Drizzle) on Neon Functions",
+		description:
+			"A Vercel AI SDK agent on Neon Functions: streams chat through the Neon AI Gateway, generates an image with OpenAI image generation, and stores it in Neon object storage indexed in Postgres via Drizzle.",
+		requires: ["database", "functions", "object-storage", "ai-gateway"],
+		source: {
+			owner: "neondatabase",
+			repo: "examples",
+			ref: "main",
+			subdir: "with-ai-sdk",
+		},
+	},
+	{
+		id: "mastra",
+		title: "Mastra personal agent (AI Gateway, Mastra Memory) on Neon Functions",
+		description:
+			"A Mastra personal-assistant agent on Neon Functions: streams chat through the Neon AI Gateway and uses Mastra Memory — backed by Neon Postgres — to remember the user across conversation threads via resource-scoped working memory.",
+		requires: ["database", "functions", "ai-gateway"],
+		source: {
+			owner: "neondatabase",
+			repo: "examples",
+			ref: "main",
+			subdir: "with-mastra",
+		},
+	},
 ];
 
-const MANIFEST_URL =
+// Primary manifest host is neon.com (CDN-backed, no GitHub rate limiting), with
+// the raw GitHub copy as a fallback and the hardcoded list as the last resort.
+// A single env override (used by tests) short-circuits the chain.
+const NEON_MANIFEST_URL = "https://neon.com/bootstrap/templates.yaml";
+const GITHUB_RAW_MANIFEST_URL =
 	"https://raw.githubusercontent.com/neondatabase/examples/main/bootstrap.yaml";
+
+function manifestUrls(): string[] {
+	const override = process.env.NEON_BOOTSTRAP_MANIFEST_URL;
+	if (override) return [override];
+	return [NEON_MANIFEST_URL, GITHUB_RAW_MANIFEST_URL];
+}
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
@@ -97,21 +138,23 @@ export function parseManifest(text: string): BootstrapTemplate[] {
 }
 
 /**
- * Fetch the template manifest from the remote bootstrap.yaml in the
- * neondatabase/examples repo. Falls back to the hardcoded list on any error.
+ * Fetch the template manifest, trying each source in {@link manifestUrls} in
+ * order and returning the first that yields a non-empty template list. Falls
+ * back to the hardcoded list when every source is unreachable or empty, so the
+ * picker never fails just because a host is down.
  */
 export async function fetchTemplates(): Promise<BootstrapTemplate[]> {
-	const url = process.env.NEON_BOOTSTRAP_MANIFEST_URL ?? MANIFEST_URL;
-	try {
-		const res = await fetch(url, {
-			signal: AbortSignal.timeout(10_000),
-		});
-		if (!res.ok) throw new Error(`HTTP ${res.status}`);
-		const text = await res.text();
-		const templates = parseManifest(text);
-		if (templates.length === 0) return FALLBACK_TEMPLATES;
-		return templates;
-	} catch {
-		return FALLBACK_TEMPLATES;
+	for (const url of manifestUrls()) {
+		try {
+			const res = await fetch(url, {
+				signal: AbortSignal.timeout(10_000),
+			});
+			if (!res.ok) throw new Error(`HTTP ${res.status}`);
+			const templates = parseManifest(await res.text());
+			if (templates.length > 0) return templates;
+		} catch {
+			// Try the next source.
+		}
 	}
+	return FALLBACK_TEMPLATES;
 }

--- a/packages/init/src/lib/phases/setup.ts
+++ b/packages/init/src/lib/phases/setup.ts
@@ -574,10 +574,14 @@ async function executeBatchedInstallation(
 	// Step 0: Bootstrap project from template if specified
 	if (isBootstrap && options.template) {
 		try {
+			// Pin @latest (and -y) so a stale globally-installed neonctl can't be
+			// picked up by npx — bootstrap's rate-limit fix lives in recent
+			// neonctl, and this runs before ensureNeonctl() updates the global.
 			await execa(
 				"npx",
 				[
-					"neonctl",
+					"-y",
+					"neonctl@latest",
 					"bootstrap",
 					".",
 					"--template",


### PR DESCRIPTION
## Problem

`neon init` (preview bootstrap) and the interactive flow scaffold by shelling out to `npx neonctl bootstrap`. Two issues meant users kept hitting **`GitHub API rate limit exceeded`**:

1. `npx neonctl` (no version pin) can resolve a **stale globally-installed neonctl**, and it runs **before** `ensureNeonctl()` updates the global — so the rate-limit fix in recent neonctl never gets used.
2. The template manifest was fetched only from raw.githubusercontent, which is also rate-limited on shared IPs (degrading the picker to the single built-in template).

## Fix

- Delegate to **`npx -y neonctl@latest bootstrap`** in both `interactive.ts` and the setup phase, so the rate-limit-free CLI is always used regardless of a stale global install.
- Fetch the manifest from **neon.com first → raw GitHub copy → built-in list**.
- Expand the built-in fallback to the **full starter set** (hono, ai-sdk, mastra) so the picker stays complete even fully offline from the manifest.

The actual template **download** fix lives in neonctl (codeload tarball); this PR ensures `neon init` users get it.

## Tests

- `neon-init` build (incl. `tsc --noEmit`) passes; biome clean.
- 35 tests pass across `bootstrap.test.ts`, `phases/setup.test.ts`, `v2.test.ts`, including a new assertion locking the full fallback starter set.
- Added a changeset (`neon-init`: patch).

## Merge order

Merge **after** the neonctl fix is published (this PR pins `neonctl@latest`). The neon.com manifest URL falls back to raw GitHub, so it does **not** block on the website PR.