### PR TITLE
feat(init): redesign template picker and add a tools list

### DIFF
--- a/.changeset/init-template-picker-tools.md
+++ b/.changeset/init-template-picker-tools.md
@@ -1,0 +1,5 @@
+---
+"neon-init": minor
+---
+
+Redesign the interactive template picker. Rows now show the template title only, and the focused row expands to `Title (tools)` with the description on its own dimmed, italic line beneath — driven by a custom `@clack/core` select so the focused option can span multiple lines. Bootstrap templates gain an optional `tools` list (the libraries/frameworks that shape the project), parsed from the manifest and surfaced in both the interactive and agent-guided flows.

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -55,6 +55,7 @@
 		"vitest": "catalog:"
 	},
 	"dependencies": {
+		"@clack/core": "0.4.2",
 		"@clack/prompts": "0.10.1",
 		"add-mcp": "^1.5.1",
 		"execa": "^9.5.2",

--- a/packages/init/src/interactive.ts
+++ b/packages/init/src/interactive.ts
@@ -5,6 +5,7 @@
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { SelectPrompt } from "@clack/core";
 import {
 	confirm,
 	isCancel,
@@ -15,7 +16,7 @@ import {
 	spinner,
 } from "@clack/prompts";
 import { execa } from "execa";
-import { bold, dim } from "yoctocolors";
+import { bold, dim, gray, italic } from "yoctocolors";
 import { ALL_CONFIGURABLE_AGENTS, getAddMcpAgentId } from "./lib/agents.js";
 import { ensureNeonctlAuth, isAuthenticated } from "./lib/auth.js";
 import {
@@ -78,6 +79,107 @@ function patchClackColors(): () => void {
 		pc.cyan = originalCyan;
 		pc.magenta = originalMagenta;
 	};
+}
+
+// clack box-drawing glyphs, mirrored from @clack/prompts so our custom
+// template picker lines up with every other step in the flow.
+const S_BAR = "│";
+const S_BAR_END = "└";
+const S_STEP_ACTIVE = "◆";
+const S_STEP_SUBMIT = "◇";
+const S_STEP_CANCEL = "■";
+const S_RADIO_ACTIVE = "●";
+const S_RADIO_INACTIVE = "○";
+
+interface TemplateOption {
+	value: string;
+	label: string;
+	tools?: string[];
+	description?: string;
+}
+
+const SENTINEL_NONE = "none";
+
+/**
+ * Bespoke template picker built on @clack/core's `SelectPrompt`.
+ *
+ * The stock `@clack/prompts` `select` can only render an option on a single
+ * line (title + a parenthesized hint on the focused row), which can't express
+ * what we want here: a clean title-only list, and a focused row that expands to
+ * `Title (tools)` with the description on its own italic line beneath. Driving
+ * the core prompt directly lets us own the frame, so we emit a second
+ * gutter-aligned line for the active option only.
+ */
+async function selectTemplate(
+	templates: BootstrapTemplate[],
+	message: string,
+): Promise<string | symbol> {
+	const options: TemplateOption[] = [
+		...templates.map((t) => ({
+			value: t.id,
+			label: t.title,
+			tools: t.tools,
+			description: t.description,
+		})),
+		{
+			value: SENTINEL_NONE,
+			label: "No thanks — continue without scaffolding",
+		},
+	];
+
+	const green = neonGreenFn;
+	// Title sits at column 6 ("│  ● "), so wrapped description lines indent four
+	// spaces past the gutter to line up under it.
+	const descIndent = "    ";
+	const descWidth = Math.max(24, (process.stdout.columns || 80) - 8);
+
+	const renderActive = (option: TemplateOption): string => {
+		const tools =
+			option.tools && option.tools.length > 0
+				? ` ${dim(`(${option.tools.join(", ")})`)}`
+				: "";
+		const head = `${green(S_RADIO_ACTIVE)} ${option.label}${tools}`;
+		if (!option.description) return head;
+		const body = wordWrap(option.description, descWidth)
+			.split("\n")
+			.map((line) => `${green(S_BAR)}${descIndent}${italic(dim(line))}`)
+			.join("\n");
+		return `${head}\n${body}`;
+	};
+
+	const prompt = new SelectPrompt<TemplateOption>({
+		options,
+		initialValue: options[0]?.value,
+		render() {
+			const active = this.options[this.cursor];
+			const heading = (symbol: string) =>
+				`${gray(S_BAR)}\n${symbol}  ${message}\n`;
+
+			if (this.state === "submit") {
+				return `${heading(green(S_STEP_SUBMIT))}${gray(S_BAR)}  ${dim(
+					active?.label ?? "",
+				)}`;
+			}
+			if (this.state === "cancel") {
+				return `${heading(green(S_STEP_CANCEL))}${gray(S_BAR)}  ${dim(
+					active?.label ?? "",
+				)}\n${gray(S_BAR)}`;
+			}
+
+			const body = this.options
+				.map((option) =>
+					option === active
+						? renderActive(option)
+						: `${dim(S_RADIO_INACTIVE)} ${dim(option.label)}`,
+				)
+				.join(`\n${green(S_BAR)}  `);
+			return `${heading(green(S_STEP_ACTIVE))}${green(S_BAR)}  ${body}\n${green(
+				S_BAR_END,
+			)}\n`;
+		},
+	});
+
+	return prompt.prompt();
 }
 
 export interface InteractiveInitOptions {
@@ -153,22 +255,10 @@ async function interactiveInitInner(
 			if (fetched && fetched.length > 0) templates = fetched;
 		} catch {}
 
-		const templateResult = await select({
-			message:
-				"No application detected. Would you like to scaffold a new project from a template?",
-			options: [
-				...templates.map((t) => ({
-					value: t.id,
-					label: t.title,
-					hint: t.description,
-				})),
-				{
-					value: "none",
-					label: "No thanks — continue without scaffolding",
-				},
-			],
-			initialValue: templates[0]?.id ?? "none",
-		});
+		const templateResult = await selectTemplate(
+			templates,
+			"No application detected. Would you like to scaffold a new project from a template?",
+		);
 		if (isCancel(templateResult)) {
 			outro("Setup cancelled.");
 			return;

--- a/packages/init/src/lib/bootstrap.test.ts
+++ b/packages/init/src/lib/bootstrap.test.ts
@@ -284,11 +284,14 @@ describe("parseManifest", () => {
 		});
 	});
 
-	test("parses both the requires and the optional services lists", () => {
+	test("parses the tools, services, and requires lists", () => {
 		const yaml = `templates:
   - id: hono
     title: Hono API
     description: A Hono template.
+    tools:
+      - Hono
+      - Drizzle
     services:
       - Postgres
       - Functions
@@ -302,8 +305,41 @@ describe("parseManifest", () => {
       subdir: with-hono
 `;
 		const t = parseManifest(yaml)[0];
+		expect(t.tools).toEqual(["Hono", "Drizzle"]);
 		expect(t.services).toEqual(["Postgres", "Functions"]);
 		expect(t.requires).toEqual(["database", "functions"]);
+	});
+
+	test("drops non-string and blank tool entries, omitting when empty", () => {
+		const withTools = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    tools:
+      - Hono
+      - ""
+      - 42
+      - Drizzle
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+		expect(parseManifest(withTools)[0].tools).toEqual(["Hono", "Drizzle"]);
+
+		const badTools = `templates:
+  - id: hono
+    title: Hono API
+    description: A Hono template.
+    tools: nope
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+`;
+		expect(parseManifest(badTools)[0]).not.toHaveProperty("tools");
 	});
 
 	test("defaults requires to ['database'] when not specified", () => {
@@ -408,11 +444,13 @@ describe("FALLBACK_TEMPLATES", () => {
 		]);
 	});
 
-	test("each template carries both services and requires", () => {
+	test("each template carries tools, services, and requires", () => {
 		for (const t of FALLBACK_TEMPLATES) {
 			expect(typeof t.id).toBe("string");
 			expect(typeof t.title).toBe("string");
 			expect(typeof t.description).toBe("string");
+			expect(Array.isArray(t.tools)).toBe(true);
+			expect((t.tools ?? []).length).toBeGreaterThan(0);
 			expect(Array.isArray(t.services)).toBe(true);
 			expect((t.services ?? []).length).toBeGreaterThan(0);
 			expect(Array.isArray(t.requires)).toBe(true);

--- a/packages/init/src/lib/bootstrap.ts
+++ b/packages/init/src/lib/bootstrap.ts
@@ -49,8 +49,15 @@ export interface BootstrapTemplate {
 	/** One-line description shown under the title in the selector. */
 	description: string;
 	/**
-	 * Neon services the template uses (e.g. "Postgres", "Functions"). Shown as a
-	 * badge next to the title in the picker. Optional — older manifests omit it.
+	 * Libraries/frameworks that shape the project (e.g. "Hono", "Drizzle").
+	 * Rendered next to the title in the picker so the row reads
+	 * "Title (tools)". Optional — older manifests omit it.
+	 */
+	tools?: string[];
+	/**
+	 * Neon services the template uses (e.g. "Postgres", "Functions"). Surfaced
+	 * alongside the description in the focused row's hint. Optional — older
+	 * manifests omit it.
 	 */
 	services?: string[];
 	/** Neon features this template needs (defaults to ["database"]). */
@@ -74,9 +81,10 @@ export interface BootstrapTemplate {
 export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 	{
 		id: "hono",
-		title: "Hono API (Drizzle, Neon Postgres) on Neon Functions",
+		title: "REST API",
 		description:
-			"A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function.",
+			"A Hono REST API on Neon Functions, backed by Neon Postgres via Drizzle.",
+		tools: ["Hono", "Drizzle"],
 		services: ["Postgres", "Functions"],
 		requires: ["database", "functions"],
 		source: {
@@ -88,9 +96,10 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 	},
 	{
 		id: "ai-sdk",
-		title: "AI SDK agent (AI Gateway, object storage, Drizzle) on Neon Functions",
+		title: "Image-generation agent",
 		description:
-			"A Vercel AI SDK agent on Neon Functions: streams chat through the Neon AI Gateway, generates an image with OpenAI image generation, and stores it in Neon object storage indexed in Postgres via Drizzle.",
+			"A Vercel AI SDK agent that streams chat through the Neon AI Gateway and stores generated images in Neon object storage, indexed in Postgres via Drizzle.",
+		tools: ["AI SDK", "Drizzle"],
 		services: ["Postgres", "Functions", "Object Storage", "AI Gateway"],
 		requires: ["database", "functions", "object-storage", "ai-gateway"],
 		source: {
@@ -102,9 +111,10 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 	},
 	{
 		id: "mastra",
-		title: "Mastra personal agent (AI Gateway, Mastra Memory) on Neon Functions",
+		title: "Personal-assistant agent",
 		description:
-			"A Mastra personal-assistant agent on Neon Functions: streams chat through the Neon AI Gateway and uses Mastra Memory — backed by Neon Postgres — to remember the user across conversation threads via resource-scoped working memory.",
+			"A Mastra agent that streams chat through the Neon AI Gateway and uses Mastra Memory on Neon Postgres to remember you across threads.",
+		tools: ["Mastra", "Mastra Memory"],
 		services: ["Postgres", "Functions", "AI Gateway"],
 		requires: ["database", "functions", "ai-gateway"],
 		source: {
@@ -160,18 +170,18 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
 
 /**
- * Normalize a manifest entry's `services` into a clean string list. Tolerant by
- * design: a missing or non-array value yields `undefined`, and non-string items
- * are dropped, so a malformed `services` never sinks an otherwise-valid
- * template (it just renders without its badge).
+ * Normalize a manifest entry's string list (`tools` or `services`) into a clean
+ * array. Tolerant by design: a missing or non-array value yields `undefined`,
+ * and non-string/blank items are dropped, so a malformed list never sinks an
+ * otherwise-valid template (it just renders without that detail).
  */
-const parseServices = (value: unknown): string[] | undefined => {
+const parseStringList = (value: unknown): string[] | undefined => {
 	if (!Array.isArray(value)) return undefined;
-	const services = value.filter(
+	const items = value.filter(
 		(item): item is string =>
 			typeof item === "string" && item.trim() !== "",
 	);
-	return services.length > 0 ? services : undefined;
+	return items.length > 0 ? items : undefined;
 };
 
 // ---------------------------------------------------------------------------
@@ -219,11 +229,13 @@ export function parseManifest(text: string): BootstrapTemplate[] {
 			item.requires.every((r: unknown) => typeof r === "string")
 				? (item.requires as NeonFeature[])
 				: DEFAULT_REQUIRES;
-		const services = parseServices(item.services);
+		const tools = parseStringList(item.tools);
+		const services = parseStringList(item.services);
 		templates.push({
 			id: item.id,
 			title: item.title,
 			description: item.description,
+			...(tools ? { tools } : {}),
 			...(services ? { services } : {}),
 			requires,
 			source: {

--- a/packages/init/src/lib/phases/setup.ts
+++ b/packages/init/src/lib/phases/setup.ts
@@ -130,7 +130,12 @@ export async function handleSetupPhase(
 }
 
 function buildTemplatePreference(
-	templates: { id: string; title: string; description: string }[],
+	templates: {
+		id: string;
+		title: string;
+		description: string;
+		tools?: string[];
+	}[],
 ) {
 	return [
 		{
@@ -139,10 +144,16 @@ function buildTemplatePreference(
 				"No application was detected in this directory. Would you like to scaffold a new project from a template?",
 			phase: "before_checks" as const,
 			options: [
-				...templates.map((t) => ({
-					value: t.id,
-					label: `${t.title} — ${t.description}`,
-				})),
+				...templates.map((t) => {
+					const tools =
+						t.tools && t.tools.length > 0
+							? ` (${t.tools.join(", ")})`
+							: "";
+					return {
+						value: t.id,
+						label: `${t.title}${tools} — ${t.description}`,
+					};
+				}),
 				{
 					value: "none",
 					label: "No thanks — continue without scaffolding",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,6 +348,9 @@ importers:
 
   packages/init:
     dependencies:
+      '@clack/core':
+        specifier: 0.4.2
+        version: 0.4.2
       '@clack/prompts':
         specifier: 0.10.1
         version: 0.10.1


### PR DESCRIPTION
## Summary
- Redesign the `neon-init` interactive template picker: each row shows the **template title only**, and the focused row expands to **`Title (tools)`** with the description on its own dimmed, italic line beneath.
- The stock `@clack/prompts` `select` can only render an option on a single line, so this drives `@clack/core`'s `SelectPrompt` directly (`selectTemplate()` in `interactive.ts`) to own the frame and emit a second, gutter-aligned line for the active option. Adds `@clack/core@0.4.2` (the version `@clack/prompts` already resolves) as a direct dep.
- Templates gain an optional **`tools`** list (the libraries/frameworks that shape the project), parsed from the bootstrap manifest (`neondatabase/examples/bootstrap.yaml`) and surfaced in both the interactive picker and the agent-guided option labels.
- `FALLBACK_TEMPLATES` updated to match the new manifest (terse, topic-first titles + tools + shortened descriptions).

### What the picker looks like
Unfocused rows are just `○ <Title>`. The focused row renders:

```
● Realtime chat (Next.js, Hono, Drizzle)
    A Next.js + Neon Auth chat over WebSockets to a Hono server, stored in
    Neon Postgres and fanned out across isolates with Postgres LISTEN/NOTIFY.
```

> Note: the source-of-truth manifest change (titles/`tools`/descriptions) already landed on `neondatabase/examples@main`.

## Test plan
- [x] `pnpm --filter neon-init test:ci` — 123/123 pass (incl. new `tools` parsing + fallback coverage)
- [x] `pnpm --filter neon-init build` — typecheck + bundle clean
- [x] `biome check` clean on touched files
- [x] Manually ran `neon-init --preview` against the live manifest in a PTY; verified title-only rows, the two-line focused row, long-description wrapping, and clean redraws when arrow-keying between variable-height rows.