### PR TITLE
feat(neoncli): add name-claim package redirecting to neonctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 | `@neondatabase/config`               | Config-as-Code for Neon: `defineConfig` types + the pure diff engine and Neon API adapter behind a `neon.ts` policy. | active     |
 | `@neondatabase/config-runtime`       | Runtime for `neon.ts` policies — `inspect` / `plan` / `apply` (push/pull) plus function bundling and deploy. | active     |
 | `@neondatabase/env`                  | Resolve and inject a branch's Neon env (`fetchEnv` / `parseEnv`, `neon-env run`) from a `neon.ts` policy. | active     |
+| `neoncli`                            | Name-claim package that redirects to the official Neon CLI, [`neonctl`](https://www.npmjs.com/package/neonctl). | active     |
 | `get-db`                             | alias for `neon-new`                                                          | deprecated |
 | `vite-plugin-db`                     | alias for `vite-plugin-neon-new`                                              | deprecated |
 | `neondb`                             | alias for `neon-new`                                                          | deprecated |

--- a/packages/neoncli/README.md
+++ b/packages/neoncli/README.md
@@ -1,0 +1,30 @@
+# neoncli
+
+> **This is not the official Neon CLI.** The official Neon command-line tool is **[`neonctl`](https://www.npmjs.com/package/neonctl)**.
+
+This package exists only to point you to the right place. If you were looking for the Neon CLI, install `neonctl` instead.
+
+## Install the official CLI
+
+```bash
+npm install -g neonctl
+# or
+brew install neonctl
+```
+
+Then run it as `neonctl` (or its `neon` alias):
+
+```bash
+neonctl auth
+neonctl projects list
+```
+
+## Links
+
+- npm: [`neonctl`](https://www.npmjs.com/package/neonctl)
+- Source: [neondatabase/neonctl](https://github.com/neondatabase/neonctl)
+- Docs: [Neon CLI reference](https://neon.com/docs/reference/neon-cli)
+
+## License
+
+Apache-2.0

--- a/packages/neoncli/package.json
+++ b/packages/neoncli/package.json
@@ -1,0 +1,49 @@
+{
+	"name": "neoncli",
+	"version": "0.0.0",
+	"description": "Not the official Neon CLI. The official tool is 'neonctl'. Install 'neonctl' instead.",
+	"keywords": [
+		"neon",
+		"neonctl",
+		"cli",
+		"postgres",
+		"database"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/neondatabase/neon-pkgs.git"
+	},
+	"license": "Apache-2.0",
+	"author": {
+		"name": "Neon",
+		"url": "https://neon.com"
+	},
+	"type": "module",
+	"bin": {
+		"neoncli": "dist/cli.js"
+	},
+	"files": [
+		"README.md",
+		"dist/",
+		"package.json"
+	],
+	"scripts": {
+		"build": "tsc --noEmit && tsdown",
+		"test": "vitest --passWithNoTests",
+		"test:ci": "vitest run --passWithNoTests",
+		"tsc": "tsc"
+	},
+	"devDependencies": {
+		"@types/node": "catalog:",
+		"tsdown": "catalog:",
+		"typescript": "catalog:",
+		"vitest": "catalog:"
+	},
+	"packageManager": "pnpm@10.4.0",
+	"engines": {
+		"node": ">=22"
+	},
+	"publishConfig": {
+		"provenance": false
+	}
+}

--- a/packages/neoncli/src/cli.ts
+++ b/packages/neoncli/src/cli.ts
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+const yellow = (text: string) => `\x1b[33m${text}\x1b[0m`;
+const bold = (text: string) => `\x1b[1m${text}\x1b[0m`;
+
+console.log("");
+console.log(yellow("`neoncli` is not the official Neon CLI."));
+console.log(`The official Neon command-line tool is ${bold("neonctl")}.`);
+console.log("");
+console.log("Install it with one of:");
+console.log("  npm install -g neonctl");
+console.log("  brew install neonctl");
+console.log("");
+console.log("Then run it as `neonctl` (or `neon`).");
+console.log("Docs: https://neon.com/docs/reference/neon-cli");
+console.log("");
+
+process.exit(0);

--- a/packages/neoncli/tsconfig.json
+++ b/packages/neoncli/tsconfig.json
@@ -1,0 +1,4 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"include": ["src"]
+}

--- a/packages/neoncli/tsdown.config.ts
+++ b/packages/neoncli/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	name: "neoncli",
+	bundle: false,
+	clean: true,
+	dts: true,
+	entry: ["src/cli.ts"],
+	format: "esm",
+	outDir: "dist",
+	treeshake: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,21 @@ importers:
         specifier: 'catalog:'
         version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
 
+  packages/neoncli:
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.17
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.8.2)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.8.2
+      vitest:
+        specifier: 'catalog:'
+        version: 3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
+
   packages/neondb:
     dependencies:
       neon-new:


### PR DESCRIPTION
## Summary

- Adds a new `neoncli` package (v0.0.0) to the monorepo whose sole purpose is to **claim the unscoped `neoncli` name on npm** so it can't be typo-squatted, and to point people to the official Neon CLI, [`neonctl`](https://www.npmjs.com/package/neonctl).
- Ships a tiny **no-dependency bin** that prints a friendly redirect notice (use `neonctl`) and exits — zero runtime deps, zero ongoing maintenance.
- README is written as the npmjs.com landing page: prominently states "this is not the official CLI" and links to `neonctl` (npm, repo, docs).
- Adds a row for `neoncli` to the root README package table.

## Notes

- Initial release is intentionally **0.0.0** (no changeset). The normal neon-pkgs release process will publish it since the version isn't yet on npm.
- `@neondatabase/neoncli` (scoped) is intentionally **not** created — only the unscoped name is squat-able and worth defending.

## Test plan

- [x] `pnpm --filter neoncli build` passes (`tsc --noEmit` + `tsdown`)
- [x] `node packages/neoncli/dist/cli.js` prints the redirect notice and exits 0
- [x] `biome ci` clean
- [x] `npm pack --dry-run` shows expected contents (README, dist, package.json)