### PR TITLE
chore(cli): pluralize resource command names with singular aliases

### DIFF
--- a/packages/cli/src/commands/__snapshots__/bucket.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/bucket.test.ts.snap
@@ -28,6 +28,14 @@ exports[`bucket > list with table output 1`] = `
 "
 `;
 
+exports[`bucket > buckets primary name lists buckets 1`] = `
+"- name: my-bucket
+  access_level: private
+- name: public-bucket
+  access_level: public_read
+"
+`;
+
 exports[`bucket > ls alias lists buckets 1`] = `
 "- name: my-bucket
   access_level: private

--- a/packages/cli/src/commands/bucket.test.ts
+++ b/packages/cli/src/commands/bucket.test.ts
@@ -81,6 +81,12 @@ describe('bucket', () => {
     });
   });
 
+  test('buckets primary name lists buckets', async ({ testCliCommand }) => {
+    await testCliCommand(['buckets', 'list', ...SCOPE], {
+      mockDir: 'single_org',
+    });
+  });
+
   test('delete', async ({ testCliCommand }) => {
     await testCliCommand(['bucket', 'delete', 'my-bucket', ...SCOPE], {
       mockDir: 'single_org',

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -62,9 +62,10 @@ export const splitBucketTarget = (
   };
 };
 
-export const command = 'bucket';
+export const command = 'buckets';
 export const describe =
   'Manage branch object-storage buckets and their objects';
+export const aliases = ['bucket'];
 export const builder = (argv: yargs.Argv) =>
   argv
     .usage('$0 bucket <sub-command> [options]')

--- a/packages/cli/src/commands/functions.ts
+++ b/packages/cli/src/commands/functions.ts
@@ -89,9 +89,9 @@ const POLL_INTERVAL_MS =
 const POLL_TIMEOUT_MS =
   Number(process.env.NEON_FUNCTIONS_POLL_TIMEOUT_MS) || 600_000;
 
-export const command = 'function';
+export const command = 'functions';
 export const describe = 'Manage Neon Functions';
-export const aliases = ['functions'];
+export const aliases = ['function'];
 export const builder = (argv: yargs.Argv) =>
   argv
     .usage('$0 function <sub-command> [options]')


### PR DESCRIPTION
## why?

Every neonctl resource command should follow one naming rule: the primary command name is plural and the singular form is an alias. Most commands already do this (`projects`/`project`, `branches`/`branch`, `databases`/`database`, `roles`/`role`, `operations`/`operation`, `orgs`/`org`). Two commands broke the rule. This change makes them consistent. All changes are backward-compatible: the old names stay usable as aliases.

Ref: LKB-0000

## what?

- [`functions.ts`](https://github.com/neondatabase/neon-pkgs/blob/stack/chore/pluralize-cli-commands/packages/cli/src/commands/functions.ts#L92): invert primary and alias — command `function` → `functions`, alias `functions` → `function`. Both names already worked; this only changes which name is canonical in help. No behavior change.
- [`bucket.ts`](https://github.com/neondatabase/neon-pkgs/blob/stack/chore/pluralize-cli-commands/packages/cli/src/commands/bucket.ts#L65): command `bucket` → `buckets`, add alias `bucket`. `bucket` keeps working.
- [`bucket.test.ts`](https://github.com/neondatabase/neon-pkgs/blob/stack/chore/pluralize-cli-commands/packages/cli/src/commands/bucket.test.ts): add a test asserting the `buckets` primary name works, mirroring the existing dual-name test in `functions.test.ts`.
- Searched all 25 top-level commands. The only other singular resource command is `vpc` (an established abbreviation), left as-is by decision. Verb/action commands (`auth`, `checkout`, `deploy`, etc.) are not collections and are out of scope.

Note: local `pnpm install` / `pnpm test` could not run in the dev sandbox — the npm proxy returns 403 for the pinned `vitest@1.6.1` tarball. Tests need to be verified in CI.

This pull request and its description were written by Isaac.