### PR TITLE
fix(functions): read waitUntil context from globalThis.NEON_REQUEST_CONTEXT

### DIFF
--- a/.changeset/funny-waituntil-context.md
+++ b/.changeset/funny-waituntil-context.md
@@ -1,0 +1,11 @@
+---
+"@neondatabase/functions": minor
+---
+
+Fix `waitUntil` so it actually picks up the runtime invocation context.
+
+The package was looking for the context under a `Symbol.for("@neondatabase/functions/request-context")` key and expected a Vercel/Next-style provider object with a `.get()` method. The Neon Functions runtime instead publishes the context as a getter on the plain `globalThis.NEON_REQUEST_CONTEXT` key that returns the context object (`{ waitUntil }`) directly. Both the key and the shape were mismatched, so `getContext()` always returned `{}` and `waitUntil` silently no-op'd on-platform.
+
+`waitUntil` now reads `globalThis.NEON_REQUEST_CONTEXT` directly (no `.get()` indirection). The off-platform no-op behavior is unchanged (matches `@vercel/functions`).
+
+The exported `NEON_FUNCTIONS_CONTEXT` symbol is replaced by the `NEON_REQUEST_CONTEXT_KEY` string constant that reflects the real runtime key.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -33,9 +33,10 @@ without branching. Passing a non-`Promise` throws a `TypeError`.
 ## Runtime integration
 
 The runtime carries the per-invocation context in an `AsyncLocalStorage` and publishes
-an accessor at `globalThis[NEON_FUNCTIONS_CONTEXT]` (a
-`Symbol.for("@neondatabase/functions/request-context")`) shaped like the providers used
-by Vercel and Next.js — a stable object exposing `get()`.
+it at `globalThis.NEON_REQUEST_CONTEXT` (the key exported as `NEON_REQUEST_CONTEXT_KEY`)
+as a getter that returns the live context object **directly** — `{ waitUntil }` during
+an invocation, `undefined` outside one. `waitUntil` reads that value straight off the
+key, so there is no `.get()` provider indirection.
 
 To make `waitUntil` resolve to a given invocation, wrap the handler with
 `runWithRequestContext`. This is intended for the Neon Functions runtime; application

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -7,13 +7,13 @@
  * - `runWithRequestContext(context, fn)` — runtime entry point that binds a
  *   per-invocation context for the duration of `fn`. Used by the Neon Functions
  *   runtime; application code should not need it.
- * - `NEON_FUNCTIONS_CONTEXT` — the `globalThis` symbol under which the context
- *   provider is published.
+ * - `NEON_REQUEST_CONTEXT_KEY` — the `globalThis` key under which the runtime
+ *   publishes the current invocation context.
  */
 
 export type { NeonFunctionsContext, WaitUntil } from "./lib/wait-until.js";
 export {
-	NEON_FUNCTIONS_CONTEXT,
+	NEON_REQUEST_CONTEXT_KEY,
 	runWithRequestContext,
 	waitUntil,
 } from "./lib/wait-until.js";

--- a/packages/functions/src/lib/wait-until.test.ts
+++ b/packages/functions/src/lib/wait-until.test.ts
@@ -1,8 +1,42 @@
 import { describe, expect, it } from "vitest";
 
