### PR TITLE
chore: release env + ai-sdk-provider; add release skill; refresh docs

### DIFF
--- a/.changeset/ai-sdk-provider-v6.md
+++ b/.changeset/ai-sdk-provider-v6.md
@@ -1,5 +1,0 @@
----
-"@neondatabase/ai-sdk-provider": minor
----
-
-Upgrade `@neondatabase/ai-sdk-provider` to the AI SDK v6 provider specification (v3 language models). Requires `ai@^6`.

--- a/.changeset/remove-force-path-style.md
+++ b/.changeset/remove-force-path-style.md
@@ -1,7 +1,0 @@
----
-"@neondatabase/env": minor
----
-
-Remove the `NEON_STORAGE_FORCE_PATH_STYLE` env var and the `storage.forcePathStyle` field from `NeonStorageEnv`.
-
-It was always `true` and has no AWS-standard env name, so the S3 SDKs never read it automatically — you already had to wire `forcePathStyle` into your `S3Client` by hand. Neon's storage gateway always requires path-style addressing, so set `forcePathStyle: true` directly on your client. `env pull` no longer writes the variable, and `parseEnv` / `toEntries` no longer read or emit it. The raw `NeonBranchStorageSnapshot.forcePathStyle` from `@neondatabase/config` (the `GET .../storage` response) is unchanged.

