### PR TITLE
feat(env): add optional key filter to parseEnv

### DIFF
--- a/.changeset/env-parse-key-filter.md
+++ b/.changeset/env-parse-key-filter.md
@@ -1,0 +1,14 @@
+---
+"@neondatabase/env": minor
+---
+
+Add an optional key filter to `parseEnv` for requiring + returning only a subset of env vars.
+
+`parseEnv(config, keys)` now accepts an array of OS-level env-var keys (e.g.
+`["DATABASE_URL", "NEON_AUTH_BASE_URL"]`) as an alternative to the function-slug scope. In
+this mode only the selected vars are enforced and returned, projected into a **narrowed**
+`NeonEnv` shape — so a Next.js app that reads `DATABASE_URL` but not `DATABASE_URL_UNPOOLED`
+no longer throws over vars it never uses. The keys are typesafe against the policy
+(`SelectableEnvKey<Config>`): selecting a var from a namespace the policy doesn't enable is a
+compile error, and the result type drops both unselected namespaces and unselected properties
+within a kept namespace.

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -14,7 +14,7 @@ npm install @neondatabase/env
 
 The library functions are **filesystem- and env-agnostic**: `fetchEnv` requires an explicit `projectId` + `branchId`. (The `neon-env` CLI does the `.neon`/`NEON_*` resolution and passes these in.)
 
-> `parseEnv` takes **no branch name**: the secret set is static (top-level `config.auth` / `config.dataApi`), so it reads those toggles directly without evaluating the per-branch closure. Its optional second argument is a **scope** — omit it for external (app/build) env, or pass a **function slug** when running inside that deployed function to also get a typed `function` namespace of its declared env keys.
+> `parseEnv` takes **no branch name**: the secret set is static (top-level `config.auth` / `config.dataApi`), so it reads those toggles directly without evaluating the per-branch closure. Its optional second argument is a **scope** _or_ a **key filter** — omit it for the full external (app/build) env, pass a **function slug** when running inside that deployed function (adds a typed `function` namespace of its declared env keys), or pass an **array of OS-level env-var keys** to require + return only that subset.
 
 ```ts
 import config from "../neon";
@@ -31,6 +31,12 @@ const env2 = parseEnv(config);
 // Inside a deployed function, pass its slug for the typed `function` namespace:
 const fnEnv = parseEnv(config, "hello");
 fnEnv.function.resendApiKey; // typed from hello's declared env keys
+
+// Key filter — only enforce + return the vars you actually use (e.g. a Next.js app that
+// reads the pooled URL but not the unpooled one). The keys autocomplete from the policy, so
+// you can only select vars the policy enables, and the result is narrowed to match:
+const { postgres } = parseEnv(config, ["DATABASE_URL"]);
+postgres.databaseUrl; // string — `databaseUrlUnpooled` is absent, and never required
 ```
 
 Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `auth` and `dataApi` are included (and statically typed) when the evaluated branch policy enables them.
