### PR TITLE
feat(functions): implement waitUntil runtime integration

### DIFF
--- a/.changeset/functions-wait-until-impl.md
+++ b/.changeset/functions-wait-until-impl.md
@@ -1,0 +1,7 @@
+---
+"@neondatabase/functions": minor
+---
+
+Implement `waitUntil()` (replaces the no-op placeholder).
+
+The function returned by `waitUntil()` now forwards the promise to the Neon Functions runtime via its per-invocation context (`globalThis[NEON_FUNCTIONS_CONTEXT]`, a `Symbol.for("@neondatabase/functions/request-context")`), keeping the invocation alive until the promise settles. Behaviour mirrors Vercel's `waitUntil`: a non-`Promise` argument throws a `TypeError`. When the runtime has not published a context (local dev, tests, non-Neon hosts), the returned function is a no-op, so the same code runs everywhere. The `NEON_FUNCTIONS_CONTEXT` symbol is now exported as the documented runtime contract.

--- a/.changeset/functions-wait-until-impl.md
+++ b/.changeset/functions-wait-until-impl.md
@@ -2,6 +2,17 @@
 "@neondatabase/functions": minor
 ---
 
-Implement `waitUntil()` (replaces the no-op placeholder).
+Implement `waitUntil` with a Vercel-compatible API (replaces the no-op placeholder).
 