--- a/.changeset/remove-storage-region.md
+++ b/.changeset/remove-storage-region.md
@@ -1,7 +1,0 @@
----
-"@neondatabase/env": minor
----
-
-Remove the `NEON_STORAGE_REGION` env var (the Neon-branded alias of `AWS_REGION`).
-
-The region is already injected under the SDK-standard `AWS_REGION`, which the AWS S3 SDKs read automatically — the duplicate `NEON_STORAGE_REGION` alias was never read back by `parseEnv` and bought nothing. `env pull` no longer writes it and `toEntries` no longer emits it. `NeonStorageEnv.region` (mapped to `AWS_REGION`) is unchanged.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: release
+description: Cut version bumps + changelogs for maintained packages in this monorepo. Detects which packages changed since their published npm version (git-vs-npm), reconciles against pending Changesets, runs `changeset version` to bump + cascade dependents, and opens a PR. This repo only produces version-bump commits — the actual npm publish happens externally (private mirror). Use when asked to "release", "cut a release", "bump versions", or "check what needs releasing".
+---
+
+# Release: version bumps + changelogs
+
+## What a "release" means in this repo
+
+This repo does **not** publish to npm. Publishing happens from a **private mirror**
+(see `chore: disable npm provenance (published from a private mirror)`). Here a release
+is only a **version-bump + CHANGELOG commit on `main`**, landed via a PR. The mirror picks
+it up and publishes.
+
+Versioning is driven by **[Changesets](https://github.com/changesets/changesets)**
+(`.changeset/config.json`, per-package `CHANGELOG.md`). `AGENTS.md` mentions an automated
+"Version Packages" PR bot — that is **stale**; those workflows were removed. The bump is run
+by hand and committed (see history: `release pending changesets`, `bump patch versions…`).
+
+`changeset version` is the engine. Git-vs-npm is the **safety net** that catches packages
+which changed but have no changeset (a forgotten release).
+
+## Which packages are "maintained"
+
+**Each package's own `README.md` is the source of truth for its status** — don't hardcode a list.
+A package is *deprecated* if its `README.md` opens with a deprecation banner (convention: a first
+heading containing `DEPRECATED`, e.g. `# ⚠️ DEPRECATED: <name>`); otherwise it's *maintained*. The
+top-level `README.md` lists only maintained packages, as a convenience index.
+
+So enumerate maintained packages as: every `packages/*/` with a `package.json` that is published
+(`"private"` absent or false) and whose `README.md` has **no** `DEPRECATED` banner.
+
+Folders under `packages/` with only `dist/`/`node_modules/` and no `package.json` are build
+artifacts — ignore them.
+
+## Procedure
+
+### 1. Detect what needs a release (git-vs-npm)
+
+For each maintained package:
+
+```bash
+# npm latest (published)
+npm view <pkg-name> version
+# local
+node -p "require('./packages/<dir>/package.json').version"
+# source commits to the folder since the commit that set the npm version
+git log --oneline <npm-release-commit>..HEAD -- packages/<dir>
+```
+
+A package **needs a release** if either:
+- `local version > npm version` (already bumped in `main`, not yet published — e.g. the mirror is behind), or
+- there are **source** commits to its folder after its last npm release.
+
+**Ignore packaging/CI-only commits** (e.g. `publishConfig.provenance` flips, lockfile-only,
+test-config-only changes) — they don't warrant a user-facing release.
+
+### 2. Reconcile against pending changesets
+
+```bash
+ls .changeset/*.md   # ignore README.md
+```
+
+Each changeset's frontmatter lists `"<pkg>": <major|minor|patch>`. Cross-check:
+- A package flagged in step 1 **with** a pending changeset → covered.
+- Flagged **without** a changeset → the gap. Create one (`.changeset/<slug>.md`) choosing the
+  bump type from the change (breaking → major; new behavior → minor; fix/internal → patch).
+  Write a user-facing summary.
+- A pending changeset for a package the detector did **not** flag → investigate (already-bumped
+  or duplicate); surface it, don't silently proceed.
+
+### 3. Bump
+
+```bash
+pnpm changeset version
+```
+
+This consumes the `.md` files, rewrites `package.json` versions, appends to each `CHANGELOG.md`,
+and — because all internal deps are `workspace:*` with `updateInternalDependencies: "patch"` —
+**recursively patch-bumps dependents** of any released package. No manual cascade needed.
+
+> Internal deps use `workspace:*`, so dependents never pin a version. The only reason to bump a
+> dependent is to republish it against the new dependency — which is exactly what this step does.
+
+### 4. Verify
+
+```bash
+git status --short              # expect: deleted .md, modified package.json + CHANGELOG.md
+pnpm lint:ci                    # biome checks formatting (incl. package.json) — must pass
+```
+
+`workspace:*` deps mean `pnpm-lock.yaml` usually does not change. If it does, commit it too.
+
+### 5. List updated packages
+
+Report each bumped package as `name: old → new` (note which are dependent-cascade bumps), so
+the user sees the release set.
+
+### 6. Open the PR
+
+```bash
+git checkout -b release-bumps   # if not already on a release branch
+git add -A
+git commit -m "chore: release pending changesets"
+git push -u origin HEAD
+gh pr create --title "chore: release pending changesets" --body "<summary>"
+```
+
+The PR body should list the bumped packages and versions. Do **not** assign reviewers, request
+reviews, or post comments unless explicitly asked. The private-mirror CI publishes on merge.
+
+## Gotchas
+
+- **CHANGELOG version gaps** can happen when a prior PR bumped `package.json` directly without a
+  changeset (e.g. `ai-sdk-provider` jumped 0.2.0 → 0.4.0 in the log, skipping 0.3.0). Surface it;
+  don't try to backfill.
+- `changeset version` writes to `/dev/tty`; the `Opening /dev/tty failed` warning is harmless.
+- Never invoke `biome`/`changeset` binaries directly — go through `pnpm` scripts / `pnpm changeset`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,25 +4,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a monorepo for Neon Launchpad packages that provide instant Postgres database provisioning without sign-ups. It contains five main packages:
-- `get-db`: A CLI tool for creating claimable Neon databases (formerly `neondb`)
-- `neondb`: Deprecated alias package for `get-db` (shows deprecation warning)
-- `vite-plugin-db`: A Vite plugin that automatically provisions databases (formerly `@neondatabase/vite-plugin-postgres`)
-- `@neondatabase/vite-plugin-postgres`: Deprecated alias package for `vite-plugin-db` (shows deprecation warning)
-- `neon-init`: A setup tool for initializing your project with Neon and Neon MCP Server
+This is a monorepo of [Neon](https://neon.com) open-source packages for the JavaScript/TypeScript
+ecosystem (CLIs, a Vite plugin, the Config-as-Code toolchain, and runtime helpers).
+
+For the list of packages and their status, see the top-level `README.md` (maintained packages)
+and each package's own `README.md` — **the per-package README is the single source of truth for
+whether a package is maintained or deprecated** (deprecated packages carry a banner at the top).
+Don't duplicate that list here.
 
 ## Development Commands
 
 ### Building
 
 ```bash
-# Build both packages
+# Build every package in the workspace
 pnpm build
 
-# Build CLI only
+# Build the neon-new CLI only
 pnpm build:cli
 
-# Build Vite plugin only
+# Build the vite-plugin-neon-new plugin only
 pnpm build:plugin
 ```
 
@@ -32,9 +33,9 @@ pnpm build:plugin
 # Run all tests
 pnpm test:ci
 
-# Run tests for specific package
-pnpm --filter get-db test
-pnpm --filter vite-plugin-db test
+# Run tests for a specific package
+pnpm --filter neon-new test
+pnpm --filter vite-plugin-neon-new test
 ```
 
 ### Linting & Formatting
@@ -51,81 +52,39 @@ pnpm lint:ci
 
 ```bash
 # Test CLI with prompts
-pnpm --filter get-db dry:run:prompt
+pnpm --filter neon-new dry:run:prompt
 
 # Test CLI with defaults
-pnpm --filter get-db dry:run
+pnpm --filter neon-new dry:run
 ```
 
 ## Architecture
 
 ### Monorepo Structure
 
--   Uses pnpm workspaces with two main packages
--   Shared dependencies managed at root level
+-   Uses pnpm workspaces (`packages/*`); shared dependency versions are pinned via the pnpm catalog (`pnpm-workspace.yaml`)
 -   Uses Biome for linting/formatting instead of ESLint/Prettier
--   Uses `tsdown` for TypeScript compilation instead of tsc directly
--   Package manager: pnpm@10.4.0, Node.js >=18.3.0
+-   Builds with `tsdown` for bundling and `tsc --noEmit` for type-checking (see each package's `build` script)
+-   Package manager: pnpm@10.30.3, Node.js >=22
 -   **Dependency Installation**: Prefer `pnpm dedupe` over `pnpm install` - it deduplicates dependencies in node_modules, minimizing conflict issues and reducing filesystem space
 
-### get-db Package (formerly neondb)
+### Per-package architecture
 
--   **Entry points**: CLI (`dist/cli.js`) and SDK exports (`./sdk`, `./launchpad`)
--   **Core functionality**: Creates claimable Neon databases via API calls
--   **CLI options**: `-y/--yes`, `-e/--env`, `-k/--key`, `-s/--seed`, `-h/--help`
--   **Dependencies**: Uses `@clack/prompts` for interactive CLI, `@neondatabase/serverless` for DB operations
-
-### neondb Package (DEPRECATED)
-
--   **Purpose**: Deprecated alias for `get-db` - shows deprecation warning and re-exports `get-db`
--   **Status**: Maintained for backwards compatibility but users should migrate to `get-db`
-
-### vite-plugin-db Package (formerly @neondatabase/vite-plugin-postgres)
-
--   **Purpose**: Automatically provisions databases during Vite development
--   **Behavior**: Checks for DATABASE_URL in .env, creates database if missing, noop in production
--   **Configuration**: Supports custom env file path, env key name, and SQL seeding
--   **Integration**: Must be placed as first plugin in Vite config
--   **Dependencies**: Uses `get-db` internally for database provisioning
-
-### @neondatabase/vite-plugin-postgres Package (DEPRECATED)
-
--   **Purpose**: Deprecated alias for `vite-plugin-db` - shows deprecation warning and re-exports `vite-plugin-db`
--   **Status**: Maintained for backwards compatibility but users should migrate to `vite-plugin-db`
-
-### neon-init Package
-
--   **Purpose**: Setup tool for configuring Neon with the user's project
--   **Entry points**: CLI (`dist/cli.js`) and SDK export (`init()` function)
--   **Core functionality**: Installs Neon Local Connect extension for VS Code/Cursor, configures MCP server for Claude CLI, and installs Neon agent skills
--   **Behavior**:
-    -   Detects available editors installed on the system
-    -   Prompts user to select which editor(s) to configure
-    -   Authenticates via OAuth using `neonctl`
-    -   Creates API key automatically via Neon API
-    -   For **VS Code** and **Cursor**: Installs Neon Local Connect extension (`databricks.neon-local-connect`) via CLI commands, configures API key via URI handler
-    -   For **Claude CLI**: Writes MCP configuration to `~/.claude.json`
-    -   Installs Neon agent skills via Vercel's `skills` CLI (runs `npx skills add neondatabase/agent-skills`)
--   **Extension Installation**:
-    -   Uses `code --install-extension` or `cursor --install-extension` commands
-    -   Finds CLI paths by checking known installation locations and using `mdfind` on macOS
-    -   Waits for extension to be fully installed before configuring
-    -   Configures API key via URI handler: `vscode://databricks.neon-local-connect/import-api-key?token=xxx`
--   **MCP Server Configuration**:
-    -   Only used for Claude CLI (not VS Code/Cursor)
-    -   Writes to `~/.claude.json` with remote MCP server URL and API key
--   **Agent Skills Integration**:
-    -   Maps editors to agent names: Cursor → `cursor`, VS Code → `github-copilot`, Claude CLI → `claude-code`
-    -   Runs skills installation with `-y` (auto-confirm) flag
-    -   Handles failures gracefully per-editor, continues with remaining editors
--   **Dependencies**: Uses `@clack/prompts` for interactive CLI, `execa` for running external commands (`neonctl`, extension CLI commands, `npx`, URI handlers)
+Each package documents its own purpose, entry points, and API in its `README.md` — read the
+relevant package's README rather than maintaining a duplicate (and drift-prone) inventory here.
+At a high level: `neon-new` is the CLI + SDK, and `vite-plugin-neon-new` builds on it; the Config-as-Code
+toolchain centers on `@neondatabase/config` (pure, side-effect-free policy types + diff engine),
+with `@neondatabase/config-runtime` (imperative `inspect`/`plan`/`apply` + function deploy; pulls in
+`esbuild`, so import it from CLIs/CI, never from a `neon.ts` policy) and `@neondatabase/env` (resolve
++ inject a branch's env) both building on `config`; plus `neon-init`, `@neondatabase/ai-sdk-provider`,
+and `@neondatabase/functions`.
 
 ### Key Implementation Details
 
--   Both packages support SQL seeding via `--seed` flag (CLI) or `seed.path` option (plugin)
+-   `neon-new` (CLI) and `vite-plugin-neon-new` (plugin) both support SQL seeding via the `--seed` flag (CLI) or `seed.path` option (plugin)
 -   Databases are "claimable" with 72-hour expiration URLs
--   Plugin writes both direct and pooled connection strings
--   SDK provides `instantNeon()` function for programmatic usage
+-   The plugin writes both direct and pooled connection strings
+-   The SDK provides an `instantNeon()` function for programmatic usage
 -   Uses TypeScript with strict configuration
 -   All packages use ESM modules (`"type": "module"`)
 
@@ -138,7 +97,7 @@ pnpm --filter get-db dry:run
 
 ## Release Management
 
-This project uses [Changesets](https://github.com/changesets/changesets) for version management and publishing.
+This project uses [Changesets](https://github.com/changesets/changesets) for version management. (Publishing to npm happens externally — see "Cutting a Release" below.)
 
 ### Creating a Changeset
 
@@ -155,17 +114,28 @@ This will:
 3. Request a summary of the changes
 4. Create a markdown file in `.changeset/` directory describing the changes
 
-### Automated Release Process
+### Cutting a Release
 
-The CI workflow automatically handles releases:
+This repo does **not** publish to npm. Publishing happens from a **private mirror**; the CI
+here (`.github/workflows/ci.yml`) only builds, lints, and tests. There is no automated
+"Version Packages" PR bot — those workflows were removed. A release in this repo is just a
+**version-bump + `CHANGELOG.md` commit landed on `main`** via a PR; the mirror publishes it.
 
-1. **Detection**: CI scans for changeset files in the `.changeset/` directory
-2. **PR Creation**: When changesets are detected on the main branch, CI automatically creates a "Version Packages" PR
-3. **Version Bump**: This PR includes:
-   - Updated version numbers in `package.json` files
-   - Updated `CHANGELOG.md` files with the changeset summaries
-   - Removal of the processed changeset files
-4. **Publishing**: When the "Version Packages" PR is merged, CI automatically publishes the new versions to npm
+To cut one:
+
+1. Make sure every changed package has a changeset under `.changeset/` (see above).
+2. Run the version bump — this consumes the changeset files, rewrites `package.json`
+   versions, appends to each `CHANGELOG.md`, and patch-bumps internal dependents
+   (`updateInternalDependencies: "patch"`, all internal deps are `workspace:*`):
+
+   ```bash
+   pnpm changeset version
+   ```
+
+3. Verify (`git status`, `pnpm lint:ci`), commit, and open a PR.
+
+The `release` Claude Code skill (`.claude/skills/release/`) automates this end to end,
+including a git-vs-npm check that flags packages which changed but lack a changeset.
 
 ### Best Practices
 

--- a/README.md
+++ b/README.md
@@ -2,17 +2,17 @@
 
 [Neon](https://neon.com) open-source packages for the JavaScript/Typescript ecosystem.
 
-| Package Name                         | Description                                                                   | Status     |
-| ------------------------------------ | ----------------------------------------------------------------------------- | ---------- |
-| `neon-init`                          | Set up your project with Neon's MCP Server for AI-powered database operations | active     |
-| `neon-new`                           | A CLI tool and SDK for creating claimable Neon databases instantly.           | active     |
-| `vite-plugin-neon-new`               | A Vite plugin that automatically provisions databases during development.     | active     |
-| `@neondatabase/config`               | Config-as-Code for Neon: `defineConfig` types + the pure diff engine and Neon API adapter behind a `neon.ts` policy. | active     |
-| `@neondatabase/config-runtime`       | Runtime for `neon.ts` policies — `inspect` / `plan` / `apply` (push/pull) plus function bundling and deploy. | active     |
-| `@neondatabase/env`                  | Resolve and inject a branch's Neon env (`fetchEnv` / `parseEnv`, `neon-env run`) from a `neon.ts` policy. | active     |
-| `get-db`                             | alias for `neon-new`                                                          | deprecated |
-| `vite-plugin-db`                     | alias for `vite-plugin-neon-new`                                              | deprecated |
-| `neondb`                             | alias for `neon-new`                                                          | deprecated |
-| `@neondatabase/vite-plugin-postgres` | alias for `vite-plugin-neon-new`                                              | deprecated |
+| Package Name                   | Description                                                                                                          |
+| ------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `neon-init`                    | Set up your project with Neon's MCP Server for AI-powered database operations.                                       |
+| `neon-new`                     | A CLI tool and SDK for creating claimable Neon databases instantly.                                                  |
+| `vite-plugin-neon-new`         | A Vite plugin that automatically provisions databases during development.                                            |
+| `@neondatabase/config`         | Config-as-Code for Neon: `defineConfig` types + the pure diff engine and Neon API adapter behind a `neon.ts` policy. |
+| `@neondatabase/config-runtime` | Runtime for `neon.ts` policies — `inspect` / `plan` / `apply` (push/pull) plus function bundling and deploy.         |
+| `@neondatabase/env`            | Resolve and inject a branch's Neon env (`fetchEnv` / `parseEnv`, `neon-env run`) from a `neon.ts` policy.            |
+| `@neondatabase/ai-sdk-provider`| Community [Vercel AI SDK](https://ai-sdk.dev) provider for the Neon AI Gateway.                                       |
+| `@neondatabase/functions`      | Runtime helpers for Neon Functions (e.g. a `waitUntil` primitive for deferring work past a response).                |
+
+Each package's own `README` is the source of truth for its status — deprecated packages carry a deprecation banner at the top of theirs. A few renamed packages are still published as deprecated aliases (`get-db` / `neondb` → `neon-new`; `vite-plugin-db` / `@neondatabase/vite-plugin-postgres` → `vite-plugin-neon-new`); they re-export the new package and print a deprecation warning.
 
 Every package under this repository is licensed under **Apache-2.0**.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@
 | `@neondatabase/ai-sdk-provider`| Community [Vercel AI SDK](https://ai-sdk.dev) provider for the Neon AI Gateway.                                       |
 | `@neondatabase/functions`      | Runtime helpers for Neon Functions (e.g. a `waitUntil` primitive for deferring work past a response).                |
 
-Each package's own `README` is the source of truth for its status — deprecated packages carry a deprecation banner at the top of theirs. A few renamed packages are still published as deprecated aliases (`get-db` / `neondb` → `neon-new`; `vite-plugin-db` / `@neondatabase/vite-plugin-postgres` → `vite-plugin-neon-new`); they re-export the new package and print a deprecation warning.
+A few renamed packages are still published as deprecated aliases (`get-db` / `neondb` → `neon-new`; `vite-plugin-db` / `@neondatabase/vite-plugin-postgres` → `vite-plugin-neon-new`); they re-export the new package and print a deprecation warning.
 
 Every package under this repository is licensed under **Apache-2.0**.

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/ai-sdk-provider
 
+## 0.4.0
+
+### Minor Changes
+
+- 9ac4b73: Upgrade `@neondatabase/ai-sdk-provider` to the AI SDK v6 provider specification (v3 language models). Requires `ai@^6`.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/ai-sdk-provider",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/README.md
+++ b/packages/config-runtime/README.md
@@ -1,0 +1,24 @@
+# @neondatabase/config-runtime
+
+Imperative runtime for [`@neondatabase/config`](../config): run a `neon.ts` policy against the Neon API — `inspect`, `plan`, `apply` (push/pull) — and bundle + deploy Neon Functions.
+
+> This package pulls in `esbuild`, so import it from your CLI or CI — **not** from a `neon.ts` policy. Keep policies side-effect-free; that's what `@neondatabase/config` is for. New code should import from `@neondatabase/config-runtime/v1` to pin a major.
+
+## Install
+
+```bash
+npm install @neondatabase/config-runtime
+```
+
+## API
+
+- `inspect` / `plan` / `apply` — read the current branch state, diff a policy against it, and apply the changes.
+- `pullConfig` / `pushConfig` — lower-level pull/push primitives.
+- `createBranch` — create a branch to target.
+- `buildFunctionBundle` — bundle Neon Functions for deploy.
+
+```ts
+import { inspect, plan, apply } from "@neondatabase/config-runtime/v1";
+```
+
+See [`@neondatabase/config`](../config) for authoring the `neon.ts` policy these operate on.

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @neondatabase/env
 
+## 0.7.0
+
+### Minor Changes
+
+- fe5d092: Remove the `NEON_STORAGE_FORCE_PATH_STYLE` env var and the `storage.forcePathStyle` field from `NeonStorageEnv`.
+
+  It was always `true` and has no AWS-standard env name, so the S3 SDKs never read it automatically — you already had to wire `forcePathStyle` into your `S3Client` by hand. Neon's storage gateway always requires path-style addressing, so set `forcePathStyle: true` directly on your client. `env pull` no longer writes the variable, and `parseEnv` / `toEntries` no longer read or emit it. The raw `NeonBranchStorageSnapshot.forcePathStyle` from `@neondatabase/config` (the `GET .../storage` response) is unchanged.
+
+- 75abe16: Remove the `NEON_STORAGE_REGION` env var (the Neon-branded alias of `AWS_REGION`).
+
+  The region is already injected under the SDK-standard `AWS_REGION`, which the AWS S3 SDKs read automatically — the duplicate `NEON_STORAGE_REGION` alias was never read back by `parseEnv` and bought nothing. `env pull` no longer writes it and `toEntries` no longer emits it. `NeonStorageEnv.region` (mapped to `AWS_REGION`) is unchanged.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/get-db/README.md
+++ b/packages/get-db/README.md
@@ -1,15 +1,19 @@
-# get-db (DEPRECATED)
+# ⚠️ DEPRECATED: get-db
 
-**This package has been renamed to [`neon-new`](https://www.npmjs.com/package/neon-new).**
+> **This package is deprecated and no longer maintained.** It has been renamed to
+> [`neon-new`](https://www.npmjs.com/package/neon-new). It still works as an alias but prints a
+> deprecation warning at runtime — please migrate.
 
-Please update your dependencies:
+## Migration
+
+Update your dependency:
 
 ```diff
 - "get-db": "^0.x.x"
 + "neon-new": "^0.x.x"
 ```
 
-And update your imports:
+Update your imports:
 
 ```diff
 - import { instantPostgres } from "get-db/sdk";
@@ -22,7 +26,5 @@ CLI usage:
 - npx get-db
 + npx neon-new
 ```
-
-This package will continue to work as an alias but will show deprecation warnings.
 
 For documentation, see the [`neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/neon-new).

--- a/packages/neondb/README.md
+++ b/packages/neondb/README.md
@@ -1,49 +1,30 @@
 # ⚠️ DEPRECATED: neondb
 
-**This package has been renamed to [`get-db`](https://www.npmjs.com/package/get-db).**
+> **This package is deprecated and no longer maintained.** It has been renamed to
+> [`neon-new`](https://www.npmjs.com/package/neon-new). It still works as an alias but prints a
+> deprecation warning at runtime — please migrate.
 
-## Migration Guide
+## Migration
 
-Please update your dependencies to use the new package name:
+Update your dependency:
 
-### CLI Usage
-
-**Before:**
-
-```bash
-npm install -g neondb
-neondb
+```diff
+- "neondb": "^0.x.x"
++ "neon-new": "^0.x.x"
 ```
 
-**After:**
+CLI usage:
 
-```bash
-npm install -g get-db
-get-db
+```diff
+- npx neondb
++ npx neon-new
 ```
 
-### Programmatic Usage
+Update your imports:
 
-**Before:**
-
-```javascript
-import { instantNeon } from "neondb/sdk";
+```diff
+- import { instantNeon } from "neondb/sdk";
++ import { instantNeon } from "neon-new/sdk";
 ```
 
-**After:**
-
-```javascript
-import { instantNeon } from "get-db/sdk";
-```
-
-### Vite Plugin
-
-The Vite plugin package (`@neondatabase/vite-plugin-postgres`) has been updated to use `get-db` internally. Make sure to update to the latest version.
-
-## Why the Rename?
-
-The package was renamed to `get-db` to better reflect its purpose and improve discoverability.
-
-## Support
-
-For issues, questions, or contributions, please visit the [get-db repository](https://github.com/neondatabase/neon-pkgs).
+For documentation, see the [`neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/neon-new).

--- a/packages/vite-plugin-db/README.md
+++ b/packages/vite-plugin-db/README.md
@@ -1,21 +1,23 @@
-# vite-plugin-db (DEPRECATED)
+# ⚠️ DEPRECATED: vite-plugin-db
 
-**This package has been renamed to [`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new).**
+> **This package is deprecated and no longer maintained.** It has been renamed to
+> [`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new). It still works as an
+> alias but prints a deprecation warning at runtime — please migrate.
 
-Please update your dependencies:
+## Migration
+
+Update your dependency:
 
 ```diff
 - "vite-plugin-db": "^0.x.x"
 + "vite-plugin-neon-new": "^0.x.x"
 ```
 
-And update your imports:
+Update your imports:
 
 ```diff
 - import { postgres } from "vite-plugin-db";
 + import { postgres } from "vite-plugin-neon-new";
 ```
-
-This package will continue to work as an alias but will show deprecation warnings.
 
 For documentation, see the [`vite-plugin-neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/vite-plugin-neon-new).

--- a/packages/vite-plugin-postgres/README.md
+++ b/packages/vite-plugin-postgres/README.md
@@ -1,55 +1,23 @@
 # ⚠️ DEPRECATED: @neondatabase/vite-plugin-postgres
 
-**This package has been renamed to [`vite-plugin-db`](https://www.npmjs.com/package/vite-plugin-db).**
+> **This package is deprecated and no longer maintained.** It has been renamed to
+> [`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new). It still works as an
+> alias but prints a deprecation warning at runtime — please migrate.
 
-## Migration Guide
+## Migration
 
-Please update your dependencies to use the new package name:
+Update your dependency:
 
-### Installation
-
-**Before:**
-
-```bash
-npm install @neondatabase/vite-plugin-postgres
-# or
-pnpm add @neondatabase/vite-plugin-postgres
+```diff
+- "@neondatabase/vite-plugin-postgres": "^0.x.x"
++ "vite-plugin-neon-new": "^0.x.x"
 ```
 
-**After:**
+Update your imports:
 
-```bash
-npm install vite-plugin-db
-# or
-pnpm add vite-plugin-db
+```diff
+- import { postgres } from "@neondatabase/vite-plugin-postgres";
++ import { postgres } from "vite-plugin-neon-new";
 ```
 
-### Usage in vite.config.ts
-
-**Before:**
-
-```typescript
-import { postgres } from "@neondatabase/vite-plugin-postgres";
-
-export default defineConfig({
-	plugins: [postgres()],
-});
-```
-
-**After:**
-
-```typescript
-import { postgres } from "vite-plugin-db";
-
-export default defineConfig({
-	plugins: [postgres()],
-});
-```
-
-## Why the Rename?
-
-The package was renamed to `vite-plugin-db` to align with the CLI package rename from `neondb` to `get-db`, providing a more consistent and intuitive naming scheme.
-
-## Support
-
-For issues, questions, or contributions, please visit the [repository](https://github.com/neondatabase/neon-pkgs).
+For documentation, see the [`vite-plugin-neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/vite-plugin-neon-new).


### PR DESCRIPTION
## Release (version bump + changelog only)

This repo doesn't publish to npm — a "release" here is just a version-bump + `CHANGELOG.md` commit; the private mirror publishes on merge. Bumps produced by consuming the three pending changesets with `pnpm changeset version`:

- **`@neondatabase/env` 0.6.0 → 0.7.0** — removed `NEON_STORAGE_REGION` and `NEON_STORAGE_FORCE_PATH_STYLE` (two `minor` changesets).
- **`@neondatabase/ai-sdk-provider` 0.3.0 → 0.4.0** — AI SDK v6 (`minor`).

No dependent cascade: internal deps are all `workspace:*`, and neither released package has a maintained dependent.

## `release` skill (baked in)

Adds `.claude/skills/release/SKILL.md` — the runbook for cutting a release in this repo: detect what changed since the published npm version (git-vs-npm), reconcile against pending Changesets (flag changed-but-no-changeset gaps), run `pnpm changeset version`, and open a PR. It documents that publishing is external and derives maintained/deprecated status from each package's own README banner (no hardcoded list).

## Docs coherence

- **Per-package README = single source of truth for status.** Standardized the deprecated banner (`# ⚠️ DEPRECATED: <name>`) across `get-db`, `neondb`, `vite-plugin-db`, `@neondatabase/vite-plugin-postgres`, and **fixed two wrong rename pointers**: `neondb` and `vite-plugin-postgres` pointed at *other deprecated packages* instead of the final maintained target (`neon-new` / `vite-plugin-neon-new`), now matching the runtime deprecation warnings.
- **Top-level README** slimmed to list only the 8 maintained packages + a note about deprecated aliases.
- Added a missing **`@neondatabase/config-runtime` README**.
- **AGENTS.md** refreshed: removed the stale package inventory (it predated the `neon-new`/`vite-plugin-neon-new` rename), fixed toolchain versions (`pnpm@10.30.3`, Node `>=22`), and corrected a false claim that CI auto-creates a "Version Packages" PR and auto-publishes (those workflows were removed; publishing is external). It now points at the per-package READMEs instead of duplicating the list.