### PR TITLE
chore(config-runtime): stop emitting source maps for deployed bundles

### DIFF
--- a/.changeset/drop-function-sourcemap.md
+++ b/.changeset/drop-function-sourcemap.md
@@ -1,0 +1,7 @@
+---
+"@neondatabase/config-runtime": patch
+---
+
+Stop generating a source map for deployed function bundles.
+
+`buildFunctionBundle` ran esbuild with `sourcemap: true`, shipping an `index.mjs.map` in every deploy archive. The Functions runtime does not run Node with source-map support, so the uploaded map is never consumed (a thrown error's stack still points into the minified `index.mjs`). It only inflated the archive, so it is no longer emitted.

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -25,7 +25,7 @@ function fn(source: string): ResolvedFunctionConfig {
 }
 
 describe("buildFunctionBundle", () => {
-	test("bundles a handler with esbuild and returns a ZIP containing index.mjs + sourcemap", async () => {
+	test("bundles a handler with esbuild and returns a ZIP containing index.mjs (no sourcemap)", async () => {
 		const helper = join(dir, "shared.ts");
 		writeFileSync(helper, "export const greeting = 'hello from neon';\n");
 		const source = join(dir, "hello-world.ts");
@@ -44,11 +44,15 @@ describe("buildFunctionBundle", () => {
 		const files = unzipSync(bundle);
 		const names = Object.keys(files).sort();
 		expect(names).toContain("index.mjs");
-		expect(names).toContain("index.mjs.map");
+		// No source map is generated — the Functions runtime never consumes it, so shipping
+		// one only inflated the archive.
+		expect(names).not.toContain("index.mjs.map");
 
 		// The bundled output should have inlined the imported constant.
 		const js = new TextDecoder().decode(files["index.mjs"]);
 		expect(js).toContain("hello from neon");
+		// And it must not carry a dangling source-map link to a file we no longer ship.
+		expect(js).not.toContain("sourceMappingURL");
 		// The ESM↔CJS interop banner is prepended so bundled CommonJS deps can `require(...)`.
 		expect(js).toContain("createRequire");
 	});

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -41,10 +41,14 @@ const ESM_CJS_INTEROP_BANNER =
  * that nothing in this package's static graph names esbuild until a deploy actually runs —
  * a second layer of protection on top of the package split.
  *
- * Mirrors: `esbuild <source> --bundle --outfile=index.mjs --sourcemap --minify --format=esm
+ * Mirrors: `esbuild <source> --bundle --outfile=index.mjs --minify --format=esm
  * --platform=node --banner:js=<createRequire shim>`, then zips the emitted files into the
  * archive the Functions deploy endpoint expects. Dependencies are bundled into the entry
  * (Node built-ins stay external); see {@link ESM_CJS_INTEROP_BANNER} for why the banner.
+ *
+ * No source map is emitted: the Functions runtime does not run Node with source-map support,
+ * so an uploaded `index.mjs.map` is never consumed (a thrown error's stack still points into
+ * the minified bundle). Generating it only inflated the deployed archive, so it is omitted.
  */
 export async function buildFunctionBundle(
 	fn: ResolvedFunctionConfig,
@@ -57,12 +61,11 @@ export async function buildFunctionBundle(
 			entryPoints: [fn.source],
 			bundle: true,
 			write: false,
-			// Emit `index.mjs` / `index.mjs.map`: the Functions runtime imports the archive's
-			// entry by the conventional `index.{js,mjs}` name, and `.mjs` makes Node load the
-			// ESM output directly. (With `write: false` and no outfile, esbuild would label the
-			// buffer `<stdout>`.)
+			// Emit `index.mjs`: the Functions runtime imports the archive's entry by the
+			// conventional `index.{js,mjs}` name, and `.mjs` makes Node load the ESM output
+			// directly. (With `write: false` and no outfile, esbuild would label the buffer
+			// `<stdout>`.) No `sourcemap` — see the doc comment above for why.
 			outfile: "index.mjs",
-			sourcemap: true,
 			minify: true,
 			format: "esm",
 			platform: "node",
@@ -88,7 +91,7 @@ export async function buildFunctionBundle(
 	// `write: false` guarantees `outputFiles`, but the type is optional — guard for safety.
 	for (const file of result.outputFiles ?? []) {
 		// esbuild returns absolute output paths; archive them under their basename
-		// (`index.mjs`, `index.mjs.map`) so the bundle layout is stable regardless of cwd.
+		// (`index.mjs`) so the bundle layout is stable regardless of cwd.
 		entries[basename(file.path)] = file.contents;
 	}
 


### PR DESCRIPTION
## Summary

`buildFunctionBundle` runs esbuild with `sourcemap: true`, shipping an `index.mjs.map` in every deploy archive. The Neon Functions runtime does **not** run Node with source-map support, so the uploaded map is never consumed — a thrown error's stack still points into the minified `index.mjs`. It only inflates the uploaded/stored archive (and cold-start payload) with no debugging benefit today.

- Removed `sourcemap: true` from `buildFunctionBundle`.
- Updated comments and the `function-bundle.test.ts` expectations (now asserts no `sourceMappingURL` link and no `index.mjs.map`).
- Added a changeset (`@neondatabase/config-runtime`: patch).

If/when the runtime gains source-map support, re-enabling is a one-line change (and we'd likely add `sourcesContent: false` to keep the map small).

## Test plan

- [x] `vitest run src/lib/function-bundle.test.ts` (2 passed)
- [ ] Deploy a function and confirm the archive contains only `index.mjs`