### PR TITLE
feat(env): inject NEON_BRANCH (branch name)

### DIFF
--- a/.changeset/env-neon-branch.md
+++ b/.changeset/env-neon-branch.md
@@ -1,0 +1,12 @@
+---
+"@neondatabase/env": minor
+---
+
+Inject `NEON_BRANCH` (the branch name) alongside the other Neon env vars.
+
+The Neon Functions runtime injects `NEON_BRANCH` into every branch (including the default)
+by default, so `fetchEnv` now surfaces the branch on a new optional `branch` namespace and
+`toEntries` emits `NEON_BRANCH`. That means `neon dev` / `neon-env run` / `neon env pull`
+write `NEON_BRANCH` into local dev too, mirroring the deployed runtime. `parseEnv` reads it
+back when present (optional — a missing `NEON_BRANCH` is not an error, so existing
+deployments and platform integrations keep working). The value is the branch **name** for now.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -33,7 +33,7 @@ const fnEnv = parseEnv(config, "hello");
 fnEnv.function.resendApiKey; // typed from hello's declared env keys
 ```
 
-Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `auth` and `dataApi` are included (and statically typed) when the evaluated branch policy enables them.
+Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `branch` (the branch name, surfaced as `NEON_BRANCH`) is always present on a `fetchEnv` result and present on a `parseEnv` result when `NEON_BRANCH` was injected; `auth` and `dataApi` are included (and statically typed) when the evaluated branch policy enables them.
 
 | Function | Description |
 | --- | --- |
@@ -52,7 +52,7 @@ neon-env run -- npm run dev
 neon-env run -- pnpm dev
 ```
 
-`run` loads `neon.ts`, resolves the branch (via `--branch`, `NEON_BRANCH_ID`, or `.neon[/project.json]`), fetches the connection strings from Neon, and spawns the command with `DATABASE_URL` / `DATABASE_URL_UNPOOLED` (and `NEON_AUTH_BASE_URL` / `NEON_AUTH_JWKS_URL` / `NEON_DATA_API_URL` when the policy enables them) injected on top of the inherited environment. Stdio is inherited so interactive dev servers keep working, and the parent exits with the child's exit code.
+`run` loads `neon.ts`, resolves the branch (via `--branch`, `NEON_BRANCH_ID`, or `.neon[/project.json]`), fetches the connection strings from Neon, and spawns the command with `NEON_BRANCH` / `DATABASE_URL` / `DATABASE_URL_UNPOOLED` (and `NEON_AUTH_BASE_URL` / `NEON_AUTH_JWKS_URL` / `NEON_DATA_API_URL` when the policy enables them) injected on top of the inherited environment. Stdio is inherited so interactive dev servers keep working, and the parent exits with the child's exit code.
 
 ### `export` — print env to stdout
 