@@ -38,7 +44,7 @@ Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `
 | Function | Description |
 | --- | --- |
 | `fetchEnv(config, { projectId, branchId, ... })` | Async. Calls the Neon API for the given project + branch and returns live connection strings (and Auth/Data API values when enabled). `projectId` and `branchId` are required (`branchId` is a `br-…` id). |
-| `parseEnv(config)` / `parseEnv(config, slug)` | Sync. Reads/validates the Neon env vars already present in `process.env` against the static policy toggles. With a function `slug`, also returns a typed `function` namespace of that function's declared env keys. Throws `PlatformError(EnvNotInjected)` listing missing vars when the env isn't populated. |
+| `parseEnv(config)` / `parseEnv(config, slug)` / `parseEnv(config, keys)` | Sync. Reads/validates the Neon env vars already present in `process.env` against the static policy toggles. With a function `slug`, also returns a typed `function` namespace of that function's declared env keys. With a `keys` array (e.g. `["DATABASE_URL"]`), only those vars are required and returned, as a narrowed namespaced shape — the keys are typesafe against the policy. Throws `PlatformError(EnvNotInjected)` listing missing vars when the env isn't populated. |
 | `toEntries(env)` | Project a resolved `NeonEnv` into `{ KEY: value }` pairs for cross-process transport (named after the web `.entries()` convention; returns a `Record`). |
 
 ## CLI

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -47,6 +47,7 @@
 		"prepare": "npm run build",
 		"test": "vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
+		"test:types": "vitest run --typecheck.enabled --typecheck.only",
 		"test:e2e": "vitest run --config vitest.e2e.config.ts",
 		"tsc": "tsc"
 	},

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -1,0 +1,108 @@
+import { defineConfig } from "@neondatabase/config/v1";
+import { describe, expectTypeOf, test } from "vitest";
+import { type NeonEnv, parseEnv, type SelectableEnvKey } from "./env.js";
+
+// Type-level tests for `parseEnv`. Run via `pnpm --filter @neondatabase/env test:types`
+// (Vitest typecheck mode) and additionally enforced by `tsc --noEmit` during the build,
+// since this file lives under `src`.
+
+describe("parseEnv key filter (types)", () => {
+	test("narrows a single postgres key to just that property", () => {
+		const env = parseEnv(defineConfig({}), ["DATABASE_URL"]);
+		expectTypeOf(env).toEqualTypeOf<{
+			postgres: { databaseUrl: string };
+		}>();
+	});
+
+	test("keeps both postgres keys when both are selected", () => {
+		const env = parseEnv(defineConfig({}), [
+			"DATABASE_URL",
+			"DATABASE_URL_UNPOOLED",
+		]);
+		expectTypeOf(env).toEqualTypeOf<{
+			postgres: { databaseUrl: string; databaseUrlUnpooled: string };
+		}>();
+	});
+
+	test("spans multiple namespaces, partial within each", () => {
+		const env = parseEnv(defineConfig({ auth: true }), [
+			"DATABASE_URL",
+			"NEON_AUTH_BASE_URL",
+		]);
+		expectTypeOf(env).toEqualTypeOf<{
+			postgres: { databaseUrl: string };
+			auth: { baseUrl: string };
+		}>();
+	});
+
+	test("an empty selection yields an empty object", () => {
+		const env = parseEnv(defineConfig({}), []);
+		expectTypeOf(env).toEqualTypeOf<Record<never, never>>();
+	});
+
+	test("storage keys are selectable once the policy declares buckets", () => {
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		const env = parseEnv(config, ["AWS_REGION"]);
+		expectTypeOf(env).toEqualTypeOf<{ storage: { region: string } }>();
+	});
+
+	test("SelectableEnvKey reflects exactly the policy's namespaces", () => {
+		const config = defineConfig({});
+		expectTypeOf<SelectableEnvKey<typeof config>>().toEqualTypeOf<
+			"DATABASE_URL" | "DATABASE_URL_UNPOOLED"
+		>();
+	});
+});
+
+describe("parseEnv key filter (negative types)", () => {
+	test("rejects a key whose namespace the policy does not enable", () => {
+		// auth is off → NEON_AUTH_BASE_URL is not a selectable key.
+		// @ts-expect-error not selectable without `auth`
+		parseEnv(defineConfig({}), ["NEON_AUTH_BASE_URL"]);
+	});
+
+	test("rejects an unknown env var key", () => {
+		// @ts-expect-error not a real Neon env var
+		parseEnv(defineConfig({}), ["NEON_BRANCH"]);
+	});
+
+	test("rejects a storage key without a buckets policy", () => {
+		// @ts-expect-error storage is not enabled
+		parseEnv(defineConfig({}), ["AWS_ACCESS_KEY_ID"]);
+	});
+
+	test("a dropped namespace is not present on the result", () => {
+		const env = parseEnv(defineConfig({}), ["DATABASE_URL"]);
+		// @ts-expect-error filtered result has no `auth` namespace
+		env.auth;
+		// @ts-expect-error the unselected key is gone from the kept namespace
+		env.postgres.databaseUrlUnpooled;
+	});
+});
+
+describe("parseEnv existing overloads still type", () => {
+	test("no scope returns the full NeonEnv", () => {
+		const config = defineConfig({ auth: true });
+		const env = parseEnv(config);
+		expectTypeOf(env).toEqualTypeOf<NeonEnv<typeof config>>();
+	});
+
+	test("a function slug adds the typed function namespace", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					hello: {
+						name: "Hello",
+						source: "./hello.ts",
+						env: { resendApiKey: "" },
+					},
+				},
+			},
+		});
+		const env = parseEnv(config, "hello");
+		expectTypeOf(env.function).toEqualTypeOf<{ resendApiKey: string }>();
+		expectTypeOf(env.function.resendApiKey).toEqualTypeOf<string>();
+	});
+});

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -376,6 +376,66 @@ describe("parseEnv", () => {
 		expect(env.dataApi.url).toBe("https://data.example.com");
 	});
 
+	describe("key filter", () => {
+		test("narrows a namespace to only the selected key", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+			const env = parseEnv(defineConfig({}), ["DATABASE_URL"]);
+			expect(env.postgres.databaseUrl).toBe("postgres://pooled");
+			// Only the selected key survives — the unpooled URL is filtered out.
+			expect("databaseUrlUnpooled" in env.postgres).toBe(false);
+		});
+
+		test("returns selected keys across multiple namespaces", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			vi.stubEnv("DATABASE_URL_UNPOOLED", "postgres://direct");
+			vi.stubEnv("NEON_AUTH_BASE_URL", "https://auth.example.com");
+			vi.stubEnv("NEON_AUTH_JWKS_URL", "https://auth.example.com/jwks");
+			const env = parseEnv(defineConfig({ auth: true }), [
+				"DATABASE_URL",
+				"NEON_AUTH_BASE_URL",
+			]);
+			expect(env.postgres.databaseUrl).toBe("postgres://pooled");
+			expect(env.auth.baseUrl).toBe("https://auth.example.com");
+			// Unselected keys are absent from their kept namespaces.
+			expect("jwksUrl" in env.auth).toBe(false);
+		});
+
+		test("does not enforce vars the policy enables but the filter omits", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			// auth is enabled in the policy, but NEON_AUTH_* is unset — filtering to just
+			// DATABASE_URL must not throw over the auth vars we never asked for.
+			const env = parseEnv(defineConfig({ auth: true }), [
+				"DATABASE_URL",
+			]);
+			expect(env.postgres.databaseUrl).toBe("postgres://pooled");
+			expect("auth" in env).toBe(false);
+		});
+
+		test("throws EnvNotInjected listing only the missing selected keys", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			// DATABASE_URL_UNPOOLED is unset; selecting it must throw and name it.
+			expect(() =>
+				parseEnv(defineConfig({}), [
+					"DATABASE_URL",
+					"DATABASE_URL_UNPOOLED",
+				]),
+			).toThrowError(/DATABASE_URL_UNPOOLED is missing/);
+		});
+
+		test("rejects a selected-but-empty value", () => {
+			vi.stubEnv("DATABASE_URL", "");
+			expect(() => parseEnv(defineConfig({}), ["DATABASE_URL"])).toThrow(
+				expect.objectContaining({ code: ErrorCode.EnvNotInjected }),
+			);
+		});
+
+		test("an empty selection returns an empty object", () => {
+			vi.stubEnv("DATABASE_URL", "postgres://pooled");
+			expect(parseEnv(defineConfig({}), [])).toEqual({});
+		});
+	});
+
 	test("projects env object to process env keys", () => {
 		const pairs = toEntries({
 			postgres: { databaseUrl: "a", databaseUrlUnpooled: "b" },

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -281,6 +281,88 @@ export type NeonFunctionEnv<C extends Config, S extends string> = {
 	function: Record<FunctionEnvKeysOf<C, S>, string>;
 };
 
+// ───────────────────────── parseEnv key filtering ─────────────────────────
+
+/**
+ * OS-level env-var keys grouped by the {@link NeonEnv} namespace they populate. Only the
+ * **input** vars `parseEnv` validates are listed — the output-only aliases in
+ * {@link NEON_ENV_VAR_KEYS} (`NEON_STORAGE_REGION`, `NEON_AI_GATEWAY_TOKEN`, …) and the
+ * always-derived `storage.forcePathStyle` are intentionally absent, so they are not
+ * selectable in a `parseEnv(config, keys)` filter. Keep in sync with {@link EnvKeyToProp}.
+ */
+interface EnvKeysByNamespace {
+	postgres: "DATABASE_URL" | "DATABASE_URL_UNPOOLED";
+	auth: "NEON_AUTH_BASE_URL" | "NEON_AUTH_JWKS_URL";
+	dataApi: "NEON_DATA_API_URL";
+	storage:
+		| "AWS_ACCESS_KEY_ID"
+		| "AWS_SECRET_ACCESS_KEY"
+		| "AWS_ENDPOINT_URL_S3"
+		| "AWS_REGION";
+	aiGateway: "OPENAI_API_KEY" | "OPENAI_BASE_URL";
+}
+
+/** The {@link NeonEnv} namespace interface backing each namespace key. */
+interface NamespaceEnv {
+	postgres: NeonPostgresEnv;
+	auth: NeonAuthEnv;
+	dataApi: NeonDataApiEnv;
+	storage: NeonStorageEnv;
+	aiGateway: NeonAiGatewayEnv;
+}
+
+/** OS-level env-var key → the camelCase property it sets on its namespace object. */
+interface EnvKeyToProp {
+	DATABASE_URL: "databaseUrl";
+	DATABASE_URL_UNPOOLED: "databaseUrlUnpooled";
+	NEON_AUTH_BASE_URL: "baseUrl";
+	NEON_AUTH_JWKS_URL: "jwksUrl";
+	NEON_DATA_API_URL: "url";
+	AWS_ACCESS_KEY_ID: "accessKeyId";
+	AWS_SECRET_ACCESS_KEY: "secretAccessKey";
+	AWS_ENDPOINT_URL_S3: "endpoint";
+	AWS_REGION: "region";
+	OPENAI_API_KEY: "apiKey";
+	OPENAI_BASE_URL: "baseUrl";
+}
+
+/**
+ * The OS-level env-var keys selectable for a given policy: the union of input vars across
+ * exactly the namespaces {@link NeonEnv}<C> carries. Drives the typesafe autocomplete of the
+ * `keys` filter — selecting a var from a namespace the policy does not enable is a type error
+ * (e.g. `NEON_AUTH_BASE_URL` is only offered once the policy turns on `auth`).
+ */
+export type SelectableEnvKey<C extends Config> =
+	EnvKeysByNamespace[keyof NeonEnv<C> & keyof EnvKeysByNamespace];
+
+/**
+ * The result shape of a **filtered** `parseEnv(config, keys)` call: the namespaced
+ * {@link NeonEnv} restricted to exactly the selected OS-level keys `K`. Namespaces with no
+ * selected key are dropped, and within a kept namespace only the selected properties survive
+ * — selecting just `["DATABASE_URL"]` yields `{ postgres: { databaseUrl: string } }`, with no
+ * `databaseUrlUnpooled`.
+ *
+ * The policy gating lives on the `parseEnv` overload (which binds `K` to
+ * {@link SelectableEnvKey}); this type only needs the selection, so it takes a bare
+ * `K extends string` and filters with `Extract`. The outer mapped type's `as` clause drops
+ * any namespace whose intersection with the selection is empty (`[…] extends [never]`,
+ * tuple-wrapped to switch off distribution); the inner one re-keys each selected OS var to its
+ * camelCase property and looks the value type up on the canonical namespace interface, so it
+ * stays correct if a field ever stops being a plain `string`.
+ */
+export type FilteredNeonEnv<K extends string> = {
+	[N in keyof EnvKeysByNamespace as [
+		Extract<K, EnvKeysByNamespace[N]>,
+	] extends [never]
+		? never
+		: N]: {
+		[P in Extract<K, EnvKeysByNamespace[N]> as EnvKeyToProp[P &
+			keyof EnvKeyToProp]]: NamespaceEnv[N][EnvKeyToProp[P &
+			keyof EnvKeyToProp] &
+			keyof NamespaceEnv[N]];
+	};
+};
+
 export interface FetchEnvOptions {
 	/**
 	 * Neon project id. **Required** — the management API addresses branches through their
@@ -899,12 +981,18 @@ function isServiceEnabledInput(
  * static (top-level `config.auth` / `config.dataApi`), so it reads those directly without
  * evaluating the per-branch closure.
  *
- * The second argument is a **scope**:
- * - omitted — *external* scope (app bootstrap, build scripts, your dev machine). Returns
- *   `{ postgres, auth?, dataApi? }`.
+ * The second argument is a **scope** or a **key filter**:
+ * - omitted — *external* scope (app bootstrap, build scripts, your dev machine). Returns the
+ *   full `{ postgres, auth?, dataApi?, … }` the policy enables.
  * - a **function slug** (a key of `config.preview.functions`) — *function* scope: you are
  *   running inside that function. Returns the same branch secrets **plus** a typed
  *   `function` namespace with the function's declared env-var keys.
+ * - an **array of OS-level env-var keys** (e.g. `["DATABASE_URL", "NEON_AUTH_BASE_URL"]`) —
+ *   *filtered* mode: only those vars are required and returned, as a narrowed namespaced
+ *   shape. The keys autocomplete from the policy ({@link SelectableEnvKey}), so you can only
+ *   pick vars the policy actually enables. Use this when a process needs just a subset (a
+ *   Next.js app that reads `DATABASE_URL` but not `DATABASE_URL_UNPOOLED`, say) and you don't
+ *   want `parseEnv` to throw over vars you never use.
  *
  * Throws `PlatformError(EnvNotInjected)` listing every missing/invalid var when the env
  * isn't fully populated, with a fix hint pointing back at `neon dev` / `neon-env run`.
@@ -920,15 +1008,32 @@ function isServiceEnabledInput(
  * // Inside the "hello" function:
  * const env = parseEnv(config, "hello");
  * env.function.resendApiKey; // typed from hello's declared env keys
+ *
+ * // Filtered: only enforce + return the pooled URL.
+ * const { postgres } = parseEnv(config, ["DATABASE_URL"]);
+ * postgres.databaseUrl; // string — `databaseUrlUnpooled` is absent
  * ```
  */
 export function parseEnv<const C extends Config>(config: C): NeonEnv<C>;
 export function parseEnv<
 	const C extends Config,
