### PR TITLE
fix(config): clearer defineConfig errors + nested preview autocomplete

### DIFF
--- a/.changeset/config-error-messages.md
+++ b/.changeset/config-error-messages.md
@@ -9,5 +9,6 @@ A bad function slug used to surface as `preview.functions.<slug>: Invalid key in
 
 - `defineConfig` validation now hoists the real reason out of zod's `invalid_key` issue, so a rejected record key reports *why* (e.g. `preview.functions.hello-world: function slug must be 1-20 lowercase letters and digits (no hyphens or other characters)`).
 - `loadConfigFromFile` surfaces a `PlatformError` thrown during evaluation verbatim (the config is invalid, not the TypeScript), reserving the "run it with tsx" hint for genuine syntax/runtime/missing-dependency failures.
+- An `undefined` function `env` value (typically a `process.env.X` referenced in `neon.ts` that is unset) used to surface as zod's opaque `preview.functions.hello.env.test: Invalid input: expected string, received undefined`. It now names the function and env key and points at the fix, e.g. `Environment variable "test" for function "hello" is undefined — its value (typically a process.env.*) is unset. Set it (e.g. add it to your .env) or provide a fallback like process.env.X ?? "".` (a non-`undefined` wrong type keeps zod's default message).
 
 Adds `isPlatformError`, a structural guard that recognises a `PlatformError` even across the jiti module-realm boundary (where `instanceof` fails), re-exported from `@neondatabase/config-runtime`.

--- a/.changeset/data-api-config.md
+++ b/.changeset/data-api-config.md
@@ -19,7 +19,7 @@ defineConfig({
 
 - **`authProvider`** is `"neon"` (default) or `"external"` (friendly values, mapped to the API's `neon_auth` / `external`). The external-IdP wiring (`jwksUrl`, `providerName`, `jwtAudience`) is only valid — and only typeable — on the `"external"` variant (the `"neon"` variant types those fields as `never`).
 - **`settings`** mirror the Neon API `DataAPISettings` in camelCase (`dbAggregatesEnabled`, `dbAnonRole`, `dbExtraSearchPath`, `dbMaxRows`, `dbSchemas`, `jwtRoleClaimKey`, `jwtCacheMaxLifetime`, `openapiMode`, `serverCorsAllowedOrigins`, `serverTimingEnabled`).
-- **A `"neon"` Data API requires Neon Auth.** Enforced both at author time (TypeScript makes `auth` required) and at runtime (zod cross-field check). An `"external"` Data API does not.
+- **A `"neon"` Data API requires Neon Auth.** Enforced both at author time and at runtime (zod cross-field check). When `dataApi` is enabled with Neon Auth but top-level `auth` is missing, the `dataApi` field's expected type carries a readable hint (`… requires `auth: true`, or use `dataApi: { authProvider: 'external', jwksUrl: ... }``) so the error points straight at the fix instead of an opaque `Type '…' is not assignable to type 'never'`. An `"external"` Data API does not require auth.
 - The auth wiring is set when the Data API is first **enabled** (carried on the create request) and is immutable afterward. Changing the runtime `settings` is reconciled as an **update** and requires `updateExisting` / `--update-existing`, like compute/TTL/`protected` drift.
 
 The `add_default_grants` / `skip_auth_schema` create-only flags are intentionally not exposed.

--- a/.changeset/preview-slug-autocomplete.md
+++ b/.changeset/preview-slug-autocomplete.md
@@ -1,0 +1,9 @@
+---
+"@neondatabase/config": patch
+---
+
+Fix `defineConfig` autocomplete **inside** the nested `preview.functions` / `preview.buckets` slug objects.
+
+The top-level `preview` fix (`Preview & PreviewInput`) restored hints for `aiGateway` / `functions` / `buckets`, but one level deeper editors still offered nothing inside a slug's value (e.g. `functions: { hello: { /* no name/source/env/dev hints */ } }`, and `buckets: { uploads: { /* no access hint */ } }`). `PreviewInput` types those records with a string index signature (`Record<string, FunctionDef>` / `Record<string, BucketDef>`), and once `defineConfig` infers `const Preview`, each authored slug becomes a *named* property on the inferred literal — a named property shadows the index signature when the editor computes the contextual type of that slug's value, so the rest of `FunctionDef` / `BucketDef` never surfaced.
+
+`defineConfig` now also intersects `preview` with `PreviewAutocomplete<Preview>`, which re-declares each inferred slug's value as `FunctionDef` / `BucketDef` (a *named* member, via a mapped type over the already-inferred keys). This puts those members back on the contextual type without going through the index signature, restoring full autocomplete and inline docs inside each function/bucket object. Type-only change — it does not widen what is accepted, change the inferred `const Preview`, or affect runtime behavior.

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -44,6 +44,7 @@
 		"prepare": "npm run build",
 		"test": "vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
+		"test:types": "vitest run --typecheck.enabled --typecheck.only",
 		"test:e2e": "vitest run --config vitest.e2e.config.ts",
 		"tsc": "tsc"
 	},

--- a/packages/config/src/lib/define-config.completions.test.ts
+++ b/packages/config/src/lib/define-config.completions.test.ts
@@ -1,0 +1,135 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { beforeAll, describe, expect, test } from "vitest";
+
+// Autocomplete regression guard for the nested `preview.functions` / `preview.buckets` slug
+// objects (see `PreviewAutocomplete` in `define-config.ts`).
+//
+// This can't be expressed with `expectTypeOf`: the *resolved* contextual type already exposed
+// the right keys before the fix — the bug lived only in the editor's completion provider,
+// where a named slug property on the inferred `const Preview` literal shadowed the
+// `Record<string, FunctionDef>` index signature. So we drive the real TypeScript language
+// service and assert on the member completions it returns at a marked cursor position.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG_DIR = resolve(HERE, "..", "..");
+// A virtual file living in `src/lib` so its `./define-config.js` import resolves to the real
+// source module under the project's module resolution.
+const FIXTURE = resolve(HERE, "__completions_fixture__.ts");
+
+let parsedOptions: ts.ParsedCommandLine;
+
+beforeAll(() => {
+	const configPath = ts.findConfigFile(
+		PKG_DIR,
+		ts.sys.fileExists,
+		"tsconfig.json",
+	);
+	if (!configPath) throw new Error("tsconfig.json not found");
+	const { config } = ts.readConfigFile(configPath, ts.sys.readFile);
+	parsedOptions = ts.parseJsonConfigFileContent(
+		config,
+		ts.sys,
+		dirname(configPath),
+	);
+});
+
+/**
+ * Return the *member* completions the language service offers at the `/*|*\/` marker in
+ * `source`. Filters out keyword/global-scope fallbacks so the list reflects the contextual
+ * object type (an empty list means "no object members were offered" — the bug we guard).
+ */
+function memberCompletionsAt(source: string): string[] {
+	const marker = "/*|*/";
+	const position = source.indexOf(marker);
+	if (position < 0) throw new Error("missing /*|*/ marker in fixture source");
+	const text = source.replace(marker, "");
+
+	const host: ts.LanguageServiceHost = {
+		getScriptFileNames: () => [FIXTURE, ...parsedOptions.fileNames],
+		getScriptVersion: () => "1",
+		getScriptSnapshot: (fileName) =>
+			fileName === FIXTURE
+				? ts.ScriptSnapshot.fromString(text)
+				: (() => {
+						const content = ts.sys.readFile(fileName);
+						return content === undefined
+							? undefined
+							: ts.ScriptSnapshot.fromString(content);
+					})(),
+		getCurrentDirectory: () => PKG_DIR,
+		getCompilationSettings: () => parsedOptions.options,
+		getDefaultLibFileName: (o) => ts.getDefaultLibFilePath(o),
+		fileExists: (f) => f === FIXTURE || ts.sys.fileExists(f),
+		readFile: (f) => (f === FIXTURE ? text : ts.sys.readFile(f)),
+		readDirectory: ts.sys.readDirectory,
+		directoryExists: ts.sys.directoryExists,
+		getDirectories: ts.sys.getDirectories,
+	};
+
+	const service = ts.createLanguageService(host, ts.createDocumentRegistry());
+	const info = service.getCompletionsAtPosition(FIXTURE, position, {
+		includeCompletionsForModuleExports: false,
+		triggerKind: ts.CompletionTriggerKind.Invoked,
+	});
+	// `isGlobalCompletion` is true when TS found no object contextual type and fell back to
+	// in-scope identifiers; treat that as "no member completions" so the bug can't hide behind
+	// thousands of global names that happen to include a matching word.
+	if (!info || info.isGlobalCompletion) return [];
+	return info.entries
+		.filter((e) => e.kind !== "keyword" && e.kind !== "warning")
+		.map((e) => e.name);
+}
+
+describe("preview slug-object autocomplete (language service)", () => {
+	test("an empty function slug object offers every FunctionDef member", () => {
+		const completions = memberCompletionsAt(`
+import { defineConfig } from "./define-config.js";
+export default defineConfig({
+	preview: { functions: { hello: { /*|*/ } } },
+});
+`);
+		expect(completions).toEqual(
+			expect.arrayContaining(["name", "source", "env", "dev"]),
+		);
+	});
+
+	test("a partial function slug object still offers the remaining members", () => {
+		const completions = memberCompletionsAt(`
+import { defineConfig } from "./define-config.js";
+export default defineConfig({
+	preview: {
+		functions: {
+			hello: { name: "Hello", source: "./hello.ts", /*|*/ },
+		},
+	},
+});
+`);
+		expect(completions).toEqual(expect.arrayContaining(["env", "dev"]));
+		// name/source are already present, so they are (correctly) not re-offered.
+		expect(completions).not.toContain("name");
+	});
+
+	test("a bucket slug object offers the BucketDef members", () => {
+		const completions = memberCompletionsAt(`
+import { defineConfig } from "./define-config.js";
+export default defineConfig({
+	preview: { buckets: { uploads: { /*|*/ } } },
+});
+`);
+		expect(completions).toContain("access");
+	});
+
+	test("the top-level preview object still offers its members", () => {
+		const completions = memberCompletionsAt(`
+import { defineConfig } from "./define-config.js";
+export default defineConfig({
+	preview: { /*|*/ },
+});
+`);
+		expect(completions).toEqual(
+			expect.arrayContaining(["aiGateway", "functions", "buckets"]),
+		);
+	});
+});

