### PR TITLE
chore(functions): simplify to expose only waitUntil (0.5.0)

### DIFF
--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @neondatabase/functions
 
+## 0.5.0
+
+### Minor Changes
+
+- Simplify the package to expose only `waitUntil`.
+
+  `waitUntil` now reads the runtime context straight off `globalThis.NEON_REQUEST_CONTEXT` with no internal `AsyncLocalStorage`. The unused `runWithRequestContext` export and the `NEON_REQUEST_CONTEXT_KEY` constant (plus the `NeonFunctionsContext`/`WaitUntil` type exports) are removed — the runtime publishes the context itself, so none of that surface was used. Behavior is unchanged: forwards to the runtime on-platform, no-op off-platform (matching `@vercel/functions`).
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -27,26 +27,13 @@ export default {
 `waitUntil(promise)` forwards the promise to the Neon Functions runtime, which keeps
 the invocation alive until the promise settles (up to the 15-minute `waitUntil` limit).
 When no invocation context is in scope — local dev, tests, or any non-Neon host — it is
-a **no-op**: the promise is accepted and ignored, so the same code runs everywhere
-without branching. Passing a non-`Promise` throws a `TypeError`.
+a **no-op**: the promise is accepted and ignored (it still runs on its own, it just
+isn't tracked), so the same code runs everywhere without branching. Passing a
+non-`Promise` throws a `TypeError`.
 
 ## Runtime integration
 
-The runtime carries the per-invocation context in an `AsyncLocalStorage` and publishes
-it at `globalThis.NEON_REQUEST_CONTEXT` (the key exported as `NEON_REQUEST_CONTEXT_KEY`)
-as a getter that returns the live context object **directly** — `{ waitUntil }` during
-an invocation, `undefined` outside one. `waitUntil` reads that value straight off the
-key, so there is no `.get()` provider indirection.
-
-To make `waitUntil` resolve to a given invocation, wrap the handler with
-`runWithRequestContext`. This is intended for the Neon Functions runtime; application
-code should not need it.
-
-```ts
-import { runWithRequestContext } from "@neondatabase/functions";
-
-runWithRequestContext({ waitUntil: realWaitUntil }, () => handler(req));
-```
-
-Because the context lives in `AsyncLocalStorage`, concurrent invocations in the same
-isolate each see their own context and never clobber one another.
+The runtime publishes the active invocation context on `globalThis.NEON_REQUEST_CONTEXT`
+as a getter that returns the live context object directly — `{ waitUntil }` during an
+invocation, `undefined` outside one. `waitUntil` reads that value straight off the
+global, so there is nothing for application code to wire up.

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/functions",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Runtime helpers for Neon Functions. Currently provides a `waitUntil` primitive for deferring async work past a response.",
 	"keywords": [
 		"neon",

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -1,19 +1,9 @@
 /**
  * `@neondatabase/functions` — runtime helpers for Neon Functions.
  *
- * - `waitUntil(promise)` — defers async work past the response by forwarding the
- *   promise to the current invocation context. No-op when no context is in scope
- *   (local dev, tests, non-Neon hosts). Mirrors `@vercel/functions`.
- * - `runWithRequestContext(context, fn)` — runtime entry point that binds a
- *   per-invocation context for the duration of `fn`. Used by the Neon Functions
- *   runtime; application code should not need it.
- * - `NEON_REQUEST_CONTEXT_KEY` — the `globalThis` key under which the runtime
- *   publishes the current invocation context.
+ * - `waitUntil(promise)` — defers async work past the response by handing the promise to
+ *   the current invocation context. No-op off-platform (local dev, tests, non-Neon hosts).
+ *   Mirrors `@vercel/functions`.
  */
 
-export type { NeonFunctionsContext, WaitUntil } from "./lib/wait-until.js";
-export {
-	NEON_REQUEST_CONTEXT_KEY,
-	runWithRequestContext,
-	waitUntil,
-} from "./lib/wait-until.js";
+export { waitUntil } from "./lib/wait-until.js";

--- a/packages/functions/src/lib/wait-until.test.ts
+++ b/packages/functions/src/lib/wait-until.test.ts
@@ -1,97 +1,46 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
-import {
-	NEON_REQUEST_CONTEXT_KEY,
-	runWithRequestContext,
-	waitUntil,
-} from "./wait-until.js";
+import { waitUntil } from "./wait-until.js";
+
+afterEach(() => {
+	globalThis.NEON_REQUEST_CONTEXT = undefined;
+});
 
 describe("waitUntil", () => {
-	it("reads the context directly off globalThis[NEON_REQUEST_CONTEXT_KEY] (runtime shape)", () => {
-		// The runtime publishes the live context object DIRECTLY under this key (a
-		// getter returning `{ waitUntil }`), not a `.get()`-style provider. Simulate
-		// that and assert we forward to it.
+	it("forwards the promise to the runtime context's waitUntil", () => {
 		const received: Promise<unknown>[] = [];
-		const promise = Promise.resolve();
-		const original = Object.getOwnPropertyDescriptor(
-			globalThis,
-			NEON_REQUEST_CONTEXT_KEY,
-		);
-		try {
-			Object.defineProperty(globalThis, NEON_REQUEST_CONTEXT_KEY, {
-				configurable: true,
-				get: () => ({
-					waitUntil: (p: Promise<unknown>) => received.push(p),
-				}),
-			});
-			waitUntil(promise);
-			expect(received).toEqual([promise]);
-		} finally {
-			if (original) {
-				Object.defineProperty(
-					globalThis,
-					NEON_REQUEST_CONTEXT_KEY,
-					original,
-				);
-			}
-		}
-	});
-
-	it("forwards the promise to the invocation context's waitUntil", () => {
-		const received: Promise<unknown>[] = [];
+		globalThis.NEON_REQUEST_CONTEXT = {
+			waitUntil: (p) => received.push(p),
+		};
 		const promise = Promise.resolve("done");
 
-		runWithRequestContext({ waitUntil: (p) => received.push(p) }, () => {
-			waitUntil(promise);
-		});
+		waitUntil(promise);
 
 		expect(received).toEqual([promise]);
 	});
 
-	it("resolves the context at call time, including from nested async work", async () => {
+	it("reads the context at call time, so a later-published context is picked up", () => {
 		const received: Promise<unknown>[] = [];
 		const promise = Promise.resolve();
 
-		await runWithRequestContext(
-			{ waitUntil: (p) => received.push(p) },
-			async () => {
-				await Promise.resolve();
-				waitUntil(promise);
-			},
-		);
+		// No context published yet → no-op.
+		waitUntil(Promise.resolve());
+		expect(received).toEqual([]);
 
+		globalThis.NEON_REQUEST_CONTEXT = {
+			waitUntil: (p) => received.push(p),
+		};
+		waitUntil(promise);
 		expect(received).toEqual([promise]);
 	});
 
-	it("isolates context across concurrent invocations", async () => {
-		const a: Promise<unknown>[] = [];
-		const b: Promise<unknown>[] = [];
-		const pa = Promise.resolve("a");
-		const pb = Promise.resolve("b");
-
-		await Promise.all([
-			runWithRequestContext({ waitUntil: (p) => a.push(p) }, async () => {
-				await Promise.resolve();
-				waitUntil(pa);
-			}),
-			runWithRequestContext({ waitUntil: (p) => b.push(p) }, async () => {
-				await Promise.resolve();
-				waitUntil(pb);
-			}),
-		]);
-
-		expect(a).toEqual([pa]);
-		expect(b).toEqual([pb]);
-	});
-
-	it("is a no-op when no invocation context is in scope", () => {
+	it("is a no-op when no invocation context is published", () => {
 		expect(() => waitUntil(Promise.resolve())).not.toThrow();
 	});
 
 	it("is a no-op when the context exposes no waitUntil", () => {
-		runWithRequestContext({}, () => {
-			expect(() => waitUntil(Promise.resolve())).not.toThrow();
-		});
+		globalThis.NEON_REQUEST_CONTEXT = {};
+		expect(() => waitUntil(Promise.resolve())).not.toThrow();
 	});
 
 	it("throws a TypeError when called without a promise", () => {

--- a/packages/functions/src/lib/wait-until.ts
+++ b/packages/functions/src/lib/wait-until.ts
@@ -1,61 +1,21 @@
 /**
- * `waitUntil` extends the lifetime of a Neon Function invocation so background work
- * (logging, cache writes, analytics, …) can finish after the response has been sent.
+ * `waitUntil(promise)` defers async work past a Neon Function's response: the runtime
+ * keeps the invocation alive until the promise settles (up to the 15-minute limit).
  *
- * The public API mirrors Vercel's `@vercel/functions`: import `waitUntil` and call it
- * directly with a promise (`waitUntil(promise)`). The active invocation context is
- * published by the runtime on `globalThis`, so it can be read without importing the
- * runtime and stays correct under concurrency.
+ * The runtime publishes the active invocation context on `globalThis.NEON_REQUEST_CONTEXT`
+ * (a getter returning `{ waitUntil }` during an invocation, `undefined` outside one), so we
+ * read it directly. Off-platform — local dev, tests, non-Neon hosts — there is no context
+ * and this is a no-op, mirroring `@vercel/functions`: the promise the caller created still
+ * runs on its own, it just isn't tracked. Passing a non-Promise throws a `TypeError`.
  */
-import { AsyncLocalStorage } from "node:async_hooks";
 
-export type WaitUntil = (promise: Promise<unknown>) => void;
-
-/**
- * The slice of the runtime context this package reads. The runtime may attach
- * additional fields; only `waitUntil` is consumed here.
- */
-export type NeonFunctionsContext = {
-	waitUntil?: WaitUntil;
-};
-
-/**
- * Well-known `globalThis` key under which the Neon Functions runtime publishes the
- * current invocation context. The runtime installs it as a getter that returns the
- * live context object DIRECTLY — `globalThis.NEON_REQUEST_CONTEXT` is `{ waitUntil }`
- * during an invocation and `undefined` outside one — so it is read as the context
- * itself, not via a `.get()`-style provider.
- */
-export const NEON_REQUEST_CONTEXT_KEY = "NEON_REQUEST_CONTEXT";
-
-type GlobalWithContext = typeof globalThis & {
-	[NEON_REQUEST_CONTEXT_KEY]?: NeonFunctionsContext;
-};
-
-const globalWithContext: GlobalWithContext = globalThis;
-
-/**
- * Backs `runWithRequestContext` for local dev and tests. When the runtime is present
- * it has already published its own accessor under the same key, so we leave that in
- * place and never publish over it.
- */
-const requestContextStore = new AsyncLocalStorage<NeonFunctionsContext>();
-
-if (!(NEON_REQUEST_CONTEXT_KEY in globalWithContext)) {
-	Object.defineProperty(globalWithContext, NEON_REQUEST_CONTEXT_KEY, {
-		configurable: true,
-		get() {
-			return requestContextStore.getStore();
-		},
-	});
-}
-
-/**
- * Reads the current invocation context off `globalThis.NEON_REQUEST_CONTEXT`, falling
- * back to an empty context outside an invocation (local dev, tests, non-Neon hosts).
- */
-function getContext(): NeonFunctionsContext {
-	return globalWithContext[NEON_REQUEST_CONTEXT_KEY] ?? {};
+declare global {
+	// Published by the Neon Functions runtime. Declared here (the only way to type an
+	// augmented global) so it can be read off `globalThis` without a cast. `var` is the
+	// required form for a global augmentation.
+	var NEON_REQUEST_CONTEXT:
+		| { waitUntil?: (promise: Promise<unknown>) => void }
+		| undefined;
 }
 
 function isPromise(value: unknown): value is Promise<unknown> {
@@ -67,33 +27,11 @@ function isPromise(value: unknown): value is Promise<unknown> {
 	);
 }
 
-/**
- * Defers async work past the response by forwarding the promise to the Neon Functions
- * runtime, which keeps the invocation alive until the promise settles.
- *
- * The context is resolved at call time from the enclosing invocation, so this stays
- * correct under concurrency. When no invocation context is in scope (local dev, tests,
- * non-Neon hosts), this is a no-op: the promise is accepted and ignored (it still runs
- * on its own — the caller already started it — it just isn't tracked).
- */
 export function waitUntil(promise: Promise<unknown>): void {
 	if (!isPromise(promise)) {
 		throw new TypeError(
 			`waitUntil can only be called with a Promise, got ${typeof promise}`,
 		);
 	}
-	getContext().waitUntil?.(promise);
-}
-
-/**
- * Runtime entry point: binds `context` as the current invocation context for the
- * duration of `fn` (and any async work it spawns), so calls to `waitUntil` inside it
- * forward to `context.waitUntil`. Intended for the Neon Functions runtime to wrap each
- * invocation; application code should not need this.
- */
-export function runWithRequestContext<T>(
-	context: NeonFunctionsContext,
-	fn: () => T,
-): T {
-	return requestContextStore.run(context, fn);
+	globalThis.NEON_REQUEST_CONTEXT?.waitUntil?.(promise);
 }


### PR DESCRIPTION
## Summary

Strips `@neondatabase/functions` down to its only real public surface: `waitUntil`.

- Removes the unused `runWithRequestContext` export and the package's internal `AsyncLocalStorage`. The Neon Functions runtime publishes the invocation context **itself** on `globalThis.NEON_REQUEST_CONTEXT`; nothing ever called the package to *set* context, so the ALS + entry point were dead.
- Removes the `NEON_REQUEST_CONTEXT_KEY` constant and the `NeonFunctionsContext` / `WaitUntil` type exports — `waitUntil` is now the sole export.
- `waitUntil` reads `globalThis.NEON_REQUEST_CONTEXT` directly (typed via a `declare global`, no cast). Behavior is unchanged: forwards to the runtime on-platform, no-op off-platform (matching `@vercel/functions`).
- Net `-128` lines.

Includes the Changesets bump (`0.4.0` → `0.5.0`, minor — the export surface shrank).

## Test plan

- [x] `pnpm tsc`
- [x] `pnpm test:ci` — 5/5 pass (rewritten to drive the runtime via `globalThis.NEON_REQUEST_CONTEXT`)
- [x] `pnpm lint:ci`