### PR TITLE
feat(env): default OPENAI_BASE_URL to MLflow chat endpoint

### DIFF
--- a/packages/ai-sdk-provider/.env.example
+++ b/packages/ai-sdk-provider/.env.example
@@ -1,3 +1,3 @@
-# Copy to .env and fill from `neonctl env pull` on a branch with AI Gateway enabled.
-NEON_AI_GATEWAY_BASE_URL=https://<branch-id>-api.ai.<region>.aws.neon.tech
+# Branch-scoped gateway host (origin only, no path) + platform token from `neonctl env pull`
+NEON_AI_GATEWAY_HOST=https://<branch-id>-api.ai.<region>.aws.neon.tech
 NEON_AI_GATEWAY_TOKEN=nt_live_...

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/ai-sdk-provider
 
+## Unreleased
+
+### Minor Changes
+
+- Read `NEON_AI_GATEWAY_HOST` (bare branch gateway origin) instead of `NEON_AI_GATEWAY_BASE_URL`.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -17,7 +17,7 @@ npm install @neondatabase/ai-sdk-provider ai@^6
 The gateway URL is branch-scoped, so both values come from the Neon Console (your project → a branch → **AI Gateway** tab), or from `neonctl env pull` / `neon dev`:
 
 ```bash
-NEON_AI_GATEWAY_BASE_URL="https://<branch-id>-api.ai.<region>.aws.neon.tech"
+NEON_AI_GATEWAY_HOST="https://<branch-id>-api.ai.<region>.aws.neon.tech"
 NEON_AI_GATEWAY_TOKEN="nt_live_..."
 ```
 
@@ -27,7 +27,7 @@ NEON_AI_GATEWAY_TOKEN="nt_live_..."
 import { neon } from "@neondatabase/ai-sdk-provider/v1";
 import { generateText } from "ai";
 
