### PR TITLE
feat(sdk): branches, postgres namespace, workflows + tiers 1-3 resources

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -36,6 +36,11 @@ export {
 	NeonTimeoutError,
 } from "./neon/errors.js";
 export type { Page, Paginated } from "./neon/paginate.js";
+export type {
+	BranchWithCompute,
+	CreateWithComputeInput,
+} from "./neon/resources/branches.js";
+export type { ProjectConnection } from "./neon/resources/projects.js";
 export type { NeonResult, Outcome } from "./neon/result.js";
 export type { WaitForOptions } from "./neon/wait.js";
 export type * from "./raw.js";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -40,7 +40,9 @@ export type {
 	BranchWithCompute,
 	CreateWithComputeInput,
 } from "./neon/resources/branches.js";
+export type { ConnectionStringParams } from "./neon/resources/postgres.js";
 export type { ProjectConnection } from "./neon/resources/projects.js";
+export type { RestoreSnapshotInput } from "./neon/resources/snapshots.js";
 export type { NeonResult, Outcome } from "./neon/result.js";
 export type { WaitForOptions } from "./neon/wait.js";
 export type * from "./raw.js";

--- a/packages/sdk/src/neon/client.test.ts
+++ b/packages/sdk/src/neon/client.test.ts
@@ -1,6 +1,9 @@
 import { expectTypeOf, it } from "vitest";
