### PR TITLE
chore: release neon-init 0.18.0

### DIFF
--- a/.changeset/neon-init-bootstrap-core.md
+++ b/.changeset/neon-init-bootstrap-core.md
@@ -1,9 +1,0 @@
----
-"neon-init": minor
----
-
-Bring the full template bootstrap implementation into `neon-init` and expose it via a new `neon-init/bootstrap` entry point.
-
-Previously `neon-init` only knew how to read the template manifest and shelled out to `npx -y neonctl@latest bootstrap` to actually scaffold a project. The manifest layer has been replaced with the complete, in-house implementation (manifest fetch/parse, single-request `codeload.github.com` tarball download, in-house gunzip + tar parsing, and on-disk scaffolding with exec-bit and symlink fidelity), so the interactive and agent setup flows now scaffold in-process — no global `neonctl` and no `npx` round-trip required.
-
-The new `neon-init/bootstrap` export ships `fetchTemplates`, `parseManifest`, `downloadTemplate`, `scaffoldTemplate`, `ensureTargetUsable`, `BootstrapInputError`, `FALLBACK_TEMPLATES`, and the `BootstrapTemplate` / `TemplateFile` / `NeonFeature` types. `BootstrapTemplate` now carries both `services` (display badge) and `requires` (Neon features) so it is a superset of the previous shape.

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neon-init
 
+## 0.18.0
+
+### Minor Changes
+
+- 700ec26: Bring the full template bootstrap implementation into `neon-init` and expose it via a new `neon-init/bootstrap` entry point.
+
+  Previously `neon-init` only knew how to read the template manifest and shelled out to `npx -y neonctl@latest bootstrap` to actually scaffold a project. The manifest layer has been replaced with the complete, in-house implementation (manifest fetch/parse, single-request `codeload.github.com` tarball download, in-house gunzip + tar parsing, and on-disk scaffolding with exec-bit and symlink fidelity), so the interactive and agent setup flows now scaffold in-process — no global `neonctl` and no `npx` round-trip required.
+
+  The new `neon-init/bootstrap` export ships `fetchTemplates`, `parseManifest`, `downloadTemplate`, `scaffoldTemplate`, `ensureTargetUsable`, `BootstrapInputError`, `FALLBACK_TEMPLATES`, and the `BootstrapTemplate` / `TemplateFile` / `NeonFeature` types. `BootstrapTemplate` now carries both `services` (display badge) and `requires` (Neon features) so it is a superset of the previous shape.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.17.2",
+	"version": "0.18.0",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Consumes the pending changeset from #227 and bumps **`neon-init` 0.17.2 → 0.18.0** (minor).

Per the release skill, this repo doesn't publish to npm directly — the external private mirror publishes on merge of this version-bump commit.

### Bumped in this run
- `neon-init`: 0.17.2 → 0.18.0 (no dependent cascade — nothing in the workspace depends on it via `workspace:*`)

### Publish backlog (main ahead of npm, awaiting the external publish)
- `neon-init`: npm 0.17.2 → main 0.18.0

All other maintained packages are in sync with npm.

### Changes
- `pnpm changeset version`: consumed `.changeset/neon-init-bootstrap-core.md`, bumped `packages/init/package.json`, appended `packages/init/CHANGELOG.md`.
- `pnpm-lock.yaml` unchanged (`workspace:*` internal deps).
- `pnpm lint:ci` (Biome) clean.

Once merged + published, this unblocks the downstream consumer neondatabase/neonctl#577 (draft).