-The function returned by `waitUntil()` now forwards the promise to the Neon Functions runtime via its per-invocation context (`globalThis[NEON_FUNCTIONS_CONTEXT]`, a `Symbol.for("@neondatabase/functions/request-context")`), keeping the invocation alive until the promise settles. Behaviour mirrors Vercel's `waitUntil`: a non-`Promise` argument throws a `TypeError`. When the runtime has not published a context (local dev, tests, non-Neon hosts), the returned function is a no-op, so the same code runs everywhere. The `NEON_FUNCTIONS_CONTEXT` symbol is now exported as the documented runtime contract.
+`waitUntil` is now called directly with a promise — `waitUntil(promise)` — matching
+`@vercel/functions` instead of returning a deferred function. The per-invocation
+context is carried by an `AsyncLocalStorage` and published on
+`globalThis[NEON_FUNCTIONS_CONTEXT]` (a `Symbol.for("@neondatabase/functions/request-context")`)
+as a `{ get() }` provider, mirroring the contract used by Vercel and Next.js. Because
+the context lives in `AsyncLocalStorage`, concurrent invocations sharing an isolate no
+longer clobber each other's context.
+
+A non-`Promise` argument throws a `TypeError`. When no invocation context is in scope
+(local dev, tests, non-Neon hosts), `waitUntil` is a no-op, so the same code runs
+everywhere. The new `runWithRequestContext(context, fn)` helper lets the runtime bind a
+context for the duration of an invocation.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -23,6 +23,12 @@ export default {
 };
 ```
 
-> **Status: not implemented yet.** `waitUntil()` currently returns a no-op function — the
-> promise you pass is accepted and ignored. Once the Neon Functions runtime ships, it will
-> register the promise with the host so the invocation stays alive until it settles.
+`waitUntil()` returns a function that forwards the promise to the Neon Functions
+runtime, which keeps the invocation alive until the promise settles (up to the
+15-minute `waitUntil` limit). When no runtime context is present — local dev, tests,
+or any non-Neon host — the returned function is a **no-op**: the promise is accepted
+and ignored, so the same code runs everywhere without branching.
+
+Under the hood the runtime publishes its per-invocation context at
+`globalThis[NEON_FUNCTIONS_CONTEXT]` (a `Symbol.for("@neondatabase/functions/request-context")`),
+mirroring the convention used by Vercel.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -10,25 +10,42 @@ npm install @neondatabase/functions
 
 ## Usage
 
+The API mirrors [`@vercel/functions`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package): import `waitUntil` and call it directly with the promise you want to keep alive.
+
 ```ts
 import { waitUntil } from "@neondatabase/functions/v1";
 
 export default {
 	async fetch(req: Request): Promise<Response> {
-		const defer = waitUntil();
 		// Fire-and-forget background work that should outlive the response.
-		defer(logRequest(req));
+		waitUntil(logRequest(req));
 		return new Response("ok");
 	},
 };
 ```
 
-`waitUntil()` returns a function that forwards the promise to the Neon Functions
-runtime, which keeps the invocation alive until the promise settles (up to the
-15-minute `waitUntil` limit). When no runtime context is present — local dev, tests,
-or any non-Neon host — the returned function is a **no-op**: the promise is accepted
-and ignored, so the same code runs everywhere without branching.
+`waitUntil(promise)` forwards the promise to the Neon Functions runtime, which keeps
+the invocation alive until the promise settles (up to the 15-minute `waitUntil` limit).
+When no invocation context is in scope — local dev, tests, or any non-Neon host — it is
+a **no-op**: the promise is accepted and ignored, so the same code runs everywhere
+without branching. Passing a non-`Promise` throws a `TypeError`.
 
-Under the hood the runtime publishes its per-invocation context at
-`globalThis[NEON_FUNCTIONS_CONTEXT]` (a `Symbol.for("@neondatabase/functions/request-context")`),
-mirroring the convention used by Vercel.
+## Runtime integration
+
+The runtime carries the per-invocation context in an `AsyncLocalStorage` and publishes
+an accessor at `globalThis[NEON_FUNCTIONS_CONTEXT]` (a
+`Symbol.for("@neondatabase/functions/request-context")`) shaped like the providers used
+by Vercel and Next.js — a stable object exposing `get()`.
+
+To make `waitUntil` resolve to a given invocation, wrap the handler with
+`runWithRequestContext`. This is intended for the Neon Functions runtime; application
+code should not need it.
+
+```ts
+import { runWithRequestContext } from "@neondatabase/functions/v1";
+
+runWithRequestContext({ waitUntil: realWaitUntil }, () => handler(req));
+```
+
+Because the context lives in `AsyncLocalStorage`, concurrent invocations in the same
+isolate each see their own context and never clobber one another.

--- a/packages/functions/src/lib/wait-until.test.ts
+++ b/packages/functions/src/lib/wait-until.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { NEON_FUNCTIONS_CONTEXT, waitUntil } from "./wait-until.js";
+
+type GlobalWithContext = typeof globalThis & {
+	[NEON_FUNCTIONS_CONTEXT]?: {
+		waitUntil?: (promise: Promise<unknown>) => void;
+	};
+};
+
+const globalWithContext: GlobalWithContext = globalThis;
+
+afterEach(() => {
+	delete globalWithContext[NEON_FUNCTIONS_CONTEXT];
+});
+
+describe("waitUntil", () => {
+	it("forwards the promise to the runtime-provided waitUntil", () => {
+		const received: Promise<unknown>[] = [];
+		globalWithContext[NEON_FUNCTIONS_CONTEXT] = {
+			waitUntil: (promise) => {
+				received.push(promise);
+			},
+		};
+
+		const defer = waitUntil();
+		const promise = Promise.resolve("done");
+		defer(promise);
+
+		expect(received).toEqual([promise]);
+	});
+
+	it("resolves the context lazily, when the deferred function is called", () => {
+		const defer = waitUntil();
+
+		const received: Promise<unknown>[] = [];
+		globalWithContext[NEON_FUNCTIONS_CONTEXT] = {
+			waitUntil: (promise) => {
+				received.push(promise);
+			},
+		};
+
+		const promise = Promise.resolve();
+		defer(promise);
+
+		expect(received).toEqual([promise]);
+	});
+
+	it("is a no-op when the runtime context is absent", () => {
+		const defer = waitUntil();
+		expect(() => defer(Promise.resolve())).not.toThrow();
+	});
+
+	it("is a no-op when the context exposes no waitUntil", () => {
+		globalWithContext[NEON_FUNCTIONS_CONTEXT] = {};
+		const defer = waitUntil();
+		expect(() => defer(Promise.resolve())).not.toThrow();
+	});
+
+	it("throws a TypeError when called without a promise", () => {
+		const defer = waitUntil();
+		// @ts-expect-error — exercising the runtime guard for untyped JS callers.
+		expect(() => defer(42)).toThrow(TypeError);
+	});
+});

--- a/packages/functions/src/lib/wait-until.test.ts
+++ b/packages/functions/src/lib/wait-until.test.ts
@@ -1,65 +1,67 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
-import { NEON_FUNCTIONS_CONTEXT, waitUntil } from "./wait-until.js";
-
-type GlobalWithContext = typeof globalThis & {
-	[NEON_FUNCTIONS_CONTEXT]?: {
-		waitUntil?: (promise: Promise<unknown>) => void;
-	};
-};
-
-const globalWithContext: GlobalWithContext = globalThis;
-
-afterEach(() => {
-	delete globalWithContext[NEON_FUNCTIONS_CONTEXT];
-});
+import { runWithRequestContext, waitUntil } from "./wait-until.js";
 
 describe("waitUntil", () => {
-	it("forwards the promise to the runtime-provided waitUntil", () => {
+	it("forwards the promise to the invocation context's waitUntil", () => {
 		const received: Promise<unknown>[] = [];
-		globalWithContext[NEON_FUNCTIONS_CONTEXT] = {
-			waitUntil: (promise) => {
-				received.push(promise);
-			},
-		};
-
-		const defer = waitUntil();
 		const promise = Promise.resolve("done");
-		defer(promise);
+
+		runWithRequestContext({ waitUntil: (p) => received.push(p) }, () => {
+			waitUntil(promise);
+		});
 
 		expect(received).toEqual([promise]);
 	});
 
-	it("resolves the context lazily, when the deferred function is called", () => {
-		const defer = waitUntil();
-
+	it("resolves the context at call time, including from nested async work", async () => {
 		const received: Promise<unknown>[] = [];
-		globalWithContext[NEON_FUNCTIONS_CONTEXT] = {
-			waitUntil: (promise) => {
-				received.push(promise);
-			},
-		};
-
 		const promise = Promise.resolve();
-		defer(promise);
+
+		await runWithRequestContext(
+			{ waitUntil: (p) => received.push(p) },
+			async () => {
+				await Promise.resolve();
+				waitUntil(promise);
+			},
+		);
 
 		expect(received).toEqual([promise]);
 	});
 
-	it("is a no-op when the runtime context is absent", () => {
-		const defer = waitUntil();
-		expect(() => defer(Promise.resolve())).not.toThrow();
+	it("isolates context across concurrent invocations", async () => {
+		const a: Promise<unknown>[] = [];
+		const b: Promise<unknown>[] = [];
+		const pa = Promise.resolve("a");
+		const pb = Promise.resolve("b");
+
+		await Promise.all([
+			runWithRequestContext({ waitUntil: (p) => a.push(p) }, async () => {
+				await Promise.resolve();
+				waitUntil(pa);
+			}),
+			runWithRequestContext({ waitUntil: (p) => b.push(p) }, async () => {
+				await Promise.resolve();
+				waitUntil(pb);
+			}),
+		]);
+
+		expect(a).toEqual([pa]);
+		expect(b).toEqual([pb]);
+	});
+
+	it("is a no-op when no invocation context is in scope", () => {
+		expect(() => waitUntil(Promise.resolve())).not.toThrow();
 	});
 
 	it("is a no-op when the context exposes no waitUntil", () => {
-		globalWithContext[NEON_FUNCTIONS_CONTEXT] = {};
-		const defer = waitUntil();
-		expect(() => defer(Promise.resolve())).not.toThrow();
+		runWithRequestContext({}, () => {
+			expect(() => waitUntil(Promise.resolve())).not.toThrow();
+		});
 	});
 
 	it("throws a TypeError when called without a promise", () => {
-		const defer = waitUntil();
 		// @ts-expect-error — exercising the runtime guard for untyped JS callers.
-		expect(() => defer(42)).toThrow(TypeError);
+		expect(() => waitUntil(42)).toThrow(TypeError);
 	});
 });

--- a/packages/functions/src/lib/wait-until.ts
+++ b/packages/functions/src/lib/wait-until.ts
@@ -8,14 +8,67 @@
 export type WaitUntil = (promise: Promise<unknown>) => void;
 
 /**
+ * Well-known `globalThis` key under which the Neon Functions runtime publishes the
+ * per-invocation context. Mirrors the convention used by Vercel
+ * (`Symbol.for("@vercel/request-context")`).
+ *
+ * The runtime assigns `globalThis[NEON_FUNCTIONS_CONTEXT]` before invoking the
+ * handler. When it is absent (local dev, tests, non-Neon hosts), `waitUntil`
+ * degrades to a no-op.
+ */
+export const NEON_FUNCTIONS_CONTEXT: unique symbol = Symbol.for(
+	"@neondatabase/functions/request-context",
+);
+
+/**
+ * The slice of the runtime context this package reads. The runtime may attach
+ * additional fields; only `waitUntil` is consumed here.
+ */
+type NeonFunctionsContext = {
+	waitUntil?: WaitUntil;
+};
+
+type GlobalWithContext = typeof globalThis & {
+	[NEON_FUNCTIONS_CONTEXT]?: NeonFunctionsContext;
+};
+
+/**
+ * Reads the current invocation context off `globalThis`, falling back to an empty
+ * context when the runtime has not provided one.
+ */
+function getContext(): NeonFunctionsContext {
+	const globalWithContext: GlobalWithContext = globalThis;
+	return globalWithContext[NEON_FUNCTIONS_CONTEXT] ?? {};
+}
+
+function isPromise(value: unknown): value is Promise<unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"then" in value &&
+		typeof value.then === "function"
+	);
+}
+
+/**
  * Returns a `waitUntil` function for the current invocation.
  *
- * NOT IMPLEMENTED YET: this is a no-op placeholder. The returned function accepts a
- * promise and ignores it. Once the Neon Functions runtime ships, this will register the
- * promise with the host so the invocation stays alive until it settles.
+ * The returned function forwards the promise to the runtime-provided
+ * `globalThis[NEON_FUNCTIONS_CONTEXT].waitUntil`, keeping the invocation alive until
+ * the promise settles. When the runtime has not published a context (or it exposes
+ * no `waitUntil`), the returned function is a no-op.
+ *
+ * The context is resolved lazily, when the returned function is called, so it stays
+ * correct even if `waitUntil()` is invoked at module scope before the runtime has
+ * wired up the request.
  */
 export function waitUntil(): WaitUntil {
-	return (_promise: Promise<unknown>): void => {
-		// no-op: the runtime integration is not implemented yet.
+	return (promise: Promise<unknown>): void => {
+		if (!isPromise(promise)) {
+			throw new TypeError(
+				`waitUntil can only be called with a Promise, got ${typeof promise}`,
+			);
+		}
+		getContext().waitUntil?.(promise);
 	};
 }

--- a/packages/functions/src/lib/wait-until.ts
+++ b/packages/functions/src/lib/wait-until.ts
@@ -2,43 +2,69 @@
  * `waitUntil` extends the lifetime of a Neon Function invocation so background work
  * (logging, cache writes, analytics, …) can finish after the response has been sent.
  *
- * It mirrors the platform primitive exposed by Cloudflare Workers / Vercel
- * (`ctx.waitUntil(promise)`).
+ * The public API mirrors Vercel's `@vercel/functions`: import `waitUntil` and call it
+ * directly with a promise (`waitUntil(promise)`). Under the hood the per-invocation
+ * context is carried by an `AsyncLocalStorage`, so concurrent invocations sharing the
+ * same isolate never clobber each other's context.
  */
-export type WaitUntil = (promise: Promise<unknown>) => void;
+import { AsyncLocalStorage } from "node:async_hooks";
 
-/**
- * Well-known `globalThis` key under which the Neon Functions runtime publishes the
- * per-invocation context. Mirrors the convention used by Vercel
- * (`Symbol.for("@vercel/request-context")`).
- *
- * The runtime assigns `globalThis[NEON_FUNCTIONS_CONTEXT]` before invoking the
- * handler. When it is absent (local dev, tests, non-Neon hosts), `waitUntil`
- * degrades to a no-op.
- */
-export const NEON_FUNCTIONS_CONTEXT: unique symbol = Symbol.for(
-	"@neondatabase/functions/request-context",
-);
+export type WaitUntil = (promise: Promise<unknown>) => void;
 
 /**
  * The slice of the runtime context this package reads. The runtime may attach
  * additional fields; only `waitUntil` is consumed here.
  */
-type NeonFunctionsContext = {
+export type NeonFunctionsContext = {
 	waitUntil?: WaitUntil;
 };
 
-type GlobalWithContext = typeof globalThis & {
-	[NEON_FUNCTIONS_CONTEXT]?: NeonFunctionsContext;
+/**
+ * The accessor published on `globalThis` so consumers can read the current
+ * invocation context without importing the runtime. Mirrors the provider shape
+ * used by Vercel (`Symbol.for("@vercel/request-context")`) and Next.js
+ * (`Symbol.for("@next/request-context")`): a stable object exposing `get()`.
+ */
+type RequestContextProvider = {
+	get(): NeonFunctionsContext | undefined;
 };
 
 /**
- * Reads the current invocation context off `globalThis`, falling back to an empty
- * context when the runtime has not provided one.
+ * Well-known `globalThis` symbol under which the per-invocation context provider is
+ * published. Mirrors the convention used by Vercel and Next.js.
+ */
+export const NEON_FUNCTIONS_CONTEXT: unique symbol = Symbol.for(
+	"@neondatabase/functions/request-context",
+);
+
+type GlobalWithContext = typeof globalThis & {
+	[NEON_FUNCTIONS_CONTEXT]?: RequestContextProvider;
+};
+
+/**
+ * Holds the per-invocation context. Each `runWithRequestContext(...)` call binds a
+ * fresh context for the duration of its callback (and any async work it spawns), so
+ * `waitUntil` always resolves to the right invocation even under concurrency.
+ */
+const requestContextStore = new AsyncLocalStorage<NeonFunctionsContext>();
+
+const globalWithContext: GlobalWithContext = globalThis;
+
+/**
+ * Publish a stable provider whose `get()` reads the current store. Installed once;
+ * if another copy of this module (or the host runtime) has already published a
+ * provider, we leave it in place rather than clobber it.
+ */
+globalWithContext[NEON_FUNCTIONS_CONTEXT] ??= {
+	get: () => requestContextStore.getStore(),
+};
+
+/**
+ * Reads the current invocation context off the `globalThis` provider, falling back to
+ * an empty context when no provider is published or no invocation is in scope.
  */
 function getContext(): NeonFunctionsContext {
-	const globalWithContext: GlobalWithContext = globalThis;
-	return globalWithContext[NEON_FUNCTIONS_CONTEXT] ?? {};
+	return globalWithContext[NEON_FUNCTIONS_CONTEXT]?.get?.() ?? {};
 }
 
 function isPromise(value: unknown): value is Promise<unknown> {
@@ -51,24 +77,31 @@ function isPromise(value: unknown): value is Promise<unknown> {
 }
 
 /**
- * Returns a `waitUntil` function for the current invocation.
+ * Defers async work past the response by forwarding the promise to the Neon Functions
+ * runtime, which keeps the invocation alive until the promise settles.
  *
- * The returned function forwards the promise to the runtime-provided
- * `globalThis[NEON_FUNCTIONS_CONTEXT].waitUntil`, keeping the invocation alive until
- * the promise settles. When the runtime has not published a context (or it exposes
- * no `waitUntil`), the returned function is a no-op.
- *
- * The context is resolved lazily, when the returned function is called, so it stays
- * correct even if `waitUntil()` is invoked at module scope before the runtime has
- * wired up the request.
+ * The context is resolved at call time from the enclosing invocation, so this stays
+ * correct under concurrency. When no invocation context is in scope (local dev, tests,
+ * non-Neon hosts), this is a no-op: the promise is accepted and ignored.
  */
-export function waitUntil(): WaitUntil {
-	return (promise: Promise<unknown>): void => {
-		if (!isPromise(promise)) {
-			throw new TypeError(
-				`waitUntil can only be called with a Promise, got ${typeof promise}`,
-			);
-		}
-		getContext().waitUntil?.(promise);
-	};
+export function waitUntil(promise: Promise<unknown>): void {
+	if (!isPromise(promise)) {
+		throw new TypeError(
+			`waitUntil can only be called with a Promise, got ${typeof promise}`,
+		);
+	}
+	getContext().waitUntil?.(promise);
+}
+
+/**
+ * Runtime entry point: binds `context` as the current invocation context for the
+ * duration of `fn` (and any async work it spawns), so calls to `waitUntil` inside it
+ * forward to `context.waitUntil`. Intended for the Neon Functions runtime to wrap each
+ * invocation; application code should not need this.
+ */
+export function runWithRequestContext<T>(
+	context: NeonFunctionsContext,
+	fn: () => T,
+): T {
+	return requestContextStore.run(context, fn);
 }

--- a/packages/functions/src/v1.ts
+++ b/packages/functions/src/v1.ts
@@ -1,9 +1,12 @@
 /**
  * `@neondatabase/functions/v1` — runtime helpers for Neon Functions.
  *
- * - `waitUntil()` — returns a function that defers async work past the response.
- *   Currently a no-op placeholder; the runtime integration is not implemented yet.
+ * - `waitUntil()` — returns a function that defers async work past the response by
+ *   forwarding the promise to the runtime-provided context. No-op when the runtime
+ *   has not published a context (local dev, tests, non-Neon hosts).
+ * - `NEON_FUNCTIONS_CONTEXT` — the `globalThis` symbol under which the runtime
+ *   publishes that context.
  */
 
 export type { WaitUntil } from "./lib/wait-until.js";
-export { waitUntil } from "./lib/wait-until.js";
+export { NEON_FUNCTIONS_CONTEXT, waitUntil } from "./lib/wait-until.js";

--- a/packages/functions/src/v1.ts
+++ b/packages/functions/src/v1.ts
@@ -1,12 +1,19 @@
 /**
  * `@neondatabase/functions/v1` — runtime helpers for Neon Functions.
  *
- * - `waitUntil()` — returns a function that defers async work past the response by
- *   forwarding the promise to the runtime-provided context. No-op when the runtime
- *   has not published a context (local dev, tests, non-Neon hosts).
- * - `NEON_FUNCTIONS_CONTEXT` — the `globalThis` symbol under which the runtime
- *   publishes that context.
+ * - `waitUntil(promise)` — defers async work past the response by forwarding the
+ *   promise to the current invocation context. No-op when no context is in scope
+ *   (local dev, tests, non-Neon hosts). Mirrors `@vercel/functions`.
+ * - `runWithRequestContext(context, fn)` — runtime entry point that binds a
+ *   per-invocation context for the duration of `fn`. Used by the Neon Functions
+ *   runtime; application code should not need it.
+ * - `NEON_FUNCTIONS_CONTEXT` — the `globalThis` symbol under which the context
+ *   provider is published.
  */
 
-export type { WaitUntil } from "./lib/wait-until.js";
-export { NEON_FUNCTIONS_CONTEXT, waitUntil } from "./lib/wait-until.js";
+export type { NeonFunctionsContext, WaitUntil } from "./lib/wait-until.js";
+export {
+	NEON_FUNCTIONS_CONTEXT,
+	runWithRequestContext,
+	waitUntil,
+} from "./lib/wait-until.js";


### PR DESCRIPTION
## Summary

Implements `waitUntil()` in `@neondatabase/functions` (replaces the no-op placeholder).

- The function returned by `waitUntil()` now forwards the promise to the Neon Functions runtime via its per-invocation context: `globalThis[NEON_FUNCTIONS_CONTEXT]`, where `NEON_FUNCTIONS_CONTEXT = Symbol.for("@neondatabase/functions/request-context")` (mirrors Vercel's `@vercel/request-context` convention).
- Matches Vercel's `waitUntil` spec: a non-`Promise` argument throws `TypeError`.
- No-ops when the runtime hasn't published a context (local dev, tests, non-Neon hosts), so the same handler code runs everywhere.
- Context is resolved lazily (at defer time), so it stays correct even if `waitUntil()` is called at module scope.
- Exports `NEON_FUNCTIONS_CONTEXT` as the documented runtime contract; README updated; changeset added (minor).

## Open question for review

The global context **key is not yet confirmed against the runtime host** — please verify `Symbol.for("@neondatabase/functions/request-context")` (and the flat `.waitUntil` shape vs. a Vercel-style `.get()` accessor) matches what the Functions runtime actually publishes. If it doesn't, `waitUntil` will silently no-op in production.

## Test plan

- [x] `pnpm tsc` (typecheck)
- [x] `pnpm test:ci` (5 tests, real `globalThis` wiring, no mocks)
- [x] `pnpm build` (tsdown)