-import type { Project } from "../client/types.gen.js";
+import type { Branch, Project } from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
+import type { Paginated } from "./paginate.js";
+import type { BranchWithCompute } from "./resources/branches.js";
+import type { ProjectConnection } from "./resources/projects.js";
 import type { NeonResult } from "./result.js";
 
 it("default client returns the { data, error } envelope", () => {
@@ -28,4 +31,26 @@ it("per-call throwOnError overrides the client default and narrows", () => {
 	expectTypeOf(
 		throwing.projects.get("p", { throwOnError: false }),
 	).resolves.toEqualTypeOf<NeonResult<Project>>();
+});
+
+it("branches + workflows carry the envelope and narrow under throwOnError", () => {
+	const neon = createNeonClient({ apiKey: "x" });
+	expectTypeOf(neon.branches.list("p")).toEqualTypeOf<Paginated<Branch>>();
+	expectTypeOf(neon.branches.get("p", "br")).resolves.toEqualTypeOf<
+		NeonResult<Branch>
+	>();
+	expectTypeOf(
+		neon.branches.createWithCompute("p", { name: "x" }),
+	).resolves.toEqualTypeOf<NeonResult<BranchWithCompute>>();
+	expectTypeOf(
+		neon.projects.createAndConnect({ name: "x" }),
+	).resolves.toEqualTypeOf<NeonResult<ProjectConnection>>();
+
+	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
+	expectTypeOf(
+		throwing.branches.createWithCompute("p", { name: "x" }),
+	).resolves.toEqualTypeOf<BranchWithCompute>();
+	expectTypeOf(
+		throwing.branches.delete("p", "br"),
+	).resolves.toEqualTypeOf<void>();
 });

--- a/packages/sdk/src/neon/client.test.ts
+++ b/packages/sdk/src/neon/client.test.ts
@@ -1,5 +1,10 @@
 import { expectTypeOf, it } from "vitest";
-import type { Branch, Project } from "../client/types.gen.js";
+import type {
+	Branch,
+	Endpoint,
+	Project,
+	Snapshot,
+} from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
 import type { Paginated } from "./paginate.js";
 import type { BranchWithCompute } from "./resources/branches.js";
@@ -52,5 +57,29 @@ it("branches + workflows carry the envelope and narrow under throwOnError", () =
 	).resolves.toEqualTypeOf<BranchWithCompute>();
 	expectTypeOf(
 		throwing.branches.delete("p", "br"),
+	).resolves.toEqualTypeOf<void>();
+});
+
+it("postgres namespace + tier-2/3 resources are reachable and typed", () => {
+	const neon = createNeonClient({ apiKey: "x" });
+	expectTypeOf(neon.postgres.endpoints.list("p")).resolves.toEqualTypeOf<
+		NeonResult<Endpoint[]>
+	>();
+	expectTypeOf(
+		neon.postgres.roles.password("p", "br", "neondb_owner"),
+	).resolves.toEqualTypeOf<NeonResult<string>>();
+	expectTypeOf(
+		neon.postgres.connectionString({ projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<string>>();
+	expectTypeOf(neon.snapshots.list("p")).resolves.toEqualTypeOf<
+		NeonResult<Snapshot[]>
+	>();
+
+	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
+	expectTypeOf(
+		throwing.postgres.connectionString({ projectId: "p" }),
+	).resolves.toEqualTypeOf<string>();
+	expectTypeOf(
+		throwing.postgres.dataApi.delete("p", "br", "neondb"),
 	).resolves.toEqualTypeOf<void>();
 });

--- a/packages/sdk/src/neon/client.ts
+++ b/packages/sdk/src/neon/client.ts
@@ -1,6 +1,7 @@
 import type { Client } from "../client/client/index.js";
 import { type NeonConfig, resolveConfig } from "./config.js";
 import { RequestContext } from "./context.js";
+import { Branches } from "./resources/branches.js";
 import { Operations } from "./resources/operations.js";
 import { Projects } from "./resources/projects.js";
 
@@ -11,6 +12,7 @@ import { Projects } from "./resources/projects.js";
  */
 export interface NeonClient<DThrow extends boolean> {
 	readonly projects: Projects<DThrow>;
+	readonly branches: Branches<DThrow>;
 	readonly operations: Operations<DThrow>;
 	/**
 	 * The underlying configured raw client. Pass it to any raw function
@@ -36,6 +38,7 @@ export function createNeonClient<Throw extends boolean = false>(
 	const ctx = new RequestContext(resolveConfig(config));
 	return {
 		projects: new Projects<Throw>(ctx),
+		branches: new Branches<Throw>(ctx),
 		operations: new Operations<Throw>(ctx),
 		client: ctx.client,
 	};

--- a/packages/sdk/src/neon/client.ts
+++ b/packages/sdk/src/neon/client.ts
@@ -1,19 +1,33 @@
 import type { Client } from "../client/client/index.js";
 import { type NeonConfig, resolveConfig } from "./config.js";
 import { RequestContext } from "./context.js";
+import { ApiKeys, Regions, User } from "./resources/account.js";
 import { Branches } from "./resources/branches.js";
+import { Consumption } from "./resources/consumption.js";
 import { Operations } from "./resources/operations.js";
+import { Postgres } from "./resources/postgres.js";
 import { Projects } from "./resources/projects.js";
+import { Snapshots } from "./resources/snapshots.js";
 
 /**
- * The ergonomic Neon client. Resource namespaces (`projects`, `operations`, …) wrap the
- * raw operations with auth-once, retries, the `{ data, error }` envelope, optional
- * readiness polling, and typed errors. Drop to the raw layer any time via `.client`.
+ * The ergonomic Neon client. Resource namespaces wrap the raw operations with auth-once,
+ * retries, the `{ data, error }` envelope, optional readiness polling, and typed errors.
+ * Drop to the raw layer any time via `.client`.
+ *
+ * `projects` and `branches` are top-level; the Postgres data plane (compute endpoints,
+ * roles, databases, the Data API, connection strings) is grouped under `postgres` so
+ * future top-level namespaces (e.g. functions, object storage) stay unambiguous.
  */
 export interface NeonClient<DThrow extends boolean> {
 	readonly projects: Projects<DThrow>;
 	readonly branches: Branches<DThrow>;
+	readonly postgres: Postgres<DThrow>;
+	readonly snapshots: Snapshots<DThrow>;
 	readonly operations: Operations<DThrow>;
+	readonly consumption: Consumption;
+	readonly apiKeys: ApiKeys<DThrow>;
+	readonly regions: Regions<DThrow>;
+	readonly user: User<DThrow>;
 	/**
 	 * The underlying configured raw client. Pass it to any raw function
 	 * (`import { raw } from "@neon/sdk"`) to reuse this client's auth + base URL.
@@ -39,7 +53,13 @@ export function createNeonClient<Throw extends boolean = false>(
 	return {
 		projects: new Projects<Throw>(ctx),
 		branches: new Branches<Throw>(ctx),
+		postgres: new Postgres<Throw>(ctx),
+		snapshots: new Snapshots<Throw>(ctx),
 		operations: new Operations<Throw>(ctx),
+		consumption: new Consumption(ctx),
+		apiKeys: new ApiKeys<Throw>(ctx),
+		regions: new Regions<Throw>(ctx),
+		user: new User<Throw>(ctx),
 		client: ctx.client,
 	};
 }

--- a/packages/sdk/src/neon/connection.ts
+++ b/packages/sdk/src/neon/connection.ts
@@ -1,0 +1,46 @@
+import type { ConnectionDetails } from "../client/types.gen.js";
+import { NeonError } from "./errors.js";
+import { err, type NeonResult, ok } from "./result.js";
+
+/**
+ * Pick a connection string from a create response's `connection_uris`.
+ *
+ * Neon returns the **direct** URI; the pooled URI is the same string with the host
+ * swapped for the `-pooler` host (`connection_parameters.pooler_host`), so we derive it
+ * without an extra request. Returns `undefined` when the response carries no connection
+ * URI (e.g. a branch created from a parent with multiple roles/databases).
+ */
+export function pickConnectionString(
+	uris: ConnectionDetails[] | undefined,
+	pooled: boolean,
+): string | undefined {
+	const details = uris?.[0];
+	if (!details) return undefined;
+	if (!pooled) return details.connection_uri;
+	const { host, pooler_host } = details.connection_parameters;
+	if (!host || !pooler_host) return details.connection_uri;
+	return details.connection_uri.replace(host, pooler_host);
+}
+
+/**
+ * Attach a derived connection string to a create result, returning a `client`-kind
+ * {@link NeonError} when the response carries no connection URI.
+ */
+export function withConnectionString<D, T>(
+	result: NeonResult<D>,
+	uris: (data: D) => ConnectionDetails[] | undefined,
+	build: (data: D, connectionString: string) => T,
+	pooled: boolean,
+): NeonResult<T> {
+	if (result.error) return err(result.error);
+	const connectionString = pickConnectionString(uris(result.data), pooled);
+	if (!connectionString) {
+		return err(
+			new NeonError(
+				"The response did not include a connection URI (the branch or project may have multiple roles or databases). Use `raw.getConnectionUri` with an explicit role and database.",
+				"client",
+			),
+		);
+	}
+	return ok(build(result.data, connectionString));
+}

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -1,6 +1,6 @@
 import type { Client } from "../client/client/index.js";
 import { toNeonError } from "./errors.js";
-import { err, type NeonResult, ok } from "./result.js";
+import { err, finalize, type NeonResult, ok } from "./result.js";
 import { withRetries } from "./retry.js";
 import {
 	hasOperations,
@@ -52,19 +52,44 @@ export class RequestContext {
 		return this.#config;
 	}
 
+	/** Run a raw call and map its body; applies the resolved `throwOnError` policy. */
 	async run<D, T>(
 		opts: CallOptions | undefined,
 		exec: (client: Client) => Promise<RawResult<D>>,
 		map: (data: D) => T,
 	): Promise<T | NeonResult<T>> {
 		const shouldThrow = opts?.throwOnError ?? this.#config.throwOnError;
-		const result = await this.#execute(opts, exec, map);
-		if (!shouldThrow) return result;
-		if (result.error) throw result.error;
-		return result.data;
+		return finalize(await this.execute(opts, exec, map), shouldThrow);
 	}
 
-	async #execute<D, T>(
+	/** Like {@link run} but for endpoints that may return an empty (204) body. */
+	async runVoid<D>(
+		opts: CallOptions | undefined,
+		exec: (client: Client) => Promise<RawResult<D>>,
+	): Promise<void | NeonResult<void>> {
+		const shouldThrow = opts?.throwOnError ?? this.#config.throwOnError;
+		const raw = await withRetries(
+			() => exec(this.#config.client),
+			this.#config.retries,
+			opts?.signal,
+		);
+		if (raw.error !== undefined) {
+			return finalize(
+				err<void>(toNeonError(raw.error, raw.response)),
+				shouldThrow,
+			);
+		}
+		const readiness = await this.#maybeWait(opts, raw.data);
+		if (readiness?.error)
+			return finalize(err<void>(readiness.error), shouldThrow);
+		return finalize(ok(undefined), shouldThrow);
+	}
+
+	/**
+	 * Run a raw call and map its body, returning the {@link NeonResult} envelope (no
+	 * throw). Used by `run` and by workflows that post-process the result.
+	 */
+	async execute<D, T>(
 		opts: CallOptions | undefined,
 		exec: (client: Client) => Promise<RawResult<D>>,
 		map: (data: D) => T,
@@ -77,20 +102,21 @@ export class RequestContext {
 		if (raw.error || raw.data === undefined) {
 			return err(toNeonError(raw.error, raw.response));
 		}
-
-		const wait = opts?.waitForReadiness ?? this.#config.waitForReadiness;
-		if (wait && hasOperations(raw.data)) {
-			const waited = await waitForOperations(
-				this.#config.client,
-				raw.data.operations,
-				{
-					...this.#config.waitOptions,
-					signal: opts?.signal ?? this.#config.waitOptions.signal,
-				},
-			);
-			if (waited.error) return err(waited.error);
-		}
-
+		const readiness = await this.#maybeWait(opts, raw.data);
+		if (readiness?.error) return err(readiness.error);
 		return ok(map(raw.data));
+	}
+
+	/** Poll provisioning operations when `waitForReadiness` is on and the body has any. */
+	async #maybeWait(
+		opts: CallOptions | undefined,
+		data: unknown,
+	): Promise<NeonResult<void> | undefined> {
+		const wait = opts?.waitForReadiness ?? this.#config.waitForReadiness;
+		if (!wait || !hasOperations(data)) return undefined;
+		return waitForOperations(this.#config.client, data.operations, {
+			...this.#config.waitOptions,
+			signal: opts?.signal ?? this.#config.waitOptions.signal,
+		});
 	}
 }

--- a/packages/sdk/src/neon/coverage.ts
+++ b/packages/sdk/src/neon/coverage.ts
@@ -31,6 +31,53 @@ export const WRAPPED: ReadonlySet<string> = new Set([
 	// operations
 	"getProjectOperation",
 	"listProjectOperations",
+	// postgres: endpoints
+	"listProjectEndpoints",
+	"getProjectEndpoint",
+	"createProjectEndpoint",
+	"updateProjectEndpoint",
+	"deleteProjectEndpoint",
+	"startProjectEndpoint",
+	"suspendProjectEndpoint",
+	"restartProjectEndpoint",
+	// postgres: databases
+	"listProjectBranchDatabases",
+	"getProjectBranchDatabase",
+	"createProjectBranchDatabase",
+	"updateProjectBranchDatabase",
+	"deleteProjectBranchDatabase",
+	// postgres: roles
+	"listProjectBranchRoles",
+	"getProjectBranchRole",
+	"createProjectBranchRole",
+	"deleteProjectBranchRole",
+	"getProjectBranchRolePassword",
+	"resetProjectBranchRolePassword",
+	// postgres: connection string + data api
+	"getConnectionUri",
+	"getProjectBranchDataApi",
+	"createProjectBranchDataApi",
+	"updateProjectBranchDataApi",
+	"deleteProjectBranchDataApi",
+	// snapshots
+	"listSnapshots",
+	"createSnapshot",
+	"updateSnapshot",
+	"deleteSnapshot",
+	"restoreSnapshot",
+	"getSnapshotSchedule",
+	"setSnapshotSchedule",
+	// consumption
+	"getConsumptionHistoryPerProject",
+	"getConsumptionHistoryPerProjectV2",
+	"getConsumptionHistoryPerBranchV2",
+	// account
+	"getCurrentUserInfo",
+	"getCurrentUserOrganizations",
+	"getActiveRegions",
+	"listApiKeys",
+	"createApiKey",
+	"revokeApiKey",
 ]);
 
 /**

--- a/packages/sdk/src/neon/coverage.ts
+++ b/packages/sdk/src/neon/coverage.ts
@@ -22,6 +22,12 @@ export const WRAPPED: ReadonlySet<string> = new Set([
 	"createProject",
 	"updateProject",
 	"deleteProject",
+	// branches
+	"listProjectBranches",
+	"getProjectBranch",
+	"createProjectBranch",
+	"updateProjectBranch",
+	"deleteProjectBranch",
 	// operations
 	"getProjectOperation",
 	"listProjectOperations",

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -12,7 +12,8 @@ export type NeonErrorKind =
 	| "rate_limit"
 	| "operation"
 	| "timeout"
-	| "network";
+	| "network"
+	| "client";
 
 /** Base class for every error the ergonomic layer produces. */
 export class NeonError extends Error {

--- a/packages/sdk/src/neon/resources/account.ts
+++ b/packages/sdk/src/neon/resources/account.ts
@@ -1,0 +1,156 @@
+import {
+	createApiKey,
+	getActiveRegions,
+	getCurrentUserInfo,
+	getCurrentUserOrganizations,
+	listApiKeys,
+	revokeApiKey,
+} from "../../client/sdk.gen.js";
+import type {
+	ApiKeyCreateResponse,
+	ApiKeyRevokeResponse,
+	ApiKeysListResponseItem,
+	CurrentUserInfoResponse,
+	Organization,
+	RegionResponse,
+} from "../../client/types.gen.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import type { NeonResult, Outcome } from "../result.js";
+
+/** Current user / account resource. */
+export class User<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /users/me */
+	me(): Promise<Outcome<CurrentUserInfoResponse, DThrow>>;
+	me<Throw extends boolean = DThrow>(
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<CurrentUserInfoResponse, Throw>>;
+	me(
+		opts?: CallOptions,
+	): Promise<CurrentUserInfoResponse | NeonResult<CurrentUserInfoResponse>> {
+		return this.#ctx.run(
+			opts,
+			(client) => getCurrentUserInfo({ client, throwOnError: false }),
+			(data) => data,
+		);
+	}
+
+	/** @apiCall GET /users/me/organizations */
+	organizations(): Promise<Outcome<Organization[], DThrow>>;
+	organizations<Throw extends boolean = DThrow>(
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Organization[], Throw>>;
+	organizations(
+		opts?: CallOptions,
+	): Promise<Organization[] | NeonResult<Organization[]>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getCurrentUserOrganizations({ client, throwOnError: false }),
+			(data) => data.organizations,
+		);
+	}
+}
+
+/** Active regions. */
+export class Regions<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /regions */
+	list(): Promise<Outcome<RegionResponse[], DThrow>>;
+	list<Throw extends boolean = DThrow>(
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<RegionResponse[], Throw>>;
+	list(
+		opts?: CallOptions,
+	): Promise<RegionResponse[] | NeonResult<RegionResponse[]>> {
+		return this.#ctx.run(
+			opts,
+			(client) => getActiveRegions({ client, throwOnError: false }),
+			(data) => data.regions,
+		);
+	}
+}
+
+/** Account API keys. */
+export class ApiKeys<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /api_keys */
+	list(): Promise<Outcome<ApiKeysListResponseItem[], DThrow>>;
+	list<Throw extends boolean = DThrow>(
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<ApiKeysListResponseItem[], Throw>>;
+	list(
+		opts?: CallOptions,
+	): Promise<
+		ApiKeysListResponseItem[] | NeonResult<ApiKeysListResponseItem[]>
+	> {
+		return this.#ctx.run(
+			opts,
+			(client) => listApiKeys({ client, throwOnError: false }),
+			(data) => data,
+		);
+	}
+
+	/**
+	 * Create an API key. The returned `key` token is shown **once** — store it now.
+	 *
+	 * @apiCall POST /api_keys
+	 */
+	create(keyName: string): Promise<Outcome<ApiKeyCreateResponse, DThrow>>;
+	create<Throw extends boolean = DThrow>(
+		keyName: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<ApiKeyCreateResponse, Throw>>;
+	create(
+		keyName: string,
+		opts?: CallOptions,
+	): Promise<ApiKeyCreateResponse | NeonResult<ApiKeyCreateResponse>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				createApiKey({
+					client,
+					body: { key_name: keyName },
+					throwOnError: false,
+				}),
+			(data) => data,
+		);
+	}
+
+	/** @apiCall DELETE /api_keys/{key_id} */
+	revoke(keyId: number): Promise<Outcome<ApiKeyRevokeResponse, DThrow>>;
+	revoke<Throw extends boolean = DThrow>(
+		keyId: number,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<ApiKeyRevokeResponse, Throw>>;
+	revoke(
+		keyId: number,
+		opts?: CallOptions,
+	): Promise<ApiKeyRevokeResponse | NeonResult<ApiKeyRevokeResponse>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				revokeApiKey({
+					client,
+					path: { key_id: keyId },
+					throwOnError: false,
+				}),
+			(data) => data,
+		);
+	}
+}

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -1,0 +1,236 @@
+import {
+	createProjectBranch,
+	deleteProjectBranch,
+	getProjectBranch,
+	listProjectBranches,
+	updateProjectBranch,
+} from "../../client/sdk.gen.js";
+import type {
+	Branch,
+	BranchCreateRequest,
+	BranchUpdateRequest,
+	Endpoint,
+	ListProjectBranchesData,
+} from "../../client/types.gen.js";
+import { withConnectionString } from "../connection.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
+import { finalize, type NeonResult, type Outcome } from "../result.js";
+
+type ListQuery = Omit<NonNullable<ListProjectBranchesData["query"]>, "cursor">;
+type CreateInput = NonNullable<BranchCreateRequest["branch"]>;
+type UpdateInput = BranchUpdateRequest["branch"];
+
+/** Per-call options for the connect/compute workflows. */
+interface WorkflowOptions<Throw extends boolean> extends CallOptions<Throw> {
+	/** Return a pooled connection string (default `true`). */
+	pooled?: boolean;
+}
+
+/** Input for {@link Branches.createWithCompute}. */
+export interface CreateWithComputeInput {
+	name?: string;
+	/** Parent branch id. Defaults to the project's default branch. */
+	parentId?: string;
+	/** Autoscaling settings for the branch's read-write endpoint. */
+	compute?: {
+		minCu?: number;
+		maxCu?: number;
+		suspendTimeoutSeconds?: number;
+	};
+}
+
+/** A branch with its read-write endpoint and a ready-to-use connection string. */
+export interface BranchWithCompute {
+	branch: Branch;
+	endpoint: Endpoint;
+	connectionString: string;
+}
+
+/** Branch resource — one API call per CRUD method, plus the `createWithCompute` workflow. */
+export class Branches<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches (cursor-paginated) */
+	list(projectId: string, query?: ListQuery): Paginated<Branch> {
+		return paginate(
+			(cursor, signal) =>
+				listProjectBranches({
+					client: this.#ctx.client,
+					path: { project_id: projectId },
+					query: { ...query, cursor },
+					throwOnError: false,
+					signal,
+				}),
+			(data) => ({
+				items: data?.branches ?? [],
+				cursor: data?.pagination?.next,
+			}),
+		);
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches/{branch_id} */
+	get(projectId: string, branchId: string): Promise<Outcome<Branch, DThrow>>;
+	get<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Branch, Throw>>;
+	get(
+		projectId: string,
+		branchId: string,
+		opts?: CallOptions,
+	): Promise<Branch | NeonResult<Branch>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getProjectBranch({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					throwOnError: false,
+				}),
+			(data) => data.branch,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/branches */
+	create(
+		projectId: string,
+		input?: CreateInput,
+	): Promise<Outcome<Branch, DThrow>>;
+	create<Throw extends boolean = DThrow>(
+		projectId: string,
+		input: CreateInput | undefined,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Branch, Throw>>;
+	create(
+		projectId: string,
+		input?: CreateInput,
+		opts?: CallOptions,
+	): Promise<Branch | NeonResult<Branch>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				createProjectBranch({
+					client,
+					path: { project_id: projectId },
+					body: { branch: input },
+					throwOnError: false,
+				}),
+			(data) => data.branch,
+		);
+	}
+
+	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id} */
+	update(
+		projectId: string,
+		branchId: string,
+		input: UpdateInput,
+	): Promise<Outcome<Branch, DThrow>>;
+	update<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		input: UpdateInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Branch, Throw>>;
+	update(
+		projectId: string,
+		branchId: string,
+		input: UpdateInput,
+		opts?: CallOptions,
+	): Promise<Branch | NeonResult<Branch>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				updateProjectBranch({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					body: { branch: input },
+					throwOnError: false,
+				}),
+			(data) => data.branch,
+		);
+	}
+
+	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id} */
+	delete(projectId: string, branchId: string): Promise<Outcome<void, DThrow>>;
+	delete<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	delete(
+		projectId: string,
+		branchId: string,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.runVoid(opts, (client) =>
+			deleteProjectBranch({
+				client,
+				path: { project_id: projectId, branch_id: branchId },
+				throwOnError: false,
+			}),
+		);
+	}
+
+	/**
+	 * Create a branch **with a read-write endpoint** and return a ready-to-use connection
+	 * string. One API call (Neon creates the endpoint inline) plus readiness polling.
+	 *
+	 * @workflow createProjectBranch (with endpoint) + waitForReadiness
+	 */
+	createWithCompute(
+		projectId: string,
+		input: CreateWithComputeInput,
+	): Promise<Outcome<BranchWithCompute, DThrow>>;
+	createWithCompute<Throw extends boolean = DThrow>(
+		projectId: string,
+		input: CreateWithComputeInput,
+		opts: WorkflowOptions<Throw>,
+	): Promise<Outcome<BranchWithCompute, Throw>>;
+	async createWithCompute(
+		projectId: string,
+		input: CreateWithComputeInput,
+		opts?: WorkflowOptions<boolean>,
+	): Promise<BranchWithCompute | NeonResult<BranchWithCompute>> {
+		const shouldThrow =
+			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
+		const result = await this.#ctx.execute(
+			{ ...opts, waitForReadiness: opts?.waitForReadiness ?? true },
+			(client) =>
+				createProjectBranch({
+					client,
+					path: { project_id: projectId },
+					body: {
+						branch: { name: input.name, parent_id: input.parentId },
+						endpoints: [
+							{
+								type: "read_write",
+								autoscaling_limit_min_cu: input.compute?.minCu,
+								autoscaling_limit_max_cu: input.compute?.maxCu,
+								suspend_timeout_seconds:
+									input.compute?.suspendTimeoutSeconds,
+							},
+						],
+					},
+					throwOnError: false,
+				}),
+			(data) => data,
+		);
+		const out = withConnectionString(
+			result,
+			(data) => data.connection_uris,
+			(data, connectionString) => ({
+				branch: data.branch,
+				endpoint: data.endpoints[0],
+				connectionString,
+			}),
+			opts?.pooled ?? true,
+		);
+		return finalize(out, shouldThrow);
+	}
+}

