### PR TITLE
test(config,env): userspace-contract regression + type-regression tests

### DIFF
--- a/packages/config/src/lib/define-config.completions.test.ts
+++ b/packages/config/src/lib/define-config.completions.test.ts
@@ -12,6 +12,11 @@ import { beforeAll, describe, expect, test } from "vitest";
 // `Record<string, FunctionDef>` index signature. So we drive the real TypeScript language
 // service and assert on the member completions it returns at a marked cursor position.
 
+// Each test boots a full TypeScript language service over the package's source. That is
+// inherently CPU-heavy and gets markedly slower under `--coverage` instrumentation and CI
+// parallelism, so the default 5s timeout is too tight. Give them generous headroom.
+const LANGUAGE_SERVICE_TIMEOUT_MS = 30_000;
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PKG_DIR = resolve(HERE, "..", "..");
 // A virtual file living in `src/lib` so its `./define-config.js` import resolves to the real
@@ -83,20 +88,26 @@ function memberCompletionsAt(source: string): string[] {
 }
 
 describe("preview slug-object autocomplete (language service)", () => {
-	test("an empty function slug object offers every FunctionDef member", () => {
-		const completions = memberCompletionsAt(`
+	test(
+		"an empty function slug object offers every FunctionDef member",
+		() => {
+			const completions = memberCompletionsAt(`
 import { defineConfig } from "./define-config.js";
 export default defineConfig({
 	preview: { functions: { hello: { /*|*/ } } },
 });
 `);
-		expect(completions).toEqual(
-			expect.arrayContaining(["name", "source", "env", "dev"]),
-		);
-	});
+			expect(completions).toEqual(
+				expect.arrayContaining(["name", "source", "env", "dev"]),
+			);
+		},
+		LANGUAGE_SERVICE_TIMEOUT_MS,
+	);
 
-	test("a partial function slug object still offers the remaining members", () => {
-		const completions = memberCompletionsAt(`
+	test(
+		"a partial function slug object still offers the remaining members",
+		() => {
+			const completions = memberCompletionsAt(`
 import { defineConfig } from "./define-config.js";
 export default defineConfig({
 	preview: {
@@ -106,30 +117,40 @@ export default defineConfig({
 	},
 });
 `);
-		expect(completions).toEqual(expect.arrayContaining(["env", "dev"]));
-		// name/source are already present, so they are (correctly) not re-offered.
-		expect(completions).not.toContain("name");
-	});
+			expect(completions).toEqual(expect.arrayContaining(["env", "dev"]));
+			// name/source are already present, so they are (correctly) not re-offered.
+			expect(completions).not.toContain("name");
+		},
+		LANGUAGE_SERVICE_TIMEOUT_MS,
+	);
 
-	test("a bucket slug object offers the BucketDef members", () => {
-		const completions = memberCompletionsAt(`
+	test(
+		"a bucket slug object offers the BucketDef members",
+		() => {
+			const completions = memberCompletionsAt(`
 import { defineConfig } from "./define-config.js";
 export default defineConfig({
 	preview: { buckets: { uploads: { /*|*/ } } },
 });
 `);
-		expect(completions).toContain("access");
-	});
+			expect(completions).toContain("access");
+		},
+		LANGUAGE_SERVICE_TIMEOUT_MS,
+	);
 
-	test("the top-level preview object still offers its members", () => {
-		const completions = memberCompletionsAt(`
+	test(
+		"the top-level preview object still offers its members",
+		() => {
+			const completions = memberCompletionsAt(`
 import { defineConfig } from "./define-config.js";
 export default defineConfig({
 	preview: { /*|*/ },
 });
 `);
-		expect(completions).toEqual(
-			expect.arrayContaining(["aiGateway", "functions", "buckets"]),
-		);
-	});
+			expect(completions).toEqual(
+				expect.arrayContaining(["aiGateway", "functions", "buckets"]),
+			);
+		},
+		LANGUAGE_SERVICE_TIMEOUT_MS,
+	);
 });

--- a/packages/config/src/v1.test-d.ts
+++ b/packages/config/src/v1.test-d.ts
@@ -1,0 +1,194 @@
+import { describe, expectTypeOf, test } from "vitest";
+import type {
+	AppliedChange,
+	BranchTarget,
+	BranchTuning,
+	BranchTuningFn,
+	BucketAccessLevel,
+	BucketDef,
+	ComputeSettings,
+	ComputeUnit,
+	ConflictReport,
+	CreateBranchInput,
+	CreateBucketInput,
+	CreateCredentialInput,
+	CreateProjectInput,
+	CredentialFeatureFlags,
+	CredentialPrincipalType,
+	CredentialScope,
+	DataApiAuthProvider,
+	DataApiConfig,
+	DataApiExternalAuthConfig,
+	DataApiInput,
+	DataApiNeonAuthConfig,
+	DataApiSettings,
+	DeployFunctionInput,
+	DiffOptions,
+	DiffResult,
+	DurationString,
+	DurationUnit,
+	EnableDataApiInput,
+	FunctionDef,
+	FunctionDevConfig,
+	FunctionRuntime,
+	FunctionTuning,
+	GetConnectionUriInput,
+	LoadConfigOptions,
+	NeonApi,
+	NeonAuthSnapshot,
+	NeonBranchSnapshot,
+	NeonBranchStorageSnapshot,
+	NeonBucketSnapshot,
+	NeonCredentialMeta,
+	NeonCredentialSecret,
+	NeonDataApiSnapshot,
+	NeonDatabaseSnapshot,
+	NeonEndpointSnapshot,
+	NeonFunctionDeploymentSnapshot,
+	NeonFunctionSnapshot,
+	NeonProjectSnapshot,
+	NeonRoleSnapshot,
+	PlanStep,
+	PostgresConfig,
+	PreviewInput,
+	PreviewTuning,
+	PushResult,
+	RemotePreviewState,
+	RemoteServiceState,
+	RemoteState,
+	ResolvedBranchConfig,
+	ResolvedBucketConfig,
+	ResolvedDataApiConfig,
+	ResolvedFunctionConfig,
+	ResolvedPreviewConfig,
+	ServiceEnabled,
+	ServiceToggle,
+	ServiceToggleInput,
+	UpdateBranchInput,
+} from "./v1.js";
+import { type Config, defineConfig } from "./v1.js";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public TYPE-export surface lock. Type-only exports cannot be enumerated at runtime, so
+// this file references every public type of `@neondatabase/config/v1`. Removing or renaming
+// any of them fails to compile here — a deliberate tripwire against an accidental breaking
+// change to the type surface. Run via `pnpm --filter @neondatabase/config test:types` and
+// enforced by `tsc --noEmit` during the build (this file lives under `src`).
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("config type-export surface", () => {
+	test("every public config type is exported (compile-time tripwire)", () => {
+		expectTypeOf<AppliedChange>().not.toBeAny();
+		expectTypeOf<BranchTarget>().not.toBeAny();
+		expectTypeOf<BranchTuning>().not.toBeAny();
+		expectTypeOf<BranchTuningFn>().not.toBeAny();
+		expectTypeOf<BucketAccessLevel>().not.toBeAny();
+		expectTypeOf<BucketDef>().not.toBeAny();
+		expectTypeOf<ComputeSettings>().not.toBeAny();
+		expectTypeOf<ComputeUnit>().not.toBeAny();
+		expectTypeOf<Config>().not.toBeAny();
+		expectTypeOf<ConflictReport>().not.toBeAny();
+		expectTypeOf<CredentialPrincipalType>().not.toBeAny();
+		expectTypeOf<CredentialScope>().not.toBeAny();
+		expectTypeOf<DataApiAuthProvider>().not.toBeAny();
+		expectTypeOf<DataApiConfig>().not.toBeAny();
+		expectTypeOf<DataApiExternalAuthConfig>().not.toBeAny();
+		expectTypeOf<DataApiInput>().not.toBeAny();
+		expectTypeOf<DataApiNeonAuthConfig>().not.toBeAny();
+		expectTypeOf<DataApiSettings>().not.toBeAny();
+		expectTypeOf<DurationString>().not.toBeAny();
+		expectTypeOf<DurationUnit>().not.toBeAny();
+		expectTypeOf<FunctionDef>().not.toBeAny();
+		expectTypeOf<FunctionDevConfig>().not.toBeAny();
+		expectTypeOf<FunctionRuntime>().not.toBeAny();
+		expectTypeOf<FunctionTuning>().not.toBeAny();
+		expectTypeOf<PostgresConfig>().not.toBeAny();
+		expectTypeOf<PreviewInput>().not.toBeAny();
+		expectTypeOf<PreviewTuning>().not.toBeAny();
+		expectTypeOf<PushResult>().not.toBeAny();
+		expectTypeOf<ResolvedBranchConfig>().not.toBeAny();
+		expectTypeOf<ResolvedBucketConfig>().not.toBeAny();
+		expectTypeOf<ResolvedDataApiConfig>().not.toBeAny();
+		expectTypeOf<ResolvedFunctionConfig>().not.toBeAny();
+		expectTypeOf<ResolvedPreviewConfig>().not.toBeAny();
+		expectTypeOf<ServiceEnabled<true>>().not.toBeAny();
+		expectTypeOf<ServiceToggle>().not.toBeAny();
+		expectTypeOf<ServiceToggleInput>().not.toBeAny();
+	});
+
+	test("every public NeonApi adapter type is exported (compile-time tripwire)", () => {
+		expectTypeOf<CreateBranchInput>().not.toBeAny();
+		expectTypeOf<CreateBucketInput>().not.toBeAny();
+		expectTypeOf<CreateCredentialInput>().not.toBeAny();
+		expectTypeOf<CreateProjectInput>().not.toBeAny();
+		expectTypeOf<CredentialFeatureFlags>().not.toBeAny();
+		expectTypeOf<DeployFunctionInput>().not.toBeAny();
+		expectTypeOf<EnableDataApiInput>().not.toBeAny();
+		expectTypeOf<GetConnectionUriInput>().not.toBeAny();
+		expectTypeOf<NeonApi>().not.toBeAny();
+		expectTypeOf<NeonAuthSnapshot>().not.toBeAny();
+		expectTypeOf<NeonBranchSnapshot>().not.toBeAny();
+		expectTypeOf<NeonBranchStorageSnapshot>().not.toBeAny();
+		expectTypeOf<NeonBucketSnapshot>().not.toBeAny();
+		expectTypeOf<NeonCredentialMeta>().not.toBeAny();
+		expectTypeOf<NeonCredentialSecret>().not.toBeAny();
+		expectTypeOf<NeonDataApiSnapshot>().not.toBeAny();
+		expectTypeOf<NeonDatabaseSnapshot>().not.toBeAny();
+		expectTypeOf<NeonEndpointSnapshot>().not.toBeAny();
+		expectTypeOf<NeonFunctionDeploymentSnapshot>().not.toBeAny();
+		expectTypeOf<NeonFunctionSnapshot>().not.toBeAny();
+		expectTypeOf<NeonProjectSnapshot>().not.toBeAny();
+		expectTypeOf<NeonRoleSnapshot>().not.toBeAny();
+		expectTypeOf<UpdateBranchInput>().not.toBeAny();
+	});
+
+	test("every public diff/loader type is exported (compile-time tripwire)", () => {
+		expectTypeOf<DiffOptions>().not.toBeAny();
+		expectTypeOf<DiffResult>().not.toBeAny();
+		expectTypeOf<PlanStep>().not.toBeAny();
+		expectTypeOf<RemotePreviewState>().not.toBeAny();
+		expectTypeOf<RemoteServiceState>().not.toBeAny();
+		expectTypeOf<RemoteState>().not.toBeAny();
+		expectTypeOf<LoadConfigOptions>().not.toBeAny();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `defineConfig` return-type stability. `defineConfig` infers the static toggles as `const`
+// literals into `Config<Auth, DataApi, Preview>` — that literal inference is exactly what
+// makes `NeonEnv<typeof config>` exact downstream (see env's NeonEnv presence matrix). If
+// inference ever widens (e.g. `auth: true` → `boolean`), the env namespaces silently break.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("defineConfig return-type stability", () => {
+	test("the returned value is a Config", () => {
+		const config = defineConfig({ auth: true });
+		expectTypeOf(config).toExtend<Config>();
+	});
+
+	test("static toggles keep their literal type (not widened to boolean)", () => {
+		const enabled = defineConfig({ auth: true });
+		expectTypeOf(enabled.auth).toEqualTypeOf<true | undefined>();
+
+		const disabled = defineConfig({ auth: false });
+		expectTypeOf(disabled.auth).toEqualTypeOf<false | undefined>();
+
+		// An omitted toggle stays `undefined` (not `boolean`), so the env namespace is absent.
+		const empty = defineConfig({});
+		expectTypeOf(empty.auth).toEqualTypeOf<undefined>();
+	});
+
+	test("declared function slugs are preserved on the returned Config", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					hello: { name: "H", source: "./h.ts" },
+					world: { name: "W", source: "./w.ts" },
+				},
+			},
+		});
+		expectTypeOf<
+			keyof NonNullable<NonNullable<typeof config.preview>["functions"]>
+		>().toEqualTypeOf<"hello" | "world">();
+	});
+});

