### PR TITLE
chore: release neon-init 0.19.0

### DIFF
--- a/.changeset/init-template-picker-tools.md
+++ b/.changeset/init-template-picker-tools.md
@@ -1,5 +1,0 @@
----
-"neon-init": minor
----
-
-Redesign the interactive template picker. Rows now show the template title only, and the focused row expands to `Title (tools)` with the description on its own dimmed, italic line beneath — driven by a custom `@clack/core` select so the focused option can span multiple lines. Bootstrap templates gain an optional `tools` list (the libraries/frameworks that shape the project), parsed from the manifest and surfaced in both the interactive and agent-guided flows.

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon-init
 
+## 0.19.0
+
+### Minor Changes
+
+- 498daf7: Redesign the interactive template picker. Rows now show the template title only, and the focused row expands to `Title (tools)` with the description on its own dimmed, italic line beneath — driven by a custom `@clack/core` select so the focused option can span multiple lines. Bootstrap templates gain an optional `tools` list (the libraries/frameworks that shape the project), parsed from the manifest and surfaced in both the interactive and agent-guided flows.
+
 ## 0.18.0
 
 ### Minor Changes

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.18.0",
+	"version": "0.19.0",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Consumes the pending `init-template-picker-tools` changeset and bumps **`neon-init` 0.18.0 → 0.19.0** (minor), updating `packages/init/CHANGELOG.md`.

## What's in 0.19.0
- Redesigned interactive template picker: title-only rows; the focused row expands to `Title (tools)` with the description on its own dimmed, italic line beneath (custom `@clack/core` select).
- Bootstrap templates gain an optional `tools` list, surfaced in both the interactive picker and the agent-guided flow.

(Feature change landed in #233; this PR is the Changesets version bump per the fallback release flow.)

## After merge
Publish from main:
```bash
gh workflow run neon-pkgs.yml --repo databricks/secure-public-registry-releases-eng \
  -f package=neon-init -f ref=main
```
Then `npm view neon-init version` should show `0.19.0`.