### PR TITLE
fix(env): update AI Gateway env pull URL

### DIFF
--- a/.changeset/gentle-gateways-drop.md
+++ b/.changeset/gentle-gateways-drop.md
@@ -1,0 +1,6 @@
+---
+"@neondatabase/env": patch
+"neonctl": patch
+---
+
+Update AI Gateway env output so `OPENAI_BASE_URL` points at the branch chat-completions endpoint (`/v1/chat/completions`) while preserving the bare `NEON_AI_GATEWAY_BASE_URL` alias.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -349,7 +349,26 @@ After pinning the branch, `checkout` also runs [`env pull`](#env-pull) by defaul
 
 ### env pull
 
-`env pull` writes the linked branch's Neon environment variables into a local dotenv file: an existing `.env` if you have one, otherwise `.env.local` (override with `--file <path>`). Only Neon-managed keys (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and the Neon Auth / Data API URLs when those services are enabled) are written; any other lines in the file are preserved. The branch comes from the closest `.neon` file, so no `--branch` is needed (pass `--branch <id|name>` to target another branch).
+`env pull` writes the linked branch's Neon environment variables into a local dotenv file: an existing `.env` if you have one, otherwise `.env.local` (override with `--file <path>`). Only values resolved by Neon are written; any other lines in the file are preserved. The branch comes from the closest `.neon` file, so no `--branch` is needed (pass `--branch <id|name>` to target another branch).
+
+The output can include these keys, depending on which services are enabled on the branch:
+
+| Key | Value |
+| --- | --- |
+| `DATABASE_URL` | `postgresql://<role>:<pw>@<endpoint-id>-pooler.<cell>.<region>.<cloud>.neon.tech/<db>?channel_binding=require&sslmode=require` |
+| `DATABASE_URL_UNPOOLED` | `postgresql://<role>:<pw>@<endpoint-id>.<cell>.<region>.<cloud>.neon.tech/<db>?channel_binding=require&sslmode=require` |
+| `NEON_BRANCH` | `<branch-slug>` (for example, `main`) |
+| `NEON_AUTH_BASE_URL` | `https://<endpoint-id>.neonauth.<cell>.<region>.<cloud>.neon.tech/<db>/auth` |
+| `NEON_AUTH_JWKS_URL` | `https://<endpoint-id>.neonauth.<cell>.<region>.<cloud>.neon.tech/<db>/auth/.well-known/jwks.json` |
+| `NEON_DATA_API_URL` | `https://<endpoint-id>.apirest.<cell>.<region>.<cloud>.neon.tech/<db>/rest/v1` |
+| `AWS_ENDPOINT_URL_S3` | `https://<branch-id>.storage.<cell>.<region>.<cloud>.neon.tech` |
+| `AWS_ACCESS_KEY_ID` | `nak_live_<32hex>` |
+| `AWS_SECRET_ACCESS_KEY` | `nsk_live_<64hex>` |
+| `AWS_REGION` | Region, for example `us-east-2` |
+| `OPENAI_BASE_URL` | `https://<branch-id>-api.ai.<cell>.<region>.<cloud>.neon.tech/v1/chat/completions` |
+| `NEON_AI_GATEWAY_BASE_URL` | `https://<branch-id>-api.ai.<cell>.<region>.<cloud>.neon.tech` |
+
+When the AI Gateway is enabled, `OPENAI_API_KEY` and `NEON_AI_GATEWAY_TOKEN` are also emitted from the minted branch credential.
 
 `link` and `checkout` invoke `env pull` automatically (see above), so you usually only run it by hand to refresh vars or to pull a different branch into a specific file:
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -50,7 +50,7 @@
     "@neondatabase/api-client": "2.7.1",
     "@neondatabase/config": "0.8.0",
     "@neondatabase/config-runtime": "0.8.0",
-    "@neondatabase/env": "0.7.0",
+    "@neondatabase/env": "workspace:*",
     "@segment/analytics-node": "1.3.0",
     "axios": "1.7.2",
     "axios-debug-log": "1.0.0",

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -256,6 +256,23 @@ describe('env pull', () => {
     );
   });
 