-// Reads NEON_AI_GATEWAY_BASE_URL + NEON_AI_GATEWAY_TOKEN from the environment.
+// Reads NEON_AI_GATEWAY_HOST + NEON_AI_GATEWAY_TOKEN from the environment.
 const { text } = await generateText({
   model: neon("claude-haiku-4-5"), // or 'gpt-5-3-codex', etc.
   prompt: "Summarize Postgres for me.",
@@ -40,7 +40,7 @@ Or configure explicitly with `createNeon`:
 import { createNeon } from "@neondatabase/ai-sdk-provider/v1";
 
 const neon = createNeon({
-  baseURL: process.env.NEON_AI_GATEWAY_BASE_URL,
+  baseURL: process.env.NEON_AI_GATEWAY_HOST,
   apiKey: process.env.NEON_AI_GATEWAY_TOKEN,
 });
 ```
@@ -94,7 +94,7 @@ for await (const part of result.fullStream) {
 Against a live branch with AI Gateway enabled:
 
 ```bash
-cp .env.example .env   # fill NEON_AI_GATEWAY_BASE_URL + NEON_AI_GATEWAY_TOKEN from `neonctl env pull`
+cp .env.example .env   # fill NEON_AI_GATEWAY_HOST + NEON_AI_GATEWAY_TOKEN from `neonctl env pull`
 pnpm test:e2e
 ```
 

--- a/packages/ai-sdk-provider/e2e/helpers.ts
+++ b/packages/ai-sdk-provider/e2e/helpers.ts
@@ -21,15 +21,15 @@ export type MatrixFamily = keyof typeof MATRIX_MODELS;
 export const REASONING_FAMILIES = new Set<MatrixFamily>(["openai", "codex"]);
 
 export function hasGatewayEnv(): boolean {
-	const baseUrl = process.env.NEON_AI_GATEWAY_BASE_URL?.trim();
+	const host = process.env.NEON_AI_GATEWAY_HOST?.trim();
 	const token = process.env.NEON_AI_GATEWAY_TOKEN?.trim();
-	return Boolean(baseUrl && token);
+	return Boolean(host && token);
 }
 
 export function assertGatewayEnv(): void {
 	if (!hasGatewayEnv()) {
 		throw new Error(
-			"NEON_AI_GATEWAY_BASE_URL and NEON_AI_GATEWAY_TOKEN are required. " +
+			"NEON_AI_GATEWAY_HOST and NEON_AI_GATEWAY_TOKEN are required. " +
 				"Create packages/ai-sdk-provider/.env (see .env.example) or export them before running pnpm test:e2e.",
 		);
 	}

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -6,7 +6,7 @@
  * Responses incl. Codex, everything else → unified MLflow), so a single
  * `neon('claude-...')` call (same base URL + token) reaches the whole catalog.
  * Ids use the canonical Neon (unprefixed) form; the legacy `databricks-` prefix
- * is also accepted. Configure with the branch-scoped `NEON_AI_GATEWAY_BASE_URL` +
+ * is also accepted. Configure with the branch-scoped `NEON_AI_GATEWAY_HOST` +
  * `NEON_AI_GATEWAY_TOKEN` emitted by `neonctl env pull` / `neon dev`, or pass
  * `baseURL` / `apiKey` explicitly.
  */
@@ -88,9 +88,9 @@ function transformNeonRequestBody(
 
 export interface NeonProviderSettings {
 	/**
-	 * Neon AI Gateway base URL — the branch-scoped host root, e.g.
-	 * `https://<branch-id>-api.ai.<region>.aws.neon.tech`. The gateway paths are
-	 * appended internally. Falls back to the `NEON_AI_GATEWAY_BASE_URL` env var.
+	 * Neon AI Gateway host — the branch-scoped origin, e.g.
+	 * `https://<branch-id>-api.ai.<region>.aws.neon.tech`. Gateway paths are
+	 * appended internally. Falls back to the `NEON_AI_GATEWAY_HOST` env var.
 	 */
 	baseURL?: string;
 
@@ -131,9 +131,9 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 		withoutTrailingSlash(
 			loadSetting({
 				settingValue: options.baseURL,
-				environmentVariableName: "NEON_AI_GATEWAY_BASE_URL",
+				environmentVariableName: "NEON_AI_GATEWAY_HOST",
 				settingName: "baseURL",
-				description: "Neon AI Gateway base URL",
+				description: "Neon AI Gateway host",
 			}),
 		);
 

--- a/packages/ai-sdk-provider/vitest.e2e.config.ts
+++ b/packages/ai-sdk-provider/vitest.e2e.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vitest/config";
 /**
  * End-to-end tests against a live Neon AI Gateway branch.
  *
- * Requires `NEON_AI_GATEWAY_BASE_URL` + `NEON_AI_GATEWAY_TOKEN` (see `.env.example`).
+ * Requires `NEON_AI_GATEWAY_HOST` + `NEON_AI_GATEWAY_TOKEN` (see `.env.example`).
  * Excluded from `test:ci` — run locally or in a gated workflow with secrets.
  */
 export default defineConfig({

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## Unreleased
+
+### Minor Changes
+
+- `OPENAI_BASE_URL` now points at the unified MLflow chat-completions route (`/ai-gateway/mlflow/v1`) instead of the OpenAI Responses route. `NEON_AI_GATEWAY_BASE_URL` remains the bare host for building native dialect URLs (`/openai/v1`, `/anthropic/v1`, …).
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Minor Changes
 
-- `OPENAI_BASE_URL` now points at the unified MLflow chat-completions route (`/ai-gateway/mlflow/v1`) instead of the OpenAI Responses route. `NEON_AI_GATEWAY_BASE_URL` remains the bare host for building native dialect URLs (`/openai/v1`, `/anthropic/v1`, …).
+- `OPENAI_BASE_URL` now points at the unified MLflow chat-completions route (`/ai-gateway/mlflow/v1`) instead of the OpenAI Responses route. `NEON_AI_GATEWAY_HOST` is the bare branch gateway origin for building native dialect URLs (`/openai/v1`, `/anthropic/v1`, …). Renamed from the misleading `NEON_AI_GATEWAY_BASE_URL`.
 
 ## 0.6.0
 

--- a/packages/env/src/lib/env.contract.test.ts
+++ b/packages/env/src/lib/env.contract.test.ts
@@ -183,7 +183,7 @@ describe("toEntries → parseEnv round-trip (cross-process transport)", () => {
 			},
 			aiGateway: {
 				apiKey: "nt_live_abc_def",
-				baseUrl: "https://x.neon.build/ai-gateway/openai/v1",
+				baseUrl: "https://x.neon.build/ai-gateway/mlflow/v1",
 			},
 		};
 

--- a/packages/env/src/lib/env.contract.test.ts
+++ b/packages/env/src/lib/env.contract.test.ts
@@ -60,7 +60,7 @@ const OUTPUT_ONLY_ENV_VARS: ReadonlySet<string> = new Set([
 	"NEON_STORAGE_REGION",
 	"NEON_STORAGE_FORCE_PATH_STYLE",
 	"NEON_AI_GATEWAY_TOKEN",
-	"NEON_AI_GATEWAY_BASE_URL",
+	"NEON_AI_GATEWAY_HOST",
 ]);
 
 /**
@@ -82,7 +82,7 @@ describe("NEON_ENV_VAR_KEYS (public OS env-var names)", () => {
 			  "aiGateway": {
 			    "apiKey": "OPENAI_API_KEY",
 			    "baseUrl": "OPENAI_BASE_URL",
-			    "neonBaseUrl": "NEON_AI_GATEWAY_BASE_URL",
+			    "neonHost": "NEON_AI_GATEWAY_HOST",
 			    "neonToken": "NEON_AI_GATEWAY_TOKEN",
 			  },
 			  "auth": {
@@ -184,6 +184,7 @@ describe("toEntries → parseEnv round-trip (cross-process transport)", () => {
 			aiGateway: {
 				apiKey: "nt_live_abc_def",
 				baseUrl: "https://x.neon.build/ai-gateway/mlflow/v1",
+				host: "https://x.neon.build",
 			},
 		};
 

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -607,8 +607,8 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect(env.aiGateway.baseUrl).toBe(
 			"https://br-cell-api.ai.c-3.aws-us-east-2.fake.neon.tech/ai-gateway/mlflow/v1",
 		);
-		// The bare-host alias (`NEON_AI_GATEWAY_BASE_URL`) must carry the cell too.
-		expect(toEntries(env).NEON_AI_GATEWAY_BASE_URL).toBe(
+		// The bare-host alias (`NEON_AI_GATEWAY_HOST`) must carry the cell too.
+		expect(toEntries(env).NEON_AI_GATEWAY_HOST).toBe(
 			"https://br-cell-api.ai.c-3.aws-us-east-2.fake.neon.tech",
 		);
 	});
@@ -734,6 +734,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect(env.aiGateway.baseUrl).toBe(
 			"https://x.neon.build/ai-gateway/mlflow/v1",
 		);
+		expect(env.aiGateway.host).toBe("https://x.neon.build");
 	});
 
 	test("parseEnv throws EnvNotInjected listing missing storage vars", () => {
@@ -768,6 +769,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 			aiGateway: {
 				apiKey: "nt_live_x_y",
 				baseUrl: "https://x.neon.build/ai-gateway/mlflow/v1",
+				host: "https://x.neon.build",
 			},
 		};
 		const pairs = toEntries(env);
@@ -784,6 +786,6 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		// Neon-branded aliases: same token, plus the bare branch gateway host (no path) —
 		// the @ai-sdk/neon provider appends the /ai-gateway/<dialect>/… routes itself.
 		expect(pairs.NEON_AI_GATEWAY_TOKEN).toBe("nt_live_x_y");
-		expect(pairs.NEON_AI_GATEWAY_BASE_URL).toBe("https://x.neon.build");
+		expect(pairs.NEON_AI_GATEWAY_HOST).toBe("https://x.neon.build");
 	});
 });

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -559,7 +559,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect("aiGateway" in env).toBe(false);
 	});
 
-	test("aiGateway policy surfaces the OpenAI env (key + OpenAI-dialect base URL)", async () => {
+	test("aiGateway policy surfaces the OpenAI env (key + MLflow chat base URL)", async () => {
 		const { api, projectId } = seededFake();
 		const env = await fetchEnv(
 			defineConfig({ preview: { aiGateway: true } }),
@@ -576,7 +576,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect(env.aiGateway.apiKey).toMatch(/^nt_live_/);
 		// Branch-scoped gateway host derived from the branch connection URI, NOT the API origin.
 		expect(env.aiGateway.baseUrl).toBe(
-			"https://br-main-api.ai.aws-us-east-1.fake.neon.tech/ai-gateway/openai/v1",
+			"https://br-main-api.ai.aws-us-east-1.fake.neon.tech/ai-gateway/mlflow/v1",
 		);
 		expect("storage" in env).toBe(false);
 	});
@@ -605,7 +605,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		);
 
 		expect(env.aiGateway.baseUrl).toBe(
-			"https://br-cell-api.ai.c-3.aws-us-east-2.fake.neon.tech/ai-gateway/openai/v1",
+			"https://br-cell-api.ai.c-3.aws-us-east-2.fake.neon.tech/ai-gateway/mlflow/v1",
 		);
 		// The bare-host alias (`NEON_AI_GATEWAY_BASE_URL`) must carry the cell too.
 		expect(toEntries(env).NEON_AI_GATEWAY_BASE_URL).toBe(
@@ -727,12 +727,12 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		vi.stubEnv("OPENAI_API_KEY", "nt_live_abc_def");
 		vi.stubEnv(
 			"OPENAI_BASE_URL",
-			"https://x.neon.build/ai-gateway/openai/v1",
+			"https://x.neon.build/ai-gateway/mlflow/v1",
 		);
 		const env = parseEnv(defineConfig({ preview: { aiGateway: true } }));
 		expect(env.aiGateway.apiKey).toBe("nt_live_abc_def");
 		expect(env.aiGateway.baseUrl).toBe(
-			"https://x.neon.build/ai-gateway/openai/v1",
+			"https://x.neon.build/ai-gateway/mlflow/v1",
 		);
 	});
 
@@ -767,7 +767,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 			},
 			aiGateway: {
 				apiKey: "nt_live_x_y",
-				baseUrl: "https://x.neon.build/ai-gateway/openai/v1",
+				baseUrl: "https://x.neon.build/ai-gateway/mlflow/v1",
 			},
 		};
 		const pairs = toEntries(env);
@@ -779,7 +779,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect(pairs.NEON_STORAGE_FORCE_PATH_STYLE).toBe("true");
 		expect(pairs.OPENAI_API_KEY).toBe("nt_live_x_y");
 		expect(pairs.OPENAI_BASE_URL).toBe(
-			"https://x.neon.build/ai-gateway/openai/v1",
+			"https://x.neon.build/ai-gateway/mlflow/v1",
 		);
 		// Neon-branded aliases: same token, plus the bare branch gateway host (no path) —
 		// the @ai-sdk/neon provider appends the /ai-gateway/<dialect>/… routes itself.

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -81,8 +81,8 @@ export const NEON_ENV_VAR_KEYS = {
 	},
 	/**
 	 * AI Gateway (Preview). Mapped onto the OpenAI SDK's standard env vars so the OpenAI
-	 * clients work from env alone; `baseUrl` carries the gateway's OpenAI-dialect route prefix
-	 * (`/ai-gateway/openai/v1`). The `NEON_AI_GATEWAY_*` aliases are also emitted: `neonToken`
+	 * clients work from env alone; `baseUrl` carries the gateway's default MLflow chat route
+	 * (`/ai-gateway/mlflow/v1`). The `NEON_AI_GATEWAY_*` aliases are also emitted: `neonToken`
 	 * mirrors the OpenAI key, and `neonBaseUrl` is the bare branch gateway host
 	 * (`scheme://host`, no path) — the `@ai-sdk/neon` provider appends the
 	 * `/ai-gateway/<dialect>/…` routes itself (https://github.com/vercel/ai/pull/15997).
@@ -95,8 +95,8 @@ export const NEON_ENV_VAR_KEYS = {
 	},
 } as const;
 
-/** OpenAI-dialect route prefix on the branch AI Gateway host. */
-const AI_GATEWAY_OPENAI_PATH = "/ai-gateway/openai/v1";
+/** Default unified chat-completions route on the branch AI Gateway host (MLflow). */
+const AI_GATEWAY_DEFAULT_PATH = "/ai-gateway/mlflow/v1";
 
 /**
  * Branch identity for the resolved branch. Always present on a `fetchEnv` result (the branch
@@ -167,8 +167,8 @@ export interface NeonStorageEnv {
 /**
  * AI Gateway access for the branch (Preview). Present on `NeonEnv` only when the policy
  * enables `preview.aiGateway`. `apiKey` is the minted credential's bearer (`api_token`);
- * `baseUrl` is the gateway's OpenAI-dialect endpoint on the branch-scoped gateway host
- * (`https://<branchId>-api.ai.<region>.…/ai-gateway/openai/v1`). Projects to the OpenAI SDK's
+ * `baseUrl` is the gateway's default MLflow chat endpoint on the branch-scoped gateway host
+ * (`https://<branchId>-api.ai.<region>.…/ai-gateway/mlflow/v1`). Projects to the OpenAI SDK's
  * standard env (`OPENAI_API_KEY`, `OPENAI_BASE_URL`), plus the `NEON_AI_GATEWAY_*` aliases.
  */
 export interface NeonAiGatewayEnv {
@@ -730,9 +730,9 @@ function aiGatewayHost(branchId: string, connectionUri: string): string {
 	return `${branchId}-api.ai.${suffix}`;
 }
 
-/** The AI Gateway's OpenAI-dialect base URL (`OPENAI_BASE_URL`) on the branch gateway host. */
+/** The AI Gateway default chat base URL (`OPENAI_BASE_URL`) on the branch gateway host. */
 function aiGatewayBaseUrl(branchId: string, connectionUri: string): string {
-	return `https://${aiGatewayHost(branchId, connectionUri)}${AI_GATEWAY_OPENAI_PATH}`;
+	return `https://${aiGatewayHost(branchId, connectionUri)}${AI_GATEWAY_DEFAULT_PATH}`;
 }
 
 /**

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -83,15 +83,15 @@ export const NEON_ENV_VAR_KEYS = {
 	 * AI Gateway (Preview). Mapped onto the OpenAI SDK's standard env vars so the OpenAI
 	 * clients work from env alone; `baseUrl` carries the gateway's default MLflow chat route
 	 * (`/ai-gateway/mlflow/v1`). The `NEON_AI_GATEWAY_*` aliases are also emitted: `neonToken`
-	 * mirrors the OpenAI key, and `neonBaseUrl` is the bare branch gateway host
-	 * (`scheme://host`, no path) — the `@ai-sdk/neon` provider appends the
-	 * `/ai-gateway/<dialect>/…` routes itself (https://github.com/vercel/ai/pull/15997).
+	 * mirrors the OpenAI key, and `neonHost` is the bare branch gateway origin
+	 * (`scheme://host`, no path) — `@neondatabase/ai-sdk-provider` appends
+	 * `/ai-gateway/<dialect>/v1` routes itself.
 	 */
 	aiGateway: {
 		apiKey: "OPENAI_API_KEY",
 		baseUrl: "OPENAI_BASE_URL",
 		neonToken: "NEON_AI_GATEWAY_TOKEN",
-		neonBaseUrl: "NEON_AI_GATEWAY_BASE_URL",
+		neonHost: "NEON_AI_GATEWAY_HOST",
 	},
 } as const;
 
@@ -173,7 +173,10 @@ export interface NeonStorageEnv {
  */
 export interface NeonAiGatewayEnv {
 	apiKey: string;
+	/** Default MLflow chat client URL (`…/ai-gateway/mlflow/v1`). Maps to `OPENAI_BASE_URL`. */
 	baseUrl: string;
+	/** Bare branch gateway origin (`https://host`). Maps to `NEON_AI_GATEWAY_HOST`. */
+	host: string;
 }
 
 /**
@@ -619,11 +622,11 @@ export async function fetchEnv<const C extends Config>(
 			} satisfies NeonStorageEnv;
 		}
 		if (wantsAiGateway) {
+			const host = aiGatewayHostUrl(branch.id, unpooled.uri);
 			result.aiGateway = {
 				apiKey: secrets.apiToken,
-				// Branch-scoped gateway host derived from the branch's connection URI — not the
-				// control-plane API origin (which doesn't serve the gateway).
 				baseUrl: aiGatewayBaseUrl(branch.id, unpooled.uri),
+				host,
 			} satisfies NeonAiGatewayEnv;
 		}
 	}
@@ -730,9 +733,14 @@ function aiGatewayHost(branchId: string, connectionUri: string): string {
 	return `${branchId}-api.ai.${suffix}`;
 }
 
+/** Full gateway origin URL (`https://<branchId>-api.ai.<suffix>`). */
+function aiGatewayHostUrl(branchId: string, connectionUri: string): string {
+	return `https://${aiGatewayHost(branchId, connectionUri)}`;
+}
+
 /** The AI Gateway default chat base URL (`OPENAI_BASE_URL`) on the branch gateway host. */
 function aiGatewayBaseUrl(branchId: string, connectionUri: string): string {
-	return `https://${aiGatewayHost(branchId, connectionUri)}${AI_GATEWAY_DEFAULT_PATH}`;
+	return `${aiGatewayHostUrl(branchId, connectionUri)}${AI_GATEWAY_DEFAULT_PATH}`;
 }
 
 /**
@@ -1143,9 +1151,13 @@ export function parseEnv(
 			OPENAI_BASE_URL: source.OPENAI_BASE_URL,
 		});
 		if (aiGateway.success) {
+			const baseUrl = aiGateway.data.OPENAI_BASE_URL;
+			const host =
+				source.NEON_AI_GATEWAY_HOST?.trim() || new URL(baseUrl).origin;
 			result.aiGateway = {
 				apiKey: aiGateway.data.OPENAI_API_KEY,
-				baseUrl: aiGateway.data.OPENAI_BASE_URL,
+				baseUrl,
+				host,
 			} satisfies NeonAiGatewayEnv;
 		} else {
 			for (const issue of aiGateway.error.issues)
@@ -1323,7 +1335,7 @@ export function toEntries(env: NeonEnv<Config>): Record<string, string> {
 		// (scheme://host, no path) — the @ai-sdk/neon provider appends the
 		// /ai-gateway/<dialect>/… routes itself (https://github.com/vercel/ai/pull/15997).
 		out[keys.neonToken] = ai.apiKey;
-		out[keys.neonBaseUrl] = new URL(ai.baseUrl).origin;
+		out[keys.neonHost] = ai.host;
 	}
 	return out;
 }


### PR DESCRIPTION
## Summary

- `OPENAI_BASE_URL` now points at `/ai-gateway/mlflow/v1` (unified chat completions) instead of `/ai-gateway/openai/v1` (OpenAI Responses).
- Renamed `NEON_AI_GATEWAY_BASE_URL` → `NEON_AI_GATEWAY_HOST` (bare branch gateway origin). Added `host` to `NeonAiGatewayEnv`.
- `@neondatabase/ai-sdk-provider` reads `NEON_AI_GATEWAY_HOST` + `NEON_AI_GATEWAY_TOKEN`.

## Motivation

OpenRouter-style DX: `new OpenAI()` and Mastra work with any catalog model without dialect swaps. `NEON_AI_GATEWAY_HOST` is the origin for building native dialect URLs (`/openai/v1`, `/anthropic/v1`, …).

## Related

- neondatabase/neon-pkgs#223 — `@neondatabase/ai-sdk-provider` AI SDK v6
- Agent skills + examples PRs in this rollout

## Test plan

- [x] `pnpm --filter @neondatabase/env test:ci` (contract + 93/94; one pre-existing branch-namespace flake)