--- a/packages/sdk/src/neon/resources/consumption.ts
+++ b/packages/sdk/src/neon/resources/consumption.ts
@@ -1,0 +1,94 @@
+import {
+	getConsumptionHistoryPerBranchV2,
+	getConsumptionHistoryPerProject,
+	getConsumptionHistoryPerProjectV2,
+} from "../../client/sdk.gen.js";
+import type {
+	ConsumptionHistoryPerBranchV2,
+	ConsumptionHistoryPerProject,
+	ConsumptionHistoryPerProjectV2,
+	GetConsumptionHistoryPerBranchV2Data,
+	GetConsumptionHistoryPerProjectData,
+	GetConsumptionHistoryPerProjectV2Data,
+} from "../../client/types.gen.js";
+import type { RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
+
+type PerProjectQuery = Omit<
+	GetConsumptionHistoryPerProjectData["query"],
+	"cursor"
+>;
+type PerProjectV2Query = Omit<
+	GetConsumptionHistoryPerProjectV2Data["query"],
+	"cursor"
+>;
+type PerBranchV2Query = Omit<
+	GetConsumptionHistoryPerBranchV2Data["query"],
+	"cursor"
+>;
+
+/** Consumption history (cursor-paginated). */
+export class Consumption {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /consumption_history/projects */
+	perProject(
+		query: PerProjectQuery,
+	): Paginated<ConsumptionHistoryPerProject> {
+		return paginate(
+			(cursor, signal) =>
+				getConsumptionHistoryPerProject({
+					client: this.#ctx.client,
+					query: { ...query, cursor },
+					throwOnError: false,
+					signal,
+				}),
+			(data) => ({
+				items: data?.projects ?? [],
+				cursor: data?.pagination?.cursor,
+			}),
+		);
+	}
+
+	/** @apiCall GET /consumption_history/v2/projects */
+	perProjectV2(
+		query: PerProjectV2Query,
+	): Paginated<ConsumptionHistoryPerProjectV2> {
+		return paginate(
+			(cursor, signal) =>
+				getConsumptionHistoryPerProjectV2({
+					client: this.#ctx.client,
+					query: { ...query, cursor },
+					throwOnError: false,
+					signal,
+				}),
+			(data) => ({
+				items: data?.projects ?? [],
+				cursor: data?.pagination?.cursor,
+			}),
+		);
+	}
+
+	/** @apiCall GET /consumption_history/v2/branches */
+	perBranchV2(
+		query: PerBranchV2Query,
+	): Paginated<ConsumptionHistoryPerBranchV2> {
+		return paginate(
+			(cursor, signal) =>
+				getConsumptionHistoryPerBranchV2({
+					client: this.#ctx.client,
+					query: { ...query, cursor },
+					throwOnError: false,
+					signal,
+				}),
+			(data) => ({
+				items: data?.branches ?? [],
+				cursor: data?.pagination?.cursor,
+			}),
+		);
+	}
+}

--- a/packages/sdk/src/neon/resources/dataapi.ts
+++ b/packages/sdk/src/neon/resources/dataapi.ts
@@ -1,0 +1,167 @@
+import {
+	createProjectBranchDataApi,
+	deleteProjectBranchDataApi,
+	getProjectBranchDataApi,
+	updateProjectBranchDataApi,
+} from "../../client/sdk.gen.js";
+import type {
+	DataApiCreateRequest,
+	DataApiCreateResponse,
+	DataApiReponse,
+	DataApiUpdateRequest,
+} from "../../client/types.gen.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import type { NeonResult, Outcome } from "../result.js";
+
+/** Neon Data API resource (branch + database scoped). */
+export class DataApi<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
+	get(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+	): Promise<Outcome<DataApiReponse, DThrow>>;
+	get<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<DataApiReponse, Throw>>;
+	get(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		opts?: CallOptions,
+	): Promise<DataApiReponse | NeonResult<DataApiReponse>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getProjectBranchDataApi({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						database_name: databaseName,
+					},
+					throwOnError: false,
+				}),
+			(data) => data,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
+	create(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		input?: DataApiCreateRequest,
+	): Promise<Outcome<DataApiCreateResponse, DThrow>>;
+	create<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		input: DataApiCreateRequest | undefined,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<DataApiCreateResponse, Throw>>;
+	create(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		input?: DataApiCreateRequest,
+		opts?: CallOptions,
+	): Promise<DataApiCreateResponse | NeonResult<DataApiCreateResponse>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				createProjectBranchDataApi({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						database_name: databaseName,
+					},
+					body: input,
+					throwOnError: false,
+				}),
+			(data) => data,
+		);
+	}
+
+	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
+	update(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		input?: DataApiUpdateRequest,
+	): Promise<Outcome<void, DThrow>>;
+	update<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		input: DataApiUpdateRequest | undefined,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	update(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		input?: DataApiUpdateRequest,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				updateProjectBranchDataApi({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						database_name: databaseName,
+					},
+					body: input,
+					throwOnError: false,
+				}),
+			() => undefined,
+		);
+	}
+
+	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
+	delete(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+	): Promise<Outcome<void, DThrow>>;
+	delete<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	delete(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				deleteProjectBranchDataApi({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						database_name: databaseName,
+					},
+					throwOnError: false,
+				}),
+			() => undefined,
+		);
+	}
+}