-import { runWithRequestContext, waitUntil } from "./wait-until.js";
+import {
+	NEON_REQUEST_CONTEXT_KEY,
+	runWithRequestContext,
+	waitUntil,
+} from "./wait-until.js";
 
 describe("waitUntil", () => {
+	it("reads the context directly off globalThis[NEON_REQUEST_CONTEXT_KEY] (runtime shape)", () => {
+		// The runtime publishes the live context object DIRECTLY under this key (a
+		// getter returning `{ waitUntil }`), not a `.get()`-style provider. Simulate
+		// that and assert we forward to it.
+		const received: Promise<unknown>[] = [];
+		const promise = Promise.resolve();
+		const original = Object.getOwnPropertyDescriptor(
+			globalThis,
+			NEON_REQUEST_CONTEXT_KEY,
+		);
+		try {
+			Object.defineProperty(globalThis, NEON_REQUEST_CONTEXT_KEY, {
+				configurable: true,
+				get: () => ({
+					waitUntil: (p: Promise<unknown>) => received.push(p),
+				}),
+			});
+			waitUntil(promise);
+			expect(received).toEqual([promise]);
+		} finally {
+			if (original) {
+				Object.defineProperty(
+					globalThis,
+					NEON_REQUEST_CONTEXT_KEY,
+					original,
+				);
+			}
+		}
+	});
+
 	it("forwards the promise to the invocation context's waitUntil", () => {
 		const received: Promise<unknown>[] = [];
 		const promise = Promise.resolve("done");

--- a/packages/functions/src/lib/wait-until.ts
+++ b/packages/functions/src/lib/wait-until.ts
@@ -3,9 +3,9 @@
  * (logging, cache writes, analytics, …) can finish after the response has been sent.
  *
  * The public API mirrors Vercel's `@vercel/functions`: import `waitUntil` and call it
- * directly with a promise (`waitUntil(promise)`). Under the hood the per-invocation
- * context is carried by an `AsyncLocalStorage`, so concurrent invocations sharing the
- * same isolate never clobber each other's context.
+ * directly with a promise (`waitUntil(promise)`). The active invocation context is
+ * published by the runtime on `globalThis`, so it can be read without importing the
+ * runtime and stays correct under concurrency.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 
@@ -20,51 +20,42 @@ export type NeonFunctionsContext = {
 };
 
 /**
- * The accessor published on `globalThis` so consumers can read the current
- * invocation context without importing the runtime. Mirrors the provider shape
- * used by Vercel (`Symbol.for("@vercel/request-context")`) and Next.js
- * (`Symbol.for("@next/request-context")`): a stable object exposing `get()`.
+ * Well-known `globalThis` key under which the Neon Functions runtime publishes the
+ * current invocation context. The runtime installs it as a getter that returns the
+ * live context object DIRECTLY — `globalThis.NEON_REQUEST_CONTEXT` is `{ waitUntil }`
+ * during an invocation and `undefined` outside one — so it is read as the context
+ * itself, not via a `.get()`-style provider.
  */
-type RequestContextProvider = {
-	get(): NeonFunctionsContext | undefined;
-};
-
-/**
- * Well-known `globalThis` symbol under which the per-invocation context provider is
- * published. Mirrors the convention used by Vercel and Next.js.
- */
-export const NEON_FUNCTIONS_CONTEXT: unique symbol = Symbol.for(
-	"@neondatabase/functions/request-context",
-);
+export const NEON_REQUEST_CONTEXT_KEY = "NEON_REQUEST_CONTEXT";
 
 type GlobalWithContext = typeof globalThis & {
-	[NEON_FUNCTIONS_CONTEXT]?: RequestContextProvider;
+	[NEON_REQUEST_CONTEXT_KEY]?: NeonFunctionsContext;
 };
-
-/**
- * Holds the per-invocation context. Each `runWithRequestContext(...)` call binds a
- * fresh context for the duration of its callback (and any async work it spawns), so
- * `waitUntil` always resolves to the right invocation even under concurrency.
- */
-const requestContextStore = new AsyncLocalStorage<NeonFunctionsContext>();
 
 const globalWithContext: GlobalWithContext = globalThis;
 
 /**
- * Publish a stable provider whose `get()` reads the current store. Installed once;
- * if another copy of this module (or the host runtime) has already published a
- * provider, we leave it in place rather than clobber it.
+ * Backs `runWithRequestContext` for local dev and tests. When the runtime is present
+ * it has already published its own accessor under the same key, so we leave that in
+ * place and never publish over it.
  */
-globalWithContext[NEON_FUNCTIONS_CONTEXT] ??= {
-	get: () => requestContextStore.getStore(),
-};
+const requestContextStore = new AsyncLocalStorage<NeonFunctionsContext>();
+
+if (!(NEON_REQUEST_CONTEXT_KEY in globalWithContext)) {
+	Object.defineProperty(globalWithContext, NEON_REQUEST_CONTEXT_KEY, {
+		configurable: true,
+		get() {
+			return requestContextStore.getStore();
+		},
+	});
+}
 
 /**
- * Reads the current invocation context off the `globalThis` provider, falling back to
- * an empty context when no provider is published or no invocation is in scope.
+ * Reads the current invocation context off `globalThis.NEON_REQUEST_CONTEXT`, falling
+ * back to an empty context outside an invocation (local dev, tests, non-Neon hosts).
  */
 function getContext(): NeonFunctionsContext {
-	return globalWithContext[NEON_FUNCTIONS_CONTEXT]?.get?.() ?? {};
+	return globalWithContext[NEON_REQUEST_CONTEXT_KEY] ?? {};
 }
 
 function isPromise(value: unknown): value is Promise<unknown> {
@@ -82,7 +73,8 @@ function isPromise(value: unknown): value is Promise<unknown> {
  *
  * The context is resolved at call time from the enclosing invocation, so this stays
  * correct under concurrency. When no invocation context is in scope (local dev, tests,
- * non-Neon hosts), this is a no-op: the promise is accepted and ignored.
+ * non-Neon hosts), this is a no-op: the promise is accepted and ignored (it still runs
+ * on its own — the caller already started it — it just isn't tracked).
  */
 export function waitUntil(promise: Promise<unknown>): void {
 	if (!isPromise(promise)) {


### PR DESCRIPTION
## Summary

`@neondatabase/functions` `waitUntil` never found the runtime invocation context, so it silently no-op'd **on-platform** (background work was dropped, exactly the behavior we wanted only for off-platform/local).

### Root cause (the bug)

Two mismatches between the package and the Neon Functions runtime worker:

1. **Wrong key.** The package read the context from `globalThis[Symbol.for("@neondatabase/functions/request-context")]`. The runtime publishes it on the plain string key `globalThis.NEON_REQUEST_CONTEXT`.
2. **Wrong shape.** The package expected a Vercel/Next-style *provider* object with a `.get()` method and called `.get()`. The runtime installs a getter that returns the **context object itself** (`{ waitUntil }`) directly.

Either mismatch alone is enough: `getContext()` always resolved to `{}`, so `getContext().waitUntil?.(promise)` did nothing.

### Fix

- Read `globalThis.NEON_REQUEST_CONTEXT` **directly** as the context (no `.get()` indirection), matching the runtime contract.
- Export `NEON_REQUEST_CONTEXT_KEY` (the real string key) in place of the unused `NEON_FUNCTIONS_CONTEXT` symbol.
- For local dev/tests, install a getter on the same key backed by this module's `AsyncLocalStorage` (only if the runtime hasn't already published one), so `runWithRequestContext` keeps working.
- **Off-platform behavior is unchanged: a deliberate no-op**, matching `@vercel/functions` (the caller-created promise still runs on its own; it just isn't tracked). Confirmed Vercel and Cloudflare both behave this way.

### Tests

- Added a regression test that simulates the runtime publishing the context directly under `NEON_REQUEST_CONTEXT_KEY` and asserts `waitUntil` forwards to it.
- Existing context/concurrency/no-op tests still pass (7/7).

## Test plan

- [x] `pnpm tsc` (typecheck)
- [x] `pnpm test:ci` — 7/7 pass