--- a/packages/config/src/lib/define-config.test-d.ts
+++ b/packages/config/src/lib/define-config.test-d.ts
@@ -1,0 +1,143 @@
+import { describe, expectTypeOf, test } from "vitest";
+import {
+	type DataApiField,
+	defineConfig,
+	type NeonAuthRequiredHint,
+} from "./define-config.js";
+import type { DataApiInput } from "./types.js";
+
+// Type-level tests for the Neon-Auth Data API cross-field guard. Run via
+// `pnpm --filter @neondatabase/config test:types` (Vitest typecheck mode) and additionally
+// enforced by `tsc --noEmit` during the build, since this file lives under `src`.
+//
+// These lock in the regression we just fixed: a Neon-Auth `dataApi` without `auth` must
+// surface the readable `NeonAuthRequiredHint` as the field's expected type (not collapse to
+// `never`), while every valid form keeps its real `DataApi & DataApiInput` type.
+
+/** `true` iff string `S` contains the substring `Sub` (template-literal match). */
+type Includes<
+	S extends string,
+	Sub extends string,
+> = S extends `${string}${Sub}${string}` ? true : false;
+
+describe("DataApiField guard (types)", () => {
+	test("a Neon-Auth dataApi (bare `true`) without auth expects the hint message", () => {
+		expectTypeOf<
+			DataApiField<undefined, true>
+		>().toEqualTypeOf<NeonAuthRequiredHint>();
+	});
+
+	test("a Neon-Auth dataApi (object form) without auth expects the hint message", () => {
+		expectTypeOf<
+			DataApiField<undefined, { settings: { dbMaxRows: 10 } }>
+		>().toEqualTypeOf<NeonAuthRequiredHint>();
+	});
+
+	test("an explicit `auth: false` is still treated as auth-disabled (expects the hint)", () => {
+		expectTypeOf<
+			DataApiField<false, true>
+		>().toEqualTypeOf<NeonAuthRequiredHint>();
+	});
+
+	test("with `auth: true` a Neon-Auth dataApi keeps its real type (not the hint)", () => {
+		expectTypeOf<DataApiField<true, true>>().toEqualTypeOf<
+			true & DataApiInput
+		>();
+		expectTypeOf<
+			DataApiField<true, true>
+		>().not.toEqualTypeOf<NeonAuthRequiredHint>();
+	});
+
+	test("with `auth: {}` (present ⇒ enabled) a Neon-Auth dataApi keeps its real type", () => {
+		expectTypeOf<
+			DataApiField<Record<never, never>, true>
+		>().not.toEqualTypeOf<NeonAuthRequiredHint>();
+	});
+
+	test("an external dataApi never needs auth (keeps its real type, even without auth)", () => {
+		expectTypeOf<
+			DataApiField<undefined, { authProvider: "external" }>
+		>().not.toEqualTypeOf<NeonAuthRequiredHint>();
+		expectTypeOf<
+			DataApiField<
+				undefined,
+				{ authProvider: "external"; jwksUrl: string }
+			>
+		>().toEqualTypeOf<
+			{ authProvider: "external"; jwksUrl: string } & DataApiInput
+		>();
+	});
+
+	test("a disabled dataApi (`false` / `{ enabled: false }`) never needs auth", () => {
+		expectTypeOf<
+			DataApiField<undefined, false>
+		>().not.toEqualTypeOf<NeonAuthRequiredHint>();
+		expectTypeOf<
+			DataApiField<undefined, { enabled: false }>
+		>().not.toEqualTypeOf<NeonAuthRequiredHint>();
+	});
+});
+
+describe("NeonAuthRequiredHint documents both fixes (types)", () => {
+	test("documents enabling Neon Auth via `auth: true`", () => {
+		expectTypeOf<
+			Includes<NeonAuthRequiredHint, "auth: true">
+		>().toEqualTypeOf<true>();
+	});
+
+	test("documents running the Data API WITHOUT Neon Auth", () => {
+		expectTypeOf<
+			Includes<NeonAuthRequiredHint, "WITHOUT Neon Auth">
+		>().toEqualTypeOf<true>();
+	});
+
+	test("documents the external-IdP escape hatch (authProvider + jwksUrl)", () => {
+		expectTypeOf<
+			Includes<NeonAuthRequiredHint, "authProvider: 'external'">
+		>().toEqualTypeOf<true>();
+		expectTypeOf<
+			Includes<NeonAuthRequiredHint, "jwksUrl">
+		>().toEqualTypeOf<true>();
+	});
+});
+
+describe("defineConfig surfaces the guard at the call site (negative types)", () => {
+	test("a Neon-Auth dataApi (`true`) without auth is a type error", () => {
+		// @ts-expect-error dataApi (neon) needs `auth` enabled.
+		defineConfig({ dataApi: true });
+	});
+
+	test("a Neon-Auth dataApi (object form) without auth is a type error", () => {
+		// @ts-expect-error dataApi (neon) needs `auth` enabled.
+		defineConfig({ dataApi: { settings: { dbMaxRows: 10 } } });
+	});
+
+	test("an explicit `auth: false` with a Neon-Auth dataApi is a type error", () => {
+		// @ts-expect-error a neon dataApi requires auth ENABLED, not `auth: false`.
+		defineConfig({ auth: false, dataApi: true });
+	});
+});
+
+describe("defineConfig accepts every valid form (positive types)", () => {
+	test("auth + bare dataApi", () => {
+		defineConfig({ auth: true, dataApi: true });
+	});
+
+	test("auth + dataApi object with settings", () => {
+		defineConfig({ auth: {}, dataApi: { settings: { dbMaxRows: 10 } } });
+	});
+
+	test("external dataApi without auth", () => {
+		defineConfig({
+			dataApi: {
+				authProvider: "external",
+				jwksUrl: "https://idp.example.com/.well-known/jwks.json",
+			},
+		});
+	});
+
+	test("a disabled dataApi without auth", () => {
+		defineConfig({ dataApi: false });
+		defineConfig({ dataApi: { enabled: false } });
+	});
+});

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -198,22 +198,85 @@ describe("resolveConfig", () => {
 	});
 
 	test("rejects a function env value that is undefined (e.g. unset process.env) at definition time", () => {
-		expect(() =>
+		// Faithful repro of the CLI scenario: a `neon.ts` writing `test: process.env.TEST`
+		// with TEST unset. `neon.ts` is evaluated (not type-checked) by neonctl via jiti, so
+		// the value arrives as a runtime `undefined`. The `@ts-expect-error` documents that the
+		// type system *also* rejects it (the env value must be a defined string).
+		const unsetEnvValue =
+			process.env.NEON_PKGS_DEFINITELY_UNSET_ENV_VAR_FOR_TEST;
+		let caught: unknown;
+		try {
 			defineConfig({
 				preview: {
 					functions: {
 						hello: {
 							name: "Hello",
 							source: "./hello.ts",
-							// Simulates `RESEND_API_KEY: process.env.RESEND_API_KEY` when unset.
+							// @ts-expect-error process.env.X is `string | undefined`; here it is unset.
+							env: { test: unsetEnvValue },
+						},
+					},
+				},
+			});
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(ConfigValidationError);
+		if (!(caught instanceof ConfigValidationError)) throw caught;
+
+		// The user-visible message is exactly what the CLI prints.
+		expect(caught.message).toContain("Invalid Neon platform config:");
+		const issue = caught.issues.join("\n");
+		// Points at the exact path…
+		expect(issue).toContain("preview.functions.hello.env.test");
+		// …names the offending function and env key explicitly…
+		expect(issue).toContain('Environment variable "test"');
+		expect(issue).toContain('function "hello"');
+		// …explains the likely cause + a fix…
+		expect(issue).toContain("process.env");
+		// …and drops zod's opaque default.
+		expect(issue).not.toContain(
+			"Invalid input: expected string, received undefined",
+		);
+	});
+
+	test("names the correct function and key when one of several env values is undefined", () => {
+		// Guards the path-extraction logic: the message must identify the *specific* function
+		// and key that is undefined, not the first function or a hardcoded name.
+		let caught: unknown;
+		try {
+			defineConfig({
+				preview: {
+					functions: {
+						alpha: {
+							name: "Alpha",
+							source: "./alpha.ts",
+							env: { OK: "present" },
+						},
+						beta: {
+							name: "Beta",
+							source: "./beta.ts",
 							env: {
-								RESEND_API_KEY: undefined as unknown as string,
+								OK: "present",
+								// @ts-expect-error simulates an unset process.env.SECRET_TOKEN.
+								secretToken: undefined,
 							},
 						},
 					},
 				},
-			}),
-		).toThrow(ConfigValidationError);
+			});
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(ConfigValidationError);
+		if (!(caught instanceof ConfigValidationError)) throw caught;
+		const issue = caught.issues.join("\n");
+		expect(issue).toContain("preview.functions.beta.env.secretToken");
+		expect(issue).toContain('Environment variable "secretToken"');
+		expect(issue).toContain('function "beta"');
+		// The healthy function/keys must not be implicated.
+		expect(issue).not.toContain('function "alpha"');
+		expect(issue).not.toContain('"OK"');
 	});
 
 	test("rejects an invalid function slug (record key) at definition time", () => {

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -9,6 +9,7 @@ import type {
 	BranchTarget,
 	BranchTuning,
 	BranchTuningFn,
+	BucketDef,
 	Config,
 	DataApiInput,
 	DataApiSettings,
@@ -39,22 +40,70 @@ type DataApiUsesNeonAuth<DataApi> = ServiceEnabled<DataApi> extends true
 		: true
 	: false;
 
-/** An `auth` toggle value that is statically guaranteed enabled (`true` / `{}` / `{ enabled: true }`). */
-type EnabledAuthToggle = true | { enabled?: true };
+/**
+ * Human-readable hint surfaced as the **expected type** of `dataApi` when a Neon-Auth Data
+ * API is declared without Neon Auth enabled (see {@link DataApiField}). TypeScript prints the
+ * offending value against this string literal — `Type 'true' is not assignable to type
+ * '…requires `auth: true`…'` — which points straight at the fix, instead of the opaque
+ * `Type 'true' is not assignable to type 'never'` an intersection guard produces.
+ *
+ * It documents **both** fixes: enabling Neon Auth (`auth: true`), and running the Data API
+ * *without* Neon Auth by verifying a third-party IdP (`authProvider: 'external'` + `jwksUrl`).
+ */
+// Exported (type-only) for the type tests in `define-config.test-d.ts`; intentionally not
+// re-exported from `v1.ts` / `index.ts`, so it stays an internal implementation detail.
+export type NeonAuthRequiredHint =
+	"`dataApi` with Neon Auth (the default `authProvider: 'neon'`) requires Neon Auth, so add `auth: true`. To enable the Data API WITHOUT Neon Auth, verify a third-party IdP instead: `dataApi: { authProvider: 'external', jwksUrl: 'https://your-idp/.well-known/jwks.json' }`";
 
 /**
- * Static cross-field guard for {@link defineConfig}. When the policy enables a Neon-Auth
- * Data API (`authProvider: "neon"`, the default) but does **not** enable top-level `auth`,
- * this resolves to `{ auth: EnabledAuthToggle }` — intersected into the parameter type, it
- * makes `auth` required and rejects `auth: false` / a missing `auth`, surfacing the rule at
- * author time. Otherwise it is `unknown` (a no-op intersection). The runtime `superRefine`
- * in {@link configInputSchema} enforces the same invariant for non-typed callers.
+ * Static cross-field guard for {@link defineConfig}, expressed as the **type of the `dataApi`
+ * field** rather than an intersected requirement on `auth`.
+ *
+ * - A Neon-Auth Data API (`authProvider: "neon"`, the default) with top-level `auth` enabled,
+ *   or any external Data API: the field keeps its normal `DataApi & DataApiInput` type (the
+ *   `& DataApiInput` preserves member autocomplete; the `const DataApi` still types the
+ *   returned {@link Config}).
+ * - A Neon-Auth Data API **without** `auth` enabled: the field's expected type collapses to
+ *   the {@link NeonAuthRequiredHint} message, so the author sees the rule (and the two fixes)
+ *   right on the `dataApi` value.
+ *
+ * The runtime `superRefine` in {@link configInputSchema} enforces the same invariant for
+ * non-typed (plain-JS) callers, so the behavior is identical — only the type-level message
+ * changes.
  */
-type RequiresNeonAuth<Auth, DataApi> = DataApiUsesNeonAuth<DataApi> extends true
-	? ServiceEnabled<Auth> extends true
-		? unknown
-		: { auth: EnabledAuthToggle }
-	: unknown;
+// Exported (type-only) for the type tests in `define-config.test-d.ts`; intentionally not
+// re-exported from `v1.ts` / `index.ts`, so it stays an internal implementation detail.
+export type DataApiField<Auth, DataApi> =
+	DataApiUsesNeonAuth<DataApi> extends true
+		? ServiceEnabled<Auth> extends true
+			? DataApi & DataApiInput
+			: NeonAuthRequiredHint
+		: DataApi & DataApiInput;
+
+/**
+ * Autocomplete bridge for the nested `preview.functions` / `preview.buckets` slug objects.
+ *
+ * {@link PreviewInput} types those records with a string index signature
+ * (`Record<string, FunctionDef>` / `Record<string, BucketDef>`). When `defineConfig` infers
+ * `const Preview`, every authored slug becomes a **named** property on the inferred literal
+ * (e.g. `{ hello: { name; source } }`), and a named property **shadows** the index signature
+ * when the editor computes the contextual type of that slug's value — so the rest of
+ * {@link FunctionDef} / {@link BucketDef} (`env`, `dev`, `access`, …) never surfaces as
+ * completions inside `hello: { … }` / `uploads: { … }`.
+ *
+ * Re-declaring each inferred slug's value as `FunctionDef` / `BucketDef` (a *named* member, via
+ * a mapped type over the already-inferred keys) puts those members back onto the contextual
+ * type without going through an index signature, which restores autocomplete. Intersected with
+ * `Preview & PreviewInput` it neither widens what is accepted (the values were already
+ * `FunctionDef` / `BucketDef`) nor perturbs the inferred `const Preview` — so slug inference for
+ * `BranchTuningFn<Preview>` and the returned {@link Config} is unchanged.
+ */
+type PreviewAutocomplete<Preview> = (Preview extends { functions: infer F }
+	? { functions: { [Slug in keyof F]: FunctionDef } }
+	: unknown) &
+	(Preview extends { buckets: infer B }
+		? { buckets: { [Name in keyof B]: BucketDef } }
+		: unknown);
 
 /**
  * Validate and freeze a Neon Platform branch policy.
@@ -93,20 +142,24 @@ export function defineConfig<
 	const Auth extends ServiceToggleInput | undefined = undefined,
 	const DataApi extends DataApiInput | undefined = undefined,
 	const Preview extends PreviewInput | undefined = undefined,
->(
-	input: {
-		// Each field is intersected with its concrete interface (not just typed as the bare
-		// generic). The generic alone — e.g. `preview?: Preview` — gives editors no members to
-		// complete against in the object-literal position (they see `{} | undefined`), so you
-		// lose hints for `aiGateway` / `functions` / `buckets`. `& PreviewInput` restores the
-		// full shape for autocomplete while still inferring the `const` literal that types the
-		// `branch` closure's slugs (BranchTuningFn<Preview>) and the returned Config.
-		auth?: Auth & ServiceToggleInput;
-		dataApi?: DataApi & DataApiInput;
-		preview?: Preview & PreviewInput;
-		branch?: BranchTuningFn<Preview>;
-	} & RequiresNeonAuth<Auth, DataApi>,
-): Config<Auth, DataApi, Preview> {
+>(input: {
+	// Each field is intersected with its concrete interface (not just typed as the bare
+	// generic). The generic alone — e.g. `preview?: Preview` — gives editors no members to
+	// complete against in the object-literal position (they see `{} | undefined`), so you
+	// lose hints for `aiGateway` / `functions` / `buckets`. `& PreviewInput` restores the
+	// full shape for autocomplete while still inferring the `const` literal that types the
+	// `branch` closure's slugs (BranchTuningFn<Preview>) and the returned Config.
+	auth?: Auth & ServiceToggleInput;
+	// The `dataApi` field carries the Neon-Auth cross-field guard at the type level (see
+	// `DataApiField`): a Neon-Auth Data API without `auth` enabled surfaces a readable hint
+	// as the field's expected type instead of collapsing the value to `never`.
+	dataApi?: DataApiField<Auth, DataApi>;
+	// `& PreviewInput` restores top-level member hints (aiGateway/functions/buckets);
+	// `& PreviewAutocomplete<Preview>` restores hints *inside* each function/bucket slug
+	// object (see `PreviewAutocomplete`), which the bare index signature otherwise hides.
+	preview?: Preview & PreviewInput & PreviewAutocomplete<Preview>;
+	branch?: BranchTuningFn<Preview>;
+}): Config<Auth, DataApi, Preview> {
 	if (typeof input === "function") {
 		throw new ConfigValidationError([
 			"defineConfig now expects an object, not a function: `export default defineConfig({ auth: true, preview: { … }, branch: (branch) => ({ … }) })`.",

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -140,6 +140,54 @@ describe("configInputSchema", () => {
 		});
 		expect(result.success).toBe(false);
 	});
+
+	test("explains an undefined function env value (e.g. unset process.env) by function + key", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					hello: {
+						name: "Hello",
+						source: "./hello.ts",
+						// Simulates `test: process.env.TEST` when TEST is unset.
+						env: { test: undefined },
+					},
+				},
+			},
+		});
+		if (result.success) throw new Error("expected failure");
+		const formatted = formatZodIssues(result.error).join("\n");
+		// Points at the exact offending path…
+		expect(formatted).toContain("preview.functions.hello.env.test");
+		// …names the function and env key explicitly…
+		expect(formatted).toContain('Environment variable "test"');
+		expect(formatted).toContain('function "hello"');
+		// …explains the likely cause and the fix…
+		expect(formatted).toContain("process.env");
+		// …and drops zod's opaque default.
+		expect(formatted).not.toContain(
+			"Invalid input: expected string, received undefined",
+		);
+	});
+
+	test("keeps zod's default message for a non-undefined wrong-typed env value", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					hello: {
+						name: "Hello",
+						source: "./hello.ts",
+						env: { count: 42 },
+					},
+				},
+			},
+		});
+		if (result.success) throw new Error("expected failure");
+		const formatted = formatZodIssues(result.error).join("\n");
+		expect(formatted).toContain("preview.functions.hello.env.count");
+		expect(formatted).toContain("expected string");
+		// The undefined-specific guidance must not fire for a defined wrong type.
+		expect(formatted).not.toContain("process.env");
+	});
 });
 
 describe("dataApiConfigSchema", () => {

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -155,11 +155,39 @@ const functionSlugSchema = z
 const bucketNameSchema = z.string().min(1).max(255);
 
 /**
- * Per-function environment map. Every value must be a defined string: a `process.env.X`
- * that is unset surfaces as `undefined` and is rejected here (rather than silently
- * shipping `undefined` into the deployment).
+ * A single function environment-variable value. Must be a defined string: a `process.env.X`
+ * that is unset evaluates to `undefined`, and the bare `z.string()` message for that case
+ * (`Invalid input: expected string, received undefined`) gives no hint that an env var is the
+ * culprit. The custom `error` replaces *only* the `undefined` case with a message that names
+ * the offending function + env key (read from the issue path) and how to fix it; any other
+ * wrong type keeps zod's default (`expected string, received number`, …).
  */
-const functionEnvSchema = z.record(z.string(), z.string());
+const functionEnvValueSchema = z.string({
+	error: (issue) => {
+		if (issue.input !== undefined) return undefined;
+		const path = issue.path ?? [];
+		const key = path.length > 0 ? String(path[path.length - 1]) : undefined;
+		const functionsIndex = path.indexOf("functions");
+		const slug =
+			functionsIndex >= 0 && functionsIndex + 1 < path.length
+				? String(path[functionsIndex + 1])
+				: undefined;
+		const subject =
+			slug !== undefined && key !== undefined
+				? `Environment variable "${key}" for function "${slug}"`
+				: key !== undefined
+					? `Environment variable "${key}"`
+					: "An environment variable";
+		return `${subject} is undefined — its value (typically a \`process.env.*\`) is unset. Set it (e.g. add it to your .env) or provide a fallback like \`process.env.X ?? ""\`.`;
+	},
+});
+
+/**
+ * Per-function environment map. Every value must be a defined string (see
+ * {@link functionEnvValueSchema}): a `process.env.X` that is unset surfaces as `undefined` and
+ * is rejected here (rather than silently shipping `undefined` into the deployment).
+ */
+const functionEnvSchema = z.record(z.string(), functionEnvValueSchema);
 
 /**
  * TCP port for a function's local dev server. Excludes 0 (which means "any port" to the OS

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
 		"src/v1.ts",
 		"src/lib/**/*.ts",
 		"!src/**/*.test.*",
+		"!src/**/*.test-d.*",
 		"!src/lib/fake-neon-api.ts",
 		"!src/lib/test-utils.ts",
 	],


### PR DESCRIPTION
## Summary

Authoring-time DX fixes for `@neondatabase/config` (the first two are **type-only — no runtime behavior change**; the third improves a runtime parse message), each with a regression test.

### 1. Clearer `dataApi`-without-auth error (type-level)

Previously, `defineConfig({ dataApi: true })` (a Neon-Auth Data API without `auth`) produced the opaque `Type 'true' is not assignable to type 'never'.` The Neon-Auth cross-field guard was an intersected requirement on `auth`, which collapsed the `dataApi` field to `never`. The guard now lives on the `dataApi` field itself, so its expected type carries a readable hint documenting **both** fixes:

```
Type 'true' is not assignable to type '`dataApi` with Neon Auth (the default
`authProvider: 'neon'`) requires Neon Auth, so add `auth: true`. To enable the
Data API WITHOUT Neon Auth, verify a third-party IdP instead:
`dataApi: { authProvider: 'external', jwksUrl: 'https://your-idp/.well-known/jwks.json' }`'.
```

The runtime zod `superRefine` enforces the same invariant for plain-JS callers — unchanged.

### 2. Autocomplete inside `preview` slug objects (type-level)

Editors offered **no** member completions inside a function/bucket slug value (`functions: { hello: { /* no name/source/env/dev */ } }`, `buckets: { uploads: { /* no access */ } }`). `PreviewInput` types those records with a string index signature, and once `defineConfig` infers `const Preview`, each authored slug is a *named* property on the inferred literal — which shadows the index signature when the editor computes the slug value's contextual type. `preview` is now also intersected with `PreviewAutocomplete<Preview>`, which re-declares each inferred slug value as `FunctionDef` / `BucketDef` (a named member), restoring `name/source/env/dev` and `access` hints. Doesn't widen what's accepted or change `const Preview` inference.

### 3. Explain undefined function `env` values when parsing (runtime message)

An unset `process.env.X` referenced in a function's `env` evaluates to `undefined` and surfaced as zod's opaque:

```
preview.functions.hello.env.test: Invalid input: expected string, received undefined
```

The function env value schema now replaces *only* the `undefined` case with a message that names the function + env key (read from the issue path) and the fix:

```
preview.functions.hello.env.test: Environment variable "test" for function
"hello" is undefined — its value (typically a process.env.*) is unset. Set it
(e.g. add it to your .env) or provide a fallback like process.env.X ?? "".
```

A non-`undefined` wrong type (e.g. a number) keeps zod's default message.

## Tests

- **`define-config.test-d.ts`** — type-level assertions locking the `dataApi` guard and that the hint documents both fixes. Adds a `test:types` script (matching `@neondatabase/env`).
- **`define-config.completions.test.ts`** — drives the TypeScript language service to assert member completions inside the slug objects (a plain type test can't catch this regression — the resolved type was already correct; only the completion provider was affected). Verified it fails when the fix is reverted.
- **`schema.test.ts`** — asserts the undefined-env message names the function + key and that a defined wrong type keeps zod's default.
- **tsdown** — exclude `*.test-d.*` from the published bundle (matching `@neondatabase/env`).

## Changesets

- `data-api-config.md` (existing, unreleased, `minor`) — updated wording for the new error behavior.
- `config-error-messages.md` (existing, unreleased, `minor`) — added a bullet for the undefined-env message.
- `preview-slug-autocomplete.md` (new, `patch`) — the nested autocomplete fix.

## Test plan

- [x] `tsc --noEmit` clean (config + dependent `env` package)
- [x] `vitest run` — 218 runtime tests pass (incl. new completion + schema tests)
- [x] `vitest run --typecheck` — type tests pass
- [x] `npm run build` — clean `dist`, no test files published
- [x] Regression-verified: completion tests fail when the autocomplete fix is reverted