+	const K extends SelectableEnvKey<C>,
+>(config: C, keys: readonly K[]): FilteredNeonEnv<K>;
+export function parseEnv<
+	const C extends Config,
 	const S extends FunctionSlugOf<C>,
 >(config: C, scope: S): NeonEnv<C> & NeonFunctionEnv<C, S>;
-export function parseEnv(config: Config, scope?: string): unknown {
+export function parseEnv(
+	config: Config,
+	scopeOrKeys?: string | readonly string[],
+): unknown {
 	const source = process.env;
+	if (Array.isArray(scopeOrKeys)) {
+		return parseFilteredEnv(source, scopeOrKeys);
+	}
+	// `Array.isArray` doesn't narrow a `readonly string[]` out of the union, so re-derive the
+	// function-slug scope from the remaining `string` shape explicitly.
+	const scope = typeof scopeOrKeys === "string" ? scopeOrKeys : undefined;
 	const issues: string[] = [];
 	const result: Record<string, unknown> = {};
 
@@ -1056,6 +1161,77 @@ export function parseEnv(config: Config, scope?: string): unknown {
 		);
 	}
 
+	return result;
+}
+
+/**
+ * Runtime reverse map for filtered `parseEnv`: OS-level env-var key → `[namespace, property]`
+ * in the {@link NeonEnv} shape. The compile-time mirror is {@link EnvKeysByNamespace} /
+ * {@link EnvKeyToProp}; keep all three in sync. Only input vars appear (no output-only
+ * aliases, no derived `forcePathStyle`).
+ */
+const FILTERABLE_ENV_KEYS: Record<string, readonly [string, string]> = {
+	DATABASE_URL: ["postgres", "databaseUrl"],
+	DATABASE_URL_UNPOOLED: ["postgres", "databaseUrlUnpooled"],
+	NEON_AUTH_BASE_URL: ["auth", "baseUrl"],
+	NEON_AUTH_JWKS_URL: ["auth", "jwksUrl"],
+	NEON_DATA_API_URL: ["dataApi", "url"],
+	AWS_ACCESS_KEY_ID: ["storage", "accessKeyId"],
+	AWS_SECRET_ACCESS_KEY: ["storage", "secretAccessKey"],
+	AWS_ENDPOINT_URL_S3: ["storage", "endpoint"],
+	AWS_REGION: ["storage", "region"],
+	OPENAI_API_KEY: ["aiGateway", "apiKey"],
+	OPENAI_BASE_URL: ["aiGateway", "baseUrl"],
+};
+
+/**
+ * Filtered counterpart to the {@link parseEnv} body: validate and return only the explicitly
+ * selected OS-level env-var keys, projected back into the narrowed namespaced shape. Unlike
+ * the full reader it never consults the policy — the selection alone decides what's required —
+ * so vars the caller didn't ask for (e.g. `DATABASE_URL_UNPOOLED`) can be absent without
+ * throwing. Mirrors the same non-empty constraint and {@link PlatformError} aggregation.
+ */
+function parseFilteredEnv(
+	source: NodeJS.ProcessEnv,
+	keys: readonly string[],
+): Record<string, Record<string, string>> {
+	const issues: string[] = [];
+	const result: Record<string, Record<string, string>> = {};
+	for (const key of keys) {
+		// Unknown keys are blocked at the type level; a runtime caller bypassing the types
+		// gets a clear error rather than a silently-dropped selection.
+		if (!Object.hasOwn(FILTERABLE_ENV_KEYS, key)) {
+			issues.push(`${key} is not a selectable Neon env variable`);
+			continue;
+		}
+		const value = source[key];
+		if (value === undefined) {
+			issues.push(`${key} is missing`);
+			continue;
+		}
+		if (value === "") {
+			issues.push(`${key} must not be empty`);
+			continue;
+		}
+		const [namespace, property] = FILTERABLE_ENV_KEYS[key];
+		const bucket = result[namespace] ?? {};
+		bucket[property] = value;
+		result[namespace] = bucket;
+	}
+	if (issues.length > 0) {
+		throw new PlatformError(
+			ErrorCode.EnvNotInjected,
+			[
+				"parseEnv: the required Neon env variables are not present in process.env.",
+				...issues.map((i) => `  - ${i}`),
+				"Inject them via one of:",
+				"  - `neon dev` / `neon-env run -- <your dev command>` (wraps the command with the vars injected)",
+				"  - your hosting platform's Neon integration (Vercel, Fly, Railway, …)",
+				"Or switch the call to `await fetchEnv(config, …)` if you're in a context that can do async I/O.",
+			].join("\n"),
+			{ details: { missing: issues } },
+		);
+	}
 	return result;
 }
 