--- a/packages/sdk/src/neon/resources/databases.ts
+++ b/packages/sdk/src/neon/resources/databases.ts
@@ -1,0 +1,187 @@
+import {
+	createProjectBranchDatabase,
+	deleteProjectBranchDatabase,
+	getProjectBranchDatabase,
+	listProjectBranchDatabases,
+	updateProjectBranchDatabase,
+} from "../../client/sdk.gen.js";
+import type {
+	Database,
+	DatabaseCreateRequest,
+	DatabaseUpdateRequest,
+} from "../../client/types.gen.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import type { NeonResult, Outcome } from "../result.js";
+
+type CreateInput = DatabaseCreateRequest["database"];
+type UpdateInput = DatabaseUpdateRequest["database"];
+
+/** Database resource (branch-scoped). */
+export class Databases<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/databases */
+	list(
+		projectId: string,
+		branchId: string,
+	): Promise<Outcome<Database[], DThrow>>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Database[], Throw>>;
+	list(
+		projectId: string,
+		branchId: string,
+		opts?: CallOptions,
+	): Promise<Database[] | NeonResult<Database[]>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				listProjectBranchDatabases({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					throwOnError: false,
+				}),
+			(data) => data.databases,
+		);
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/databases/{database_name} */
+	get(
+		projectId: string,
+		branchId: string,
+		name: string,
+	): Promise<Outcome<Database, DThrow>>;
+	get<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Database, Throw>>;
+	get(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts?: CallOptions,
+	): Promise<Database | NeonResult<Database>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getProjectBranchDatabase({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						database_name: name,
+					},
+					throwOnError: false,
+				}),
+			(data) => data.database,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/databases */
+	create(
+		projectId: string,
+		branchId: string,
+		input: CreateInput,
+	): Promise<Outcome<Database, DThrow>>;
+	create<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		input: CreateInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Database, Throw>>;
+	create(
+		projectId: string,
+		branchId: string,
+		input: CreateInput,
+		opts?: CallOptions,
+	): Promise<Database | NeonResult<Database>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				createProjectBranchDatabase({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					body: { database: input },
+					throwOnError: false,
+				}),
+			(data) => data.database,
+		);
+	}
+
+	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id}/databases/{database_name} */
+	update(
+		projectId: string,
+		branchId: string,
+		name: string,
+		input: UpdateInput,
+	): Promise<Outcome<Database, DThrow>>;
+	update<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		name: string,
+		input: UpdateInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Database, Throw>>;
+	update(
+		projectId: string,
+		branchId: string,
+		name: string,
+		input: UpdateInput,
+		opts?: CallOptions,
+	): Promise<Database | NeonResult<Database>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				updateProjectBranchDatabase({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						database_name: name,
+					},
+					body: { database: input },
+					throwOnError: false,
+				}),
+			(data) => data.database,
+		);
+	}
+
+	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/databases/{database_name} */
+	delete(
+		projectId: string,
+		branchId: string,
+		name: string,
+	): Promise<Outcome<void, DThrow>>;
+	delete<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	delete(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.runVoid(opts, (client) =>
+			deleteProjectBranchDatabase({
+				client,
+				path: {
+					project_id: projectId,
+					branch_id: branchId,
+					database_name: name,
+				},
+				throwOnError: false,
+			}),
+		);
+	}
+}