--- a/packages/config/src/v1.test.ts
+++ b/packages/config/src/v1.test.ts
@@ -3,8 +3,10 @@ import {
 	createRealNeonApi,
 	defineConfig,
 	diffConfig,
+	errors,
 	loadConfigFromFile,
 	resolveConfig,
+	schemas,
 } from "./v1.js";
 
 describe("v1 surface", () => {
@@ -31,5 +33,84 @@ describe("v1 surface", () => {
 		expect("inspect" in surface).toBe(false);
 		expect("pushConfig" in surface).toBe(false);
 		expect("pullConfig" in surface).toBe(false);
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public value-export surface lock. Removing or renaming an export is a breaking change
+// for everyone importing `@neondatabase/config`; these snapshots make that change explicit
+// and reviewable rather than silent. (Type-only exports are guarded in `v1.test-d.ts`.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("@neondatabase/config public value surface", () => {
+	test("v1 value exports are stable", async () => {
+		const surface = await import("./v1.js");
+		expect(Object.keys(surface).sort()).toMatchInlineSnapshot(`
+			[
+			  "ConfigLoadError",
+			  "ConfigValidationError",
+			  "DATA_API_AUTH_PROVIDERS",
+			  "ErrorCode",
+			  "MissingContextError",
+			  "PlatformError",
+			  "PushAbortedError",
+			  "PushConflictError",
+			  "createNeonApiFromOptions",
+			  "createRealNeonApi",
+			  "credentialScopesSatisfied",
+			  "defineConfig",
+			  "deriveCredentialScopes",
+			  "diffConfig",
+			  "errors",
+			  "isPlatformError",
+			  "loadConfigFromFile",
+			  "resolveApiKey",
+			  "resolveConfig",
+			  "schemas",
+			]
+		`);
+	});
+
+	test("the `errors` namespace is stable", () => {
+		expect(Object.keys(errors).sort()).toMatchInlineSnapshot(`
+			[
+			  "ConfigLoadError",
+			  "ConfigValidationError",
+			  "ErrorCode",
+			  "MissingContextError",
+			  "PlatformError",
+			  "PushAbortedError",
+			  "PushConflictError",
+			  "isPlatformError",
+			]
+		`);
+	});
+
+	test("the `schemas` namespace is stable", () => {
+		expect(Object.keys(schemas).sort()).toMatchInlineSnapshot(`
+			[
+			  "branchTuning",
+			  "bucket",
+			  "computeSettings",
+			  "config",
+			  "dataApi",
+			  "dataApiInput",
+			  "dataApiSettings",
+			  "function",
+			  "functionTuning",
+			  "postgres",
+			  "preview",
+			  "service",
+			  "serviceInput",
+			]
+		`);
+	});
+
+	test("the default entry point re-exports exactly the v1 surface", async () => {
+		const [v1, index] = await Promise.all([
+			import("./v1.js"),
+			import("./index.js"),
+		]);
+		expect(Object.keys(index).sort()).toEqual(Object.keys(v1).sort());
 	});
 });

--- a/packages/env/src/lib/env.contract.test.ts
+++ b/packages/env/src/lib/env.contract.test.ts
@@ -1,0 +1,220 @@
+import { defineConfig } from "@neondatabase/config/v1";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { NEON_ENV_VAR_KEYS, type NeonEnv, parseEnv, toEntries } from "./env.js";
+import { stubCleanNeonEnv } from "./test-utils.js";
+
+beforeEach(() => stubCleanNeonEnv());
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Userspace-contract regression tests for the env package.
+//
+// These guard the contracts users (and platform integrations) depend on but that no
+// behavioral test exercises directly:
+//   1. The OS-level env-var NAMES (`DATABASE_URL`, `NEON_AUTH_BASE_URL`, …) — renaming one
+//      silently breaks every `.env` file and platform integration.
+//   2. The internal maps that must stay in sync — `NEON_ENV_VAR_KEYS` (names) ↔ the per-
+//      namespace zod schemas ↔ `FILTERABLE_ENV_KEYS` (filter reverse map) ↔ the `parseEnv`
+//      filter types. Adding a var to one and forgetting the others means `parseEnv` silently
+//      stops validating / returning it.
+//   3. The `toEntries` → `parseEnv` round-trip (the cross-process transport contract).
+//   4. The public value-export surface of `@neondatabase/env/v1`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Every **input** OS env-var the package reads back via `parseEnv`, paired with the
+ * {@link NeonEnv} namespace + camelCase property it populates. This is the test's source of
+ * truth; the cross-checks below tie it to `NEON_ENV_VAR_KEYS`, the per-namespace zod schemas,
+ * and the `parseEnv` key filter. Output-only aliases (see {@link OUTPUT_ONLY_ENV_VARS}) are
+ * intentionally excluded — they are emitted by `toEntries` but never parsed back.
+ */
+const INPUT_ENV_KEYS = [
+	{ key: "DATABASE_URL", namespace: "postgres", prop: "databaseUrl" },
+	{
+		key: "DATABASE_URL_UNPOOLED",
+		namespace: "postgres",
+		prop: "databaseUrlUnpooled",
+	},
+	{ key: "NEON_AUTH_BASE_URL", namespace: "auth", prop: "baseUrl" },
+	{ key: "NEON_AUTH_JWKS_URL", namespace: "auth", prop: "jwksUrl" },
+	{ key: "NEON_DATA_API_URL", namespace: "dataApi", prop: "url" },
+	{ key: "AWS_ACCESS_KEY_ID", namespace: "storage", prop: "accessKeyId" },
+	{
+		key: "AWS_SECRET_ACCESS_KEY",
+		namespace: "storage",
+		prop: "secretAccessKey",
+	},
+	{ key: "AWS_ENDPOINT_URL_S3", namespace: "storage", prop: "endpoint" },
+	{ key: "AWS_REGION", namespace: "storage", prop: "region" },
+	{ key: "OPENAI_API_KEY", namespace: "aiGateway", prop: "apiKey" },
+	{ key: "OPENAI_BASE_URL", namespace: "aiGateway", prop: "baseUrl" },
+] as const;
+
+/**
+ * Env-vars `toEntries` emits but `parseEnv` never reads back: the branch name (optional), the
+ * derived storage flag, the Neon-specific region alias, and the AI-gateway aliases. Listed so
+ * the completeness check below can prove every *other* env-var in `NEON_ENV_VAR_KEYS` is a
+ * covered input — i.e. adding a new input var without a test fails loudly.
+ */
+const OUTPUT_ONLY_ENV_VARS: ReadonlySet<string> = new Set([
+	"NEON_BRANCH",
+	"NEON_STORAGE_REGION",
+	"NEON_STORAGE_FORCE_PATH_STYLE",
+	"NEON_AI_GATEWAY_TOKEN",
+	"NEON_AI_GATEWAY_BASE_URL",
+]);
+
+/**
+ * A policy that turns on every secret-bearing namespace, so every input env-var above is
+ * type-level *selectable* by the `parseEnv(config, keys)` filter. (Filtered `parseEnv` does
+ * not consult the policy at runtime, but the overload constrains `keys` to the policy's
+ * `SelectableEnvKey`, so the config must enable each namespace for the keys to type-check.)
+ */
+const allNamespacesConfig = defineConfig({
+	auth: true,
+	dataApi: true,
+	preview: { buckets: { uploads: {} }, aiGateway: true },
+});
+
+describe("NEON_ENV_VAR_KEYS (public OS env-var names)", () => {
+	test("is a stable public contract (rename = breaking change for users + platforms)", () => {
+		expect(NEON_ENV_VAR_KEYS).toMatchInlineSnapshot(`
+			{
+			  "aiGateway": {
+			    "apiKey": "OPENAI_API_KEY",
+			    "baseUrl": "OPENAI_BASE_URL",
+			    "neonBaseUrl": "NEON_AI_GATEWAY_BASE_URL",
+			    "neonToken": "NEON_AI_GATEWAY_TOKEN",
+			  },
+			  "auth": {
+			    "baseUrl": "NEON_AUTH_BASE_URL",
+			    "jwksUrl": "NEON_AUTH_JWKS_URL",
+			  },
+			  "branch": {
+			    "name": "NEON_BRANCH",
+			  },
+			  "dataApi": {
+			    "url": "NEON_DATA_API_URL",
+			  },
+			  "postgres": {
+			    "databaseUrl": "DATABASE_URL",
+			    "databaseUrlUnpooled": "DATABASE_URL_UNPOOLED",
+			  },
+			  "storage": {
+			    "accessKeyId": "AWS_ACCESS_KEY_ID",
+			    "endpoint": "AWS_ENDPOINT_URL_S3",
+			    "forcePathStyle": "NEON_STORAGE_FORCE_PATH_STYLE",
+			    "region": "AWS_REGION",
+			    "regionNeon": "NEON_STORAGE_REGION",
+			    "secretAccessKey": "AWS_SECRET_ACCESS_KEY",
+			  },
+			}
+		`);
+	});
+});
+
+describe("env-var map consistency (names ↔ schemas ↔ filter)", () => {
+	test.each(INPUT_ENV_KEYS)(
+		"$key maps to $namespace.$prop and round-trips through the parseEnv filter",
+		(entry) => {
+			// (a) The OS name matches NEON_ENV_VAR_KEYS for that namespace/property.
+			expect(NEON_ENV_VAR_KEYS).toHaveProperty(
+				[entry.namespace, entry.prop],
+				entry.key,
+			);
+			// (b) Selecting the key returns its value under the right namespace/property —
+			//     this exercises the runtime filter reverse map + the filter result type.
+			vi.stubEnv(entry.key, `value-${entry.key}`);
+			expect(parseEnv(allNamespacesConfig, [entry.key])).toHaveProperty(
+				[entry.namespace, entry.prop],
+				`value-${entry.key}`,
+			);
+		},
+	);
+
+	test.each(INPUT_ENV_KEYS)(
+		"$key is required when selected (unset → EnvNotInjected naming it)",
+		(entry) => {
+			// No stub: the var is unset, so selecting it must throw and name it (this drives
+			// the per-namespace zod `min(1)` / required check via the filter path).
+			expect(() =>
+				parseEnv(allNamespacesConfig, [entry.key]),
+			).toThrowError(new RegExp(`${entry.key} is missing`));
+		},
+	);
+
+	test("every input env-var in NEON_ENV_VAR_KEYS is covered by a map test", () => {
+		// Catches *additions*: a new input var added to NEON_ENV_VAR_KEYS (but not to
+		// INPUT_ENV_KEYS / the filter) shows up here as an uncovered key.
+		const allNames = Object.values(NEON_ENV_VAR_KEYS).flatMap((namespace) =>
+			Object.values(namespace),
+		);
+		const inputNames = allNames
+			.filter((name) => !OUTPUT_ONLY_ENV_VARS.has(name))
+			.sort();
+		const coveredNames = INPUT_ENV_KEYS.map((e) => e.key).sort();
+		expect(inputNames).toEqual(coveredNames);
+	});
+});
+
+describe("toEntries → parseEnv round-trip (cross-process transport)", () => {
+	test("every namespace survives projection to OS env and back", () => {
+		const config = defineConfig({
+			auth: true,
+			dataApi: true,
+			preview: { buckets: { uploads: {} }, aiGateway: true },
+		});
+		const env: NeonEnv<typeof config> = {
+			postgres: {
+				databaseUrl: "postgres://pooled",
+				databaseUrlUnpooled: "postgres://direct",
+			},
+			branch: { name: "preview/foo" },
+			auth: {
+				baseUrl: "https://auth.example.com",
+				jwksUrl: "https://auth.example.com/.well-known/jwks.json",
+			},
+			dataApi: { url: "https://data.example.com" },
+			storage: {
+				accessKeyId: "nak_live_abc",
+				secretAccessKey: "s".repeat(64),
+				endpoint: "https://br.storage.neon.build",
+				region: "us-east-2",
+				forcePathStyle: true,
+			},
+			aiGateway: {
+				apiKey: "nt_live_abc_def",
+				baseUrl: "https://x.neon.build/ai-gateway/openai/v1",
+			},
+		};
+
+		// Project to OS env-vars and inject them, exactly as `neon-env run` does.
+		for (const [key, value] of Object.entries(toEntries(env))) {
+			vi.stubEnv(key, value);
+		}
+
+		// Re-reading through parseEnv must reconstruct the identical NeonEnv.
+		expect(parseEnv(config)).toEqual(env);
+	});
+});
+
+describe("@neondatabase/env/v1 public surface", () => {
+	test("value exports are stable (removing/renaming one is a breaking change)", async () => {
+		const surface = await import("../v1.js");
+		expect(Object.keys(surface).sort()).toMatchInlineSnapshot(`
+			[
+			  "NEON_ENV_VAR_KEYS",
+			  "fetchEnv",
+			  "parseEnv",
+			  "toEntries",
+			]
+		`);
+	});
+
+	test("the default entry point re-exports exactly the v1 surface", async () => {
+		const [v1, index] = await Promise.all([
+			import("../v1.js"),
+			import("../index.js"),
+		]);
+		expect(Object.keys(index).sort()).toEqual(Object.keys(v1).sort());
+	});
+});

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -1,5 +1,17 @@
-import { defineConfig } from "@neondatabase/config/v1";
+import { type Config, defineConfig } from "@neondatabase/config/v1";
 import { describe, expectTypeOf, test } from "vitest";
+import type {
+	FetchEnvOptions,
+	FilteredNeonEnv,
+	FunctionSlugOf,
+	NeonAiGatewayEnv,
+	NeonAuthEnv,
+	NeonBranchEnv,
+	NeonDataApiEnv,
+	NeonFunctionEnv,
+	NeonPostgresEnv,
+	NeonStorageEnv,
+} from "./env.js";
 import { type NeonEnv, parseEnv, type SelectableEnvKey } from "./env.js";
 
 // Type-level tests for `parseEnv`. Run via `pnpm --filter @neondatabase/env test:types`
@@ -104,5 +116,188 @@ describe("parseEnv existing overloads still type", () => {
 		const env = parseEnv(config, "hello");
 		expectTypeOf(env.function).toEqualTypeOf<{ resendApiKey: string }>();
 		expectTypeOf(env.function.resendApiKey).toEqualTypeOf<string>();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NeonEnv<C> namespace-presence matrix.
+//
+// `NeonEnv<C>` is the crown-jewel userspace type: the shape every consumer reads
+// (`env.postgres.databaseUrl`, `env.auth.baseUrl`, …). Its optional namespaces are derived
+// from the static policy, and a regression there (e.g. `storage` always present, or `auth`
+// never inferred) breaks user code *silently* — the resolved indexed type can still look
+// right while presence flips. These assertions pin which namespaces each policy yields.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Reduce a policy's `NeonEnv` to a boolean-per-namespace presence record, so an entire
+ * policy's namespace set can be asserted in one exact `toEqualTypeOf`. `postgres` and the
+ * optional `branch` key are always present; the rest are gated on the policy.
+ */
+type NamespacePresence<C extends Config> = {
+	postgres: "postgres" extends keyof NeonEnv<C> ? true : false;
+	branch: "branch" extends keyof NeonEnv<C> ? true : false;
+	auth: "auth" extends keyof NeonEnv<C> ? true : false;
+	dataApi: "dataApi" extends keyof NeonEnv<C> ? true : false;
+	storage: "storage" extends keyof NeonEnv<C> ? true : false;
+	aiGateway: "aiGateway" extends keyof NeonEnv<C> ? true : false;
+};
+
+/** The presence record of a postgres-only policy (no secret namespaces). */
+type PostgresOnly = {
+	postgres: true;
+	branch: true;
+	auth: false;
+	dataApi: false;
+	storage: false;
+	aiGateway: false;
+};
+
+describe("NeonEnv namespace presence (types)", () => {
+	test("an empty policy yields only postgres (+ optional branch)", () => {
+		const empty = defineConfig({});
+		expectTypeOf<
+			NamespacePresence<typeof empty>
+		>().toEqualTypeOf<PostgresOnly>();
+	});
+
+	test("auth toggles add (or omit) the auth namespace", () => {
+		const authTrue = defineConfig({ auth: true });
+		const authObj = defineConfig({ auth: {} });
+		const authFalse = defineConfig({ auth: false });
+		const authDisabled = defineConfig({ auth: { enabled: false } });
+		expectTypeOf<
+			NamespacePresence<typeof authTrue>["auth"]
+		>().toEqualTypeOf<true>();
+		expectTypeOf<
+			NamespacePresence<typeof authObj>["auth"]
+		>().toEqualTypeOf<true>();
+		// Disabled toggles must NOT add the namespace.
+		expectTypeOf<
+			NamespacePresence<typeof authFalse>["auth"]
+		>().toEqualTypeOf<false>();
+		expectTypeOf<
+			NamespacePresence<typeof authDisabled>["auth"]
+		>().toEqualTypeOf<false>();
+		// When present, the namespace is exactly NeonAuthEnv.
+		expectTypeOf<
+			NeonEnv<typeof authTrue>["auth"]
+		>().toEqualTypeOf<NeonAuthEnv>();
+	});
+
+	test("dataApi toggles add (or omit) the dataApi namespace", () => {
+		// External Data API: enabled, no Neon Auth required.
+		const external = defineConfig({
+			dataApi: {
+				authProvider: "external",
+				jwksUrl: "https://idp.example.com/jwks.json",
+			},
+		});
+		const neon = defineConfig({ auth: true, dataApi: true });
+		const disabled = defineConfig({ dataApi: false });
+		expectTypeOf<
+			NamespacePresence<typeof external>["dataApi"]
+		>().toEqualTypeOf<true>();
+		expectTypeOf<
+			NeonEnv<typeof external>["dataApi"]
+		>().toEqualTypeOf<NeonDataApiEnv>();
+		// Neon Data API (requires auth) is enabled too.
+		expectTypeOf<
+			NamespacePresence<typeof neon>["dataApi"]
+		>().toEqualTypeOf<true>();
+		// Disabled → omitted.
+		expectTypeOf<
+			NamespacePresence<typeof disabled>["dataApi"]
+		>().toEqualTypeOf<false>();
+	});
+
+	test("preview.buckets adds the storage namespace (only when non-empty)", () => {
+		const withBucket = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		const emptyBuckets = defineConfig({ preview: { buckets: {} } });
+		expectTypeOf<
+			NamespacePresence<typeof withBucket>["storage"]
+		>().toEqualTypeOf<true>();
+		expectTypeOf<
+			NeonEnv<typeof withBucket>["storage"]
+		>().toEqualTypeOf<NeonStorageEnv>();
+		// An empty buckets record declares no bucket → no storage namespace.
+		expectTypeOf<
+			NamespacePresence<typeof emptyBuckets>["storage"]
+		>().toEqualTypeOf<false>();
+	});
+
+	test("preview.aiGateway adds (or omits) the aiGateway namespace", () => {
+		const on = defineConfig({ preview: { aiGateway: true } });
+		const off = defineConfig({ preview: { aiGateway: false } });
+		expectTypeOf<
+			NamespacePresence<typeof on>["aiGateway"]
+		>().toEqualTypeOf<true>();
+		expectTypeOf<
+			NeonEnv<typeof on>["aiGateway"]
+		>().toEqualTypeOf<NeonAiGatewayEnv>();
+		expectTypeOf<
+			NamespacePresence<typeof off>["aiGateway"]
+		>().toEqualTypeOf<false>();
+	});
+
+	test("preview.functions alone adds no env namespace (functions are not secrets here)", () => {
+		const fnOnly = defineConfig({
+			preview: {
+				functions: { hello: { name: "H", source: "./h.ts" } },
+			},
+		});
+		expectTypeOf<
+			NamespacePresence<typeof fnOnly>
+		>().toEqualTypeOf<PostgresOnly>();
+	});
+
+	test("a fully-enabled policy yields every namespace", () => {
+		const everything = defineConfig({
+			auth: true,
+			dataApi: true,
+			preview: { buckets: { uploads: {} }, aiGateway: true },
+		});
+		expectTypeOf<NamespacePresence<typeof everything>>().toEqualTypeOf<{
+			postgres: true;
+			branch: true;
+			auth: true;
+			dataApi: true;
+			storage: true;
+			aiGateway: true;
+		}>();
+	});
+
+	test("a bare, untyped Config yields only postgres (no namespace leakage)", () => {
+		// The default `Config` (no literal toggle info) must not optimistically add the
+		// secret namespaces — an untyped policy reads as "postgres only".
+		expectTypeOf<NamespacePresence<Config>>().toEqualTypeOf<PostgresOnly>();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Type-export presence lock. Type-only exports can't be enumerated at runtime, so this
+// references every public type from `./env.js`. Removing or renaming one fails compilation
+// here — a deliberate tripwire for an accidental breaking change to the type surface.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("env type-export surface", () => {
+	test("every public type is exported (compile-time tripwire)", () => {
+		const sample = defineConfig({
+			preview: { functions: { hello: { name: "H", source: "./h.ts" } } },
+		});
+		expectTypeOf<FetchEnvOptions>().not.toBeAny();
+		expectTypeOf<FilteredNeonEnv<"DATABASE_URL">>().not.toBeAny();
+		expectTypeOf<FunctionSlugOf<typeof sample>>().not.toBeAny();
+		expectTypeOf<NeonAiGatewayEnv>().not.toBeAny();
+		expectTypeOf<NeonAuthEnv>().not.toBeAny();
+		expectTypeOf<NeonBranchEnv>().not.toBeAny();
+		expectTypeOf<NeonDataApiEnv>().not.toBeAny();
+		expectTypeOf<NeonEnv>().not.toBeAny();
+		expectTypeOf<NeonFunctionEnv<typeof sample, "hello">>().not.toBeAny();
+		expectTypeOf<NeonPostgresEnv>().not.toBeAny();
+		expectTypeOf<NeonStorageEnv>().not.toBeAny();
+		expectTypeOf<SelectableEnvKey<typeof sample>>().not.toBeAny();
 	});
 });


### PR DESCRIPTION
## Summary

Adds regression tests that guard the contracts users and platform integrations depend on but that no existing test exercised directly. **Test-only — no source or public-API changes** (verified: `git diff` touches only `*.test.ts` / `*.test-d.ts`).

These target the "silent break" class: changes that compile and pass every behavioral test while breaking userspace — env-var renames, drift between the env-var maps, regressions in the `NeonEnv<C>` type derivation, and accidental removal of public exports.

### `@neondatabase/env`

**Runtime — `src/lib/env.contract.test.ts` (new):**
- **Snapshot `NEON_ENV_VAR_KEYS`** — the public OS env-var names (`DATABASE_URL`, `NEON_AUTH_BASE_URL`, `OPENAI_API_KEY`, …) are a hard contract (`.env` files, platform integrations). A rename is now an explicit, reviewed diff.
- **Map-consistency cross-check** — data-driven over every input var, ties `NEON_ENV_VAR_KEYS` ↔ the per-namespace zod schemas ↔ the `parseEnv` key filter together, plus a completeness check that fails if a new input var is added without coverage.
- **`toEntries` → `parseEnv` round-trip** across every namespace (the cross-process transport contract).
- **Public value-export surface lock** (+ `index` === `v1`).

**Types — `src/lib/env.test-d.ts` (extended):**
- **Exhaustive `NeonEnv<C>` namespace-presence matrix** — the crown-jewel userspace type. `postgres`/`branch` always present; `auth`/`dataApi`/`storage`/`aiGateway` gated on the policy, including disabled toggles, empty `buckets`, functions-only, fully-enabled, and the bare untyped `Config` (no namespace leakage).
- **Type-export presence lock** for every public type.

### `@neondatabase/config`

**Runtime — `src/v1.test.ts` (extended):**
- **Value-export surface lock** for `v1`, plus the `errors` and `schemas` namespaces (+ `index` === `v1`).

**Types — `src/v1.test-d.ts` (new):**
- **Type-export presence lock** for every public config + NeonApi adapter type.
- **`defineConfig` return-type stability** — static toggles keep their literal type (not widened to `boolean`) and declared function slugs are preserved. This is the inference that keeps `NeonEnv<typeof config>` exact downstream.

## How regressions are caught

- Runtime tests run in `pnpm test:ci`.
- Type tests (`.test-d.ts`) are enforced by the `build` job (`tsc --noEmit` over `src`); also runnable via `pnpm --filter … test:types`. They are excluded from the published bundle (`tsdown` ignores `*.test-d.*`).

## Verified the tests have teeth

- Renaming one env var (`DATABASE_URL` → `DATABASE_URL_X`) → **4** contract-test failures (snapshot, map, required check, round-trip).
- Inverting the `storage` derivation (`HasBuckets<C> extends true` → `false`) → **8** type-test failures.

No changeset: nothing in the published packages changes.

## Test plan

- [x] `config`: 223 runtime tests + 23 type tests pass; `tsc --noEmit` clean
- [x] `env`: 93 runtime tests + 21 type tests pass; `tsc --noEmit` clean
- [x] Mutation-verified the new guards fail when the contracts are broken
- [x] `git diff` confirms only test files changed