--- a/packages/env/src/v1.ts
+++ b/packages/env/src/v1.ts
@@ -13,6 +13,7 @@
 
 export type {
 	FetchEnvOptions,
+	FilteredNeonEnv,
 	FunctionSlugOf,
 	NeonAiGatewayEnv,
 	NeonAuthEnv,
@@ -21,6 +22,7 @@ export type {
 	NeonFunctionEnv,
 	NeonPostgresEnv,
 	NeonStorageEnv,
+	SelectableEnvKey,
 } from "./lib/env.js";
 export {
 	fetchEnv,

--- a/packages/env/tsdown.config.ts
+++ b/packages/env/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
 		"src/cli.ts",
 		"src/lib/**/*.ts",
 		"!src/**/*.test.*",
+		"!src/**/*.test-d.*",
 		"!src/lib/fake-neon-api.ts",
 		"!src/lib/test-utils.ts",
 	],


### PR DESCRIPTION
## Summary
- Adds a third way to call `parseEnv`: a **typesafe key filter**. `parseEnv(config, ["DATABASE_URL", ...])` requires and returns only the selected OS-level env vars, instead of every variable the policy implies.
- Use case: a process that only uses a subset (e.g. a Next.js app reading `DATABASE_URL` but not `DATABASE_URL_UNPOOLED`) no longer throws over vars it never uses.
- The keys are typesafe via `SelectableEnvKey<Config>` — autocomplete only offers vars the policy enables, and selecting one from a disabled namespace is a compile error.
- The result type (`FilteredNeonEnv<K>`) is narrowed: it drops unselected namespaces and unselected properties within a kept namespace (selecting `["DATABASE_URL"]` yields `{ postgres: { databaseUrl: string } }`).
- Composes with the existing overloads — an array is unambiguous vs. the function-slug `string` at both runtime (`Array.isArray`) and the type level. Filter and function-slug scope remain separate, mutually-exclusive overloads.

## Changes
- `src/lib/env.ts`: new overload + `SelectableEnvKey` / `FilteredNeonEnv` types + `parseFilteredEnv` runtime + `FILTERABLE_ENV_KEYS` reverse map.
- `src/v1.ts`: export `SelectableEnvKey` and `FilteredNeonEnv`.
- `src/lib/env.test-d.ts` (new): Vitest `expectTypeOf` type tests (positive equalities + `@ts-expect-error` negatives), plus a `test:types` script.
- `src/lib/env.test.ts`: runtime tests for the filter.
- `tsdown.config.ts`: exclude `*.test-d.*` from the published bundle.
- `README.md` + changeset (`minor`).

## Test plan
- [x] `pnpm --filter @neondatabase/env tsc` clean
- [x] `pnpm --filter @neondatabase/env test:ci` (63 tests)
- [x] `pnpm --filter @neondatabase/env test:types` (12 type tests, no type errors)
- [x] `pnpm --filter @neondatabase/env build` — verified `dist/` excludes `test-d` and `expect-type`