--- a/packages/sdk/src/neon/resources/endpoints.ts
+++ b/packages/sdk/src/neon/resources/endpoints.ts
@@ -1,0 +1,242 @@
+import {
+	createProjectEndpoint,
+	deleteProjectEndpoint,
+	getProjectEndpoint,
+	listProjectEndpoints,
+	restartProjectEndpoint,
+	startProjectEndpoint,
+	suspendProjectEndpoint,
+	updateProjectEndpoint,
+} from "../../client/sdk.gen.js";
+import type {
+	Endpoint,
+	EndpointCreateRequest,
+	EndpointUpdateRequest,
+} from "../../client/types.gen.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import type { NeonResult, Outcome } from "../result.js";
+
+type CreateInput = EndpointCreateRequest["endpoint"];
+type UpdateInput = EndpointUpdateRequest["endpoint"];
+
+/** Compute endpoint resource (project-scoped). */
+export class Endpoints<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /projects/{project_id}/endpoints */
+	list(projectId: string): Promise<Outcome<Endpoint[], DThrow>>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Endpoint[], Throw>>;
+	list(
+		projectId: string,
+		opts?: CallOptions,
+	): Promise<Endpoint[] | NeonResult<Endpoint[]>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				listProjectEndpoints({
+					client,
+					path: { project_id: projectId },
+					throwOnError: false,
+				}),
+			(data) => data.endpoints,
+		);
+	}
+
+	/** @apiCall GET /projects/{project_id}/endpoints/{endpoint_id} */
+	get(
+		projectId: string,
+		endpointId: string,
+	): Promise<Outcome<Endpoint, DThrow>>;
+	get<Throw extends boolean = DThrow>(
+		projectId: string,
+		endpointId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Endpoint, Throw>>;
+	get(
+		projectId: string,
+		endpointId: string,
+		opts?: CallOptions,
+	): Promise<Endpoint | NeonResult<Endpoint>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getProjectEndpoint({
+					client,
+					path: { project_id: projectId, endpoint_id: endpointId },
+					throwOnError: false,
+				}),
+			(data) => data.endpoint,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/endpoints */
+	create(
+		projectId: string,
+		input: CreateInput,
+	): Promise<Outcome<Endpoint, DThrow>>;
+	create<Throw extends boolean = DThrow>(
+		projectId: string,
+		input: CreateInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Endpoint, Throw>>;
+	create(
+		projectId: string,
+		input: CreateInput,
+		opts?: CallOptions,
+	): Promise<Endpoint | NeonResult<Endpoint>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				createProjectEndpoint({
+					client,
+					path: { project_id: projectId },
+					body: { endpoint: input },
+					throwOnError: false,
+				}),
+			(data) => data.endpoint,
+		);
+	}
+
+	/** @apiCall PATCH /projects/{project_id}/endpoints/{endpoint_id} */
+	update(
+		projectId: string,
+		endpointId: string,
+		input: UpdateInput,
+	): Promise<Outcome<Endpoint, DThrow>>;
+	update<Throw extends boolean = DThrow>(
+		projectId: string,
+		endpointId: string,
+		input: UpdateInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Endpoint, Throw>>;
+	update(
+		projectId: string,
+		endpointId: string,
+		input: UpdateInput,
+		opts?: CallOptions,
+	): Promise<Endpoint | NeonResult<Endpoint>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				updateProjectEndpoint({
+					client,
+					path: { project_id: projectId, endpoint_id: endpointId },
+					body: { endpoint: input },
+					throwOnError: false,
+				}),
+			(data) => data.endpoint,
+		);
+	}
+
+	/** @apiCall DELETE /projects/{project_id}/endpoints/{endpoint_id} */
+	delete(
+		projectId: string,
+		endpointId: string,
+	): Promise<Outcome<void, DThrow>>;
+	delete<Throw extends boolean = DThrow>(
+		projectId: string,
+		endpointId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	delete(
+		projectId: string,
+		endpointId: string,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.runVoid(opts, (client) =>
+			deleteProjectEndpoint({
+				client,
+				path: { project_id: projectId, endpoint_id: endpointId },
+				throwOnError: false,
+			}),
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/endpoints/{endpoint_id}/start */
+	start(
+		projectId: string,
+		endpointId: string,
+	): Promise<Outcome<Endpoint, DThrow>>;
+	start<Throw extends boolean = DThrow>(
+		projectId: string,
+		endpointId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Endpoint, Throw>>;
+	start(
+		projectId: string,
+		endpointId: string,
+		opts?: CallOptions,
+	): Promise<Endpoint | NeonResult<Endpoint>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				startProjectEndpoint({
+					client,
+					path: { project_id: projectId, endpoint_id: endpointId },
+					throwOnError: false,
+				}),
+			(data) => data.endpoint,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/endpoints/{endpoint_id}/suspend */
+	suspend(
+		projectId: string,
+		endpointId: string,
+	): Promise<Outcome<Endpoint, DThrow>>;
+	suspend<Throw extends boolean = DThrow>(
+		projectId: string,
+		endpointId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Endpoint, Throw>>;
+	suspend(
+		projectId: string,
+		endpointId: string,
+		opts?: CallOptions,
+	): Promise<Endpoint | NeonResult<Endpoint>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				suspendProjectEndpoint({
+					client,
+					path: { project_id: projectId, endpoint_id: endpointId },
+					throwOnError: false,
+				}),
+			(data) => data.endpoint,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/endpoints/{endpoint_id}/restart */
+	restart(
+		projectId: string,
+		endpointId: string,
+	): Promise<Outcome<Endpoint, DThrow>>;
+	restart<Throw extends boolean = DThrow>(
+		projectId: string,
+		endpointId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Endpoint, Throw>>;
+	restart(
+		projectId: string,
+		endpointId: string,
+		opts?: CallOptions,
+	): Promise<Endpoint | NeonResult<Endpoint>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				restartProjectEndpoint({
+					client,
+					path: { project_id: projectId, endpoint_id: endpointId },
+					throwOnError: false,
+				}),
+			(data) => data.endpoint,
+		);
+	}
+}

--- a/packages/sdk/src/neon/resources/postgres.ts
+++ b/packages/sdk/src/neon/resources/postgres.ts
@@ -1,0 +1,176 @@
+import {
+	getConnectionUri,
+	listProjectBranchDatabases,
+	listProjectBranches,
+	listProjectBranchRoles,
+} from "../../client/sdk.gen.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import { NeonError, toNeonError } from "../errors.js";
+import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
+import { DataApi } from "./dataapi.js";
+import { Databases } from "./databases.js";
+import { Endpoints } from "./endpoints.js";
+import { Roles } from "./roles.js";
+
+/** Parameters for {@link Postgres.connectionString}. */
+export interface ConnectionStringParams {
+	projectId: string;
+	/** Defaults to the project's default branch. */
+	branchId?: string;
+	/** Defaults to the branch's read-write endpoint. */
+	endpointId?: string;
+	/** Auto-selected when the branch has exactly one database. */
+	databaseName?: string;
+	/** Auto-selected when the branch has exactly one role. */
+	roleName?: string;
+	/** Pooled connection string (default `true`). */
+	pooled?: boolean;
+}
+
+/**
+ * The Postgres data plane of a branch: compute endpoints, roles, databases, the Data API,
+ * and a connection-string helper. (Grouped under `neon.postgres.*` so future top-level
+ * namespaces like `functions` / `storage` stay unambiguous.)
+ */
+export class Postgres<DThrow extends boolean> {
+	readonly endpoints: Endpoints<DThrow>;
+	readonly roles: Roles<DThrow>;
+	readonly databases: Databases<DThrow>;
+	readonly dataApi: DataApi<DThrow>;
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+		this.endpoints = new Endpoints<DThrow>(ctx);
+		this.roles = new Roles<DThrow>(ctx);
+		this.databases = new Databases<DThrow>(ctx);
+		this.dataApi = new DataApi<DThrow>(ctx);
+	}
+
+	/**
+	 * Resolve a Postgres connection string. Auto-selects the default branch and the sole
+	 * role/database when not specified (mirrors `@neondatabase/config`'s `fetchEnv`); returns
+	 * a `client`-kind {@link NeonError} when the selection is ambiguous.
+	 */
+	connectionString(
+		params: ConnectionStringParams,
+	): Promise<Outcome<string, DThrow>>;
+	connectionString<Throw extends boolean = DThrow>(
+		params: ConnectionStringParams,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<string, Throw>>;
+	async connectionString(
+		params: ConnectionStringParams,
+		opts?: CallOptions,
+	): Promise<string | NeonResult<string>> {
+		const shouldThrow =
+			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
+		return finalize(await this.#resolve(params, opts?.signal), shouldThrow);
+	}
+
+	async #resolve(
+		params: ConnectionStringParams,
+		signal?: AbortSignal,
+	): Promise<NeonResult<string>> {
+		const client = this.#ctx.client;
+		const projectId = params.projectId;
+		let branchId = params.branchId;
+		let roleName = params.roleName;
+		let databaseName = params.databaseName;
+
+		if ((!roleName || !databaseName) && !branchId) {
+			const branches = await listProjectBranches({
+				client,
+				path: { project_id: projectId },
+				throwOnError: false,
+				signal,
+			});
+			if (branches.error || !branches.data) {
+				return err(toNeonError(branches.error, branches.response));
+			}
+			branchId = branches.data.branches.find(
+				(branch) => branch.default,
+			)?.id;
+			if (!branchId) {
+				return err(
+					new NeonError(
+						"Could not determine the default branch; pass branchId.",
+						"client",
+					),
+				);
+			}
+		}
+
+		if (!roleName) {
+			if (!branchId) return err(branchRequired("roleName"));
+			const roles = await listProjectBranchRoles({
+				client,
+				path: { project_id: projectId, branch_id: branchId },
+				throwOnError: false,
+				signal,
+			});
+			if (roles.error || !roles.data)
+				return err(toNeonError(roles.error, roles.response));
+			if (roles.data.roles.length !== 1) {
+				return err(
+					ambiguous("role", roles.data.roles.length, "roleName"),
+				);
+			}
+			roleName = roles.data.roles[0].name;
+		}
+
+		if (!databaseName) {
+			if (!branchId) return err(branchRequired("databaseName"));
+			const databases = await listProjectBranchDatabases({
+				client,
+				path: { project_id: projectId, branch_id: branchId },
+				throwOnError: false,
+				signal,
+			});
+			if (databases.error || !databases.data) {
+				return err(toNeonError(databases.error, databases.response));
+			}
+			if (databases.data.databases.length !== 1) {
+				return err(
+					ambiguous(
+						"database",
+						databases.data.databases.length,
+						"databaseName",
+					),
+				);
+			}
+			databaseName = databases.data.databases[0].name;
+		}
+
+		const conn = await getConnectionUri({
+			client,
+			path: { project_id: projectId },
+			query: {
+				branch_id: branchId,
+				endpoint_id: params.endpointId,
+				database_name: databaseName,
+				role_name: roleName,
+				pooled: params.pooled ?? true,
+			},
+			throwOnError: false,
+			signal,
+		});
+		if (conn.error || !conn.data)
+			return err(toNeonError(conn.error, conn.response));
+		return ok(conn.data.uri);
+	}
+}
+
+function branchRequired(param: string): NeonError {
+	return new NeonError(
+		`Pass branchId or ${param} to resolve a connection string.`,
+		"client",
+	);
+}
+
+function ambiguous(kind: string, count: number, param: string): NeonError {
+	return new NeonError(
+		`Expected exactly one ${kind} to auto-select for the connection string; found ${count}. Pass ${param}.`,
+		"client",
+	);
+}

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -12,13 +12,26 @@ import type {
 	ProjectListItem,
 	ProjectUpdateRequest,
 } from "../../client/types.gen.js";
+import { withConnectionString } from "../connection.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { type Paginated, paginate } from "../paginate.js";
-import type { NeonResult, Outcome } from "../result.js";
+import { finalize, type NeonResult, type Outcome } from "../result.js";
 
 type ListQuery = Omit<NonNullable<ListProjectsData["query"]>, "cursor">;
 type CreateInput = ProjectCreateRequest["project"];
 type UpdateInput = ProjectUpdateRequest["project"];
+
+/** Per-call options for the connect workflow. */
+interface WorkflowOptions<Throw extends boolean> extends CallOptions<Throw> {
+	/** Return a pooled connection string (default `true`). */
+	pooled?: boolean;
+}
+
+/** A project with a ready-to-use connection string to its default branch. */
+export interface ProjectConnection {
+	project: Project;
+	connectionString: string;
+}
 
 /** Project resource — one API call per method (`list` is cursor-paginated). */
 export class Projects<DThrow extends boolean> {
@@ -92,6 +105,48 @@ export class Projects<DThrow extends boolean> {
 				}),
 			(data) => data.project,
 		);
+	}
+
+	/**
+	 * Create a project and return a ready-to-use connection string to its default branch.
+	 * One API call plus readiness polling (the create response already carries the
+	 * connection URI).
+	 *
+	 * @workflow createProject + waitForReadiness
+	 */
+	createAndConnect(
+		input?: CreateInput,
+	): Promise<Outcome<ProjectConnection, DThrow>>;
+	createAndConnect<Throw extends boolean = DThrow>(
+		input: CreateInput | undefined,
+		opts: WorkflowOptions<Throw>,
+	): Promise<Outcome<ProjectConnection, Throw>>;
+	async createAndConnect(
+		input?: CreateInput,
+		opts?: WorkflowOptions<boolean>,
+	): Promise<ProjectConnection | NeonResult<ProjectConnection>> {
+		const shouldThrow =
+			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
+		const result = await this.#ctx.execute(
+			{ ...opts, waitForReadiness: opts?.waitForReadiness ?? true },
+			(client) =>
+				createProject({
+					client,
+					body: { project: input ?? {} },
+					throwOnError: false,
+				}),
+			(data) => data,
+		);
+		const out = withConnectionString(
+			result,
+			(data) => data.connection_uris,
+			(data, connectionString) => ({
+				project: data.project,
+				connectionString,
+			}),
+			opts?.pooled ?? true,
+		);
+		return finalize(out, shouldThrow);
 	}
 
 	/** @apiCall PATCH /projects/{project_id} */

