### PR TITLE
feat(init): bring bootstrap scaffolding in-house, expose neon-init/bootstrap

### DIFF
--- a/.changeset/neon-init-bootstrap-core.md
+++ b/.changeset/neon-init-bootstrap-core.md
@@ -1,0 +1,9 @@
+---
+"neon-init": minor
+---
+
+Bring the full template bootstrap implementation into `neon-init` and expose it via a new `neon-init/bootstrap` entry point.
+
+Previously `neon-init` only knew how to read the template manifest and shelled out to `npx -y neonctl@latest bootstrap` to actually scaffold a project. The manifest layer has been replaced with the complete, in-house implementation (manifest fetch/parse, single-request `codeload.github.com` tarball download, in-house gunzip + tar parsing, and on-disk scaffolding with exec-bit and symlink fidelity), so the interactive and agent setup flows now scaffold in-process — no global `neonctl` and no `npx` round-trip required.
+
+The new `neon-init/bootstrap` export ships `fetchTemplates`, `parseManifest`, `downloadTemplate`, `scaffoldTemplate`, `ensureTargetUsable`, `BootstrapInputError`, `FALLBACK_TEMPLATES`, and the `BootstrapTemplate` / `TemplateFile` / `NeonFeature` types. `BootstrapTemplate` now carries both `services` (display badge) and `requires` (Neon features) so it is a superset of the previous shape.

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -26,6 +26,10 @@
 		".": {
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
+		},
+		"./bootstrap": {
+			"import": "./dist/lib/bootstrap.js",
+			"types": "./dist/lib/bootstrap.d.ts"
 		}
 	},
 	"files": [
@@ -54,6 +58,7 @@
 		"@clack/prompts": "0.10.1",
 		"add-mcp": "^1.5.1",
 		"execa": "^9.5.2",
+		"fflate": "^0.8.3",
 		"picocolors": "^1.1.1",
 		"yaml": "^2.9.0",
 		"yargs": "^18.0.0",

--- a/packages/init/src/interactive.ts
+++ b/packages/init/src/interactive.ts
@@ -23,6 +23,7 @@ import {
 	FALLBACK_TEMPLATES,
 	fetchTemplates,
 	type NeonFeature,
+	scaffoldTemplate,
 } from "./lib/bootstrap.js";
 import { detectAgent, detectIde } from "./lib/detect-agent.js";
 import { detectAvailableEditors } from "./lib/editors.js";
@@ -182,22 +183,9 @@ async function interactiveInitInner(
 					`Scaffolding project from template "${selectedTemplate.title}"...`,
 				);
 				try {
-					// Pin @latest (and -y) so a stale globally-installed neonctl
-					// can't be picked up by npx — bootstrap's rate-limit fix lives
-					// in recent neonctl.
-					await execa(
-						"npx",
-						[
-							"-y",
-							"neonctl@latest",
-							"bootstrap",
-							".",
-							"--template",
-							selectedTemplate.id,
-							"--force",
-						],
-						{ stdio: "pipe", timeout: 120000 },
-					);
+					await scaffoldTemplate(selectedTemplate, ".", {
+						onWarn: (message) => log.warn(message),
+					});
 					bootstrapS.stop(
 						dim(
 							`Scaffolded project from "${selectedTemplate.title}" ✓`,

--- a/packages/init/src/lib/bootstrap.test.ts
+++ b/packages/init/src/lib/bootstrap.test.ts
@@ -1,35 +1,309 @@
-import { describe, expect, test } from "vitest";
-import { FALLBACK_TEMPLATES, parseManifest } from "./bootstrap.js";
+import {
+	lstatSync,
+	mkdtempSync,
+	readFileSync,
+	readlinkSync,
+	rmSync,
+} from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { gunzipSync, gzipSync } from "fflate";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	type BootstrapTemplate,
+	FALLBACK_TEMPLATES,
+	parseManifest,
+	parseTar,
+	scaffoldTemplate,
+	selectTemplateFiles,
+} from "./bootstrap.js";
+
+// ---------------------------------------------------------------------------
+// Minimal tar builder, used to exercise parseTar with real archive bytes (the
+// same layout codeload.github.com produces: a single top-level dir, a leading
+// pax global header, directory entries, files, and symlinks).
+// ---------------------------------------------------------------------------
+
+type TarInput =
+	| { name: string; type: "file"; mode: number; content: string }
+	| { name: string; type: "dir" }
+	| { name: string; type: "symlink"; target: string }
+	| { name: string; type: "pax-global"; content: string };
+
+const TYPEFLAG = {
+	file: "0",
+	dir: "5",
+	symlink: "2",
+	"pax-global": "g",
+} as const;
+
+const tarHeader = (
+	name: string,
+	size: number,
+	mode: number,
+	typeflag: string,
+	linkname = "",
+): Buffer => {
+	const header = Buffer.alloc(512, 0);
+	header.write(name, 0, "utf8");
+	header.write(`${(mode & 0o7777).toString(8).padStart(7, "0")}\0`, 100);
+	header.write("0000000\0", 108); // uid
+	header.write("0000000\0", 116); // gid
+	header.write(`${size.toString(8).padStart(11, "0")}\0`, 124);
+	header.write("00000000000\0", 136); // mtime
+	header.write("        ", 148); // checksum placeholder (8 spaces)
+	header.write(typeflag, 156, 1);
+	header.write(linkname, 157, "utf8");
+	header.write("ustar\0", 257);
+	header.write("00", 263);
+	let sum = 0;
+	for (let i = 0; i < 512; i++) sum += header[i];
+	header.write(`${sum.toString(8).padStart(6, "0")}\0 `, 148);
+	return header;
+};
+
+const padTo512 = (buf: Buffer): Buffer => {
+	const rem = buf.length % 512;
+	return rem === 0 ? buf : Buffer.concat([buf, Buffer.alloc(512 - rem)]);
+};
+
+const buildTar = (inputs: TarInput[]): Buffer => {
+	const blocks: Buffer[] = [];
+	for (const input of inputs) {
+		if (input.type === "file" || input.type === "pax-global") {
+			const content = Buffer.from(input.content);
+			const mode = input.type === "file" ? input.mode : 0o644;
+			blocks.push(
+				tarHeader(
+					input.name,
+					content.length,
+					mode,
+					TYPEFLAG[input.type],
+				),
+			);
+			blocks.push(padTo512(content));
+		} else if (input.type === "symlink") {
+			blocks.push(
+				tarHeader(input.name, 0, 0o777, TYPEFLAG.symlink, input.target),
+			);
+		} else {
+			blocks.push(tarHeader(input.name, 0, 0o755, TYPEFLAG.dir));
+		}
+	}
+	blocks.push(Buffer.alloc(1024)); // two zero blocks terminate the archive
+	return Buffer.concat(blocks);
+};
+
+// A tarball shaped like codeload's: top-level "examples-main/" dir, a pax
+// global header up front, and a sibling example that must be filtered out.
+const EXAMPLE_TAR: TarInput[] = [
+	{
+		name: "pax_global_header",
+		type: "pax-global",
+		content: "52 comment=0000\n",
+	},
+	{ name: "examples-main/", type: "dir" },
+	{ name: "examples-main/with-hono/", type: "dir" },
+	{
+		name: "examples-main/with-hono/package.json",
+		type: "file",
+		mode: 0o644,
+		content: '{\n  "name": "with-hono"\n}\n',
+	},
+	{ name: "examples-main/with-hono/src/", type: "dir" },
+	{
+		name: "examples-main/with-hono/src/index.ts",
+		type: "file",
+		mode: 0o644,
+		content: 'export const app = "hono";\n',
+	},
+	{
+		name: "examples-main/with-hono/scripts/run.sh",
+		type: "file",
+		mode: 0o755,
+		content: "#!/bin/sh\necho hi\n",
+	},
+	{
+		name: "examples-main/with-hono/.claude/skills/neon",
+		type: "symlink",
+		target: "../../package.json",
+	},
+	{
+		name: "examples-main/with-remix/package.json",
+		type: "file",
+		mode: 0o644,
+		content: '{ "name": "with-remix" }\n',
+	},
+];
+
+describe("parseTar + selectTemplateFiles", () => {
+	const entries = parseTar(buildTar(EXAMPLE_TAR));
+
+	test("skips the pax global header but keeps directory entries for the caller to filter", () => {
+		const names = entries.map((e) => e.name);
+		expect(names).not.toContain("pax_global_header");
+		expect(entries.some((e) => e.type === "5")).toBe(true);
+		const files = selectTemplateFiles(entries, "with-hono");
+		expect(files.every((f) => f.path !== "" && !f.path.endsWith("/"))).toBe(
+			true,
+		);
+	});
+
+	test("keeps only files under the subdir, prefix stripped", () => {
+		const files = selectTemplateFiles(entries, "with-hono");
+		expect(files.map((f) => f.path).sort()).toEqual([
+			".claude/skills/neon",
+			"package.json",
+			"scripts/run.sh",
+			"src/index.ts",
+		]);
+	});
+
+	test("preserves contents, exec bits, and symlink targets", () => {
+		const byPath = Object.fromEntries(
+			selectTemplateFiles(entries, "with-hono").map((f) => [f.path, f]),
+		);
+
+		const pkg = byPath["package.json"];
+		expect(pkg.kind).toBe("file");
+		if (pkg.kind === "file") {
+			expect(pkg.bytes.toString("utf8")).toBe(
+				'{\n  "name": "with-hono"\n}\n',
+			);
+			expect(pkg.executable).toBe(false);
+		}
+
+		const script = byPath["scripts/run.sh"];
+		expect(script.kind === "file" && script.executable).toBe(true);
+
+		const link = byPath[".claude/skills/neon"];
+		expect(link.kind).toBe("symlink");
+		if (link.kind === "symlink") {
+			expect(link.target).toBe("../../package.json");
+		}
+	});
+
+	test("does not leak a sibling example from the same repo", () => {
+		const files = selectTemplateFiles(entries, "with-hono");
+		expect(files.some((f) => f.path.includes("with-remix"))).toBe(false);
+	});
+
+	test("tolerates a trailing or leading slash on the subdir", () => {
+		expect(selectTemplateFiles(entries, "with-hono/")).toHaveLength(4);
+		expect(selectTemplateFiles(entries, "/with-hono")).toHaveLength(4);
+	});
+
+	test("returns nothing for a subdir that does not exist", () => {
+		expect(selectTemplateFiles(entries, "nope")).toEqual([]);
+	});
+
+	test("round-trips through gzip the way the downloader decompresses it", () => {
+		const gz = gzipSync(new Uint8Array(buildTar(EXAMPLE_TAR)));
+		const files = selectTemplateFiles(
+			parseTar(Buffer.from(gunzipSync(gz))),
+			"with-hono",
+		);
+		expect(files).toHaveLength(4);
+	});
+});
+
+// A single pax "<len> key=value\n" record. The length prefix counts itself, so
+// it's solved by fixed-point iteration — the same shape GNU/BSD tar emit.
+const paxRecord = (key: string, value: string): string => {
+	const record = `${key}=${value}`;
+	let len = record.length + 1;
+	for (let i = 0; i < 5; i++) len = `${len} ${record}\n`.length;
+	return `${len} ${record}\n`;
+};
+
+const buildPaxOverride = (records: string, next: TarInput): Buffer => {
+	const body = Buffer.from(records);
+	return Buffer.concat([
+		tarHeader("pax_header", body.length, 0o644, "x"),
+		padTo512(body),
+		buildTar([next]),
+	]);
+};
+
+describe("parseTar long paths", () => {
+	test("honors pax extended headers that override a long path", () => {
+		const longPath = `examples-main/with-hono/${"a".repeat(120)}/deep.txt`;
+		const tar = buildPaxOverride(paxRecord("path", longPath), {
+			name: "examples-main/with-hono/short.txt",
+			type: "file",
+			mode: 0o644,
+			content: "deep\n",
+		});
+
+		const match = parseTar(tar).find((e) => e.name === longPath);
+		expect(match?.data.toString("utf8")).toBe("deep\n");
+	});
+
+	test("honors pax extended headers that override a long symlink target", () => {
+		const longTarget = `../../${"b".repeat(130)}/target`;
+		const tar = buildPaxOverride(paxRecord("linkpath", longTarget), {
+			name: "examples-main/with-hono/link",
+			type: "symlink",
+			target: "placeholder",
+		});
+
+		const files = selectTemplateFiles(parseTar(tar), "with-hono");
+		const link = files.find((f) => f.path === "link");
+		expect(link?.kind).toBe("symlink");
+		if (link?.kind === "symlink") expect(link.target).toBe(longTarget);
+	});
+});
 
 describe("parseManifest", () => {
-	test("parses a valid manifest with requires", () => {
+	test("parses a valid manifest, defaulting requires and omitting services", () => {
 		const yaml = `templates:
   - id: hono
     title: Hono API
     description: A Hono template.
-    requires:
-      - database
     source:
       owner: neondatabase
       repo: examples
       ref: main
       subdir: with-hono
-  - id: next-auth
-    title: Next.js with Auth
-    description: A Next.js template with auth.
+`;
+		const templates = parseManifest(yaml);
+		expect(templates).toHaveLength(1);
+		expect(templates[0]).toEqual({
+			id: "hono",
+			title: "Hono API",
+			description: "A Hono template.",
+			requires: ["database"],
+			source: {
+				owner: "neondatabase",
+				repo: "examples",
+				ref: "main",
+				subdir: "with-hono",
+			},
+		});
+	});
+
+	test("parses both the requires and the optional services lists", () => {
+		const yaml = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    services:
+      - Postgres
+      - Functions
     requires:
       - database
-      - auth
+      - functions
     source:
       owner: neondatabase
       repo: examples
       ref: main
-      subdir: with-next-auth
+      subdir: with-hono
 `;
-		const templates = parseManifest(yaml);
-		expect(templates).toHaveLength(2);
-		expect(templates[0].requires).toEqual(["database"]);
-		expect(templates[1].requires).toEqual(["database", "auth"]);
+		const t = parseManifest(yaml)[0];
+		expect(t.services).toEqual(["Postgres", "Functions"]);
+		expect(t.requires).toEqual(["database", "functions"]);
 	});
 
 	test("defaults requires to ['database'] when not specified", () => {
@@ -43,9 +317,44 @@ describe("parseManifest", () => {
       ref: main
       subdir: with-hono
 `;
-		const templates = parseManifest(yaml);
-		expect(templates).toHaveLength(1);
-		expect(templates[0].requires).toEqual(["database"]);
+		expect(parseManifest(yaml)[0].requires).toEqual(["database"]);
+	});
+
+	test("drops non-string and blank service entries", () => {
+		const yaml = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    services:
+      - Postgres
+      - ""
+      - 42
+      - Functions
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+		expect(parseManifest(yaml)[0].services).toEqual([
+			"Postgres",
+			"Functions",
+		]);
+	});
+
+	test("omits services when the field is absent or not a list", () => {
+		const badServices = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    services: nope
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+		expect(parseManifest(badServices)[0]).not.toHaveProperty("services");
 	});
 
 	test("skips malformed entries and keeps valid ones", () => {
@@ -91,10 +400,6 @@ describe("parseManifest", () => {
 });
 
 describe("FALLBACK_TEMPLATES", () => {
-	test("contains at least one template", () => {
-		expect(FALLBACK_TEMPLATES.length).toBeGreaterThan(0);
-	});
-
 	test("offers the full starter set, not just one template", () => {
 		expect(FALLBACK_TEMPLATES.map((t) => t.id)).toEqual([
 			"hono",
@@ -103,11 +408,13 @@ describe("FALLBACK_TEMPLATES", () => {
 		]);
 	});
 
-	test("each template has required fields", () => {
+	test("each template carries both services and requires", () => {
 		for (const t of FALLBACK_TEMPLATES) {
 			expect(typeof t.id).toBe("string");
 			expect(typeof t.title).toBe("string");
 			expect(typeof t.description).toBe("string");
+			expect(Array.isArray(t.services)).toBe(true);
+			expect((t.services ?? []).length).toBeGreaterThan(0);
 			expect(Array.isArray(t.requires)).toBe(true);
 			expect(t.requires.length).toBeGreaterThan(0);
 			expect(typeof t.source.owner).toBe("string");
@@ -115,5 +422,84 @@ describe("FALLBACK_TEMPLATES", () => {
 			expect(typeof t.source.ref).toBe("string");
 			expect(typeof t.source.subdir).toBe("string");
 		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// scaffoldTemplate end-to-end: a real local HTTP server stands in for the
+// codeload tarball host, so the whole download/decompress/extract/write path
+// runs with no mocking of our own code.
+// ---------------------------------------------------------------------------
+
+describe("scaffoldTemplate", () => {
+	let server: Server;
+	let base: string;
+	let dest: string;
+	const previousCodeload = process.env.NEON_BOOTSTRAP_GITHUB_CODELOAD;
+
+	const TEMPLATE: BootstrapTemplate = {
+		id: "hono",
+		title: "Hono API",
+		description: "A Hono template.",
+		requires: ["database", "functions"],
+		source: {
+			owner: "neondatabase",
+			repo: "examples",
+			ref: "main",
+			subdir: "with-hono",
+		},
+	};
+
+	beforeEach(async () => {
+		const tarball = Buffer.from(
+			gzipSync(new Uint8Array(buildTar(EXAMPLE_TAR))),
+		);
+		server = createServer((_req, res) => {
+			res.setHeader("content-type", "application/gzip");
+			res.end(tarball);
+		});
+		await new Promise<void>((resolve) => server.listen(0, resolve));
+		base = `http://localhost:${(server.address() as AddressInfo).port}`;
+		process.env.NEON_BOOTSTRAP_GITHUB_CODELOAD = base;
+		dest = mkdtempSync(join(tmpdir(), "neon-init-bootstrap-"));
+	});
+
+	afterEach(async () => {
+		rmSync(dest, { recursive: true, force: true });
+		if (previousCodeload === undefined) {
+			delete process.env.NEON_BOOTSTRAP_GITHUB_CODELOAD;
+		} else {
+			process.env.NEON_BOOTSTRAP_GITHUB_CODELOAD = previousCodeload;
+		}
+		await new Promise<void>((resolve, reject) =>
+			server.close((err) => (err ? reject(err) : resolve())),
+		);
+	});
+
+	test("writes the template subtree, preserving files, exec bits, and symlinks", async () => {
+		const written = await scaffoldTemplate(TEMPLATE, dest);
+		expect(written).toBe(4);
+
+		expect(readFileSync(join(dest, "package.json"), "utf8")).toBe(
+			'{\n  "name": "with-hono"\n}\n',
+		);
+		expect(readFileSync(join(dest, "src/index.ts"), "utf8")).toBe(
+			'export const app = "hono";\n',
+		);
+
+		// The executable bit survives the round-trip.
+		expect(lstatSync(join(dest, "scripts/run.sh")).mode & 0o111).not.toBe(
+			0,
+		);
+
+		// The symlink is recreated as a real symlink pointing at its target.
+		const link = join(dest, ".claude/skills/neon");
+		expect(lstatSync(link).isSymbolicLink()).toBe(true);
+		expect(readlinkSync(link)).toBe("../../package.json");
+
+		// A sibling example in the same repo must not leak into the copy.
+		expect(() =>
+			readFileSync(join(dest, "with-remix/package.json")),
+		).toThrow();
 	});
 });

--- a/packages/init/src/lib/bootstrap.ts
+++ b/packages/init/src/lib/bootstrap.ts
@@ -1,4 +1,31 @@
+import {
+	chmodSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { gunzipSync } from "fflate";
 import YAML from "yaml";
+
+/**
+ * A scaffold template that lives in a subdirectory of a public GitHub repo we
+ * control. Bootstrapping copies that subdirectory into a target folder —
+ * conceptually the same as `degit user/repo/subdir`, but implemented in-house.
+ *
+ * The whole template is pulled in a single request: we download the repo's
+ * gzipped tarball from `codeload.github.com` and extract only the subdir we
+ * want. That endpoint is unauthenticated and is NOT subject to the 60-requests
+ * per-hour limit of the REST API (`api.github.com`), so bootstrapping works out
+ * of the box on shared/corporate networks without a GITHUB_TOKEN. We lean on
+ * `fflate` for gunzip and parse the tar in-house, so we never pull in a heavy
+ * dependency tree just to copy a few files.
+ */
 
 /**
  * Neon features that a template or project may require.
@@ -15,15 +42,25 @@ export type NeonFeature =
 const DEFAULT_REQUIRES: NeonFeature[] = ["database"];
 
 export interface BootstrapTemplate {
+	/** Stable id used by `--template` and analytics. */
 	id: string;
+	/** Human label shown in the interactive selector. */
 	title: string;
+	/** One-line description shown under the title in the selector. */
 	description: string;
-	/** Neon features this template needs (defaults to ["database"]) */
+	/**
+	 * Neon services the template uses (e.g. "Postgres", "Functions"). Shown as a
+	 * badge next to the title in the picker. Optional — older manifests omit it.
+	 */
+	services?: string[];
+	/** Neon features this template needs (defaults to ["database"]). */
 	requires: NeonFeature[];
 	source: {
 		owner: string;
 		repo: string;
+		/** Branch (or tag) the template is pulled from. */
 		ref: string;
+		/** Subdirectory within the repo to copy (no leading/trailing slash). */
 		subdir: string;
 	};
 }
@@ -40,6 +77,7 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 		title: "Hono API (Drizzle, Neon Postgres) on Neon Functions",
 		description:
 			"A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function.",
+		services: ["Postgres", "Functions"],
 		requires: ["database", "functions"],
 		source: {
 			owner: "neondatabase",
@@ -53,6 +91,7 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 		title: "AI SDK agent (AI Gateway, object storage, Drizzle) on Neon Functions",
 		description:
 			"A Vercel AI SDK agent on Neon Functions: streams chat through the Neon AI Gateway, generates an image with OpenAI image generation, and stores it in Neon object storage indexed in Postgres via Drizzle.",
+		services: ["Postgres", "Functions", "Object Storage", "AI Gateway"],
 		requires: ["database", "functions", "object-storage", "ai-gateway"],
 		source: {
 			owner: "neondatabase",
@@ -66,6 +105,7 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 		title: "Mastra personal agent (AI Gateway, Mastra Memory) on Neon Functions",
 		description:
 			"A Mastra personal-assistant agent on Neon Functions: streams chat through the Neon AI Gateway and uses Mastra Memory — backed by Neon Postgres — to remember the user across conversation threads via resource-scoped working memory.",
+		services: ["Postgres", "Functions", "AI Gateway"],
 		requires: ["database", "functions", "ai-gateway"],
 		source: {
 			owner: "neondatabase",
@@ -75,6 +115,68 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 		},
 	},
 ];
+
+export const templateIds = (templates: BootstrapTemplate[]): string =>
+	templates.map((t) => t.id).join(", ");
+
+export const findTemplate = (
+	templates: BootstrapTemplate[],
+	id: string,
+): BootstrapTemplate | undefined => templates.find((t) => t.id === id);
+
+/** A single file or symlink to materialize, already resolved with its bytes. */
+export type TemplateFile =
+	| {
+			kind: "file";
+			/** Path relative to the target directory (subdir prefix stripped). */
+			path: string;
+			bytes: Buffer;
+			executable: boolean;
+	  }
+	| {
+			kind: "symlink";
+			path: string;
+			/** The (relative) link target. */
+			target: string;
+	  };
+
+const githubToken = (): string =>
+	process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN ?? "";
+
+// A token is never required for public templates, but we forward it when
+// present so the same code path works behind proxies that authenticate, and
+// (in future) for private template repos.
+const downloadHeaders = (): Record<string, string> => ({
+	"User-Agent": "neon-init",
+	...(githubToken() ? { Authorization: `Bearer ${githubToken()}` } : {}),
+});
+
+// The codeload host is overridable so the e2e tests can point the downloader at
+// a local server (the same trick `--api-host` uses to redirect the Neon API).
+const codeloadBase = (): string =>
+	process.env.NEON_BOOTSTRAP_GITHUB_CODELOAD ?? "https://codeload.github.com";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+/**
+ * Normalize a manifest entry's `services` into a clean string list. Tolerant by
+ * design: a missing or non-array value yields `undefined`, and non-string items
+ * are dropped, so a malformed `services` never sinks an otherwise-valid
+ * template (it just renders without its badge).
+ */
+const parseServices = (value: unknown): string[] | undefined => {
+	if (!Array.isArray(value)) return undefined;
+	const services = value.filter(
+		(item): item is string =>
+			typeof item === "string" && item.trim() !== "",
+	);
+	return services.length > 0 ? services : undefined;
+};
+
+// ---------------------------------------------------------------------------
+// Remote template manifest
+// ---------------------------------------------------------------------------
 
 // Primary manifest host is neon.com (CDN-backed, no GitHub rate limiting), with
 // the raw GitHub copy as a fallback and the hardcoded list as the last resort.
@@ -88,9 +190,6 @@ function manifestUrls(): string[] {
 	if (override) return [override];
 	return [NEON_MANIFEST_URL, GITHUB_RAW_MANIFEST_URL];
 }
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null;
 
 export function parseManifest(text: string): BootstrapTemplate[] {
 	const data: unknown = YAML.parse(text);
@@ -114,17 +213,18 @@ export function parseManifest(text: string): BootstrapTemplate[] {
 		) {
 			continue;
 		}
-		// Parse requires — accept string array, default to ["database"]
+		// Parse requires — accept a string array, default to ["database"].
 		const requires: NeonFeature[] =
 			Array.isArray(item.requires) &&
 			item.requires.every((r: unknown) => typeof r === "string")
 				? (item.requires as NeonFeature[])
 				: DEFAULT_REQUIRES;
-
+		const services = parseServices(item.services);
 		templates.push({
 			id: item.id,
 			title: item.title,
 			description: item.description,
+			...(services ? { services } : {}),
 			requires,
 			source: {
 				owner: item.source.owner,
@@ -147,6 +247,7 @@ export async function fetchTemplates(): Promise<BootstrapTemplate[]> {
 	for (const url of manifestUrls()) {
 		try {
 			const res = await fetch(url, {
+				headers: downloadHeaders(),
 				signal: AbortSignal.timeout(10_000),
 			});
 			if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -158,3 +259,344 @@ export async function fetchTemplates(): Promise<BootstrapTemplate[]> {
 	}
 	return FALLBACK_TEMPLATES;
 }
+
+// ---------------------------------------------------------------------------
+// Tar parsing
+// ---------------------------------------------------------------------------
+
+/** A raw entry decoded from a tar stream, before subdir filtering. */
+type TarEntry = {
+	/** Full path as stored in the archive (includes the top-level dir). */
+	name: string;
+	/** POSIX type flag: '0' file, '5' directory, '2' symlink, etc. */
+	type: string;
+	/** File permission bits. */
+	mode: number;
+	/** Symlink target (for type '2'). */
+	linkname: string;
+	/** File contents (for type '0'). */
+	data: Buffer;
+};
+
+const TAR_BLOCK = 512;
+
+const readTarString = (buf: Buffer, offset: number, length: number): string => {
+	let end = offset;
+	const max = offset + length;
+	while (end < max && buf[end] !== 0) end++;
+	return buf.toString("utf8", offset, end);
+};
+
+const readTarOctal = (buf: Buffer, offset: number, length: number): number => {
+	const text = readTarString(buf, offset, length).trim();
+	if (text === "") return 0;
+	const value = parseInt(text, 8);
+	return Number.isNaN(value) ? 0 : value;
+};
+
+const isZeroBlock = (buf: Buffer, offset: number): boolean => {
+	for (let i = offset; i < offset + TAR_BLOCK; i++) {
+		if (buf[i] !== 0) return false;
+	}
+	return true;
+};
+
+/**
+ * Parse pax extended-header records ("<len> <key>=<value>\n"). GitHub uses
+ * these for the global header and for any path that doesn't fit the legacy
+ * 100-byte name field, so we must honor at least `path` and `linkpath`.
+ */
+const parsePaxRecords = (data: Buffer): Record<string, string> => {
+	const records: Record<string, string> = {};
+	let pos = 0;
+	const text = data.toString("utf8");
+	while (pos < text.length) {
+		const space = text.indexOf(" ", pos);
+		if (space === -1) break;
+		const len = parseInt(text.slice(pos, space), 10);
+		if (Number.isNaN(len) || len <= 0) break;
+		const record = text.slice(space + 1, pos + len - 1); // drop trailing "\n"
+		const eq = record.indexOf("=");
+		if (eq !== -1) records[record.slice(0, eq)] = record.slice(eq + 1);
+		pos += len;
+	}
+	return records;
+};
+
+/**
+ * Decode a (decompressed) tar archive into its file/symlink entries. Pure and
+ * dependency-free so it can be unit tested without touching the network.
+ * Handles the ustar `prefix` field, pax extended headers (type 'x'/'g'), and
+ * GNU long-name/long-link headers (type 'L'/'K') so deep template paths and
+ * long symlink targets round-trip correctly.
+ */
+export const parseTar = (buf: Buffer): TarEntry[] => {
+	const entries: TarEntry[] = [];
+	// Overrides carried from a preceding pax/GNU header to the next real entry.
+	let overridePath: string | undefined;
+	let overrideLink: string | undefined;
+	let offset = 0;
+
+	while (offset + TAR_BLOCK <= buf.length) {
+		if (isZeroBlock(buf, offset)) break;
+
+		let name = readTarString(buf, offset, 100);
+		const mode = readTarOctal(buf, offset + 100, 8);
+		const size = readTarOctal(buf, offset + 124, 12);
+		const typeByte = buf[offset + 156];
+		const type = typeByte === 0 ? "0" : String.fromCharCode(typeByte);
+		let linkname = readTarString(buf, offset + 157, 100);
+		const magic = readTarString(buf, offset + 257, 6);
+		if (magic.startsWith("ustar")) {
+			const prefix = readTarString(buf, offset + 345, 155);
+			if (prefix !== "") name = `${prefix}/${name}`;
+		}
+
+		offset += TAR_BLOCK;
+		const data = buf.subarray(offset, offset + size);
+		offset += Math.ceil(size / TAR_BLOCK) * TAR_BLOCK;
+
+		if (type === "x") {
+			const records = parsePaxRecords(data);
+			if (records.path !== undefined) overridePath = records.path;
+			if (records.linkpath !== undefined) overrideLink = records.linkpath;
+			continue;
+		}
+		if (type === "g") {
+			// Global pax header (e.g. GitHub's comment block): not per-entry state.
+			continue;
+		}
+		if (type === "L" || type === "K") {
+			const longValue = data.toString("utf8").replace(/\0+$/, "");
+			if (type === "L") overridePath = longValue;
+			else overrideLink = longValue;
+			continue;
+		}
+
+		if (overridePath !== undefined) name = overridePath;
+		if (overrideLink !== undefined) linkname = overrideLink;
+		overridePath = undefined;
+		overrideLink = undefined;
+
+		entries.push({ name, type, mode, linkname, data: Buffer.from(data) });
+	}
+
+	return entries;
+};
+
+/**
+ * Map decoded tar entries to the files under `subdir`, with the top-level
+ * archive directory and the `subdir/` prefix stripped from each path. Pure so
+ * it can be unit tested. Directory and other non-regular entries are dropped —
+ * writing files re-creates their parent directories.
+ */
+export const selectTemplateFiles = (
+	entries: TarEntry[],
+	subdir: string,
+): TemplateFile[] => {
+	const prefix = `${subdir.replace(/^\/+|\/+$/g, "")}/`;
+	const files: TemplateFile[] = [];
+	for (const entry of entries) {
+		// codeload wraps everything in a single top-level dir ("<repo>-<ref>/");
+		// strip that first segment to get the repo-relative path.
+		const slash = entry.name.indexOf("/");
+		if (slash === -1) continue;
+		const repoPath = entry.name.slice(slash + 1);
+		if (!repoPath.startsWith(prefix)) continue;
+		const path = repoPath.slice(prefix.length);
+		if (path === "") continue;
+		if (entry.type === "2") {
+			files.push({ kind: "symlink", path, target: entry.linkname });
+		} else if (entry.type === "0" || entry.type === "7") {
+			files.push({
+				kind: "file",
+				path,
+				bytes: entry.data,
+				executable: (entry.mode & 0o111) !== 0,
+			});
+		}
+		// Directories ('5') and any other node types are intentionally skipped.
+	}
+	return files;
+};
+
+const tarballUrl = (template: BootstrapTemplate): string => {
+	const { owner, repo, ref } = template.source;
+	return `${codeloadBase()}/${owner}/${repo}/tar.gz/${ref}`;
+};
+
+const friendlyGithubError = (status: number, url: string): Error => {
+	if (status === 404) {
+		return new Error(
+			`GitHub returned 404 for ${url}. The template repo or ref may have moved.`,
+		);
+	}
+	if (status === 403 || status === 429) {
+		return new Error(
+			`GitHub rate limited the template download (${url}). Set a GITHUB_TOKEN environment variable to raise the limit, then retry.`,
+		);
+	}
+	return new Error(`GitHub returned HTTP ${status} for ${url}.`);
+};
+
+/**
+ * Download a template and resolve it to the exact set of files to write. The
+ * entire subtree is captured in one tarball request, so the copy is atomically
+ * consistent: a push to the template repo mid-download cannot produce a
+ * mismatched checkout (unlike fetching a file list and then each blob).
+ */
+export const downloadTemplate = async (
+	template: BootstrapTemplate,
+): Promise<TemplateFile[]> => {
+	const url = tarballUrl(template);
+
+	let gzipped: Buffer;
+	try {
+		const res = await fetch(url, {
+			headers: downloadHeaders(),
+			signal: AbortSignal.timeout(30_000),
+		});
+		if (!res.ok) throw friendlyGithubError(res.status, url);
+		gzipped = Buffer.from(await res.arrayBuffer());
+	} catch (err) {
+		throw err instanceof Error ? err : new Error(String(err));
+	}
+
+	let tar: Buffer;
+	try {
+		tar = Buffer.from(gunzipSync(new Uint8Array(gzipped)));
+	} catch (err) {
+		throw new Error(
+			`Failed to decompress the template archive from ${url}: ${
+				err instanceof Error ? err.message : String(err)
+			}`,
+		);
+	}
+
+	const { owner, repo, ref, subdir } = template.source;
+	const files = selectTemplateFiles(parseTar(tar), subdir);
+	if (files.length === 0) {
+		throw new Error(
+			`Template subdirectory "${subdir}" was not found in ${owner}/${repo}@${ref}.`,
+		);
+	}
+	return files;
+};
+
+// ---------------------------------------------------------------------------
+// Target validation + scaffolding to disk
+// ---------------------------------------------------------------------------
+
+/**
+ * A bad caller-supplied input that an agent (or human) can correct: an unknown
+ * template id or a non-empty target directory. Carries an `agentCode` so an
+ * agent surface can report a precise error code instead of a generic
+ * INTERNAL_ERROR, while a human path just surfaces the clear `message`.
+ */
+export class BootstrapInputError extends Error {
+	readonly agentCode: string;
+	constructor(message: string, agentCode: string) {
+		super(message);
+		this.name = "BootstrapInputError";
+		this.agentCode = agentCode;
+	}
+}
+
+/**
+ * Ensure `dir` is safe to scaffold into: it must be missing, or an empty
+ * directory (a lone `.git` is ignored so you can scaffold into a freshly
+ * `git init`ed folder). `force` allows scaffolding into a non-empty directory,
+ * overwriting colliding files. Throws a {@link BootstrapInputError} otherwise.
+ */
+export const ensureTargetUsable = (dir: string, force: boolean): void => {
+	if (!existsSync(dir)) return;
+	if (!statSync(dir).isDirectory()) {
+		throw new BootstrapInputError(
+			`Target ${dir} already exists and is not a directory.`,
+			"TARGET_NOT_DIRECTORY",
+		);
+	}
+	const contents = readdirSync(dir).filter((name) => name !== ".git");
+	if (contents.length > 0 && !force) {
+		throw new BootstrapInputError(
+			`Target directory ${dir} is not empty. Use --force to scaffold into it anyway (colliding files will be overwritten), or choose an empty directory.`,
+			"TARGET_NOT_EMPTY",
+		);
+	}
+};
+
+const isSymlink = (path: string): boolean => {
+	try {
+		return lstatSync(path).isSymbolicLink();
+	} catch {
+		return false;
+	}
+};
+
+const errnoCode = (err: unknown): string | undefined => {
+	if (
+		typeof err === "object" &&
+		err !== null &&
+		"code" in err &&
+		typeof err.code === "string"
+	) {
+		return err.code;
+	}
+	return undefined;
+};
+
+const writeSymlink = (
+	dest: string,
+	target: string,
+	onWarn?: (message: string) => void,
+): void => {
+	if (isSymlink(dest)) rmSync(dest, { force: true });
+	try {
+		symlinkSync(target, dest);
+	} catch (err) {
+		// Windows refuses symlinks without elevated rights / developer mode. The
+		// template still works for most tooling if we drop a regular file holding
+		// the link target, so we degrade gracefully instead of failing the copy.
+		if (errnoCode(err) === "EPERM" || process.platform === "win32") {
+			onWarn?.(
+				`Could not create symlink ${dest} -> ${target}; wrote it as a regular file instead.`,
+			);
+			writeFileSync(dest, target);
+			return;
+		}
+		throw err;
+	}
+};
+
+export interface ScaffoldOptions {
+	/** Called for non-fatal warnings (e.g. a symlink that fell back to a file). */
+	onWarn?: (message: string) => void;
+}
+
+/**
+ * Download `template` and materialize its files into `targetDir`, creating
+ * parent directories, preserving executable bits, and recreating symlinks
+ * (with a graceful regular-file fallback on platforms that disallow them).
+ * Returns the number of files written. The caller is responsible for any
+ * target validation ({@link ensureTargetUsable}) and user-facing progress.
+ */
+export const scaffoldTemplate = async (
+	template: BootstrapTemplate,
+	targetDir: string,
+	options: ScaffoldOptions = {},
+): Promise<number> => {
+	const files = await downloadTemplate(template);
+
+	mkdirSync(targetDir, { recursive: true });
+	for (const file of files) {
+		const dest = join(targetDir, file.path);
+		mkdirSync(dirname(dest), { recursive: true });
+		if (file.kind === "symlink") {
+			writeSymlink(dest, file.target, options.onWarn);
+		} else {
+			writeFileSync(dest, file.bytes);
+			if (file.executable) chmodSync(dest, 0o755);
+		}
+	}
+	return files.length;
+};

--- a/packages/init/src/lib/phases/setup.test.ts
+++ b/packages/init/src/lib/phases/setup.test.ts
@@ -66,6 +66,9 @@ vi.mock("../bootstrap.js", () => {
 	return {
 		fetchTemplates: vi.fn().mockResolvedValue(templates),
 		FALLBACK_TEMPLATES: templates,
+		findTemplate: (ts: typeof templates, id: string) =>
+			ts.find((t) => t.id === id),
+		scaffoldTemplate: vi.fn().mockResolvedValue(1),
 	};
 });
 

--- a/packages/init/src/lib/phases/setup.ts
+++ b/packages/init/src/lib/phases/setup.ts
@@ -6,7 +6,9 @@ import { resolveAddMcpAgentId } from "../agents.js";
 import {
 	FALLBACK_TEMPLATES,
 	fetchTemplates,
+	findTemplate,
 	type NeonFeature,
+	scaffoldTemplate,
 } from "../bootstrap.js";
 import {
 	detectIde,
@@ -627,22 +629,14 @@ async function executeBatchedInstallation(
 	// Step 0: Bootstrap project from template if specified
 	if (isBootstrap && options.template) {
 		try {
-			// Pin @latest (and -y) so a stale globally-installed neonctl can't be
-			// picked up by npx — bootstrap's rate-limit fix lives in recent
-			// neonctl, and this runs before ensureNeonctl() updates the global.
-			await execa(
-				"npx",
-				[
-					"-y",
-					"neonctl@latest",
-					"bootstrap",
-					".",
-					"--template",
-					options.template,
-					"--force",
-				],
-				{ stdio: "pipe", timeout: 120000 },
-			);
+			const templates = await fetchTemplates();
+			const template =
+				findTemplate(templates, options.template) ??
+				findTemplate(FALLBACK_TEMPLATES, options.template);
+			if (!template) {
+				throw new Error(`Unknown template "${options.template}".`);
+			}
+			await scaffoldTemplate(template, ".");
 			results.push({
 				id: "bootstrap",
 				description: `Scaffolded project from template "${options.template}"`,

--- a/packages/init/src/v2.test.ts
+++ b/packages/init/src/v2.test.ts
@@ -45,6 +45,9 @@ vi.mock("./lib/bootstrap.js", () => {
 	return {
 		fetchTemplates: vi.fn().mockResolvedValue(templates),
 		FALLBACK_TEMPLATES: templates,
+		findTemplate: (ts: typeof templates, id: string) =>
+			ts.find((t) => t.id === id),
+		scaffoldTemplate: vi.fn().mockResolvedValue(1),
 	};
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,7 +104,7 @@ importers:
         version: 1.130.17(@tanstack/react-query@5.81.4(react@19.1.1))(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@tanstack/router-core@1.131.37)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-start':
         specifier: ^1.131.37
-        version: 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
+        version: 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.1)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/router-plugin':
         specifier: ^1.131.37
         version: 1.131.37(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -357,6 +357,9 @@ importers:
       execa:
         specifier: ^9.5.2
         version: 9.6.0
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       picocolors:
         specifier: ^1.1.1
         version: 1.1.1
@@ -935,14 +938,14 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@emnapi/core@1.10.0':
-    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+  '@emnapi/core@1.11.0':
+    resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.0':
+    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
 
-  '@emnapi/wasi-threads@1.2.1':
-    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
@@ -1163,8 +1166,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  '@napi-rs/wasm-runtime@1.1.4':
-    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1224,8 +1227,8 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@oxc-project/types@0.134.0':
-    resolution: {integrity: sha512-T0xuRRKrQFmocH8y+jGfpmSkGcheaJExY9lEihmR1Gm2aH+75B8CzgU2rABRQSzzDxLjZ15Sc0bRVLj5lVeNXQ==}
+  '@oxc-project/types@0.135.0':
+    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -1337,97 +1340,97 @@ packages:
   '@quansync/fs@0.1.4':
     resolution: {integrity: sha512-vy/41FCdnIalPTQCb2Wl0ic1caMdzGus4ktDp+gpZesQNydXcx8nhh8qB3qMPbGkictOTaXgXEUUfQEm8DQYoA==}
 
-  '@rolldown/binding-android-arm64@1.1.0':
-    resolution: {integrity: sha512-gCYzGOSkYY6Z034suzd20euvds7lPzMEEla62DJGE/ZAlR4OMBnNbvnBSsIGUCAr52gaWMsloGxP4tVGtN5aCA==}
+  '@rolldown/binding-android-arm64@1.1.1':
+    resolution: {integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.0':
-    resolution: {integrity: sha512-JQBD77MNgu+4Z6RAyg69acugdrhhVoWesr3l47zohYZ2YV2fwkWMArkN/2p4l6Ei+Sno7W5q+UsKdVWq5Ens0w==}
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.0':
-    resolution: {integrity: sha512-p/8cXUTK4Sob604e+xxPhVSbDFf29E6J0l/xESM9rdCfn3aDai3nEs6TnMHUsdD5aNlFz0+gDbiGlozLKGa2YA==}
+  '@rolldown/binding-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.0':
-    resolution: {integrity: sha512-KbtOSlVv6fElujiZWMcC3aQYhEwLVVf073RcwlSmpGQvIsKZFUqc0ef4sjUuurRwfbiI6JJXji9DQn+86hawmQ==}
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    resolution: {integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
-    resolution: {integrity: sha512-9fZ9i0o0/MQaw7om6Z6TsT7tfCk0jtbEFtC+aPqZL5RNsGWNcHvn6EHgL3dAprjq+AZzPTAQjg2JtpJaMt+6pg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    resolution: {integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.0':
-    resolution: {integrity: sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.0':
-    resolution: {integrity: sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==}
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
-    resolution: {integrity: sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.0':
-    resolution: {integrity: sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.0':
-    resolution: {integrity: sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.0':
-    resolution: {integrity: sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==}
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.0':
-    resolution: {integrity: sha512-4+fexHayrLCWpriPh4c6dNvL4an34DEZCG7zOM/FD5QNF6h8DT+bDXzyB/kfC8lDJbaFb7jKShtnjDQFXVQEjg==}
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    resolution: {integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.0':
-    resolution: {integrity: sha512-SbL++MNmOw6QamrwIGDMSSfM4ceTzFr+RjbOExJSLLBinScU4WI5OdA413h1qwPw2yH7lVF1+H4svQ+6mSXKTQ==}
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    resolution: {integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.0':
-    resolution: {integrity: sha512-+xTE6XC7wBgk0VKRXGG+QAnyW5S9b8vfsFpiMjf0waQTmSQSU8onsH/beyZ8X4aXVveJnotiy7VDjLOaW8bTrg==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    resolution: {integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.0':
-    resolution: {integrity: sha512-Ogji1TQNqH3ACLnYr+1Ns1nyrJ0CO2P585u9Hsh02pXvtFiFpgtgT2b3P4PnCOU86VVCvqtAeCN4OftMT8KU4w==}
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1932,8 +1935,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@tybys/wasm-util@0.10.1':
-    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -3965,8 +3968,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.1.0:
-    resolution: {integrity: sha512-zpMvlJhs5PkXRTtKc0CaLBVI9AR/VDiJFpM+kx//hgToEca7FgMlGjaRIisXBcb19T76LswgmKECSQ96hjWr5A==}
+  rolldown@1.1.1:
+    resolution: {integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5333,18 +5336,18 @@ snapshots:
 
   '@csstools/css-tokenizer@3.0.4': {}
 
-  '@emnapi/core@1.10.0':
+  '@emnapi/core@1.11.0':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.1
+      '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.1':
+  '@emnapi/wasi-threads@1.2.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5513,11 +5516,11 @@ snapshots:
       - encoding
       - supports-color
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@tybys/wasm-util': 0.10.2
     optional: true
 
   '@neondatabase/api-client@2.7.1':
@@ -5590,7 +5593,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@oxc-project/types@0.134.0': {}
+  '@oxc-project/types@0.135.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -5676,53 +5679,53 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rolldown/binding-android-arm64@1.1.0':
+  '@rolldown/binding-android-arm64@1.1.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.0':
+  '@rolldown/binding-darwin-arm64@1.1.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.0':
+  '@rolldown/binding-darwin-x64@1.1.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.0':
+  '@rolldown/binding-freebsd-x64@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.0':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.0':
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.0':
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.0':
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.0':
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.0':
+  '@rolldown/binding-linux-x64-musl@1.1.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.0':
+  '@rolldown/binding-openharmony-arm64@1.1.1':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.0':
+  '@rolldown/binding-wasm32-wasi@1.1.1':
     dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.0':
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.0':
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
     optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -6004,9 +6007,9 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-plugin@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
+  '@tanstack/react-start-plugin@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(rolldown@1.1.1)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
-      '@tanstack/start-plugin-core': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@tanstack/start-plugin-core': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.1)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       pathe: 2.0.3
       vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -6056,10 +6059,10 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@tanstack/react-start@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
+  '@tanstack/react-start@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rolldown@1.1.1)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@tanstack/react-start-client': 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@tanstack/react-start-plugin': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@tanstack/react-start-plugin': 1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(rolldown@1.1.1)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/react-start-server': 1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/start-server-functions-client': 1.131.37(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
       '@tanstack/start-server-functions-server': 1.131.2(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))
@@ -6198,7 +6201,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/start-plugin-core@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.0)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
+  '@tanstack/start-plugin-core@1.131.37(@netlify/blobs@9.1.2)(@tanstack/react-router@1.131.37(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(rolldown@1.1.1)(vite-plugin-solid@2.11.6(solid-js@1.9.6)(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)))(vite@6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/core': 7.28.5
@@ -6214,7 +6217,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.10
       cheerio: 1.1.2
       h3: 1.13.0
-      nitropack: 2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.0)
+      nitropack: 2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.1)
       pathe: 2.0.3
       ufo: 1.6.1
       vite: 6.4.1(@types/node@20.19.17)(jiti@2.7.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.5)(yaml@2.9.0)
@@ -6318,7 +6321,7 @@ snapshots:
       '@types/react': 19.1.12
       '@types/react-dom': 19.1.9(@types/react@19.1.12)
 
-  '@tybys/wasm-util@0.10.1':
+  '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7937,7 +7940,7 @@ snapshots:
       qs: 6.14.1
     optional: true
 
-  nitropack@2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.0):
+  nitropack@2.12.5(@netlify/blobs@9.1.2)(rolldown@1.1.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.0
       '@rollup/plugin-alias': 5.1.1(rollup@4.50.1)
@@ -7990,7 +7993,7 @@ snapshots:
       pretty-bytes: 7.0.1
       radix3: 1.1.2
       rollup: 4.50.1
-      rollup-plugin-visualizer: 6.0.3(rolldown@1.1.0)(rollup@4.50.1)
+      rollup-plugin-visualizer: 6.0.3(rolldown@1.1.1)(rollup@4.50.1)
       scule: 1.3.0
       semver: 7.7.2
       serve-placeholder: 2.0.2
@@ -8426,7 +8429,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.6(rolldown@1.1.0)(typescript@5.8.2):
+  rolldown-plugin-dts@0.15.6(rolldown@1.1.1)(typescript@5.8.2):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -8436,42 +8439,42 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
-      rolldown: 1.1.0
+      rolldown: 1.1.1
     optionalDependencies:
       typescript: 5.8.2
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.1.0:
+  rolldown@1.1.1:
     dependencies:
-      '@oxc-project/types': 0.134.0
+      '@oxc-project/types': 0.135.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.0
-      '@rolldown/binding-darwin-arm64': 1.1.0
-      '@rolldown/binding-darwin-x64': 1.1.0
-      '@rolldown/binding-freebsd-x64': 1.1.0
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.0
-      '@rolldown/binding-linux-arm64-gnu': 1.1.0
-      '@rolldown/binding-linux-arm64-musl': 1.1.0
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.0
-      '@rolldown/binding-linux-s390x-gnu': 1.1.0
-      '@rolldown/binding-linux-x64-gnu': 1.1.0
-      '@rolldown/binding-linux-x64-musl': 1.1.0
-      '@rolldown/binding-openharmony-arm64': 1.1.0
-      '@rolldown/binding-wasm32-wasi': 1.1.0
-      '@rolldown/binding-win32-arm64-msvc': 1.1.0
-      '@rolldown/binding-win32-x64-msvc': 1.1.0
+      '@rolldown/binding-android-arm64': 1.1.1
+      '@rolldown/binding-darwin-arm64': 1.1.1
+      '@rolldown/binding-darwin-x64': 1.1.1
+      '@rolldown/binding-freebsd-x64': 1.1.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.1
+      '@rolldown/binding-linux-arm64-gnu': 1.1.1
+      '@rolldown/binding-linux-arm64-musl': 1.1.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.1
+      '@rolldown/binding-linux-s390x-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-musl': 1.1.1
+      '@rolldown/binding-openharmony-arm64': 1.1.1
+      '@rolldown/binding-wasm32-wasi': 1.1.1
+      '@rolldown/binding-win32-arm64-msvc': 1.1.1
+      '@rolldown/binding-win32-x64-msvc': 1.1.1
 
-  rollup-plugin-visualizer@6.0.3(rolldown@1.1.0)(rollup@4.50.1):
+  rollup-plugin-visualizer@6.0.3(rolldown@1.1.1)(rollup@4.50.1):
     dependencies:
       open: 8.4.2
       picomatch: 4.0.3
       source-map: 0.7.6
       yargs: 17.7.2
     optionalDependencies:
-      rolldown: 1.1.0
+      rolldown: 1.1.1
       rollup: 4.50.1
 
   rollup@4.50.1:
@@ -8855,8 +8858,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.1.0
-      rolldown-plugin-dts: 0.15.6(rolldown@1.1.0)(typescript@5.8.2)
+      rolldown: 1.1.1
+      rolldown-plugin-dts: 0.15.6(rolldown@1.1.1)(typescript@5.8.2)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15


### PR DESCRIPTION
## Summary

Moves the full `neonctl bootstrap` template-scaffolding implementation into `neon-init` and exposes it as a reusable `neon-init/bootstrap` entry point. This de-duplicates the bootstrap logic that previously lived in two places and lets `neon init`'s flows scaffold **in-process** instead of shelling out to `npx -y neonctl@latest bootstrap`.

### What changed

- **`packages/init/src/lib/bootstrap.ts`** — replaced the manifest-only layer with the complete in-house implementation:
  - manifest fetch/parse (native `fetch`, env-overridable hosts)
  - single-request `codeload.github.com` tarball download (no GitHub REST rate limits, optional `GITHUB_TOKEN`)
  - in-house gunzip (`fflate`) + tar parsing (ustar prefix, pax/GNU long paths, symlinks)
  - `scaffoldTemplate()` writes to disk preserving exec bits and symlinks (with a graceful regular-file fallback on platforms that forbid symlinks)
  - `ensureTargetUsable()` + `BootstrapInputError` for target validation
- **`BootstrapTemplate`** is now a superset carrying both `services` (display badge) and `requires` (Neon features).
- **New `neon-init/bootstrap` export** ships `fetchTemplates`, `parseManifest`, `downloadTemplate`, `scaffoldTemplate`, `ensureTargetUsable`, `BootstrapInputError`, `FALLBACK_TEMPLATES`, and the `BootstrapTemplate` / `TemplateFile` / `NeonFeature` types.
- **`interactive.ts` + `phases/setup.ts`** now call `scaffoldTemplate(...)` directly — the `npx neonctl@latest bootstrap` shell-out is gone.
- Added `fflate` dependency and a `minor` changeset for `neon-init`.

### Why

`neonctl bootstrap` was the source of truth (download + tar + write), while `neon-init` carried a duplicate manifest layer and delegated the actual scaffolding back to a pinned `npx neonctl@latest`. Consolidating the core in `neon-init` removes the duplication, drops the npx round-trip / stale-global-neonctl concerns, and gives `neonctl` a single shared implementation to import (follow-up PR).

## Test plan

- [x] `pnpm --filter neon-init build` (tsc + tsdown) passes
- [x] `pnpm --filter neon-init test:ci` — 122 passing, incl. ported tar/manifest unit tests and a new no-mock `scaffoldTemplate` e2e (local HTTP server + real disk writes)
- [x] `pnpm lint:ci` (Biome) clean
- [ ] Follow-up: neonctl PR consumes `neon-init/bootstrap` (draft, blocked on this release)