+  it('writes the AI Gateway OpenAI URL and Neon base URL when enabled', async () => {
+    writeFileSync(
+      join(cwd, 'neon.ts'),
+      'export default { preview: { aiGateway: true } };\n',
+    );
+
+    await pull(baseProps(new FakeNeonApi(), cwd));
+
+    const content = readFileSync(join(cwd, '.env.local'), 'utf8');
+    expect(content).toMatch(
+      /^OPENAI_BASE_URL=https:\/\/br-snowy-frost-12345-api\.ai\.fake\.neon\.tech\/v1\/chat\/completions$/m,
+    );
+    expect(content).toMatch(
+      /^NEON_AI_GATEWAY_BASE_URL=https:\/\/br-snowy-frost-12345-api\.ai\.fake\.neon\.tech$/m,
+    );
+  });
+
   it('updates an existing .env in place, preserving other keys', async () => {
     writeFileSync(
       join(cwd, '.env'),

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -80,14 +80,22 @@ Flags (both commands): `--config <path>`, `--project-id`, `--branch`, `--api-key
 
 ## Env vars produced
 
-| Key | From |
+| Key | Value |
 | --- | --- |
-| `NEON_BRANCH` | the resolved branch **name** — mirrors what the Neon Functions runtime injects on every branch, so local dev matches the deployed runtime |
-| `DATABASE_URL` | pooled connection string |
-| `DATABASE_URL_UNPOOLED` | direct connection string |
-| `NEON_AUTH_BASE_URL` | Neon Auth integration (when `auth` is enabled) |
-| `NEON_AUTH_JWKS_URL` | Neon Auth JWKS endpoint for verifying issued tokens (when `auth` is enabled) |
-| `NEON_DATA_API_URL` | Data API integration (when `dataApi` is enabled) |
+| `DATABASE_URL` | `postgresql://<role>:<pw>@<endpoint-id>-pooler.<cell>.<region>.<cloud>.neon.tech/<db>?channel_binding=require&sslmode=require` |
+| `DATABASE_URL_UNPOOLED` | `postgresql://<role>:<pw>@<endpoint-id>.<cell>.<region>.<cloud>.neon.tech/<db>?channel_binding=require&sslmode=require` |
+| `NEON_BRANCH` | `<branch-slug>` (for example, `main`) |
+| `NEON_AUTH_BASE_URL` | `https://<endpoint-id>.neonauth.<cell>.<region>.<cloud>.neon.tech/<db>/auth` |
+| `NEON_AUTH_JWKS_URL` | `https://<endpoint-id>.neonauth.<cell>.<region>.<cloud>.neon.tech/<db>/auth/.well-known/jwks.json` |
+| `NEON_DATA_API_URL` | `https://<endpoint-id>.apirest.<cell>.<region>.<cloud>.neon.tech/<db>/rest/v1` |
+| `AWS_ENDPOINT_URL_S3` | `https://<branch-id>.storage.<cell>.<region>.<cloud>.neon.tech` |
+| `AWS_ACCESS_KEY_ID` | `nak_live_<32hex>` |
+| `AWS_SECRET_ACCESS_KEY` | `nsk_live_<64hex>` |
+| `AWS_REGION` | Region, for example `us-east-2` |
+| `OPENAI_BASE_URL` | `https://<branch-id>-api.ai.<cell>.<region>.<cloud>.neon.tech/v1/chat/completions` |
+| `NEON_AI_GATEWAY_BASE_URL` | `https://<branch-id>-api.ai.<cell>.<region>.<cloud>.neon.tech` |
+
+When the AI Gateway is enabled, `OPENAI_API_KEY` and `NEON_AI_GATEWAY_TOKEN` are also emitted from the minted branch credential.
 
 ## Resolution
 

--- a/packages/env/src/lib/env.contract.test.ts
+++ b/packages/env/src/lib/env.contract.test.ts
@@ -178,7 +178,7 @@ describe("toEntries → parseEnv round-trip (cross-process transport)", () => {
 			},
 			aiGateway: {
 				apiKey: "nt_live_abc_def",
-				baseUrl: "https://x.neon.build/ai-gateway/openai/v1",
+				baseUrl: "https://x.neon.build/v1/chat/completions",
 			},
 		};
 

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -575,7 +575,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect(env.aiGateway.apiKey).toMatch(/^nt_live_/);
 		// Branch-scoped gateway host derived from the branch connection URI, NOT the API origin.
 		expect(env.aiGateway.baseUrl).toBe(
-			"https://br-main-api.ai.aws-us-east-1.fake.neon.tech/ai-gateway/openai/v1",
+			"https://br-main-api.ai.aws-us-east-1.fake.neon.tech/v1/chat/completions",
 		);
 		expect("storage" in env).toBe(false);
 	});
@@ -604,7 +604,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		);
 
 		expect(env.aiGateway.baseUrl).toBe(
-			"https://br-cell-api.ai.c-3.aws-us-east-2.fake.neon.tech/ai-gateway/openai/v1",
+			"https://br-cell-api.ai.c-3.aws-us-east-2.fake.neon.tech/v1/chat/completions",
 		);
 		// The bare-host alias (`NEON_AI_GATEWAY_BASE_URL`) must carry the cell too.
 		expect(toEntries(env).NEON_AI_GATEWAY_BASE_URL).toBe(
@@ -724,12 +724,12 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		vi.stubEnv("OPENAI_API_KEY", "nt_live_abc_def");
 		vi.stubEnv(
 			"OPENAI_BASE_URL",
-			"https://x.neon.build/ai-gateway/openai/v1",
+			"https://x.neon.build/v1/chat/completions",
 		);
 		const env = parseEnv(defineConfig({ preview: { aiGateway: true } }));
 		expect(env.aiGateway.apiKey).toBe("nt_live_abc_def");
 		expect(env.aiGateway.baseUrl).toBe(
-			"https://x.neon.build/ai-gateway/openai/v1",
+			"https://x.neon.build/v1/chat/completions",
 		);
 	});
 