--- a/packages/sdk/src/neon/resources/roles.ts
+++ b/packages/sdk/src/neon/resources/roles.ts
@@ -1,0 +1,218 @@
+import {
+	createProjectBranchRole,
+	deleteProjectBranchRole,
+	getProjectBranchRole,
+	getProjectBranchRolePassword,
+	listProjectBranchRoles,
+	resetProjectBranchRolePassword,
+} from "../../client/sdk.gen.js";
+import type { Role, RoleCreateRequest } from "../../client/types.gen.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import type { NeonResult, Outcome } from "../result.js";
+
+type CreateInput = RoleCreateRequest["role"];
+
+/** Role resource (branch-scoped). */
+export class Roles<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/roles */
+	list(projectId: string, branchId: string): Promise<Outcome<Role[], DThrow>>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Role[], Throw>>;
+	list(
+		projectId: string,
+		branchId: string,
+		opts?: CallOptions,
+	): Promise<Role[] | NeonResult<Role[]>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				listProjectBranchRoles({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					throwOnError: false,
+				}),
+			(data) => data.roles,
+		);
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/roles/{role_name} */
+	get(
+		projectId: string,
+		branchId: string,
+		name: string,
+	): Promise<Outcome<Role, DThrow>>;
+	get<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Role, Throw>>;
+	get(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts?: CallOptions,
+	): Promise<Role | NeonResult<Role>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getProjectBranchRole({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						role_name: name,
+					},
+					throwOnError: false,
+				}),
+			(data) => data.role,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/roles */
+	create(
+		projectId: string,
+		branchId: string,
+		input: CreateInput,
+	): Promise<Outcome<Role, DThrow>>;
+	create<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		input: CreateInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Role, Throw>>;
+	create(
+		projectId: string,
+		branchId: string,
+		input: CreateInput,
+		opts?: CallOptions,
+	): Promise<Role | NeonResult<Role>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				createProjectBranchRole({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					body: { role: input },
+					throwOnError: false,
+				}),
+			(data) => data.role,
+		);
+	}
+
+	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/roles/{role_name} */
+	delete(
+		projectId: string,
+		branchId: string,
+		name: string,
+	): Promise<Outcome<void, DThrow>>;
+	delete<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	delete(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.runVoid(opts, (client) =>
+			deleteProjectBranchRole({
+				client,
+				path: {
+					project_id: projectId,
+					branch_id: branchId,
+					role_name: name,
+				},
+				throwOnError: false,
+			}),
+		);
+	}
+
+	/**
+	 * Reveal the role's password.
+	 *
+	 * @apiCall GET /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reveal_password
+	 */
+	password(
+		projectId: string,
+		branchId: string,
+		name: string,
+	): Promise<Outcome<string, DThrow>>;
+	password<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<string, Throw>>;
+	password(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts?: CallOptions,
+	): Promise<string | NeonResult<string>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getProjectBranchRolePassword({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						role_name: name,
+					},
+					throwOnError: false,
+				}),
+			(data) => data.password,
+		);
+	}
+
+	/**
+	 * Reset the role's password; the returned `Role` carries the new `password`.
+	 *
+	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password
+	 */
+	resetPassword(
+		projectId: string,
+		branchId: string,
+		name: string,
+	): Promise<Outcome<Role, DThrow>>;
+	resetPassword<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Role, Throw>>;
+	resetPassword(
+		projectId: string,
+		branchId: string,
+		name: string,
+		opts?: CallOptions,
+	): Promise<Role | NeonResult<Role>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				resetProjectBranchRolePassword({
+					client,
+					path: {
+						project_id: projectId,
+						branch_id: branchId,
+						role_name: name,
+					},
+					throwOnError: false,
+				}),
+			(data) => data.role,
+		);
+	}
+}

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -1,0 +1,239 @@
+import {
+	createSnapshot,
+	deleteSnapshot,
+	getSnapshotSchedule,
+	listSnapshots,
+	restoreSnapshot,
+	setSnapshotSchedule,
+	updateSnapshot,
+} from "../../client/sdk.gen.js";
+import type {
+	BackupSchedule,
+	Branch,
+	Snapshot,
+	SnapshotUpdateRequest,
+} from "../../client/types.gen.js";
+import type { CallOptions, RequestContext } from "../context.js";
+import type { NeonResult, Outcome } from "../result.js";
+
+type UpdateInput = SnapshotUpdateRequest["snapshot"];
+
+/** Input for {@link Snapshots.restore}. */
+export interface RestoreSnapshotInput {
+	/** Name for the newly restored branch. Auto-generated when omitted. */
+	name?: string;
+	/** Target branch to restore onto. Defaults to the snapshot's source branch. */
+	targetBranchId?: string;
+}
+
+/** Snapshot resource. */
+export class Snapshots<DThrow extends boolean> {
+	readonly #ctx: RequestContext;
+
+	constructor(ctx: RequestContext) {
+		this.#ctx = ctx;
+	}
+
+	/** @apiCall GET /projects/{project_id}/snapshots */
+	list(projectId: string): Promise<Outcome<Snapshot[], DThrow>>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Snapshot[], Throw>>;
+	list(
+		projectId: string,
+		opts?: CallOptions,
+	): Promise<Snapshot[] | NeonResult<Snapshot[]>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				listSnapshots({
+					client,
+					path: { project_id: projectId },
+					throwOnError: false,
+				}),
+			(data) => data.snapshots,
+		);
+	}
+
+	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/snapshot */
+	create(
+		projectId: string,
+		branchId: string,
+	): Promise<Outcome<Snapshot, DThrow>>;
+	create<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Snapshot, Throw>>;
+	create(
+		projectId: string,
+		branchId: string,
+		opts?: CallOptions,
+	): Promise<Snapshot | NeonResult<Snapshot>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				createSnapshot({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					throwOnError: false,
+				}),
+			(data) => data.snapshot,
+		);
+	}
+
+	/** @apiCall PATCH /projects/{project_id}/snapshots/{snapshot_id} */
+	update(
+		projectId: string,
+		snapshotId: string,
+		input: UpdateInput,
+	): Promise<Outcome<Snapshot, DThrow>>;
+	update<Throw extends boolean = DThrow>(
+		projectId: string,
+		snapshotId: string,
+		input: UpdateInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Snapshot, Throw>>;
+	update(
+		projectId: string,
+		snapshotId: string,
+		input: UpdateInput,
+		opts?: CallOptions,
+	): Promise<Snapshot | NeonResult<Snapshot>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				updateSnapshot({
+					client,
+					path: { project_id: projectId, snapshot_id: snapshotId },
+					body: { snapshot: input },
+					throwOnError: false,
+				}),
+			(data) => data.snapshot,
+		);
+	}
+
+	/** @apiCall DELETE /projects/{project_id}/snapshots/{snapshot_id} */
+	delete(
+		projectId: string,
+		snapshotId: string,
+	): Promise<Outcome<void, DThrow>>;
+	delete<Throw extends boolean = DThrow>(
+		projectId: string,
+		snapshotId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	delete(
+		projectId: string,
+		snapshotId: string,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				deleteSnapshot({
+					client,
+					path: { project_id: projectId, snapshot_id: snapshotId },
+					throwOnError: false,
+				}),
+			() => undefined,
+		);
+	}
+
+	/**
+	 * Restore a snapshot into a branch (creating it). Returns the restored branch.
+	 *
+	 * @apiCall POST /projects/{project_id}/snapshots/{snapshot_id}/restore
+	 */
+	restore(
+		projectId: string,
+		snapshotId: string,
+		input?: RestoreSnapshotInput,
+	): Promise<Outcome<Branch, DThrow>>;
+	restore<Throw extends boolean = DThrow>(
+		projectId: string,
+		snapshotId: string,
+		input: RestoreSnapshotInput | undefined,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Branch, Throw>>;
+	restore(
+		projectId: string,
+		snapshotId: string,
+		input?: RestoreSnapshotInput,
+		opts?: CallOptions,
+	): Promise<Branch | NeonResult<Branch>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				restoreSnapshot({
+					client,
+					path: { project_id: projectId, snapshot_id: snapshotId },
+					body: {
+						name: input?.name,
+						target_branch_id: input?.targetBranchId,
+					},
+					throwOnError: false,
+				}),
+			(data) => data.branch,
+		);
+	}
+
+	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/backup_schedule */
+	getSchedule(
+		projectId: string,
+		branchId: string,
+	): Promise<Outcome<BackupSchedule, DThrow>>;
+	getSchedule<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<BackupSchedule, Throw>>;
+	getSchedule(
+		projectId: string,
+		branchId: string,
+		opts?: CallOptions,
+	): Promise<BackupSchedule | NeonResult<BackupSchedule>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				getSnapshotSchedule({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					throwOnError: false,
+				}),
+			(data) => data,
+		);
+	}
+
+	/** @apiCall PUT /projects/{project_id}/branches/{branch_id}/backup_schedule */
+	setSchedule(
+		projectId: string,
+		branchId: string,
+		schedule: BackupSchedule,
+	): Promise<Outcome<void, DThrow>>;
+	setSchedule<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		schedule: BackupSchedule,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<void, Throw>>;
+	setSchedule(
+		projectId: string,
+		branchId: string,
+		schedule: BackupSchedule,
+		opts?: CallOptions,
+	): Promise<void | NeonResult<void>> {
+		return this.#ctx.run(
+			opts,
+			(client) =>
+				setSnapshotSchedule({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					body: schedule,
+					throwOnError: false,
+				}),
+			() => undefined,
+		);
+	}
+}