@@ -76,6 +76,7 @@ Flags (both commands): `--config <path>`, `--project-id`, `--branch`, `--api-key
 
 | Key | From |
 | --- | --- |
+| `NEON_BRANCH` | the resolved branch **name** — mirrors what the Neon Functions runtime injects on every branch, so local dev matches the deployed runtime |
 | `DATABASE_URL` | pooled connection string |
 | `DATABASE_URL_UNPOOLED` | direct connection string |
 | `NEON_AUTH_BASE_URL` | Neon Auth integration (when `auth` is enabled) |

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -67,6 +67,18 @@ describe("fetchEnv", () => {
 		expect(env.postgres.databaseUrl).toContain("-pooler");
 	});
 
+	test("surfaces the branch name as NEON_BRANCH", async () => {
+		const { api, projectId } = seededFake();
+		const env = await fetchEnv(defineConfig({}), {
+			api,
+			projectId,
+			branchId: "br-main",
+		});
+		// `NEON_BRANCH` mirrors the Functions runtime; uses the branch name (not the id).
+		expect(env.branch?.name).toBe("main");
+		expect(toEntries(env).NEON_BRANCH).toBe("main");
+	});
+
 	test("requires auth integration when policy enables auth", async () => {
 		const { api, projectId } = seededFake();
 		const config = defineConfig({ auth: true });
@@ -183,6 +195,22 @@ describe("parseEnv", () => {
 		vi.stubEnv("DATABASE_URL", "postgres://pooled");
 		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
 		const env = parseEnv(defineConfig({}));
+		expect(env.postgres.databaseUrl).toBe("postgres://pooled");
+	});
+
+	test("reads NEON_BRANCH when injected", () => {
+		vi.stubEnv("DATABASE_URL", "postgres://pooled");
+		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+		vi.stubEnv("NEON_BRANCH", "preview/foo");
+		const env = parseEnv(defineConfig({}));
+		expect(env.branch?.name).toBe("preview/foo");
+	});
+
+	test("omits the branch namespace when NEON_BRANCH is absent (no throw)", () => {
+		vi.stubEnv("DATABASE_URL", "postgres://pooled");
+		vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+		const env = parseEnv(defineConfig({}));
+		expect(env.branch).toBeUndefined();
 		expect(env.postgres.databaseUrl).toBe("postgres://pooled");
 	});
 

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -45,6 +45,14 @@ const NEON_MANAGED_AUTH_ROLES: ReadonlySet<string> = new Set([
 ]);
 
 export const NEON_ENV_VAR_KEYS = {
+	/**
+	 * Branch identity. `NEON_BRANCH` carries the branch **name** and is injected into the
+	 * Neon Functions runtime on every branch (including the default) by default. `env pull` /
+	 * `neon dev` / `neon-env run` emit it too so local dev mirrors the deployed runtime.
+	 */
+	branch: {
+		name: "NEON_BRANCH",
+	},
 	postgres: {
 		databaseUrl: "DATABASE_URL",
 		databaseUrlUnpooled: "DATABASE_URL_UNPOOLED",
@@ -89,6 +97,16 @@ export const NEON_ENV_VAR_KEYS = {
 
 /** OpenAI-dialect route prefix on the branch AI Gateway host. */
 const AI_GATEWAY_OPENAI_PATH = "/ai-gateway/openai/v1";
+
+/**
+ * Branch identity for the resolved branch. Always present on a `fetchEnv` result (the branch
+ * name is always known); on a `parseEnv` result it's present only when `NEON_BRANCH` was
+ * injected into `process.env` (the Functions runtime injects it by default, as do `neon dev` /
+ * `neon-env run` / `env pull`). `name` is the branch **name** (e.g. `main`, `preview/foo`).
+ */
+export interface NeonBranchEnv {
+	name: string;
+}
 
 /** Per-namespace inner shapes. Exposed so consumers can name the parts independently. */
 export interface NeonPostgresEnv {
@@ -239,6 +257,11 @@ type AiGatewayOn<C extends Config> = [NonNullable<C["preview"]>] extends [never]
  */
 export type NeonEnv<C extends Config = Config> = {
 	postgres: NeonPostgresEnv;
+	/**
+	 * Branch identity (`NEON_BRANCH`). Optional because `parseEnv` only surfaces it when the
+	 * var was injected; `fetchEnv` always populates it.
+	 */
+	branch?: NeonBranchEnv;
 } & (ServiceOn<NonNullable<C["auth"]>> extends true
 	? { auth: NeonAuthEnv }
 	: NoNamespace) &
@@ -427,6 +450,10 @@ export async function fetchEnv<const C extends Config>(
 			databaseUrl: pooled.uri,
 			databaseUrlUnpooled: unpooled.uri,
 		},
+		// Branch identity, mirroring what the Functions runtime injects on every branch.
+		// Surfaced as `NEON_BRANCH` so local dev (`neon dev` / `neon-env run` / `env pull`)
+		// matches the deployed runtime. Uses the branch name.
+		branch: { name: branch.name } satisfies NeonBranchEnv,
 	};
 
 	if (wantsAuth) {
@@ -945,6 +972,15 @@ export function parseEnv(config: Config, scope?: string): unknown {
 		for (const issue of pg.error.issues) issues.push(issue.message);
 	}
 
+	// Branch identity is optional: the Functions runtime injects `NEON_BRANCH` on every
+	// branch by default and `neon dev` / `neon-env run` / `env pull` emit it too, but older
+	// runtimes and platform integrations may not, so a missing value is not an error — we
+	// just omit the namespace rather than failing the whole parse.
+	const branchName = source[NEON_ENV_VAR_KEYS.branch.name];
+	if (branchName !== undefined && branchName !== "") {
+		result.branch = { name: branchName } satisfies NeonBranchEnv;
+	}
+
 	if (isServiceEnabledInput(config.auth)) {
 		const auth = authEnvSchema.safeParse({
 			NEON_AUTH_BASE_URL: source.NEON_AUTH_BASE_URL,
@@ -1078,6 +1114,9 @@ export function toEntries(env: NeonEnv<Config>): Record<string, string> {
 		[NEON_ENV_VAR_KEYS.postgres.databaseUrlUnpooled]:
 			env.postgres.databaseUrlUnpooled,
 	};
+	if (env.branch) {
+		out[NEON_ENV_VAR_KEYS.branch.name] = env.branch.name;
+	}
 	const withAuth = env as { auth?: NeonAuthEnv };
 	if (withAuth.auth) {
 		out[NEON_ENV_VAR_KEYS.auth.baseUrl] = withAuth.auth.baseUrl;

--- a/packages/env/src/v1.ts
+++ b/packages/env/src/v1.ts
@@ -16,6 +16,7 @@ export type {
 	FunctionSlugOf,
 	NeonAiGatewayEnv,
 	NeonAuthEnv,
+	NeonBranchEnv,
 	NeonDataApiEnv,
 	NeonEnv,
 	NeonFunctionEnv,


### PR DESCRIPTION
## Summary

The Neon Functions runtime now injects `NEON_BRANCH` into every branch (including the default) by default. This makes `@neondatabase/env` emit the same var locally so `neon dev` / `neon-env run` / `neon env pull` mirror the deployed runtime.

- Add an optional `branch` namespace to `NeonEnv` (`NeonBranchEnv { name }`); `fetchEnv` always populates it from the resolved branch.
- `toEntries` emits `NEON_BRANCH` (the branch **name** — see note below), so it flows into `neon dev`, `neon-env run`, and `neonctl env pull` (which derives its var list from `NEON_ENV_VAR_KEYS`, so it picks this up automatically once it bumps the dep).
- `parseEnv` reads `NEON_BRANCH` back **optionally** — a missing value is not an error, so existing function deployments and platform integrations (Vercel, etc.) keep working.
- Docs (README) + changeset (minor).

### Note on the value
Per request, `NEON_BRANCH` is set to the branch **name** for now (e.g. `main`, `preview/foo`). If the runtime actually injects the branch **id**, we should switch `fetchEnv` to `branch.id` for parity — easy one-line change.

## Test plan

- [x] `pnpm --filter @neondatabase/env test:ci` (60 passed)
- [x] `pnpm --filter @neondatabase/env tsc` + `build`
- [x] Added tests: `fetchEnv` surfaces `NEON_BRANCH`, `toEntries` emits it, `parseEnv` reads it when present / omits it (no throw) when absent