### PR TITLE
chore: release neonctl@2.27.1

### DIFF
--- a/.changeset/move-cli-into-monorepo.md
+++ b/.changeset/move-cli-into-monorepo.md
@@ -1,5 +1,0 @@
----
-"neonctl": patch
----
-
-Republish `neonctl` from the `neon-pkgs` monorepo (`packages/cli`). The CLI source has moved from `neondatabase/neonctl`; no functional changes.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.27.1
+
+### Patch Changes
+
+- 68a080f: Republish `neonctl` from the `neon-pkgs` monorepo (`packages/cli`). The CLI source has moved from `neondatabase/neonctl`; no functional changes.
+
 ## 2.27.0
 
 ### Moved into the monorepo

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Summary

First **`neonctl`** release cut from the `neon-pkgs` monorepo (`packages/cli`). Consumes the move changeset and bumps `2.27.0 → 2.27.1`; no functional changes.

This is the validation that the new publishing path works end to end before the `neon` rename:
1. Merge this PR.
2. Dispatch `neon-pkgs.yml` (`package=neonctl`, `ref=main`) in `databricks/secure-public-registry-releases-eng` → publishes `neonctl@2.27.1` to npm and creates a GitHub release `neonctl@2.27.1` with the standalone binaries.

## Test plan

- [ ] CI green
- [ ] `npm view neonctl version` → `2.27.1` after the publish workflow
- [ ] Homebrew autobump picks up `2.27.1` from npm