### PR TITLE
feat(ai-sdk-provider): AI SDK v6 compatibility

### DIFF
--- a/.changeset/ai-sdk-provider-v6.md
+++ b/.changeset/ai-sdk-provider-v6.md
@@ -1,0 +1,5 @@
+---
+"@neondatabase/ai-sdk-provider": minor
+---
+
+Upgrade `@neondatabase/ai-sdk-provider` to the AI SDK v6 provider specification (v3 language models). Requires `ai@^6`.

--- a/packages/ai-sdk-provider/.env.example
+++ b/packages/ai-sdk-provider/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and fill from `neonctl env pull` on a branch with AI Gateway enabled.
+NEON_AI_GATEWAY_BASE_URL=https://<branch-id>-api.ai.<region>.aws.neon.tech
+NEON_AI_GATEWAY_TOKEN=nt_live_...

--- a/packages/ai-sdk-provider/.gitignore
+++ b/packages/ai-sdk-provider/.gitignore
@@ -1,0 +1,4 @@
+# Local e2e credentials — never commit
+.env
+.env.*
+!.env.example

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -87,6 +87,18 @@ for await (const part of result.fullStream) {
 
 - `generateImage()` and embeddings (`embed` / `embedMany`) are not offered by the gateway and throw `NoSuchModelError`.
 - `gpt-oss-*` models return a non-standard ("harmony") response shape on the unified endpoint and are not fully supported.
+- OpenAI Responses multi-turn tool flows (`generateText` + `stepCountIs`) can return 502 from the gateway; tool calling is covered on Anthropic/Google/Meta in e2e.
+
+## End-to-end tests
+
+Against a live branch with AI Gateway enabled:
+
+```bash
+cp .env.example .env   # fill NEON_AI_GATEWAY_BASE_URL + NEON_AI_GATEWAY_TOKEN from `neonctl env pull`
+pnpm test:e2e
+```
+
+The matrix covers one models.dev `neon` model per family (Anthropic, OpenAI, Codex, Gemini, Meta) across `generateText`, `streamText`, `generateObject`, tool calling, and `neon.tools.imageGeneration`. Skipped when gateway env vars are absent.
 
 ## Versioning
 

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -1,6 +1,6 @@
 # @neondatabase/ai-sdk-provider
 
-Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://neon.com) AI Gateway.
+Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://neon.com) AI Gateway. Requires **AI SDK v6** (`ai@^6`).
 
 The Neon AI Gateway is **branch-scoped**: each Neon project branch gets its own gateway host, and a platform token authorizes requests for that branch. This provider routes each model to the best gateway endpoint (Anthropic → native Messages, OpenAI → native Responses incl. **Codex**, everything else → unified OpenAI-compatible MLflow endpoint), so a single `neon('claude-...')` call reaches the whole catalog.
 
@@ -9,7 +9,7 @@ Model ids use the canonical Neon (unprefixed) form — `claude-sonnet-4-6`, `gpt
 ## Install
 
 ```bash
-npm install @neondatabase/ai-sdk-provider
+npm install @neondatabase/ai-sdk-provider ai@^6
 ```
 
 ## Configuration
@@ -68,12 +68,11 @@ Available on OpenAI models via the Responses `image_generation` tool (there is n
 ```ts
 import { streamText } from "ai";
 import { neon } from "@neondatabase/ai-sdk-provider/v1";
-import { imageGeneration } from "@ai-sdk/openai/internal";
 
 const result = streamText({
   model: neon("gpt-5-mini"),
   prompt: "Generate an image of a red apple on a wooden table",
-  tools: { image: imageGeneration({ partialImages: 3 }) },
+  tools: { image: neon.tools.imageGeneration({ partialImages: 3 }) },
 });
 
 for await (const part of result.fullStream) {

--- a/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
@@ -1,0 +1,176 @@
+import {
+	generateObject,
+	generateText,
+	stepCountIs,
+	streamText,
+	tool,
+} from "ai";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { neon } from "../src/v1.js";
+import {
+	assertGatewayEnv,
+	expectNoHardFailureWarnings,
+	hasGatewayEnv,
+	MATRIX_MODELS,
+	type MatrixFamily,
+	maxTokensFor,
+	REASONING_FAMILIES,
+} from "./helpers.js";
+
+const PROMPT = "Reply with exactly three words.";
+const SYSTEM = "You are a terse assistant. Never use more than three words.";
+
+const summarySchema = z.object({
+	topic: z.string(),
+	wordCount: z.number(),
+});
+
+const weatherTool = tool({
+	description: "Return the current temperature for a city in Fahrenheit.",
+	inputSchema: z.object({ city: z.string() }),
+	execute: async ({ city }) => ({ city, tempF: 72 }),
+});
+
+/** Families where structured output is expected to work end-to-end. */
+const STRUCTURED_FAMILIES = new Set<MatrixFamily>([
+	"anthropic",
+	"openai",
+	"google",
+	"meta",
+]);
+
+/** Families where multi-step tool calling is exercised (OpenAI Responses multi-turn tools can 502 on the gateway). */
+const TOOL_FAMILIES = new Set<MatrixFamily>(["anthropic", "google", "meta"]);
+
+function modelOptions(family: MatrixFamily) {
+	const maxOutputTokens = maxTokensFor(family);
+	if (!REASONING_FAMILIES.has(family)) {
+		return { maxOutputTokens };
+	}
+	return {
+		maxOutputTokens,
+		providerOptions: {
+			openai: { reasoningEffort: "low" as const },
+		},
+	};
+}
+
+describe.skipIf(!hasGatewayEnv())(
+	"e2e — Neon AI Gateway capability matrix",
+	() => {
+		assertGatewayEnv();
+
+		describe.each(
+			Object.entries(MATRIX_MODELS) as Array<[MatrixFamily, string]>,
+		)("%s (%s)", (family, modelId) => {
+			it("generateText", async () => {
+				const result = await generateText({
+					model: neon(modelId),
+					prompt: PROMPT,
+					...modelOptions(family),
+				});
+				expect(result.text.trim().length).toBeGreaterThan(0);
+				expectNoHardFailureWarnings(result.warnings);
+			});
+
+			it("generateText with system prompt", async () => {
+				const result = await generateText({
+					model: neon(modelId),
+					system: SYSTEM,
+					prompt: "Say hello.",
+					...modelOptions(family),
+				});
+				expect(result.text.trim().length).toBeGreaterThan(0);
+				expectNoHardFailureWarnings(result.warnings);
+			});
+
+			it("streamText", async () => {
+				const result = streamText({
+					model: neon(modelId),
+					prompt: PROMPT,
+					...modelOptions(family),
+				});
+				let text = "";
+				for await (const part of result.textStream) {
+					text += part;
+				}
+				expect(text.trim().length).toBeGreaterThan(0);
+			});
+
+			it.skipIf(!STRUCTURED_FAMILIES.has(family))(
+				"generateObject",
+				async () => {
+					const result = await generateObject({
+						model: neon(modelId),
+						schema: summarySchema,
+						prompt: 'Summarize "serverless postgres" in the schema.',
+						...modelOptions(family),
+					});
+					expect(result.object.topic.length).toBeGreaterThan(0);
+					expect(result.object.wordCount).toBeGreaterThan(0);
+					expectNoHardFailureWarnings(result.warnings);
+				},
+			);
+
+			it.skipIf(!TOOL_FAMILIES.has(family))(
+				"tool calling (generateText + stepCountIs)",
+				async () => {
+					const result = await generateText({
+						model: neon(modelId),
+						prompt: "What is the temperature in Paris? Use the weather tool.",
+						tools: { weather: weatherTool },
+						stopWhen: stepCountIs(5),
+						...modelOptions(family),
+					});
+					expect(result.text.trim().length).toBeGreaterThan(0);
+					expect(result.steps.length).toBeGreaterThanOrEqual(1);
+				},
+			);
+		});
+
+		describe("OpenAI Responses — imageGeneration tool", () => {
+			it("streamText with neon.tools.imageGeneration returns JPEG", async () => {
+				const result = streamText({
+					model: neon(MATRIX_MODELS.openai),
+					prompt: "Generate a simple red circle on a white background.",
+					tools: {
+						image_generation: neon.tools.imageGeneration({
+							outputFormat: "jpeg",
+							quality: "low",
+							outputCompression: 30,
+							size: "1024x1024",
+						}),
+					},
+					...modelOptions("openai"),
+				});
+
+				let gotImage = false;
+				for await (const part of result.fullStream) {
+					if (
+						part.type === "tool-result" &&
+						part.toolName === "image_generation" &&
+						typeof part.output === "object" &&
+						part.output !== null &&
+						"result" in part.output &&
+						typeof part.output.result === "string" &&
+						part.output.result.length > 1000
+					) {
+						gotImage = true;
+					}
+				}
+				expect(gotImage).toBe(true);
+			}, 120_000);
+		});
+
+		describe("known gateway limitations", () => {
+			it.skip("gpt-oss harmony response shape is not OpenAI-compatible on MLflow", () => {
+				// Documented limitation — see README.
+			});
+
+			it.skip("OpenAI Responses multi-turn tool follow-up can 502 on the gateway", () => {
+				// gpt-5-mini tool calling works for the first step but follow-up requests can 502.
+			});
+		});
+	},
+);

--- a/packages/ai-sdk-provider/e2e/helpers.ts
+++ b/packages/ai-sdk-provider/e2e/helpers.ts
@@ -1,0 +1,50 @@
+/**
+ * Representative models from the models.dev `neon` provider — one per gateway route
+ * family. See `NEON_MODELS_DEV_IDS` / `NEON_EXTRA_MODEL_IDS` in neon-chat-options.ts.
+ */
+export const MATRIX_MODELS = {
+	/** Native Anthropic Messages API */
+	anthropic: "claude-haiku-4-5",
+	/** Native OpenAI Responses API */
+	openai: "gpt-5-mini",
+	/** Native OpenAI Responses API (Codex) */
+	codex: "gpt-5-3-codex",
+	/** Unified MLflow endpoint (Gemini) */
+	google: "gemini-2-5-flash",
+	/** Unified MLflow endpoint (Meta) */
+	meta: "llama-4-maverick",
+} as const;
+
+export type MatrixFamily = keyof typeof MATRIX_MODELS;
+
+/** GPT-5 reasoning models on Responses can consume the whole budget on reasoning tokens. */
+export const REASONING_FAMILIES = new Set<MatrixFamily>(["openai", "codex"]);
+
+export function hasGatewayEnv(): boolean {
+	const baseUrl = process.env.NEON_AI_GATEWAY_BASE_URL?.trim();
+	const token = process.env.NEON_AI_GATEWAY_TOKEN?.trim();
+	return Boolean(baseUrl && token);
+}
+
+export function assertGatewayEnv(): void {
+	if (!hasGatewayEnv()) {
+		throw new Error(
+			"NEON_AI_GATEWAY_BASE_URL and NEON_AI_GATEWAY_TOKEN are required. " +
+				"Create packages/ai-sdk-provider/.env (see .env.example) or export them before running pnpm test:e2e.",
+		);
+	}
+}
+
+export function maxTokensFor(family: MatrixFamily): number {
+	return REASONING_FAMILIES.has(family) ? 2048 : 512;
+}
+
+/** Dropped-parameter warnings from the provider are expected, not failures. */
+export function expectNoHardFailureWarnings(
+	warnings: Array<{ type: string }> | undefined,
+): void {
+	if (!warnings?.length) return;
+	for (const warning of warnings) {
+		expect(warning.type).not.toBe("other");
+	}
+}

--- a/packages/ai-sdk-provider/e2e/load-env.ts
+++ b/packages/ai-sdk-provider/e2e/load-env.ts
@@ -1,0 +1,23 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Load `packages/ai-sdk-provider/.env` into `process.env` for e2e runs.
+ * Existing process env wins (so CI can inject secrets without a file).
+ */
+const here = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(here, "..", ".env");
+
+if (existsSync(envPath)) {
+	const raw = readFileSync(envPath, "utf-8");
+	for (const rawLine of raw.split("\n")) {
+		const line = rawLine.trim();
+		if (line === "" || line.startsWith("#")) continue;
+		const eq = line.indexOf("=");
+		if (eq <= 0) continue;
+		const key = line.slice(0, eq).trim();
+		const value = line.slice(eq + 1).trim();
+		if (process.env[key] === undefined) process.env[key] = value;
+	}
+}

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -47,6 +47,7 @@
 		"test": "vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"test:drift": "NEON_DRIFT_CHECK=1 vitest run neon-catalog-drift",
+		"test:e2e": "vitest run --config vitest.e2e.config.ts",
 		"tsc": "tsc"
 	},
 	"devDependencies": {

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/ai-sdk-provider",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",
@@ -52,6 +52,7 @@
 	"devDependencies": {
 		"@types/node": "catalog:",
 		"@vitest/coverage-v8": "3.0.9",
+		"ai": "6.0.132",
 		"console-fail-test": "0.5.0",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
@@ -66,13 +67,14 @@
 		"provenance": false
 	},
 	"dependencies": {
-		"@ai-sdk/anthropic": "4.0.0-beta.42",
-		"@ai-sdk/openai": "4.0.0-beta.44",
-		"@ai-sdk/openai-compatible": "3.0.0-beta.36",
-		"@ai-sdk/provider": "4.0.0-beta.14",
-		"@ai-sdk/provider-utils": "5.0.0-beta.30"
+		"@ai-sdk/anthropic": "3.0.82",
+		"@ai-sdk/openai": "3.0.69",
+		"@ai-sdk/openai-compatible": "2.0.48",
+		"@ai-sdk/provider": "3.0.10",
+		"@ai-sdk/provider-utils": "4.0.27"
 	},
 	"peerDependencies": {
+		"ai": "^6.0.0",
 		"zod": "^3.25.76 || ^4.1.8"
 	}
 }

--- a/packages/ai-sdk-provider/src/lib/neon-anthropic-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-anthropic-language-model.ts
@@ -1,9 +1,9 @@
-import { AnthropicLanguageModel } from "@ai-sdk/anthropic/internal";
+import { AnthropicMessagesLanguageModel } from "@ai-sdk/anthropic/internal";
 import type {
-	LanguageModelV4,
-	LanguageModelV4CallOptions,
-	LanguageModelV4GenerateResult,
-	LanguageModelV4StreamResult,
+	LanguageModelV3,
+	LanguageModelV3CallOptions,
+	LanguageModelV3GenerateResult,
+	LanguageModelV3StreamResult,
 } from "@ai-sdk/provider";
 
 /**
@@ -17,12 +17,12 @@ import type {
  * `toolStreaming` option so streaming tool calls work. Users can still override.
  */
 export class NeonAnthropicLanguageModel
-	extends AnthropicLanguageModel
-	implements LanguageModelV4
+	extends AnthropicMessagesLanguageModel
+	implements LanguageModelV3
 {
 	private withGatewayCompat(
-		options: LanguageModelV4CallOptions,
-	): LanguageModelV4CallOptions {
+		options: LanguageModelV3CallOptions,
+	): LanguageModelV3CallOptions {
 		const anthropic = options.providerOptions?.anthropic;
 		// Respect an explicit user setting.
 		if (anthropic != null && "toolStreaming" in anthropic) {
@@ -38,14 +38,14 @@ export class NeonAnthropicLanguageModel
 	}
 
 	override doGenerate(
-		options: LanguageModelV4CallOptions,
-	): Promise<LanguageModelV4GenerateResult> {
+		options: LanguageModelV3CallOptions,
+	): Promise<LanguageModelV3GenerateResult> {
 		return super.doGenerate(this.withGatewayCompat(options));
 	}
 
 	override doStream(
-		options: LanguageModelV4CallOptions,
-	): Promise<LanguageModelV4StreamResult> {
+		options: LanguageModelV3CallOptions,
+	): Promise<LanguageModelV3StreamResult> {
 		return super.doStream(this.withGatewayCompat(options));
 	}
 }

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
@@ -1,10 +1,9 @@
 import type {
-	LanguageModelV4CallOptions,
-	LanguageModelV4StreamPart,
-	SharedV4ProviderOptions,
-	SharedV4Warning,
+	LanguageModelV3CallOptions,
+	LanguageModelV3StreamPart,
+	SharedV3ProviderOptions,
+	SharedV3Warning,
 } from "@ai-sdk/provider";
-import { isCustomReasoning } from "@ai-sdk/provider-utils";
 import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
 
 /**
@@ -14,11 +13,11 @@ import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
  */
 export function applyNeonCapabilities(
 	modelId: string,
-	options: LanguageModelV4CallOptions,
-): { options: LanguageModelV4CallOptions; warnings: SharedV4Warning[] } {
+	options: LanguageModelV3CallOptions,
+): { options: LanguageModelV3CallOptions; warnings: SharedV3Warning[] } {
 	const caps = getNeonModelCapabilities(modelId);
-	const warnings: SharedV4Warning[] = [];
-	const patch: Partial<LanguageModelV4CallOptions> = {};
+	const warnings: SharedV3Warning[] = [];
+	const patch: Partial<LanguageModelV3CallOptions> = {};
 
 	const dropUnsupported = (feature: string) => {
 		warnings.push({
@@ -66,6 +65,7 @@ export function applyNeonCapabilities(
 		patch.seed = undefined;
 		dropUnsupported("seed");
 	}
+
 	if (options.stopSequences != null && !caps.supportsStopSequences) {
 		patch.stopSequences = undefined;
 		dropUnsupported("stopSequences");
@@ -79,14 +79,11 @@ export function applyNeonCapabilities(
 				(group) =>
 					"reasoningEffort" in group && group.reasoningEffort != null,
 			);
-		const hasReasoningOption =
-			isCustomReasoning(options.reasoning) &&
-			options.reasoning !== "none";
 
-		if (hasProviderEffort || hasReasoningOption) {
+		if (hasProviderEffort) {
 			dropUnsupported("reasoningEffort");
-			if (hasProviderEffort && providerOptions != null) {
-				const cleaned: SharedV4ProviderOptions = {};
+			if (providerOptions != null) {
+				const cleaned: SharedV3ProviderOptions = {};
 				for (const [key, group] of Object.entries(providerOptions)) {
 					if ("reasoningEffort" in group) {
 						const { reasoningEffort: _removed, ...rest } = group;
@@ -96,9 +93,6 @@ export function applyNeonCapabilities(
 					}
 				}
 				patch.providerOptions = cleaned;
-			}
-			if (hasReasoningOption) {
-				patch.reasoning = undefined;
 			}
 		}
 	}
@@ -112,11 +106,11 @@ export function applyNeonCapabilities(
 /**
  * Merge additional warnings into the `stream-start` part of a model stream.
  */
-export function mergeStreamStartWarnings(extra: SharedV4Warning[]) {
+export function mergeStreamStartWarnings(extra: SharedV3Warning[]) {
 	let merged = false;
 	return new TransformStream<
-		LanguageModelV4StreamPart,
-		LanguageModelV4StreamPart
+		LanguageModelV3StreamPart,
+		LanguageModelV3StreamPart
 	>({
 		transform(part, controller) {
 			if (!merged && part.type === "stream-start") {

--- a/packages/ai-sdk-provider/src/lib/neon-chat-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-chat-language-model.ts
@@ -1,9 +1,9 @@
 import { OpenAICompatibleChatLanguageModel } from "@ai-sdk/openai-compatible";
 import type {
-	LanguageModelV4,
-	LanguageModelV4CallOptions,
-	LanguageModelV4GenerateResult,
-	LanguageModelV4StreamResult,
+	LanguageModelV3,
+	LanguageModelV3CallOptions,
+	LanguageModelV3GenerateResult,
+	LanguageModelV3StreamResult,
 } from "@ai-sdk/provider";
 import {
 	applyNeonCapabilities,
@@ -21,11 +21,11 @@ import {
  */
 export class NeonChatLanguageModel
 	extends OpenAICompatibleChatLanguageModel
-	implements LanguageModelV4
+	implements LanguageModelV3
 {
 	override async doGenerate(
-		options: LanguageModelV4CallOptions,
-	): Promise<LanguageModelV4GenerateResult> {
+		options: LanguageModelV3CallOptions,
+	): Promise<LanguageModelV3GenerateResult> {
 		const { options: adjusted, warnings } = applyNeonCapabilities(
 			this.modelId,
 			options,
@@ -37,8 +37,8 @@ export class NeonChatLanguageModel
 	}
 
 	override async doStream(
-		options: LanguageModelV4CallOptions,
-	): Promise<LanguageModelV4StreamResult> {
+		options: LanguageModelV3CallOptions,
+	): Promise<LanguageModelV3StreamResult> {
 		const { options: adjusted, warnings } = applyNeonCapabilities(
 			this.modelId,
 			options,

--- a/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
@@ -1,9 +1,9 @@
 import { OpenAIResponsesLanguageModel } from "@ai-sdk/openai/internal";
 import type {
-	LanguageModelV4,
-	LanguageModelV4CallOptions,
-	LanguageModelV4GenerateResult,
-	LanguageModelV4StreamResult,
+	LanguageModelV3,
+	LanguageModelV3CallOptions,
+	LanguageModelV3GenerateResult,
+	LanguageModelV3StreamResult,
 } from "@ai-sdk/provider";
 
 /**
@@ -21,15 +21,15 @@ import type {
  */
 export class NeonResponsesLanguageModel
 	extends OpenAIResponsesLanguageModel
-	implements LanguageModelV4
+	implements LanguageModelV3
 {
 	private get isReasoningFamily(): boolean {
 		return /gpt-5/.test(this.modelId.toLowerCase());
 	}
 
 	private withForcedReasoning(
-		options: LanguageModelV4CallOptions,
-	): LanguageModelV4CallOptions {
+		options: LanguageModelV3CallOptions,
+	): LanguageModelV3CallOptions {
 		if (!this.isReasoningFamily) {
 			return options;
 		}
@@ -48,14 +48,14 @@ export class NeonResponsesLanguageModel
 	}
 
 	override doGenerate(
-		options: LanguageModelV4CallOptions,
-	): Promise<LanguageModelV4GenerateResult> {
+		options: LanguageModelV3CallOptions,
+	): Promise<LanguageModelV3GenerateResult> {
 		return super.doGenerate(this.withForcedReasoning(options));
 	}
 
 	override doStream(
-		options: LanguageModelV4CallOptions,
-	): Promise<LanguageModelV4StreamResult> {
+		options: LanguageModelV3CallOptions,
+	): Promise<LanguageModelV3StreamResult> {
 		return super.doStream(this.withForcedReasoning(options));
 	}
 }

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -10,11 +10,12 @@
  * `NEON_AI_GATEWAY_TOKEN` emitted by `neonctl env pull` / `neon dev`, or pass
  * `baseURL` / `apiKey` explicitly.
  */
+import { openai as openaiProvider } from "@ai-sdk/openai";
 import type { ProviderErrorStructure } from "@ai-sdk/openai-compatible";
 import {
-	type LanguageModelV4,
+	type LanguageModelV3,
 	NoSuchModelError,
-	type ProviderV4,
+	type ProviderV3,
 } from "@ai-sdk/provider";
 import {
 	type FetchFunction,
@@ -106,15 +107,18 @@ export interface NeonProviderSettings {
 	fetch?: FetchFunction;
 }
 
-export interface NeonProvider extends ProviderV4 {
+export interface NeonProvider extends ProviderV3 {
 	/** Creates a Neon AI Gateway model for text generation. */
-	(modelId: NeonChatModelId): LanguageModelV4;
+	(modelId: NeonChatModelId): LanguageModelV3;
 
 	/** Creates a Neon AI Gateway model for text generation. */
-	languageModel(modelId: NeonChatModelId): LanguageModelV4;
+	languageModel(modelId: NeonChatModelId): LanguageModelV3;
 
 	/** Creates a Neon AI Gateway chat model for text generation. */
-	chat(modelId: NeonChatModelId): LanguageModelV4;
+	chat(modelId: NeonChatModelId): LanguageModelV3;
+
+	/** OpenAI Responses tools (e.g. `imageGeneration`) for OpenAI-routed models. */
+	tools: typeof openaiProvider.tools;
 
 	/** @deprecated Use `embeddingModel` instead. */
 	textEmbeddingModel(modelId: string): never;
@@ -180,7 +184,7 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 			supportsStructuredOutputs: true,
 		});
 
-	const createLanguageModel = (modelId: NeonChatModelId): LanguageModelV4 => {
+	const createLanguageModel = (modelId: NeonChatModelId): LanguageModelV3 => {
 		switch (getNeonModelRoute(modelId)) {
 			case "anthropic":
 				return createAnthropicModel(modelId);
@@ -193,9 +197,10 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 
 	const provider = (modelId: NeonChatModelId) => createLanguageModel(modelId);
 
-	provider.specificationVersion = "v4" as const;
+	provider.specificationVersion = "v3" as const;
 	provider.languageModel = createLanguageModel;
 	provider.chat = createLanguageModel;
+	provider.tools = openaiProvider.tools;
 
 	provider.embeddingModel = (modelId: string) => {
 		throw new NoSuchModelError({ modelId, modelType: "embeddingModel" });

--- a/packages/ai-sdk-provider/vitest.config.ts
+++ b/packages/ai-sdk-provider/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
 			exclude: ["src/**/*.test.ts"],
 			reporter: ["html", "lcov"],
 		},
-		exclude: ["lib", "node_modules", "dist"],
+		exclude: ["lib", "node_modules", "dist", "e2e", "**/*.e2e.test.ts"],
 		setupFiles: ["console-fail-test/setup"],
 	},
 });

--- a/packages/ai-sdk-provider/vitest.e2e.config.ts
+++ b/packages/ai-sdk-provider/vitest.e2e.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+/**
+ * End-to-end tests against a live Neon AI Gateway branch.
+ *
+ * Requires `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` (see `.env.example`).
+ * Excluded from `test:ci` — run locally or in a gated workflow with secrets.
+ */
+export default defineConfig({
+	test: {
+		include: ["e2e/**/*.e2e.test.ts"],
+		exclude: ["node_modules", "dist"],
+		setupFiles: ["./e2e/load-env.ts"],
+		testTimeout: 120_000,
+		hookTimeout: 120_000,
+		pool: "forks",
+		poolOptions: {
+			forks: {
+				singleFork: true,
+			},
+		},
+		reporters: ["verbose"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,20 +161,20 @@ importers:
   packages/ai-sdk-provider:
     dependencies:
       '@ai-sdk/anthropic':
-        specifier: 4.0.0-beta.42
-        version: 4.0.0-beta.42(zod@4.4.3)
+        specifier: 3.0.82
+        version: 3.0.82(zod@4.4.3)
       '@ai-sdk/openai':
-        specifier: 4.0.0-beta.44
-        version: 4.0.0-beta.44(zod@4.4.3)
+        specifier: 3.0.69
+        version: 3.0.69(zod@4.4.3)
       '@ai-sdk/openai-compatible':
-        specifier: 3.0.0-beta.36
-        version: 3.0.0-beta.36(zod@4.4.3)
+        specifier: 2.0.48
+        version: 2.0.48(zod@4.4.3)
       '@ai-sdk/provider':
-        specifier: 4.0.0-beta.14
-        version: 4.0.0-beta.14
+        specifier: 3.0.10
+        version: 3.0.10
       '@ai-sdk/provider-utils':
-        specifier: 5.0.0-beta.30
-        version: 5.0.0-beta.30(zod@4.4.3)
+        specifier: 4.0.27
+        version: 4.0.27(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -182,6 +182,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 3.0.9
         version: 3.0.9(vitest@3.0.9(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
+      ai:
+        specifier: 6.0.132
+        version: 6.0.132(zod@4.4.3)
       console-fail-test:
         specifier: 0.5.0
         version: 0.5.0
@@ -549,32 +552,48 @@ importers:
 
 packages:
 
-  '@ai-sdk/anthropic@4.0.0-beta.42':
-    resolution: {integrity: sha512-FdfNFc6ScMEMSXP2pjfpbCdFEKhznSzKgrAluNLZN4x+XAK4yoU2jhWUp8pHW085OyMA9Kg53HK1paIi3gED9g==}
+  '@ai-sdk/anthropic@3.0.82':
+    resolution: {integrity: sha512-WKKou2wbhGGYV8PSALAPyV2YY4nfCqCPkyBzYtJtDA9yCcIFwsbtkTNgg7bqtLCVzeEsY7wwxRoCWy+EMfrw/A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai-compatible@3.0.0-beta.36':
-    resolution: {integrity: sha512-aYCyXlIgOonStbme/ZvPMntVZWiPcHrvn+HX/awO3SO+leoXv3ZwtAviFRk+2LuX57s+SQrPpMGlU+ZCEIQTHg==}
+  '@ai-sdk/gateway@3.0.76':
+    resolution: {integrity: sha512-tQWC8ty42Mcs2p7EENNwvVkX5z1nBTQCE7qOfDPv1ifSCmsSc1zGIdnZfwAXr3eTA132DwJfXAcp1QgpGKQw0w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@4.0.0-beta.44':
-    resolution: {integrity: sha512-kXdGA6vyh9SwL/B11UhODjbw0koFkDA/yD7hacBxMHSZx6l3T9hZLECEwOkn6OZDrQR+vno5Ka/pUyXrG82BkQ==}
+  '@ai-sdk/openai-compatible@2.0.48':
+    resolution: {integrity: sha512-z9MC6M4Oh/yUY/F/eszOtO8wc2nMz99XmZQKd2gWTtyIfe716xTfrKe3aYZKg20NZDtyjqPPKPSR+wqz7q1T7Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@5.0.0-beta.30':
-    resolution: {integrity: sha512-X3AxTsFJZr9Mw32SncWJA4/ShU8NA/XjhoallCYdcdQZ2gZZ/cIDyJJ6pNh1aBhicRNHv2ndgI6w/H2NGNIjOA==}
+  '@ai-sdk/openai@3.0.69':
+    resolution: {integrity: sha512-T/J3ED6ERDsine+crkXHfraisSG20k6BkBdgjvXCvySYnnJ19IaLIOsQPYfvXdOsKrl0LVNghooTV/nKCA7SmQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider@4.0.0-beta.14':
-    resolution: {integrity: sha512-SMijtjVHs38n0dMkTcNuGrnStiF76OhAqS0R+ZX4iXUnuPPyTxQoVcF8Xuf2AoBB5rqndTId5FVT05bgqD5KsA==}
+  '@ai-sdk/provider-utils@4.0.20':
+    resolution: {integrity: sha512-gpUIj9uDhIGbuo9afKEgQ074BWmhvK4THJAAeBjRnroTy2yQYo6rbtGD7pQDMZM8ouXPYmT/SCdkWVJ0KcpX8A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
     engines: {node: '>=18'}
 
   '@ampproject/remapping@2.3.0':
@@ -1200,6 +1219,10 @@ packages:
   '@oozcitak/util@8.3.8':
     resolution: {integrity: sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==}
     engines: {node: '>=8.0'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.134.0':
     resolution: {integrity: sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==}
@@ -1973,6 +1996,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2040,9 +2067,6 @@ packages:
     resolution: {integrity: sha512-ueFCcIPaMgtuYDS9u0qlUoEvj6GiSsKrwnOLPp9SshqjtcRaR1IEHRjoReq3sXNydsF5i0ZnmuYgXq9dV53t0g==}
     engines: {node: '>=18.0.0'}
 
-  '@workflow/serde@4.1.0':
-    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
-
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -2073,6 +2097,12 @@ packages:
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
+
+  ai@6.0.132:
+    resolution: {integrity: sha512-B+r6j2q8dOou0MZl5imavEWwPxM+DCvc0p3Af7IdjvB+sMqav7/bYNI5KsGkpqTzs2vp0ZAZWL5w87/udbJYCA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -4777,33 +4807,50 @@ packages:
 
 snapshots:
 
-  '@ai-sdk/anthropic@4.0.0-beta.42(zod@4.4.3)':
+  '@ai-sdk/anthropic@3.0.82(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.14
-      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/openai-compatible@3.0.0-beta.36(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.76(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.14
-      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.20(zod@4.4.3)
+      '@vercel/oidc': 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/openai@4.0.0-beta.44(zod@4.4.3)':
+  '@ai-sdk/openai-compatible@2.0.48(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.14
-      '@ai-sdk/provider-utils': 5.0.0-beta.30(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@5.0.0-beta.30(zod@4.4.3)':
+  '@ai-sdk/openai@3.0.69(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 4.0.0-beta.14
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.20(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
-  '@ai-sdk/provider@4.0.0-beta.14':
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.8':
     dependencies:
       json-schema: 0.4.0
 
@@ -5540,6 +5587,8 @@ snapshots:
       '@oozcitak/util': 8.3.8
 
   '@oozcitak/util@8.3.8': {}
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.134.0': {}
 
@@ -6358,6 +6407,8 @@ snapshots:
       - rollup
       - supports-color
 
+  '@vercel/oidc@3.1.0': {}
+
   '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.28.5
@@ -6465,8 +6516,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@workflow/serde@4.1.0': {}
-
   abbrev@3.0.1: {}
 
   abort-controller@3.0.0:
@@ -6495,6 +6544,14 @@ snapshots:
       - supports-color
 
   agent-base@7.1.3: {}
+
+  ai@6.0.132(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.76(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.20(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ansi-colors@4.1.3: {}
 


### PR DESCRIPTION
## Summary

- Migrates `@neondatabase/ai-sdk-provider` from the AI SDK v4 beta provider stack (`@ai-sdk/provider@4.0.0-beta`) to the v6 stable stack (`@ai-sdk/provider@3.0.x`, specification version **v3**).
- Adds `neon.tools.imageGeneration` (re-exported from `@ai-sdk/openai`) so OpenAI Responses flows can swap `openai` → `neon` one-to-one.
- Bumps package to `0.3.0` with `ai@^6` as a peer dependency.
- Adds live gateway e2e capability matrix (`pnpm test:e2e`) — one models.dev `neon` model per family.

## Motivation

`ai@5`/`ai@6` reject v4-spec providers with `Unsupported model version v4`. Console snippets and examples using `@neondatabase/ai-sdk-provider` failed against current AI SDK releases.

## with-ai-sdk drop-in replacement

```diff
- import { openai } from '@ai-sdk/openai';
+ import { neon } from '@neondatabase/ai-sdk-provider/v1';

  const result = streamText({
-   model: openai('gpt-5-mini'),
+   model: neon('gpt-5-mini'),
    tools: {
-     image_generation: openai.tools.imageGeneration({ ... }),
+     image_generation: neon.tools.imageGeneration({ ... }),
    },
  });
```

## E2E tests

Requires a branch with AI Gateway enabled:

```bash
cd packages/ai-sdk-provider
cp .env.example .env   # NEON_AI_GATEWAY_BASE_URL + NEON_AI_GATEWAY_TOKEN from `neonctl env pull`
pnpm test:e2e
```

Matrix (23 passing against live gateway):

| Family | Model | generateText | streamText | generateObject | tools | imageGeneration |
|--------|-------|:---:|:---:|:---:|:---:|:---:|
| Anthropic | claude-haiku-4-5 | ✓ | ✓ | ✓ | ✓ | — |
| OpenAI | gpt-5-mini | ✓ | ✓ | ✓ | —* | ✓ |
| Codex | gpt-5-3-codex | ✓ | ✓ | — | — | — |
| Google | gemini-2-5-flash | ✓ | ✓ | ✓ | ✓ | — |
| Meta | llama-4-maverick | ✓ | ✓ | ✓ | ✓ | — |

\* OpenAI Responses multi-turn tool follow-up can 502 on the gateway; tool calling is covered on Anthropic/Google/Meta.

Known gaps documented as skipped tests: `gpt-oss-*` harmony response shape, OpenAI multi-turn tool 502.

## Test plan

- [x] `pnpm --filter @neondatabase/ai-sdk-provider test:ci` (9 unit tests pass)
- [x] `pnpm --filter @neondatabase/ai-sdk-provider tsc`
- [x] `pnpm --filter @neondatabase/ai-sdk-provider test:e2e` (23 passed, 5 skipped)
- [x] Manual smoke with `ai@6.0.132` + `generateText` for `claude-haiku-4-5` and `gpt-5-mini`
- [x] Manual smoke with `streamText` + `neon.tools.imageGeneration` (JPEG tool result returned)
- [ ] Update `neondatabase/examples/with-ai-sdk` to use `neon` provider after publish