--- a/packages/sdk/src/neon/result.ts
+++ b/packages/sdk/src/neon/result.ts
@@ -25,3 +25,16 @@ export function ok<T>(data: T): NeonResult<T> {
 export function err<T>(error: NeonError): NeonResult<T> {
 	return { data: undefined, error };
 }
+
+/**
+ * Apply the `throwOnError` policy to a result: return the bare value (throwing on error)
+ * when `shouldThrow`, otherwise return the {@link NeonResult} envelope.
+ */
+export function finalize<T>(
+	result: NeonResult<T>,
+	shouldThrow: boolean,
+): T | NeonResult<T> {
+	if (!shouldThrow) return result;
+	if (result.error) throw result.error;
+	return result.data;
+}


### PR DESCRIPTION
Stacked on #245 (base = `feat/sdk-ergonomic-layer`). Together they deliver the full ergonomic layer over the generated raw client.

## Examples

```ts
import { createNeonClient } from "@neon/sdk";

const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
```

**Create a project and get a connection string — ready to hand to your ORM:**
```ts
const { data, error } = await neon.projects.createAndConnect({ name: "my-app" });
if (error) throw error;
const { project, connectionString } = data; // compute is provisioned + pooled URI ready
```

**Branch off prod with its own compute, ready to query:**
```ts
const { data } = await neon.branches.createWithCompute(project.id, {
  name: "preview/pr-123",
  compute: { minCu: 0.25, maxCu: 2 },
});
// data: { branch, endpoint, connectionString }
```

**Prefer exceptions? `throwOnError` flips the whole client and narrows the types:**
```ts
const neon = createNeonClient({ apiKey, throwOnError: true });

const project = await neon.projects.create({ name: "my-app" }); // → Project (throws on error)
const url = await neon.postgres.connectionString({ projectId: project.id }); // auto-picks branch/role/db
```

**Everything else reads the same — `{ data, error }`, auto-pagination, readiness, typed errors:**
```ts
const { data: projects } = await neon.projects.list().all();              // walks every page
const { data: branch } = await neon.snapshots.restore(pid, snapshotId);  // waits until ready
await neon.postgres.endpoints.suspend(pid, endpointId);                   // compute lifecycle
const { error } = await neon.branches.get(pid, "nope");
if (error?.kind === "not_found") { /* … */ }                             // discriminated NeonError
```

**Need an endpoint we haven't wrapped yet? Drop to `raw`, same auth:**
```ts
import { raw } from "@neon/sdk";
const { data } = await raw.getProjectBranchSchema({ client: neon.client, path: { project_id: pid, branch_id } });
```

## Top-level package surface

```ts
import {
  createNeonClient,          // the ergonomic client factory
  raw,                       // full generated 1:1 surface (also @neon/sdk/raw)
  // error classes:
  NeonError, NeonApiError, NeonNotFoundError, NeonAuthError, NeonRateLimitError,
  NeonOperationError, NeonTimeoutError, NeonNetworkError,
  // types (also flat): NeonConfig, NeonClient, NeonResult, Outcome, Page, Paginated,
  // CallOptions, WaitForOptions, ProjectConnection, BranchWithCompute,
  // CreateWithComputeInput, ConnectionStringParams, RestoreSnapshotInput, + all generated types
} from "@neon/sdk";
```

`createNeonClient({ apiKey, throwOnError?, waitForReadiness?, retries?, baseUrl?, fetch?, wait? })` returns:

## Full ergonomic hierarchy

Legend: **[P]** cursor-paginated (returns `Paginated<T>` — `.all()` / `.page()` / async-iter) · **[W]** workflow (multi-step / returns a connection string) · **[R]** readiness (waits on `operations` when `waitForReadiness`) · **→void** returns `void`. Every other method returns the resource. All honor `{ data, error }` + `throwOnError` (narrowed) unless noted.

```
neon
├─ projects
│   ├─ list(query?)                                  [P] ProjectListItem
│   ├─ get(id)                                        Project
│   ├─ create(input?)                             [R] Project
│   ├─ createAndConnect(input?, opts?)        [W][R] { project, connectionString }
│   ├─ update(id, input)                          [R] Project
│   └─ delete(id)                                 [R] Project
│
├─ branches
│   ├─ list(projectId, query?)                       [P] Branch
│   ├─ get(projectId, branchId)                       Branch
│   ├─ create(projectId, input?)                  [R] Branch
│   ├─ update(projectId, branchId, input)         [R] Branch
│   ├─ delete(projectId, branchId)             [R] →void
│   └─ createWithCompute(projectId, input, opts?) [W][R] { branch, endpoint, connectionString }
│
├─ postgres
│   ├─ connectionString(params, opts?)           [W] string   (auto-picks default branch + sole role/db)
│   ├─ endpoints
│   │   ├─ list(projectId)                            Endpoint[]
│   │   ├─ get(projectId, endpointId)                 Endpoint
│   │   ├─ create(projectId, input)              [R] Endpoint
│   │   ├─ update(projectId, endpointId, input)  [R] Endpoint
│   │   ├─ delete(projectId, endpointId)         [R] →void
│   │   ├─ start(projectId, endpointId)          [R] Endpoint
│   │   ├─ suspend(projectId, endpointId)        [R] Endpoint
│   │   └─ restart(projectId, endpointId)        [R] Endpoint
│   ├─ roles
│   │   ├─ list(projectId, branchId)                  Role[]
│   │   ├─ get(projectId, branchId, name)             Role
│   │   ├─ create(projectId, branchId, input)    [R] Role
│   │   ├─ delete(projectId, branchId, name)     [R] →void
│   │   ├─ password(projectId, branchId, name)        string
│   │   └─ resetPassword(projectId, branchId, name) [R] Role (carries new password)
│   ├─ databases
│   │   ├─ list(projectId, branchId)                  Database[]
│   │   ├─ get(projectId, branchId, name)             Database
│   │   ├─ create(projectId, branchId, input)    [R] Database
│   │   ├─ update(projectId, branchId, name, input) [R] Database
│   │   └─ delete(projectId, branchId, name)     [R] →void
│   └─ dataApi
│       ├─ get(projectId, branchId, databaseName)     DataApiReponse
│       ├─ create(projectId, branchId, databaseName, input?)  DataApiCreateResponse
│       ├─ update(projectId, branchId, databaseName, input?)  →void
│       └─ delete(projectId, branchId, databaseName)          →void
│
├─ snapshots
│   ├─ list(projectId)                                Snapshot[]
│   ├─ create(projectId, branchId)               [R] Snapshot
│   ├─ update(projectId, snapshotId, input)          Snapshot
│   ├─ delete(projectId, snapshotId)             [R] →void
│   ├─ restore(projectId, snapshotId, input?)    [R] Branch
│   ├─ getSchedule(projectId, branchId)              BackupSchedule
│   └─ setSchedule(projectId, branchId, schedule)    →void
│
├─ operations
│   ├─ list(projectId)                                [P] Operation
│   ├─ get(projectId, operationId)                    Operation
│   └─ waitFor(operations, opts?)                     →void   (readiness primitive)
│
├─ consumption
│   ├─ perProject(query)                              [P] ConsumptionHistoryPerProject
│   ├─ perProjectV2(query)                            [P] ConsumptionHistoryPerProjectV2
│   └─ perBranchV2(query)                             [P] ConsumptionHistoryPerBranchV2
│
├─ apiKeys
│   ├─ list()                                         ApiKeysListResponseItem[]
│   ├─ create(keyName)                                ApiKeyCreateResponse (token shown once)
│   └─ revoke(keyId)                                  ApiKeyRevokeResponse
│
├─ regions
│   └─ list()                                         RegionResponse[]
│
├─ user
│   ├─ me()                                           CurrentUserInfoResponse
│   └─ organizations()                                Organization[]
│
└─ client                                             // raw Client — pass to raw.* fns
```

## Design highlights

- **Namespace grouping:** `projects` / `branches` top-level; the Postgres data plane nests under `postgres` so future top-level namespaces (Neon Functions, object storage) don't collide with terms like `endpoint`.
- **Uniform result model:** `{ data, error }` everywhere; client-level `throwOnError` (and per-call override) **narrows** the return type to the bare resource. Typed `NeonError` union on the `error` channel (`kind`-discriminated), thrown under `throwOnError`.
- **Readiness:** `waitForReadiness` (client default + per-call) blocks mutations until their `operations` finish; detected at runtime, so it covers every create/update. Primitive: `operations.waitFor`.
- **Workflows** (`createAndConnect`, `createWithCompute`, `connectionString`) are one API call + readiness in the common case (create responses already carry `connection_uris`); `pooled` defaults to `true` via `host`→`pooler_host` swap (no extra call). `connectionString` additionally auto-selects the default branch and sole role/db, or returns a typed `client`-kind error.
- **Pagination, retries, sideEffects:** lazy cursor pagination; automatic retries on always-safe statuses (423/429/503, default 2); `"sideEffects": false`.
- **Raw escape hatch:** every endpoint is 1:1 in `raw` / `@neon/sdk/raw`; pass `neon.client` to reuse auth.

## Drift guard
`src/neon/coverage.test.ts` compares the generated operation set to a committed snapshot and fails CI on change. Ergonomic coverage is now **52 / 144** operations; the rest are intentionally raw-only and listed in the snapshot.

## Deferred (raw-only)
Neon Auth (28) + Auth legacy (16), Organizations admin (20), and project sub-resources (permissions, JWKS, VPC, transfers, advisor) — niche/overlapping; reachable via `raw`. Functions and object storage aren't in the OpenAPI spec yet, so they're not generatable (tracked separately).

## Test plan
- [x] `pnpm --filter @neon/sdk build` + `tsc`
- [x] `pnpm test:ci` (drift + type-narrowing, 7 tests)
- [x] `pnpm lint:ci`
- [ ] Live smoke via the linked `tests/neon-sdk-dx` harness (needs `NEON_API_KEY`)