### PR TITLE
chore(sdk): rename @neondatabase/sdk → @neon/sdk

### DIFF
--- a/.changeset/neon-sdk-initial-release.md
+++ b/.changeset/neon-sdk-initial-release.md
@@ -1,8 +1,8 @@
 ---
-"@neondatabase/sdk": minor
+"@neon/sdk": minor
 ---
 
-Initial release of `@neondatabase/sdk` — the official TypeScript SDK for the Neon API, and the successor to `@neondatabase/api-client`.
+Initial release of `@neon/sdk` — the official TypeScript SDK for the Neon API, and the successor to `@neondatabase/api-client`.
 
 - Generated from Neon's [OpenAPI specification](https://neon.com/api_spec/release/v2.json) with [`@hey-api/openapi-ts`](https://heyapi.dev) on top of a Fetch-based client. It drops the `axios` dependency, so it runs unchanged on Node.js, Bun, Deno, edge runtimes, and the browser.
 - Every endpoint is exposed as an individually importable, tree-shakeable function (`listProjects`, `createProject`, `createProjectBranch`, …), alongside all request/response/error types and the client primitives (`createClient`, `createConfig`, and the preconfigured default `client`).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you're looking for a single package's docs, see its own `README.md` under `pa
 
 | Package | Description |
 | --- | --- |
-| `@neondatabase/sdk` | The official TypeScript SDK for the Neon API — a modern, Fetch-based client generated from Neon's OpenAPI spec (successor to `@neondatabase/api-client`). |
+| `@neon/sdk` | The official TypeScript SDK for the Neon API — a modern, Fetch-based client generated from Neon's OpenAPI spec (successor to `@neondatabase/api-client`). |
 | `@neondatabase/functions` | Runtime helpers for Neon Functions (e.g. a `waitUntil` primitive for deferring work past a response). |
 | `@neondatabase/ai-sdk-provider` | Community [Vercel AI SDK](https://ai-sdk.dev) provider for the Neon AI Gateway. |
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,4 +1,4 @@
-# @neondatabase/sdk
+# @neon/sdk
 
 The official TypeScript SDK for the [Neon API](https://api-docs.neon.tech/reference) — a modern, Fetch-based client generated from Neon's [OpenAPI specification](https://neon.com/api_spec/release/v2.json).
 
@@ -7,7 +7,7 @@ This is the successor to [`@neondatabase/api-client`](https://www.npmjs.com/pack
 ## Install
 
 ```bash
-npm install @neondatabase/sdk
+npm install @neon/sdk
 ```
 
 Requires Node.js >= 22 (or any runtime with a global `fetch`).
@@ -17,7 +17,7 @@ Requires Node.js >= 22 (or any runtime with a global `fetch`).
 Get an API key from the [Neon Console](https://console.neon.tech/app/settings#api-keys), then configure the default client and call any endpoint:
 
 ```ts
-import { client, listProjects } from "@neondatabase/sdk";
+import { client, listProjects } from "@neon/sdk";
 
 client.setConfig({
 	auth: () => process.env.NEON_API_KEY,
@@ -37,7 +37,7 @@ Each call returns `{ data, error, request, response }` by default — no `try/ca
 Path parameters, query parameters, and request bodies are fully typed per endpoint:
 
 ```ts
-import { createProject, getProject } from "@neondatabase/sdk";
+import { createProject, getProject } from "@neon/sdk";
 
 const created = await createProject({
 	body: { project: { name: "my-app", region_id: "aws-us-east-1" } },
@@ -55,7 +55,7 @@ configurations (different keys, base URLs, or a custom `fetch`), create your own
 and pass it per call:
 
 ```ts
-import { createClient, createConfig, listProjects } from "@neondatabase/sdk";
+import { createClient, createConfig, listProjects } from "@neon/sdk";
 
 const myClient = createClient(
 	createConfig({
@@ -80,9 +80,9 @@ This package re-exports the full generated surface from a single entry point:
 The client is generated from a vendored, pinned copy of the spec in [`spec/neon-openapi.json`](./spec/neon-openapi.json) using [`@hey-api/openapi-ts`](https://heyapi.dev).
 
 ```bash
-pnpm --filter @neondatabase/sdk spec:pull   # refresh the vendored spec from neon.com
-pnpm --filter @neondatabase/sdk generate     # regenerate src/client
-pnpm --filter @neondatabase/sdk build        # typecheck + bundle
+pnpm --filter @neon/sdk spec:pull   # refresh the vendored spec from neon.com
+pnpm --filter @neon/sdk generate     # regenerate src/client
+pnpm --filter @neon/sdk build        # typecheck + bundle
 ```
 
 ## License

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@neondatabase/sdk",
+	"name": "@neon/sdk",
 	"version": "0.0.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * `@neondatabase/sdk` — the official TypeScript SDK for the Neon API.
+ * `@neon/sdk` — the official TypeScript SDK for the Neon API.
  *
  * Generated from Neon's OpenAPI specification with `@hey-api/openapi-ts` on top of
  * a Fetch-based client. This entry point re-exports the full generated surface:
@@ -12,7 +12,7 @@
  *
  * @example
  * ```ts
- * import { client, listProjects } from "@neondatabase/sdk";
+ * import { client, listProjects } from "@neon/sdk";
  *
  * client.setConfig({ auth: () => process.env.NEON_API_KEY });
  *

--- a/packages/sdk/tsdown.config.ts
+++ b/packages/sdk/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	name: "@neondatabase/sdk",
+	name: "@neon/sdk",
 	bundle: false,
 	clean: true,
 	dts: true,


### PR DESCRIPTION
## Summary

Adopts the new **`@neon`** npm scope for the SDK before its first release. Since `@neondatabase/sdk` was **never published** (the changeset still cuts the initial `0.x`), this is a straightforward rename, **not** a migration — no deprecation/alias needed.

Renames `@neondatabase/sdk` → `@neon/sdk` across:
- `packages/sdk/package.json` (`name`)
- `packages/sdk/README.md` + root `README.md` package table
- `packages/sdk/tsdown.config.ts` (`name`)
- `packages/sdk/src/index.ts` entry docblock + example
- `.changeset/neon-sdk-initial-release.md` (changeset key + body)

Generated `src/client/**` is untouched (it never referenced the package name). `@neondatabase/api-client` references are intentionally left as-is (that's the separate, still-published predecessor).

## Test plan
- [x] `pnpm --filter @neon/sdk build` (tsc + tsdown) green
- [x] `pnpm lint:ci` green
- [ ] Confirm the publish workflow in `secure-public-registry-releases-eng` allows the `@neon/sdk` name (scope allowlist) before triggering the release.