@@ -763,7 +763,7 @@ describe("branch storage + AI Gateway (Preview)", () => {
 			},
 			aiGateway: {
 				apiKey: "nt_live_x_y",
-				baseUrl: "https://x.neon.build/ai-gateway/openai/v1",
+				baseUrl: "https://x.neon.build/v1/chat/completions",
 			},
 		};
 		const pairs = toEntries(env);
@@ -773,10 +773,9 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		expect(pairs.AWS_REGION).toBe("us-east-2");
 		expect(pairs.OPENAI_API_KEY).toBe("nt_live_x_y");
 		expect(pairs.OPENAI_BASE_URL).toBe(
-			"https://x.neon.build/ai-gateway/openai/v1",
+			"https://x.neon.build/v1/chat/completions",
 		);
-		// Neon-branded aliases: same token, plus the bare branch gateway host (no path) —
-		// the @ai-sdk/neon provider appends the /ai-gateway/<dialect>/… routes itself.
+		// Neon-branded aliases: same token, plus the bare branch gateway host (no path).
 		expect(pairs.NEON_AI_GATEWAY_TOKEN).toBe("nt_live_x_y");
 		expect(pairs.NEON_AI_GATEWAY_BASE_URL).toBe("https://x.neon.build");
 	});

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -78,10 +78,9 @@ export const NEON_ENV_VAR_KEYS = {
 	/**
 	 * AI Gateway (Preview). Mapped onto the OpenAI SDK's standard env vars so the OpenAI
 	 * clients work from env alone; `baseUrl` carries the gateway's OpenAI-dialect route prefix
-	 * (`/ai-gateway/openai/v1`). The `NEON_AI_GATEWAY_*` aliases are also emitted: `neonToken`
-	 * mirrors the OpenAI key, and `neonBaseUrl` is the bare branch gateway host
-	 * (`scheme://host`, no path) — the `@ai-sdk/neon` provider appends the
-	 * `/ai-gateway/<dialect>/…` routes itself (https://github.com/vercel/ai/pull/15997).
+	 * (`/v1/chat/completions`). The `NEON_AI_GATEWAY_*` aliases are also emitted:
+	 * `neonToken` mirrors the OpenAI key, and `neonBaseUrl` is the bare branch gateway host
+	 * (`scheme://host`, no path).
 	 */
 	aiGateway: {
 		apiKey: "OPENAI_API_KEY",
@@ -91,8 +90,8 @@ export const NEON_ENV_VAR_KEYS = {
 	},
 } as const;
 
-/** OpenAI-dialect route prefix on the branch AI Gateway host. */
-const AI_GATEWAY_OPENAI_PATH = "/ai-gateway/openai/v1";
+/** OpenAI-compatible chat-completions route on the branch AI Gateway host. */
+const AI_GATEWAY_OPENAI_PATH = "/v1/chat/completions";
 
 /**
  * Branch identity for the resolved branch. Always present on a `fetchEnv` result (the branch
@@ -163,7 +162,7 @@ export interface NeonStorageEnv {
  * AI Gateway access for the branch (Preview). Present on `NeonEnv` only when the policy
  * enables `preview.aiGateway`. `apiKey` is the minted credential's bearer (`api_token`);
  * `baseUrl` is the gateway's OpenAI-dialect endpoint on the branch-scoped gateway host
- * (`https://<branchId>-api.ai.<region>.…/ai-gateway/openai/v1`). Projects to the OpenAI SDK's
+ * (`https://<branchId>-api.ai.<region>.…/v1/chat/completions`). Projects to the OpenAI SDK's
  * standard env (`OPENAI_API_KEY`, `OPENAI_BASE_URL`), plus the `NEON_AI_GATEWAY_*` aliases.
  */
 export interface NeonAiGatewayEnv {
@@ -1302,8 +1301,7 @@ export function toEntries(env: NeonEnv<Config>): Record<string, string> {
 		out[keys.apiKey] = ai.apiKey;
 		out[keys.baseUrl] = ai.baseUrl;
 		// Neon-branded aliases: the same bearer, plus the bare branch gateway host
-		// (scheme://host, no path) — the @ai-sdk/neon provider appends the
-		// /ai-gateway/<dialect>/… routes itself (https://github.com/vercel/ai/pull/15997).
+		// (scheme://host, no path) for Neon-native clients.
 		out[keys.neonToken] = ai.apiKey;
 		out[keys.neonBaseUrl] = new URL(ai.baseUrl).origin;
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: 0.8.0
         version: 0.8.0
       '@neondatabase/env':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: workspace:*
+        version: link:../env
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -1818,11 +1818,6 @@ packages:
   '@neondatabase/config@0.8.0':
     resolution: {integrity: sha512-ReOBVC+9j7X81C6DKtT94wimyHHjPv/LRpGPI2VAcSWSHyT/yGrNSwvT9WwNW1GsUXQNYBJh/3gzUCGhQrTazg==}
     engines: {node: '>=22'}
-
-  '@neondatabase/env@0.7.0':
-    resolution: {integrity: sha512-A5GsnHZm0e6mf9MTB3+Q1TWuNhiAsluOqCsG2M/u9WKMvk9pzRMzN38kZMQ1EKh05UJa7CNNA7bXTr9wtEWwog==}
-    engines: {node: '>=22'}
-    hasBin: true
 
   '@neondatabase/serverless@1.0.1':
     resolution: {integrity: sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==}
@@ -7794,15 +7789,6 @@ snapshots:
     dependencies:
       '@neondatabase/api-client': 2.7.1
       jiti: 2.7.0
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@neondatabase/env@0.7.0':
-    dependencies:
-      '@neondatabase/config': 0.8.0
-      yargs: 18.0.0
       zod: 4.4.3
     transitivePeerDependencies:
       - debug


### PR DESCRIPTION
## Summary
- Update `@neondatabase/env` so AI Gateway `OPENAI_BASE_URL` uses `/v1/chat/completions` on the branch gateway host.
- Add `neonctl env pull` coverage for AI Gateway dotenv output and link `neonctl` to the workspace env package.
- Document the current env variable shapes for `neonctl env pull` and `@neondatabase/env`, and add a changeset for both packages.

## Test plan
- `pnpm --filter @neondatabase/env test:ci`
- `pnpm --filter neonctl exec vitest run src/commands/env.test.ts`

Replaces #224.