### PR TITLE
feat(config): migrate Neon API adapter to @neon/sdk (drop @neondatabase/api-client)

### DIFF
--- a/.changeset/config-migrate-to-neon-sdk.md
+++ b/.changeset/config-migrate-to-neon-sdk.md
@@ -1,0 +1,5 @@
+---
+"@neondatabase/config": patch
+---
+
+Migrate the real Neon API adapter (`createRealNeonApi`) from the deprecated `@neondatabase/api-client` (axios) to the new fetch-based `@neon/sdk` raw layer. The `NeonApi` façade and all behavior are unchanged — the standard project/branch/endpoint/role/database/data-api calls now go through `@neon/sdk/raw`, and a small `unwrap` helper re-throws non-2xx responses in the same shape the existing error wrapper and 423 retry already consume. This drops `@neondatabase/api-client` from the package's runtime dependencies in favor of the zero-dependency `@neon/sdk`.

--- a/packages/cli/generateOptionsFromSpec.ts
+++ b/packages/cli/generateOptionsFromSpec.ts
@@ -24,8 +24,11 @@ const typesMapping = {
 } as const;
 
 (async () => {
+  // Source the Neon OpenAPI spec from the `@neon/sdk` workspace package, which
+  // vendors it under `spec/` (kept in sync via its `spec:pull` script). This
+  // replaces the spec that used to ship inside `@neondatabase/api-client`.
   const spec: OpenAPIV3.Document = (await SwaggerParser.dereference(
-    './node_modules/@neondatabase/api-client/public-v2-for-users.gen.yaml',
+    '../sdk/spec/neon-openapi.json',
   )) as any;
   const outFile = createWriteStream('./src/parameters.gen.ts', 'utf8');
   outFile.write('// FILE IS GENERATED, DO NOT EDIT\n\n');

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,7 @@
     "package.json"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "scripts": {
     "generateParams": "tsx generateOptionsFromSpec.ts",
@@ -47,13 +47,11 @@
   },
   "dependencies": {
     "@hono/node-server": "2.0.4",
-    "@neondatabase/api-client": "2.7.1",
+    "@neon/sdk": "workspace:*",
     "@neondatabase/config": "0.8.0",
     "@neondatabase/config-runtime": "0.8.0",
     "@neondatabase/env": "0.7.0",
     "@segment/analytics-node": "1.3.0",
-    "axios": "1.7.2",
-    "axios-debug-log": "1.0.0",
     "chalk": "5.3.0",
     "chokidar": "5.0.0",
     "cli-table": "0.3.11",
@@ -65,6 +63,7 @@
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",
     "prompts": "2.4.2",
+    "undici": "^8.5.0",
     "which": "3.0.1",
     "yaml": "2.4.5",
     "yargs": "17.7.2"

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -2,7 +2,6 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { Analytics, TrackParams } from '@segment/analytics-node';
-import { isAxiosError } from 'axios';
 
 import { CREDENTIALS_FILE } from './config.js';
 import { isCurrentBranchProbe } from './context.js';
@@ -10,7 +9,7 @@ import { getGithubEnvVars, isCi } from './env.js';
 import { ErrorCode } from './errors.js';
 import { log } from './log.js';
 import pkg from './pkg.js';
-import { getApiClient } from './api.js';
+import { getApiClient, isNeonApiError } from './api.js';
 
 const WRITE_KEY = '3SQXn5ejjXWLEJ8xU2PRYhAotLtTaeeV';
 
@@ -139,8 +138,8 @@ export const sendError = (err: Error, errCode: ErrorCode) => {
   if (!client) {
     return;
   }
-  const axiosError = isAxiosError(err) ? err : undefined;
-  const requestId = axiosError?.response?.headers['x-neon-ret-request-id'];
+  const apiError = isNeonApiError(err) ? err : undefined;
+  const requestId = apiError?.headers?.['x-neon-ret-request-id'];
   if (requestId) {
     log.debug('Failed request ID: %s', requestId);
   }
@@ -151,7 +150,7 @@ export const sendError = (err: Error, errCode: ErrorCode) => {
       message: err.message,
       stack: err.stack,
       errCode,
-      statusCode: axiosError?.response?.status,
+      statusCode: apiError?.status,
       requestId: requestId,
     },
   });

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -1,26 +1,261 @@
-import { createApiClient } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+// Thin fetch-based client layer over `@neon/sdk` (the official, fetch-native
+// Neon SDK). neonctl was originally built on the axios-based
+// `@neondatabase/api-client`, whose generated `Api` object exposes one
+// positional method per endpoint and resolves to an `AxiosResponse`. This module
+// reproduces exactly the subset of `Api` methods neonctl uses, backed by the
+// tree-shakeable `@neon/sdk/raw` functions, and returns a small
+// `{ data, status, headers }` envelope the call sites destructure.
+//
+// On a non-2xx response (or a network/timeout failure) it throws a single typed
+// {@link NeonApiError}; every call site narrows failures with
+// {@link isNeonApiError} and reads `error.status` / `error.data`. There is no
+// axios anywhere in neonctl: requests go through the global `fetch`, and this is
+// the one place HTTP errors are shaped.
+
+import { Readable } from 'node:stream';
+
+import { EnvHttpProxyAgent, setGlobalDispatcher } from 'undici';
+
+import { createClient, createConfig, type Client } from '@neon/sdk/raw';
+import * as raw from '@neon/sdk/raw';
 
 import { log } from './log.js';
 import pkg from './pkg.js';
+
+// Node's global `fetch` (undici) ignores HTTP_PROXY / HTTPS_PROXY / NO_PROXY,
+// whereas the axios-based client neonctl used previously honored them. Restore
+// that behaviour by installing a proxy-aware global dispatcher — but only when a
+// proxy is actually configured, so the default (no-proxy) path stays untouched.
+// This covers every `fetch` neonctl makes, including the direct S3 upload.
+const PROXY_ENV_VARS = [
+  'HTTP_PROXY',
+  'http_proxy',
+  'HTTPS_PROXY',
+  'https_proxy',
+  'ALL_PROXY',
+  'all_proxy',
+];
+if (PROXY_ENV_VARS.some((name) => process.env[name])) {
+  setGlobalDispatcher(new EnvHttpProxyAgent());
+}
 
 export type ApiCallProps = {
   apiKey: string;
   apiHost?: string;
 };
 
-export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) =>
-  createApiClient({
-    apiKey,
-    baseURL: apiHost,
-    timeout: 60000,
-    headers: {
-      'User-Agent': `neonctl v${pkg.version}`,
+const DEFAULT_API_HOST = 'https://console.neon.tech/api/v2';
+const REQUEST_TIMEOUT_MS = 60_000;
+const USER_AGENT = `neonctl v${pkg.version}`;
+
+/** Mirrors the api-client `ContentType` enum used by the `request()` escape hatch. */
+export enum ContentType {
+  Json = 'application/json',
+  FormData = 'multipart/form-data',
+  UrlEncoded = 'application/x-www-form-urlencoded',
+  Text = 'text/plain',
+}
+
+/**
+ * The minimal response envelope neonctl relies on. Call sites only ever read
+ * `.data`, and the object-storage download helper also reads `.headers`, so
+ * those are the only fields we surface.
+ */
+export type ApiResponse<T> = {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+};
+
+/** Result shape of every `@neon/sdk/raw` function in non-throwing mode. */
+type RawResult<T> = {
+  data?: T;
+  error?: unknown;
+  response?: Response;
+  request?: Request;
+};
+
+/**
+ * The single error type thrown by the neonctl API layer. It carries the HTTP
+ * status and parsed body for a non-2xx response, or a `code` (e.g. `ETIMEDOUT`)
+ * for a network/timeout failure. Call sites narrow with {@link isNeonApiError}
+ * and read `status` / `data` rather than reaching into an axios-shaped object.
+ */
+export class NeonApiError extends Error {
+  readonly status?: number;
+  readonly statusText?: string;
+  /** The parsed response body (object for JSON, string for non-JSON). */
+  readonly data?: unknown;
+  readonly headers?: Record<string, string>;
+  /** The request path, for debug logging. */
+  readonly requestPath?: string;
+  /** A non-HTTP failure code, e.g. `ETIMEDOUT` for a request timeout. */
+  readonly code?: string;
+
+  constructor(
+    message: string,
+    init: {
+      status?: number;
+      statusText?: string;
+      data?: unknown;
+      headers?: Record<string, string>;
+      requestPath?: string;
+      code?: string;
+    } = {},
+  ) {
+    super(message);
+    this.name = 'NeonApiError';
+    this.status = init.status;
+    this.statusText = init.statusText;
+    this.data = init.data;
+    this.headers = init.headers;
+    this.requestPath = init.requestPath;
+    this.code = init.code;
+  }
+}
+
+/** Narrow an unknown error to a {@link NeonApiError}. */
+export function isNeonApiError(err: unknown): err is NeonApiError {
+  return err instanceof NeonApiError;
+}
+
+/** Extract a `message` string from a parsed error body, if present. */
+export function messageFromBody(body: unknown): string | undefined {
+  if (body && typeof body === 'object' && 'message' in body) {
+    const message = body.message;
+    if (typeof message === 'string') return message;
+  }
+  return undefined;
+}
+
+/** Extract a machine-readable `code` string from a parsed error body, if present. */
+export function codeFromBody(body: unknown): string | undefined {
+  if (body && typeof body === 'object' && 'code' in body) {
+    const code = body.code;
+    if (typeof code === 'string') return code;
+  }
+  return undefined;
+}
+
+/**
+ * Adapt a WHATWG `ReadableStream` (what `fetch` gives us as `response.body`) to
+ * a Node `Readable`, so callers can `pipeline()` the body straight to disk. Done
+ * by hand rather than `Readable.fromWeb` to sidestep the DOM-vs-`node:stream/web`
+ * `ReadableStream` type friction without an unsafe cast.
+ */
+function webStreamToNodeReadable(body: ReadableStream<Uint8Array>): Readable {
+  const reader = body.getReader();
+  return new Readable({
+    async read() {
+      try {
+        const { done, value } = await reader.read();
+        this.push(done ? null : Buffer.from(value));
+      } catch (err) {
+        this.destroy(
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
     },
   });
+}
+
+function headersToObject(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = {};
+  headers.forEach((value, key) => {
+    out[key] = value;
+  });
+  return out;
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.name === 'AbortError' || err.name === 'TimeoutError')
+  );
+}
+
+/**
+ * Walk an error's `cause` chain to find the underlying socket/DNS `code` (e.g.
+ * `ECONNREFUSED`, `ENOTFOUND`) — `fetch` surfaces these as the `cause` of a bare
+ * `TypeError: fetch failed`. Preserving the code lets `isNetworkError` classify
+ * the resulting {@link NeonApiError} as a connectivity failure.
+ */
+function readSocketCode(err: unknown): string | undefined {
+  let current: unknown = err;
+  for (let depth = 0; depth < 6 && current != null; depth++) {
+    if (typeof current === 'object' && 'code' in current) {
+      const code = (current as { code?: unknown }).code;
+      if (typeof code === 'string') return code;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return undefined;
+}
+
+/** Build a {@link NeonApiError} from a non-2xx `Response` and its parsed body. */
+function httpError(response: Response, body: unknown): NeonApiError {
+  let requestPath: string | undefined;
+  try {
+    requestPath = new URL(response.url).pathname;
+  } catch {
+    // response.url may be empty in some runtimes; the path is best-effort.
+  }
+  return new NeonApiError(
+    messageFromBody(body) ??
+      `Request failed with status code ${response.status}`,
+    {
+      status: response.status,
+      statusText: response.statusText,
+      data: body,
+      headers: headersToObject(response.headers),
+      requestPath,
+    },
+  );
+}
+
+/**
+ * Translate a thrown `fetch` failure into a {@link NeonApiError}. A request
+ * timeout uses `ECONNABORTED` (matching the old axios behaviour, and excluded
+ * from `isNetworkError`'s connectivity codes so it's still reported as a
+ * timeout). A connection failure keeps its real socket code (e.g.
+ * `ECONNREFUSED`) so `isNetworkError` recognises it as a connectivity problem.
+ */
+function networkError(err: unknown): NeonApiError {
+  if (isAbortError(err)) {
+    return new NeonApiError('Request timed out', { code: 'ECONNABORTED' });
+  }
+  return new NeonApiError(err instanceof Error ? err.message : String(err), {
+    code: readSocketCode(err) ?? 'ENETWORK',
+  });
+}
+
+/**
+ * `fetch` with neonctl's request timeout applied (preserving any caller signal)
+ * and lightweight debug logging of the request line + response status — the
+ * fetch-native replacement for the old `axios-debug-log` wiring.
+ */
+const timedFetch: typeof fetch = async (input, init) => {
+  const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
+  const signal = init?.signal
+    ? AbortSignal.any([init.signal, timeout])
+    : timeout;
+  const method =
+    init?.method ?? (input instanceof Request ? input.method : 'GET');
+  const url = input instanceof Request ? input.url : String(input);
+  log.debug('%s %s', method.toUpperCase(), url);
+  const response = await fetch(input, { ...init, signal });
+  log.debug('%d %s', response.status, response.statusText);
+  return response;
+};
 
 const RETRY_COUNT = 5;
 const RETRY_DELAY = 3000;
+
+/**
+ * Retry a call while the API answers 423 (Locked) — Neon's "a prior mutation on
+ * this resource is still in flight" signal.
+ */
 export const retryOnLock = async <T>(fn: () => Promise<T>): Promise<T> => {
   let attempt = 0;
   let errOut: unknown;
@@ -29,7 +264,7 @@ export const retryOnLock = async <T>(fn: () => Promise<T>): Promise<T> => {
       return await fn();
     } catch (err) {
       errOut = err;
-      if (isAxiosError(err) && err.response?.status === 423) {
+      if (isNeonApiError(err) && err.status === 423) {
         attempt++;
         log.info(
           `Resource is locked. Waiting ${RETRY_DELAY}ms before retrying...`,
@@ -42,3 +277,851 @@ export const retryOnLock = async <T>(fn: () => Promise<T>): Promise<T> => {
   }
   throw errOut;
 };
+
+function buildUrl(
+  apiHost: string,
+  path: string,
+  query?: Record<string, QueryValue>,
+): string {
+  const url = new URL(
+    `${apiHost.replace(/\/+$/, '')}/${path.replace(/^\/+/, '')}`,
+  );
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url.toString();
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (text.trim() === '') return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Match axios' `responseType: 'json'` behaviour: a body that isn't valid
+    // JSON is surfaced as the raw string rather than coerced into an object, so
+    // callers' `body?.message` checks correctly see "no structured message".
+    return text;
+  }
+}
+
+/** A single query-string parameter value (serialized via `String()`). */
+type QueryValue = string | number | boolean | null | undefined;
+
+/** Parameters accepted by the low-level `request()` escape hatch. */
+export type RequestParams = {
+  path: string;
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
+  query?: Record<string, QueryValue>;
+  body?: unknown;
+  type?: ContentType;
+  format?: 'json' | 'stream';
+  secure?: boolean;
+};
+
+export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) => {
+  const baseUrl = apiHost ?? DEFAULT_API_HOST;
+  const client: Client = createClient(
+    createConfig({
+      auth: () => apiKey,
+      baseUrl,
+      fetch: timedFetch,
+      headers: { 'User-Agent': USER_AGENT },
+    }),
+  );
+
+  /** Await a raw call, unwrap to a `{ data, status, headers }` envelope, or throw {@link NeonApiError}. */
+  async function call<T>(
+    run: () => Promise<RawResult<T>>,
+  ): Promise<ApiResponse<T>> {
+    let result: RawResult<T>;
+    try {
+      result = await run();
+    } catch (err) {
+      throw networkError(err);
+    }
+    const response = result.response;
+    if (!response) {
+      throw networkError(
+        result.error ?? new Error('No response from Neon API'),
+      );
+    }
+    if (!response.ok) {
+      throw httpError(response, result.error ?? result.data);
+    }
+    return {
+      data: result.data as T,
+      status: response.status,
+      statusText: response.statusText,
+      headers: headersToObject(response.headers),
+    };
+  }
+
+  /**
+   * Low-level request used by the object-storage and functions helpers for
+   * endpoints not (yet) modeled as typed SDK functions. Mirrors the api-client
+   * `HttpClient.request()`: `format: 'json'` parses the body, `format: 'stream'`
+   * returns a Node `Readable`, and `type: ContentType.FormData` sends multipart.
+   */
+  async function request<T = unknown>(
+    params: RequestParams,
+  ): Promise<ApiResponse<T>> {
+    const url = buildUrl(baseUrl, params.path, params.query);
+    const headers: Record<string, string> = { 'User-Agent': USER_AGENT };
+    if (params.secure !== false) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+
+    let payload: BodyInit | undefined;
+    if (
+      params.body instanceof FormData ||
+      params.type === ContentType.FormData
+    ) {
+      payload = params.body as BodyInit;
+    } else if (params.body !== undefined) {
+      headers['Content-Type'] = ContentType.Json;
+      payload = JSON.stringify(params.body);
+    }
+
+    let response: Response;
+    try {
+      response = await timedFetch(url, {
+        method: params.method,
+        headers,
+        ...(payload !== undefined ? { body: payload } : {}),
+      });
+    } catch (err) {
+      throw networkError(err);
+    }
+
+    if (!response.ok) {
+      // For a streamed download the error body arrives as a stream too; hand it
+      // back as a Node `Readable` so the caller can drain it for a message.
+      const errorBody =
+        params.format === 'stream' && response.body
+          ? webStreamToNodeReadable(response.body)
+          : await readJsonBody(response);
+      throw httpError(response, errorBody);
+    }
+
+    let data: unknown;
+    if (params.format === 'stream') {
+      data = response.body
+        ? webStreamToNodeReadable(response.body)
+        : undefined;
+    } else {
+      data = await readJsonBody(response);
+    }
+    return {
+      data: data as T,
+      status: response.status,
+      statusText: response.statusText,
+      headers: headersToObject(response.headers),
+    };
+  }
+
+  return {
+    request,
+
+    // ─── Account / user ──────────────────────────────────────────────────
+    getCurrentUserInfo: () =>
+      call(() => raw.getCurrentUserInfo({ client })),
+    getCurrentUserOrganizations: () =>
+      call(() => raw.getCurrentUserOrganizations({ client })),
+    getAuthDetails: () => call(() => raw.getAuthDetails({ client })),
+    getActiveRegions: () => call(() => raw.getActiveRegions({ client })),
+
+    // ─── Projects ────────────────────────────────────────────────────────
+    listProjects: (
+      query: NonNullable<raw.ListProjectsData['query']> = {},
+    ) => call(() => raw.listProjects({ client, query })),
+    listSharedProjects: (
+      query: NonNullable<raw.ListProjectsData['query']> = {},
+    ) =>
+      call(() =>
+        raw.listSharedProjects({
+          client,
+          query: {
+            ...(query.cursor !== undefined
+              ? { cursor: query.cursor }
+              : {}),
+            ...(query.limit !== undefined
+              ? { limit: query.limit }
+              : {}),
+            ...(query.search !== undefined
+              ? { search: query.search }
+              : {}),
+          },
+        }),
+      ),
+    getProject: (projectId: string) =>
+      call(() =>
+        raw.getProject({ client, path: { project_id: projectId } }),
+      ),
+    createProject: (data: NonNullable<raw.CreateProjectData['body']>) =>
+      call(() => raw.createProject({ client, body: data })),
+    updateProject: (
+      projectId: string,
+      data: NonNullable<raw.UpdateProjectData['body']>,
+    ) =>
+      call(() =>
+        raw.updateProject({
+          client,
+          path: { project_id: projectId },
+          body: data,
+        }),
+      ),
+    deleteProject: (projectId: string) =>
+      call(() =>
+        raw.deleteProject({ client, path: { project_id: projectId } }),
+      ),
+    recoverProject: (projectId: string) =>
+      call(() =>
+        raw.recoverProject({ client, path: { project_id: projectId } }),
+      ),
+    listProjectOperations: ({
+      projectId,
+      ...query
+    }: { projectId: string } & NonNullable<
+      raw.ListProjectOperationsData['query']
+    >) =>
+      call(() =>
+        raw.listProjectOperations({
+          client,
+          path: { project_id: projectId },
+          query,
+        }),
+      ),
+
+    // ─── Branches ────────────────────────────────────────────────────────
+    listProjectBranches: ({
+      projectId,
+      ...query
+    }: { projectId: string } & NonNullable<
+      raw.ListProjectBranchesData['query']
+    >) =>
+      call(() =>
+        raw.listProjectBranches({
+          client,
+          path: { project_id: projectId },
+          query,
+        }),
+      ),
+    createProjectBranch: (
+      projectId: string,
+      data?: raw.CreateProjectBranchData['body'],
+    ) =>
+      call(() =>
+        raw.createProjectBranch({
+          client,
+          path: { project_id: projectId },
+          ...(data !== undefined ? { body: data } : {}),
+        }),
+      ),
+    getProjectBranch: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.getProjectBranch({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    updateProjectBranch: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.UpdateProjectBranchData['body']>,
+    ) =>
+      call(() =>
+        raw.updateProjectBranch({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    deleteProjectBranch: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.deleteProjectBranch({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    restoreProjectBranch: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.RestoreProjectBranchData['body']>,
+    ) =>
+      call(() =>
+        raw.restoreProjectBranch({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    setDefaultProjectBranch: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.setDefaultProjectBranch({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    getProjectBranchSchema: ({
+      projectId,
+      branchId,
+      ...query
+    }: { projectId: string; branchId: string } & NonNullable<
+      raw.GetProjectBranchSchemaData['query']
+    >) =>
+      call(() =>
+        raw.getProjectBranchSchema({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          query,
+        }),
+      ),
+    listProjectBranchEndpoints: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.listProjectBranchEndpoints({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    createProjectEndpoint: (
+      projectId: string,
+      data: NonNullable<raw.CreateProjectEndpointData['body']>,
+    ) =>
+      call(() =>
+        raw.createProjectEndpoint({
+          client,
+          path: { project_id: projectId },
+          body: data,
+        }),
+      ),
+
+    // ─── Databases ───────────────────────────────────────────────────────
+    listProjectBranchDatabases: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.listProjectBranchDatabases({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    createProjectBranchDatabase: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.CreateProjectBranchDatabaseData['body']>,
+    ) =>
+      call(() =>
+        raw.createProjectBranchDatabase({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    deleteProjectBranchDatabase: (
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+    ) =>
+      call(() =>
+        raw.deleteProjectBranchDatabase({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            database_name: databaseName,
+          },
+        }),
+      ),
+
+    // ─── Roles ───────────────────────────────────────────────────────────
+    listProjectBranchRoles: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.listProjectBranchRoles({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    createProjectBranchRole: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.CreateProjectBranchRoleData['body']>,
+    ) =>
+      call(() =>
+        raw.createProjectBranchRole({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    deleteProjectBranchRole: (
+      projectId: string,
+      branchId: string,
+      roleName: string,
+    ) =>
+      call(() =>
+        raw.deleteProjectBranchRole({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            role_name: roleName,
+          },
+        }),
+      ),
+    getProjectBranchRolePassword: (
+      projectId: string,
+      branchId: string,
+      roleName: string,
+    ) =>
+      call(() =>
+        raw.getProjectBranchRolePassword({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            role_name: roleName,
+          },
+        }),
+      ),
+
+    // ─── Data API ────────────────────────────────────────────────────────
+    createProjectBranchDataApi: (
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+      data: NonNullable<raw.CreateProjectBranchDataApiData['body']>,
+    ) =>
+      call(() =>
+        raw.createProjectBranchDataApi({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            database_name: databaseName,
+          },
+          body: data,
+        }),
+      ),
+    updateProjectBranchDataApi: (
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+      data: NonNullable<raw.UpdateProjectBranchDataApiData['body']>,
+    ) =>
+      call(() =>
+        raw.updateProjectBranchDataApi({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            database_name: databaseName,
+          },
+          body: data,
+        }),
+      ),
+    deleteProjectBranchDataApi: (
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+    ) =>
+      call(() =>
+        raw.deleteProjectBranchDataApi({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            database_name: databaseName,
+          },
+        }),
+      ),
+    getProjectBranchDataApi: (
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+    ) =>
+      call(() =>
+        raw.getProjectBranchDataApi({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            database_name: databaseName,
+          },
+        }),
+      ),
+
+    // ─── VPC endpoints (project + organization) ──────────────────────────
+    listProjectVpcEndpoints: (projectId: string) =>
+      call(() =>
+        raw.listProjectVpcEndpoints({
+          client,
+          path: { project_id: projectId },
+        }),
+      ),
+    assignProjectVpcEndpoint: (
+      projectId: string,
+      vpcEndpointId: string,
+      data: NonNullable<raw.AssignProjectVpcEndpointData['body']>,
+    ) =>
+      call(() =>
+        raw.assignProjectVpcEndpoint({
+          client,
+          path: {
+            project_id: projectId,
+            vpc_endpoint_id: vpcEndpointId,
+          },
+          body: data,
+        }),
+      ),
+    deleteProjectVpcEndpoint: (projectId: string, vpcEndpointId: string) =>
+      call(() =>
+        raw.deleteProjectVpcEndpoint({
+          client,
+          path: {
+            project_id: projectId,
+            vpc_endpoint_id: vpcEndpointId,
+          },
+        }),
+      ),
+    listOrganizationVpcEndpoints: (orgId: string, regionId: string) =>
+      call(() =>
+        raw.listOrganizationVpcEndpoints({
+          client,
+          path: { org_id: orgId, region_id: regionId },
+        }),
+      ),
+    getOrganizationVpcEndpointDetails: (
+      orgId: string,
+      regionId: string,
+      vpcEndpointId: string,
+    ) =>
+      call(() =>
+        raw.getOrganizationVpcEndpointDetails({
+          client,
+          path: {
+            org_id: orgId,
+            region_id: regionId,
+            vpc_endpoint_id: vpcEndpointId,
+          },
+        }),
+      ),
+    assignOrganizationVpcEndpoint: (
+      orgId: string,
+      regionId: string,
+      vpcEndpointId: string,
+      data: NonNullable<raw.AssignOrganizationVpcEndpointData['body']>,
+    ) =>
+      call(() =>
+        raw.assignOrganizationVpcEndpoint({
+          client,
+          path: {
+            org_id: orgId,
+            region_id: regionId,
+            vpc_endpoint_id: vpcEndpointId,
+          },
+          body: data,
+        }),
+      ),
+    deleteOrganizationVpcEndpoint: (
+      orgId: string,
+      regionId: string,
+      vpcEndpointId: string,
+    ) =>
+      call(() =>
+        raw.deleteOrganizationVpcEndpoint({
+          client,
+          path: {
+            org_id: orgId,
+            region_id: regionId,
+            vpc_endpoint_id: vpcEndpointId,
+          },
+        }),
+      ),
+
+    // ─── Neon Auth ───────────────────────────────────────────────────────
+    getNeonAuth: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.getNeonAuth({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    createNeonAuth: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.CreateNeonAuthData['body']>,
+    ) =>
+      call(() =>
+        raw.createNeonAuth({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    disableNeonAuth: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.DisableNeonAuthData['body']>,
+    ) =>
+      call(() =>
+        raw.disableNeonAuth({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    listBranchNeonAuthOauthProviders: (
+      projectId: string,
+      branchId: string,
+    ) =>
+      call(() =>
+        raw.listBranchNeonAuthOauthProviders({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    addBranchNeonAuthOauthProvider: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.AddBranchNeonAuthOauthProviderData['body']>,
+    ) =>
+      call(() =>
+        raw.addBranchNeonAuthOauthProvider({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    updateBranchNeonAuthOauthProvider: (
+      projectId: string,
+      branchId: string,
+      oauthProviderId: raw.NeonAuthOauthProviderId,
+      data: NonNullable<
+        raw.UpdateBranchNeonAuthOauthProviderData['body']
+      >,
+    ) =>
+      call(() =>
+        raw.updateBranchNeonAuthOauthProvider({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            oauth_provider_id: oauthProviderId,
+          },
+          body: data,
+        }),
+      ),
+    deleteBranchNeonAuthOauthProvider: (
+      projectId: string,
+      branchId: string,
+      oauthProviderId: raw.NeonAuthOauthProviderId,
+    ) =>
+      call(() =>
+        raw.deleteBranchNeonAuthOauthProvider({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            oauth_provider_id: oauthProviderId,
+          },
+        }),
+      ),
+    listBranchNeonAuthTrustedDomains: (
+      projectId: string,
+      branchId: string,
+    ) =>
+      call(() =>
+        raw.listBranchNeonAuthTrustedDomains({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    addBranchNeonAuthTrustedDomain: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.AddBranchNeonAuthTrustedDomainData['body']>,
+    ) =>
+      call(() =>
+        raw.addBranchNeonAuthTrustedDomain({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    deleteBranchNeonAuthTrustedDomain: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<
+        raw.DeleteBranchNeonAuthTrustedDomainData['body']
+      >,
+    ) =>
+      call(() =>
+        raw.deleteBranchNeonAuthTrustedDomain({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    getNeonAuthAllowLocalhost: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.getNeonAuthAllowLocalhost({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    updateNeonAuthAllowLocalhost: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.UpdateNeonAuthAllowLocalhostData['body']>,
+    ) =>
+      call(() =>
+        raw.updateNeonAuthAllowLocalhost({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    getNeonAuthEmailAndPasswordConfig: (
+      projectId: string,
+      branchId: string,
+    ) =>
+      call(() =>
+        raw.getNeonAuthEmailAndPasswordConfig({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    updateNeonAuthEmailAndPasswordConfig: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<
+        raw.UpdateNeonAuthEmailAndPasswordConfigData['body']
+      >,
+    ) =>
+      call(() =>
+        raw.updateNeonAuthEmailAndPasswordConfig({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    getNeonAuthEmailProvider: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.getNeonAuthEmailProvider({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    updateNeonAuthEmailProvider: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.UpdateNeonAuthEmailProviderData['body']>,
+    ) =>
+      call(() =>
+        raw.updateNeonAuthEmailProvider({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    sendNeonAuthTestEmail: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.SendNeonAuthTestEmailData['body']>,
+    ) =>
+      call(() =>
+        raw.sendNeonAuthTestEmail({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    getNeonAuthPluginConfigs: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.getNeonAuthPluginConfigs({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    updateNeonAuthOrganizationPlugin: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.UpdateNeonAuthOrganizationPluginData['body']>,
+    ) =>
+      call(() =>
+        raw.updateNeonAuthOrganizationPlugin({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    getNeonAuthWebhookConfig: (projectId: string, branchId: string) =>
+      call(() =>
+        raw.getNeonAuthWebhookConfig({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+        }),
+      ),
+    updateNeonAuthWebhookConfig: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.UpdateNeonAuthWebhookConfigData['body']>,
+    ) =>
+      call(() =>
+        raw.updateNeonAuthWebhookConfig({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    createBranchNeonAuthNewUser: (
+      projectId: string,
+      branchId: string,
+      data: NonNullable<raw.CreateBranchNeonAuthNewUserData['body']>,
+    ) =>
+      call(() =>
+        raw.createBranchNeonAuthNewUser({
+          client,
+          path: { project_id: projectId, branch_id: branchId },
+          body: data,
+        }),
+      ),
+    deleteBranchNeonAuthUser: (
+      projectId: string,
+      branchId: string,
+      authUserId: string,
+    ) =>
+      call(() =>
+        raw.deleteBranchNeonAuthUser({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            auth_user_id: authUserId,
+          },
+        }),
+      ),
+    updateNeonAuthUserRole: (
+      projectId: string,
+      branchId: string,
+      authUserId: string,
+      data: NonNullable<raw.UpdateNeonAuthUserRoleData['body']>,
+    ) =>
+      call(() =>
+        raw.updateNeonAuthUserRole({
+          client,
+          path: {
+            project_id: projectId,
+            branch_id: branchId,
+            auth_user_id: authUserId,
+          },
+          body: data,
+        }),
+      ),
+  };
+};
+
+/** The neonctl API client — a thin fetch-based façade over `@neon/sdk`. */
+export type NeonApiClient = ReturnType<typeof getApiClient>;

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -1,5 +1,4 @@
-import { Api } from '@neondatabase/api-client';
-import axios from 'axios';
+import type { NeonApiClient } from '../api.js';
 
 import {
   existsSync,
@@ -18,7 +17,7 @@ import { test } from '../test_utils/fixtures';
 import { startOauthServer } from '../test_utils/oauth_server';
 import { authFlow, ensureAuth, deleteCredentials } from './auth';
 
-vi.mock('open', () => ({ default: vi.fn((url: string) => axios.get(url)) }));
+vi.mock('open', () => ({ default: vi.fn((url: string) => fetch(url)) }));
 vi.mock('../pkg.ts', () => ({ default: { version: '0.0.0' } }));
 
 describe('auth', () => {
@@ -59,14 +58,14 @@ describe('auth', () => {
 describe('ensureAuth', () => {
   let configDir = '';
   let oauthServer: OAuth2Server;
-  let mockApiClient: Api<unknown>;
+  let mockApiClient: NeonApiClient;
   let authSpy: any;
   let refreshTokenSpy: any;
 
   beforeAll(async () => {
     configDir = mkdtempSync('test-config');
     oauthServer = await startOauthServer();
-    mockApiClient = {} as Api<unknown>;
+    mockApiClient = {} as NeonApiClient;
     authSpy = vi.spyOn(authModule, 'auth');
     refreshTokenSpy = vi.spyOn(authModule, 'refreshToken');
   });

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { createHash } from 'node:crypto';
 import yargs from 'yargs';
 
-import { Api } from '@neondatabase/api-client';
+import type { NeonApiClient } from '../api.js';
 
 import { getApiClient } from '../api.js';
 import { auth, refreshToken } from '../auth.js';
@@ -76,7 +76,7 @@ export const authFlow = async ({
 const preserveCredentials = async (
   path: string,
   credentials: ExtendedTokenSet,
-  apiClient: Api<unknown>,
+  apiClient: NeonApiClient,
 ) => {
   const {
     data: { id },
@@ -98,7 +98,7 @@ const handleExistingToken = async (
   tokenSet: ExtendedTokenSet,
   props: AuthProps,
   credentialsPath: string,
-): Promise<{ apiKey: string; apiClient: Api<unknown> } | null> => {
+): Promise<{ apiKey: string; apiClient: NeonApiClient } | null> => {
   // Use existing access_token, if present and valid
   if (tokenSet.access_token && tokenSet.expires_at > Date.now()) {
     log.debug('Using existing valid access_token');
@@ -155,7 +155,7 @@ const handleExistingToken = async (
 export const ensureAuth = async (
   props: AuthProps & {
     apiKey: string;
-    apiClient: Api<unknown>;
+    apiClient: NeonApiClient;
     help: boolean;
   },
 ) => {

--- a/packages/cli/src/commands/branches.ts
+++ b/packages/cli/src/commands/branches.ts
@@ -1,4 +1,5 @@
-import { Branch, EndpointType } from '@neondatabase/api-client';
+import { Branch } from '@neon/sdk';
+import { EndpointType } from '../utils/api_enums.js';
 import yargs from 'yargs';
 
 import { contextBranch, readContextFile } from '../context.js';
@@ -503,9 +504,12 @@ const deleteBranch = async (props: ProjectScopeProps & IdOrNameProps) => {
   const { data } = await retryOnLock(() =>
     props.apiClient.deleteProjectBranch(props.projectId, branchId),
   );
-  writer(props).end(data.branch, {
-    fields: BRANCH_FIELDS,
-  });
+  // A 204 (branch already gone) carries no body; only a 200 returns it.
+  if (data) {
+    writer(props).end(data.branch, {
+      fields: BRANCH_FIELDS,
+    });
+  }
 };
 
 const get = async (props: ProjectScopeProps & IdOrNameProps) => {

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -3,9 +3,8 @@ import { stat, unlink } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { pipeline } from 'node:stream/promises';
 import yargs from 'yargs';
-import axios, { isAxiosError } from 'axios';
 
-import { retryOnLock } from '../api.js';
+import { isNeonApiError, retryOnLock } from '../api.js';
 import { BranchScopeProps } from '../types.js';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { log } from '../log.js';
@@ -296,7 +295,7 @@ const deleteBucket = async (
       }),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       throw new Error(
         `Bucket "${props.name}" not found on branch ${branchId}.`,
       );
@@ -453,13 +452,41 @@ const objectNotFoundMessage = (
   bucket: string,
   branchId: string,
 ): string => {
-  if (isAxiosError(err)) {
-    const serverMessage = serverErrorMessage(err.response?.data);
+  if (isNeonApiError(err)) {
+    const serverMessage = serverErrorMessage(err.data);
     if (serverMessage !== undefined) {
       return serverMessage;
     }
   }
   return objectNotFoundFallback(key, bucket, branchId);
+};
+
+// Stream a file from disk as a WHATWG `ReadableStream` suitable for a `fetch`
+// request body, applying backpressure so we never read faster than the upload
+// drains. Uses the global `ReadableStream` (what `fetch` expects) directly, so
+// there's no Node-vs-DOM stream type bridging.
+const fileToWebStream = (path: string): ReadableStream<Uint8Array> => {
+  const source = createReadStream(path);
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      source.on('data', (chunk: Buffer) => {
+        controller.enqueue(new Uint8Array(chunk));
+        if ((controller.desiredSize ?? 0) <= 0) source.pause();
+      });
+      source.on('end', () => {
+        controller.close();
+      });
+      source.on('error', (err) => {
+        controller.error(err instanceof Error ? err : new Error(String(err)));
+      });
+    },
+    pull() {
+      source.resume();
+    },
+    cancel() {
+      source.destroy();
+    },
+  });
 };
 
 const getObject = async (
@@ -480,11 +507,11 @@ const getObject = async (
       objectKey: key,
     });
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       // The download response is a stream, so a 404 body arrives as a stream
       // too; drain and parse it to recover the server's message (which
       // distinguishes a missing bucket from a missing object).
-      const serverMessage = await streamErrorMessage(err.response.data);
+      const serverMessage = await streamErrorMessage(err.data);
       throw new Error(
         serverMessage ?? objectNotFoundFallback(key, bucket, branchId),
       );
@@ -559,16 +586,16 @@ const putObject = async (
       contentType: props.contentType,
     }));
   } catch (err: unknown) {
-    if (isAxiosError(err)) {
-      const status = err.response?.status;
+    if (isNeonApiError(err)) {
+      const status = err.status;
       if (status === 404) {
         throw new Error(objectNotFoundMessage(err, key, bucket, branchId));
       }
       // Any other HTTP error from the console (e.g. 403 when the caller lacks
       // write permission on the bucket) carries the same JSON `{ message }`
-      // body, so surface that rather than a bare axios message. When the body
-      // has no usable message, fall back to a clean status-bearing error.
-      const serverMessage = serverErrorMessage(err.response?.data);
+      // body, so surface that rather than a bare error. When the body has no
+      // usable message, fall back to a clean status-bearing error.
+      const serverMessage = serverErrorMessage(err.data);
       throw new Error(
         serverMessage ??
           `Failed to presign upload for "${key}" in bucket "${bucket}" on branch ${branchId}${
@@ -579,40 +606,46 @@ const putObject = async (
     throw err;
   }
 
-  // Stream the file straight into the PUT body; never buffer the whole file.
-  // The presigned URL targets the branch S3 data-plane endpoint directly, so
-  // this PUT goes through a plain axios call rather than the console api-client.
+  // Stream the file straight into the PUT body via `fetch`; never buffer the
+  // whole file. The presigned URL targets the branch S3 data-plane endpoint
+  // directly, so this PUT bypasses the console API entirely.
   //
   // `presign.headers` carries the signature-relevant headers (e.g. host,
   // content-type); the server does not sign Content-Length, so we set it
-  // ourselves from the stat'd size to keep the upload streamed, not chunked.
-  // `maxRedirects: 0` ensures we never resend the file bytes and signed headers
-  // to a different host if the data-plane endpoint were to answer with a
-  // redirect.
+  // ourselves from the stat'd size. `redirect: 'error'` ensures we never resend
+  // the file bytes and signed headers to a different host if the data-plane
+  // endpoint were to answer with a redirect. `duplex: 'half'` is required by
+  // fetch when streaming a request body.
+  const upload: RequestInit & { duplex: 'half' } = {
+    method: 'PUT',
+    headers: {
+      ...presign.headers,
+      'Content-Length': String(fileSize),
+    },
+    body: fileToWebStream(props.file),
+    redirect: 'error',
+    duplex: 'half',
+  };
+  let uploadResponse: Response;
   try {
-    await axios.put(presign.url, createReadStream(props.file), {
-      headers: {
-        ...presign.headers,
-        'Content-Length': fileSize,
-      },
-      maxBodyLength: Infinity,
-      maxContentLength: Infinity,
-      maxRedirects: 0,
-    });
+    uploadResponse = await fetch(presign.url, upload);
   } catch (err: unknown) {
+    // A transport-level failure (DNS, connection reset, redirect when none is
+    // allowed). Surface a clean message without leaking the signed URL.
+    throw new Error(
+      `Failed to upload "${props.file}" to "${key}" in bucket "${bucket}" on branch ${branchId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  if (!uploadResponse.ok) {
     // The upload targets the S3 data plane, whose error bodies are XML rather
     // than the JSON `{ message }` the console returns, so surface the status
-    // (and axios message) rather than leaking a raw error. Never include the
-    // presigned URL, which carries the signature.
-    if (isAxiosError(err)) {
-      const status = err.response?.status;
-      throw new Error(
-        `Failed to upload "${props.file}" to "${key}" in bucket "${bucket}" on branch ${branchId}${
-          status !== undefined ? ` (HTTP ${status})` : ''
-        }: ${err.message}`,
-      );
-    }
-    throw err;
+    // rather than the body. Never include the presigned URL, which carries the
+    // signature.
+    throw new Error(
+      `Failed to upload "${props.file}" to "${key}" in bucket "${bucket}" on branch ${branchId} (HTTP ${uploadResponse.status}): Request failed with status code ${uploadResponse.status}`,
+    );
   }
 
   log.info(
@@ -665,7 +698,7 @@ const deleteObject = async (
       }),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       throw new Error(objectNotFoundMessage(err, rest, bucket, branchId));
     }
     throw err;

--- a/packages/cli/src/commands/checkout.ts
+++ b/packages/cli/src/commands/checkout.ts
@@ -1,5 +1,5 @@
-import { Branch } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+import { Branch } from '@neon/sdk';
+import { isNeonApiError } from '../api.js';
 import chalk from 'chalk';
 import prompts from 'prompts';
 import yargs from 'yargs';
@@ -296,7 +296,7 @@ const resolveOrgId = async (
     const { data } = await props.apiClient.getProject(projectId);
     return data.project.org_id ?? undefined;
   } catch (err) {
-    if (isAxiosError(err) && err.response?.status === 401) {
+    if (isNeonApiError(err) && err.status === 401) {
       throw err;
     }
     log.debug(
@@ -390,7 +390,7 @@ const tryAutoDetectProject = async (
     // `fillSingleProject` throws on "No projects found" / "Multiple projects
     // found" — both mean we can't pick a project automatically. Network/auth
     // errors are real and should surface to the user.
-    if (isAxiosError(err)) {
+    if (isNeonApiError(err)) {
       throw err;
     }
     log.debug(

--- a/packages/cli/src/commands/connection_string.ts
+++ b/packages/cli/src/commands/connection_string.ts
@@ -1,9 +1,5 @@
-import {
-  Database,
-  Endpoint,
-  EndpointType,
-  Role,
-} from '@neondatabase/api-client';
+import { Database, Endpoint, Role } from '@neon/sdk';
+import { EndpointType } from '../utils/api_enums.js';
 import yargs from 'yargs';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';

--- a/packages/cli/src/commands/data_api.ts
+++ b/packages/cli/src/commands/data_api.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs';
-import { isAxiosError } from 'axios';
 
-import { retryOnLock } from '../api.js';
+import { isNeonApiError, retryOnLock } from '../api.js';
 import { BranchScopeProps } from '../types.js';
 import {
   branchIdFromProps,
@@ -11,10 +10,10 @@ import {
 import { log } from '../log.js';
 import { writer } from '../writer.js';
 import type {
-  DataAPICreateRequest,
-  DataAPISettings,
-  DataAPIUpdateRequest,
-} from '@neondatabase/api-client';
+  DataApiCreateRequest as DataAPICreateRequest,
+  DataApiSettings as DataAPISettings,
+  DataApiUpdateRequest as DataAPIUpdateRequest,
+} from '@neon/sdk';
 
 const SETTINGS_FIELDS = [
   'db_aggregates_enabled',
@@ -305,7 +304,7 @@ const update = async (
       );
       current = data.settings ?? undefined;
     } catch (err: unknown) {
-      if (isAxiosError(err) && err.response?.status === 404) {
+      if (isNeonApiError(err) && err.status === 404) {
         throw new Error(
           `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
         );
@@ -333,7 +332,7 @@ const update = async (
       ),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       throw new Error(
         `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
       );
@@ -361,7 +360,7 @@ const refreshSchema = async (props: DataApiProps): Promise<void> => {
       ),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       throw new Error(
         `Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
       );
@@ -390,7 +389,7 @@ const deleteDataApi = async (props: DataApiProps): Promise<void> => {
       ),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       throw new Error(
         `Data API is not provisioned for ${database} on branch ${branchId}.`,
       );

--- a/packages/cli/src/commands/databases.ts
+++ b/packages/cli/src/commands/databases.ts
@@ -4,7 +4,7 @@ import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 
 import { BranchScopeProps } from '../types.js';
 import { writer } from '../writer.js';
-import { Role } from '@neondatabase/api-client';
+import { Role } from '@neon/sdk';
 
 export const DATABASE_FIELDS = ['name', 'owner_name', 'created_at'] as const;
 
@@ -124,7 +124,10 @@ export const deleteDb = async (
     ),
   );
 
-  writer(props).end(data.database, {
-    fields: DATABASE_FIELDS,
-  });
+  // A 204 (database already gone) carries no body; only a 200 returns it.
+  if (data) {
+    writer(props).end(data.database, {
+      fields: DATABASE_FIELDS,
+    });
+  }
 };

--- a/packages/cli/src/commands/functions.ts
+++ b/packages/cli/src/commands/functions.ts
@@ -2,7 +2,7 @@ import { existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import yargs from 'yargs';
-import { isAxiosError } from 'axios';
+import { isNeonApiError } from '../api.js';
 
 import { retryOnLock } from '../api.js';
 import { log } from '../log.js';
@@ -239,10 +239,8 @@ const emitDeployResult = (
 // A poll error worth retrying: a network error (no HTTP response), a 5xx, or a
 // 404 from eventual consistency. Anything else (e.g. 401/403) is surfaced.
 const isTransient = (err: unknown): boolean =>
-  isAxiosError(err) &&
-  (err.response === undefined ||
-    err.response.status === 404 ||
-    err.response.status >= 500);
+  isNeonApiError(err) &&
+  (err.status === undefined || err.status === 404 || err.status >= 500);
 
 const deploy = async (props: DeployProps) => {
   if (props.path !== undefined || props.entry !== undefined) {
@@ -306,7 +304,7 @@ const deploy = async (props: DeployProps) => {
     );
     before = fn.current_deployment?.id;
   } catch (err: unknown) {
-    if (!(isAxiosError(err) && err.response?.status === 404)) throw err;
+    if (!(isNeonApiError(err) && err.status === 404)) throw err;
   }
 
   await retryOnLock(() =>
@@ -467,7 +465,7 @@ const deleteFn = async (props: BranchScopeProps & { slug: string }) => {
       deleteFunction(props.apiClient, props.projectId, branchId, props.slug),
     );
   } catch (err: unknown) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       throw new Error(
         `Function "${props.slug}" not found on branch ${branchId}.`,
       );

--- a/packages/cli/src/commands/ip_allow.ts
+++ b/packages/cli/src/commands/ip_allow.ts
@@ -2,7 +2,7 @@ import yargs from 'yargs';
 import { CommonProps, ProjectScopeProps } from '../types';
 import { writer } from '../writer.js';
 import { fillSingleProject } from '../utils/enrichers.js';
-import { Project, ProjectUpdateRequest } from '@neondatabase/api-client';
+import { Project, ProjectUpdateRequest } from '@neon/sdk';
 import { projectUpdateRequest } from '../parameters.gen.js';
 import { log } from '../log.js';
 

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -4,8 +4,8 @@ import {
   ProjectCreateRequest,
   ProjectListItem,
   RegionResponse,
-} from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+} from '@neon/sdk';
+import { isNeonApiError, messageFromBody } from '../api.js';
 import prompts, { InitialReturnValue } from 'prompts';
 import yargs from 'yargs';
 
@@ -386,7 +386,7 @@ class LinkInputError extends Error {
 }
 
 const httpStatus = (err: unknown): number | undefined =>
-  isAxiosError(err) ? err.response?.status : undefined;
+  isNeonApiError(err) ? err.status : undefined;
 
 /**
  * Fetch a project, turning the common failure modes into clear, actionable
@@ -1053,12 +1053,8 @@ const emitAgent = (response: AgentResponse) => {
 const ORG_KEY_LIMITED_FRAGMENT = 'not allowed for organization API keys';
 
 const isOrgKeyLimitedError = (err: unknown): boolean => {
-  if (!isAxiosError(err)) return false;
-  const data = err.response?.data;
-  if (data === undefined || data === null || typeof data !== 'object') {
-    return false;
-  }
-  const message = (data as { message?: unknown }).message;
+  if (!isNeonApiError(err)) return false;
+  const message = messageFromBody(err.data);
   return (
     typeof message === 'string' && message.includes(ORG_KEY_LIMITED_FRAGMENT)
   );
@@ -1156,15 +1152,11 @@ const toAgentError = (
   if (err instanceof LinkInputError) {
     return { status: 'error', code: err.agentCode, message: err.message };
   }
-  if (isAxiosError(err)) {
-    const status = err.response?.status;
-    const data = err.response?.data;
-    const apiMessage =
-      typeof data === 'object' && data !== null
-        ? (data as { message?: unknown }).message
-        : undefined;
+  if (isNeonApiError(err)) {
+    const status = err.status;
+    const apiMessage = messageFromBody(err.data);
     const message =
-      typeof apiMessage === 'string' && apiMessage.length > 0
+      apiMessage !== undefined && apiMessage.length > 0
         ? apiMessage
         : err.message;
     let code = 'API_ERROR';
@@ -1255,10 +1247,10 @@ const fetchRegions = async (props: CommonProps): Promise<RegionResponse[]> => {
       return data.regions;
     }
   } catch (err) {
-    if (isAxiosError(err)) {
+    if (isNeonApiError(err)) {
       log.debug(
         'getActiveRegions failed (%s), falling back to the static region list.',
-        err.response?.status ?? err.code ?? err.message,
+        err.status ?? err.code ?? err.message,
       );
     } else {
       const message = err instanceof Error ? err.message : String(err);

--- a/packages/cli/src/commands/neon_auth.ts
+++ b/packages/cli/src/commands/neon_auth.ts
@@ -1,15 +1,16 @@
-import {
-  NeonAuthSupportedAuthProvider,
+import type {
   NeonAuthCreateIntegrationResponse,
   NeonAuthIntegration,
+} from '@neon/sdk';
+import {
+  NeonAuthSupportedAuthProvider,
   NeonAuthOauthProviderId,
   NeonAuthOauthProviderType,
   NeonAuthEmailVerificationMethod,
-} from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+} from '../utils/api_enums.js';
 import chalk from 'chalk';
 import yargs from 'yargs';
-import { retryOnLock } from '../api.js';
+import { codeFromBody, isNeonApiError, retryOnLock } from '../api.js';
 import { branchIdFromProps, fillSingleProject } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';
 import { writer } from '../writer.js';
@@ -671,7 +672,7 @@ const enable = async (props: AuthBranchProps & { databaseName?: string }) => {
       }),
     ));
   } catch (err) {
-    if (isAxiosError(err) && err.response?.status === 409) {
+    if (isNeonApiError(err) && err.status === 409) {
       alreadyEnabled = true;
       ({ data } = await props.apiClient.getNeonAuth(props.projectId, branchId));
     } else {
@@ -715,7 +716,7 @@ const status = async (props: AuthBranchProps) => {
   try {
     ({ data } = await props.apiClient.getNeonAuth(props.projectId, branchId));
   } catch (err) {
-    if (isAxiosError(err) && err.response?.status === 404) {
+    if (isNeonApiError(err) && err.status === 404) {
       printMessage('Neon Auth is not configured for this branch');
       return;
     }
@@ -798,9 +799,8 @@ const oauthProviderAdd = async (
     ));
   } catch (err) {
     if (
-      isAxiosError(err) &&
-      (err.response?.data as { code?: string } | undefined)?.code ===
-        'INVALID_SHARED_OAUTH_PROVIDER'
+      isNeonApiError(err) &&
+      codeFromBody(err.data) === 'INVALID_SHARED_OAUTH_PROVIDER'
     ) {
       throw new Error(
         `The "${props.providerId}" provider requires your own OAuth app credentials.\n` +
@@ -847,9 +847,8 @@ const oauthProviderUpdate = async (
     ));
   } catch (err) {
     if (
-      isAxiosError(err) &&
-      (err.response?.data as { code?: string } | undefined)?.code ===
-        'INVALID_SHARED_OAUTH_PROVIDER'
+      isNeonApiError(err) &&
+      codeFromBody(err.data) === 'INVALID_SHARED_OAUTH_PROVIDER'
     ) {
       throw new Error(
         `The "${props.providerId}" provider requires your own OAuth app credentials.\n` +

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -3,7 +3,7 @@ import {
   ProjectListItem,
   ProjectUpdateRequest,
   Organization,
-} from '@neondatabase/api-client';
+} from '@neon/sdk';
 import yargs from 'yargs';
 
 import { log } from '../log.js';
@@ -16,7 +16,7 @@ import { writer } from '../writer.js';
 import { psql } from '../utils/psql.js';
 import { updateContextFile } from '../context.js';
 import { getComputeUnits } from '../utils/compute_units.js';
-import { isAxiosError } from 'axios';
+import { isNeonApiError, messageFromBody } from '../api.js';
 import prompts, { InitialReturnValue } from 'prompts';
 import { isCi } from '../env.js';
 
@@ -433,9 +433,9 @@ const handleMissingOrgId = async (
 
 const isOrgIdError = (err: any) => {
   return (
-    isAxiosError(err) &&
-    err.response?.status == 400 &&
-    err.response?.data?.message?.includes('org_id is required')
+    isNeonApiError(err) &&
+    err.status === 400 &&
+    messageFromBody(err.data)?.includes('org_id is required')
   );
 };
 

--- a/packages/cli/src/commands/psql.ts
+++ b/packages/cli/src/commands/psql.ts
@@ -1,4 +1,4 @@
-import { EndpointType } from '@neondatabase/api-client';
+import { EndpointType } from '../utils/api_enums.js';
 import yargs from 'yargs';
 import { fillSingleProject } from '../utils/enrichers.js';
 import { BranchScopeProps } from '../types.js';

--- a/packages/cli/src/commands/roles.ts
+++ b/packages/cli/src/commands/roles.ts
@@ -100,7 +100,10 @@ export const deleteRole = async (
       props.role,
     ),
   );
-  writer(props).end(data.role, {
-    fields: ROLES_FIELDS,
-  });
+  // A 204 (role already gone) carries no body; only a 200 returns the role.
+  if (data) {
+    writer(props).end(data.role, {
+      fields: ROLES_FIELDS,
+    });
+  }
 };

--- a/packages/cli/src/commands/schema_diff.ts
+++ b/packages/cli/src/commands/schema_diff.ts
@@ -1,6 +1,6 @@
 import { BranchScopeProps } from '../types';
 import { createPatch } from 'diff';
-import { Branch, Database } from '@neondatabase/api-client';
+import { Branch, Database } from '@neon/sdk';
 import chalk from 'chalk';
 import { writer } from '../writer.js';
 import { branchIdFromProps } from '../utils/enrichers.js';
@@ -9,7 +9,7 @@ import {
   PointInTime,
   PointInTimeBranchId,
 } from '../utils/point_in_time.js';
-import { isAxiosError } from 'axios';
+import { isNeonApiError, messageFromBody } from '../api.js';
 import { sendError } from '../analytics.js';
 import { log } from '../log.js';
 
@@ -124,11 +124,10 @@ const fetchSchema = async (
     });
     return response.data.sql ?? '';
   } catch (error) {
-    if (isAxiosError(error)) {
-      const data = error.response?.data;
+    if (isNeonApiError(error)) {
       sendError(error, 'API_ERROR');
       throw new Error(
-        data.message ??
+        messageFromBody(error.data) ??
           `Error while fetching schema for branch ${pointInTime.branchId}`,
       );
     }

--- a/packages/cli/src/commands/vpc_endpoints.ts
+++ b/packages/cli/src/commands/vpc_endpoints.ts
@@ -1,4 +1,4 @@
-import { VPCEndpointAssignment } from '@neondatabase/api-client';
+import { VpcEndpointAssignment as VPCEndpointAssignment } from '@neon/sdk';
 import yargs from 'yargs';
 import {
   CommonProps,

--- a/packages/cli/src/errors.test.ts
+++ b/packages/cli/src/errors.test.ts
@@ -1,4 +1,3 @@
-import { AxiosError } from 'axios';
 import { describe, expect, it } from 'vitest';
 
 import { isNetworkError, matchErrorCode } from './errors.js';
@@ -34,8 +33,8 @@ describe('isNetworkError', () => {
     expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true);
   });
 
-  it('detects an axios "Network Error"', () => {
-    expect(isNetworkError(new AxiosError('Network Error'))).toBe(true);
+  it('detects a "Network Error" message', () => {
+    expect(isNetworkError(new Error('Network Error'))).toBe(true);
   });
 
   it('detects a top-level socket code without a wrapping message', () => {

--- a/packages/cli/src/functions_api.ts
+++ b/packages/cli/src/functions_api.ts
@@ -1,4 +1,4 @@
-import { ContentType } from '@neondatabase/api-client';
+import { ContentType } from './api.js';
 import { CommonProps } from './types.js';
 
 export type DeploymentStatus = 'pending' | 'building' | 'completed' | 'failed';
@@ -84,7 +84,7 @@ export const deleteFunction = async (
   branchId: string,
   slug: string,
 ): Promise<void> => {
-  await apiClient.request<unknown>({
+  await apiClient.request({
     path: `${functionsPath(projectId, branchId)}/${encodeURIComponent(slug)}`,
     method: 'DELETE',
     secure: true,
@@ -111,7 +111,7 @@ export const createDeployment = async (
 
   // The deploy POST returns an operation the CLI cannot poll; the body is
   // ignored. We only need the request to succeed.
-  await apiClient.request<unknown>({
+  await apiClient.request({
     path: `${functionsPath(projectId, branchId)}/${encodeURIComponent(
       slug,
     )}/deployments`,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,19 +1,7 @@
 import { basename } from 'node:path';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
-import axiosDebug from 'axios-debug-log';
-axiosDebug({
-  request(debug, config) {
-    debug(`${config.method?.toUpperCase()} ${config.url}`);
-  },
-  response(debug, response) {
-    debug(`${response.status} ${response.statusText}`);
-  },
-  error(debug, error) {
-    debug(error);
-  },
-});
-import { Api } from '@neondatabase/api-client';
+import { isNeonApiError, messageFromBody, type NeonApiClient } from './api.js';
 
 import { ensureAuth, deleteCredentials } from './commands/auth.js';
 import { defaultDir, ensureConfigDir } from './config.js';
@@ -30,7 +18,6 @@ import {
   sendError,
   trackEvent,
 } from './analytics.js';
-import { isAxiosError } from 'axios';
 import {
   isNetworkError,
   matchErrorCode,
@@ -125,8 +112,8 @@ builder = builder
     },
     apiClient: {
       hidden: true,
-      coerce: (v) => v as Api<unknown>,
-      default: null as unknown as Api<unknown>,
+      coerce: (v) => v as NeonApiClient,
+      default: null as unknown as NeonApiClient,
     },
     'context-file': {
       describe: 'Context file',
@@ -195,11 +182,10 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
   }
 
   // A connection-level failure (no response ever reached us) reads as a cryptic
-  // `fetch failed` on the @neon/sdk / fetch path (env pull / config / deploy and link's
-  // bundled env pull), or surfaces no user-facing message at all on the axios path. Detect
-  // it first — across either transport — and swap in one clear "check your connection" hint.
-  // We deliberately do not retry here: re-running the whole command could re-trigger a
-  // non-idempotent step (e.g. project create), so retries belong at the request layer.
+  // `fetch failed` from the @neon/sdk / global `fetch` path. Detect it first and
+  // swap in one clear "check your connection" hint. We deliberately do not retry
+  // here: re-running the whole command could re-trigger a non-idempotent step
+  // (e.g. project create), so retries belong at the request layer.
   if (isNetworkError(err)) {
     log.error(NETWORK_ERROR_MESSAGE);
     const error = err instanceof Error ? err : new Error(NETWORK_ERROR_MESSAGE);
@@ -207,12 +193,12 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
     return false;
   }
 
-  if (isAxiosError(err)) {
+  if (isNeonApiError(err)) {
     if (err.code === 'ECONNABORTED') {
       log.error('Request timed out');
       sendError(err, 'REQUEST_TIMEOUT');
       return false;
-    } else if (err.response?.status === 401) {
+    } else if (err.status === 401) {
       sendError(err, 'AUTH_FAILED');
       log.info('Authentication failed, deleting credentials...');
       try {
@@ -226,14 +212,15 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
         return false;
       }
     } else {
-      if (err.response?.data?.message) {
-        log.error(err.response?.data?.message);
+      const serverMessage = messageFromBody(err.data);
+      if (serverMessage) {
+        log.error(serverMessage);
       }
       log.debug(
         'status: %d %s | path: %s',
-        err.response?.status,
-        err.response?.statusText,
-        err.request?.path,
+        err.status,
+        err.statusText,
+        err.requestPath,
       );
       sendError(err, 'API_ERROR');
       return false;

--- a/packages/cli/src/parameters.gen.ts
+++ b/packages/cli/src/parameters.gen.ts
@@ -109,17 +109,17 @@ export const projectCreateRequest = {
   },
   'project.provisioner': {
               type: "string",
-              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
+              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n* serverless-platform\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
               demandOption: false,
   },
   'project.region_id': {
               type: "string",
-              description: "The region identifier. Refer to our [Regions](https://neon.tech/docs/introduction/regions) documentation for supported regions. Values are specified in this format: `aws-us-east-1`\n",
+              description: "The region identifier. Refer to our [Regions](https://neon.com/docs/introduction/regions) documentation for supported regions. Values are specified in this format: `aws-us-east-1`\n",
               demandOption: false,
   },
   'project.default_endpoint_settings.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.com/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
   'project.pg_version': {
@@ -238,7 +238,7 @@ export const projectUpdateRequest = {
   },
   'project.default_endpoint_settings.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.com/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
   'project.history_retention_seconds': {
@@ -315,12 +315,12 @@ export const branchCreateRequestEndpointOptions = {
   },
   'provisioner': {
               type: "string",
-              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
+              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n* serverless-platform\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
               demandOption: false,
   },
   'suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.com/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
 } as const;
@@ -372,17 +372,17 @@ export const endpointCreateRequest = {
   },
   'endpoint.provisioner': {
               type: "string",
-              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
+              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n* serverless-platform\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
               demandOption: false,
   },
   'endpoint.pooler_enabled': {
               type: "boolean",
-              description: "Whether to enable connection pooling for the compute endpoint\n",
+              description: "DEPRECATED. Whether to enable connection pooling for the compute endpoint.\nThe recommended way to enable connection pooling is to append `-pooler` to the endpoint ID in the connection string.\nSee [How to use connection pooling](https://neon.com/docs/connect/connection-pooling#how-to-use-connection-pooling)\n",
               demandOption: false,
   },
   'endpoint.pooler_mode': {
               type: "string",
-              description: "The connection pooler mode. Neon supports PgBouncer in `transaction` mode only.\n",
+              description: "DEPRECATED. The connection pooler mode. This field is deprecated and will be removed after 2026-06-20.\n",
               demandOption: false,
  choices: ["transaction"],
   },
@@ -398,7 +398,7 @@ export const endpointCreateRequest = {
   },
   'endpoint.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.com/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
   'endpoint.name': {
@@ -416,7 +416,7 @@ export const endpointUpdateRequest = {
   },
   'endpoint.provisioner': {
               type: "string",
-              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
+              description: "The Neon compute provisioner.\nSpecify the `k8s-neonvm` provisioner to create a compute endpoint that supports Autoscaling.\n\nProvisioner can be one of the following values:\n* k8s-pod\n* k8s-neonvm\n* serverless-platform\n\nClients must expect, that any string value that is not documented in the description above should be treated as a error. UNKNOWN value if safe to treat as an error too.\n",
               demandOption: false,
   },
   'endpoint.settings.preload_libraries.use_defaults': {
@@ -431,12 +431,12 @@ export const endpointUpdateRequest = {
   },
   'endpoint.pooler_enabled': {
               type: "boolean",
-              description: "Whether to enable connection pooling for the compute endpoint\n",
+              description: "DEPRECATED. Whether to enable connection pooling for the compute endpoint.\nThe recommended way to enable connection pooling is to append `-pooler` to the endpoint ID in the connection string.\nSee [How to use connection pooling](https://neon.com/docs/connect/connection-pooling#how-to-use-connection-pooling)\n",
               demandOption: false,
   },
   'endpoint.pooler_mode': {
               type: "string",
-              description: "The connection pooler mode. Neon supports PgBouncer in `transaction` mode only.\n",
+              description: "DEPRECATED. The connection pooler mode. This field is deprecated and will be removed after 2026-06-20.\n",
               demandOption: false,
  choices: ["transaction"],
   },
@@ -452,7 +452,7 @@ export const endpointUpdateRequest = {
   },
   'endpoint.suspend_timeout_seconds': {
               type: "number",
-              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.tech/docs/manage/endpoints#scale-to-zero-configuration).\n",
+              description: "Duration of inactivity in seconds after which the compute endpoint is\nautomatically suspended. The value `0` means use the default value.\nThe value `-1` means never suspend. The default value is `300` seconds (5 minutes).\nThe minimum value is `60` seconds (1 minute).\nThe maximum value is `604800` seconds (1 week). For more information, see\n[Scale to zero configuration](https://neon.com/docs/manage/endpoints#scale-to-zero-configuration).\n",
               demandOption: false,
   },
   'endpoint.name': {

--- a/packages/cli/src/storage_api.ts
+++ b/packages/cli/src/storage_api.ts
@@ -1,25 +1,23 @@
 // Typed client helpers for the branch object-storage (bucket/object) API.
 //
 // These endpoints are part of the Neon object-storage surface (the "Buckets"
-// tag in the public API). They are not yet exposed as typed methods on the
-// published `@neondatabase/api-client` package, so the request/response types
-// and the thin call helpers live here. They are implemented on top of the
-// api-client's public `request()` method, which means they reuse the exact
-// same authentication, base URL, headers and retry behaviour as every other
-// neonctl command. When the generated client gains these methods, the call
-// sites in `src/commands/bucket.ts` can switch over with no behavioural
-// change.
+// tag in the public API). They are not yet exposed as typed methods on
+// `@neon/sdk`, so the request/response types and the thin call helpers live
+// here. They are implemented on top of the API client's low-level `request()`
+// method, which reuses the exact same authentication, base URL, headers and
+// retry behaviour as every other neonctl command. When the SDK gains these
+// methods, the call sites in `src/commands/bucket.ts` can switch over with no
+// behavioural change.
 
 import { type Readable } from 'node:stream';
 
-import { type Api } from '@neondatabase/api-client';
+import type { NeonApiClient } from './api.js';
 
-export type ApiClient = Api<unknown>;
+export type ApiClient = NeonApiClient;
 
-// The api-client bundles its own axios version, whose `AxiosResponse` type is
-// not assignable to the one neonctl depends on directly. Callers only ever read
-// `.data` (and, for the download helper, `.headers`), so we expose that minimal
-// shape and let the helpers return the client's native promise unchanged.
+// Callers only ever read `.data` (and, for the download helper, `.headers`), so
+// we expose that minimal shape and let the helpers return the client's native
+// promise unchanged.
 type ApiResponse<T> = { data: T };
 type ApiResponseWithHeaders<T> = {
   data: T;

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,8 +1,8 @@
-import { Api } from '@neondatabase/api-client';
 import { TokenEndpointResponse } from 'openid-client';
+import type { NeonApiClient } from './api.js';
 
 export type CommonProps = {
-  apiClient: Api<unknown>;
+  apiClient: NeonApiClient;
   apiKey: string;
   apiHost: string;
   output: 'yaml' | 'json' | 'table';

--- a/packages/cli/src/utils/api_enums.ts
+++ b/packages/cli/src/utils/api_enums.ts
@@ -1,0 +1,47 @@
+// Runtime enum-like constants for Neon API string unions.
+//
+// `@neondatabase/api-client` generated TypeScript `enum`s (real runtime objects)
+// for fields like the compute endpoint type. `@neon/sdk` instead models these as
+// plain string-literal union *types*, which have no runtime value — so code that
+// read `EndpointType.ReadWrite` or `Object.values(EndpointType)` no longer works.
+//
+// These `as const` objects restore that runtime surface, and each is paired with
+// a same-named type whose union is identical to the corresponding `@neon/sdk`
+// type, so values stay assignable in both directions.
+
+export const EndpointType = {
+  ReadOnly: 'read_only',
+  ReadWrite: 'read_write',
+} as const;
+export type EndpointType = (typeof EndpointType)[keyof typeof EndpointType];
+
+export const NeonAuthOauthProviderId = {
+  Google: 'google',
+  Github: 'github',
+  Microsoft: 'microsoft',
+  Vercel: 'vercel',
+} as const;
+export type NeonAuthOauthProviderId =
+  (typeof NeonAuthOauthProviderId)[keyof typeof NeonAuthOauthProviderId];
+
+export const NeonAuthOauthProviderType = {
+  Standard: 'standard',
+  Shared: 'shared',
+} as const;
+export type NeonAuthOauthProviderType =
+  (typeof NeonAuthOauthProviderType)[keyof typeof NeonAuthOauthProviderType];
+
+export const NeonAuthSupportedAuthProvider = {
+  Mock: 'mock',
+  Stack: 'stack',
+  BetterAuth: 'better_auth',
+} as const;
+export type NeonAuthSupportedAuthProvider =
+  (typeof NeonAuthSupportedAuthProvider)[keyof typeof NeonAuthSupportedAuthProvider];
+
+export const NeonAuthEmailVerificationMethod = {
+  Link: 'link',
+  Otp: 'otp',
+} as const;
+export type NeonAuthEmailVerificationMethod =
+  (typeof NeonAuthEmailVerificationMethod)[keyof typeof NeonAuthEmailVerificationMethod];

--- a/packages/cli/src/utils/branch_picker.ts
+++ b/packages/cli/src/utils/branch_picker.ts
@@ -1,4 +1,6 @@
-import { Api, Branch, EndpointType } from '@neondatabase/api-client';
+import { Branch } from '@neon/sdk';
+import { EndpointType } from './api_enums.js';
+import type { NeonApiClient } from '../api.js';
 import prompts from 'prompts';
 
 import { retryOnLock } from '../api.js';
@@ -106,7 +108,7 @@ export const promptNewBranchName = async (
  * the new branch id.
  */
 export const createBranch = async (
-  apiClient: Api<unknown>,
+  apiClient: NeonApiClient,
   projectId: string,
   name: string,
   branches: Branch[],

--- a/packages/cli/src/utils/compute_units.ts
+++ b/packages/cli/src/utils/compute_units.ts
@@ -1,4 +1,4 @@
-import { ComputeUnit } from '@neondatabase/api-client';
+import { ComputeUnit } from '@neon/sdk';
 
 type Autoscaling = {
   autoscaling_limit_min_cu?: ComputeUnit;

--- a/packages/cli/src/utils/enrichers.ts
+++ b/packages/cli/src/utils/enrichers.ts
@@ -1,8 +1,8 @@
 import { BranchScopeProps, CommonProps, OrgScopeProps } from '../types.js';
 import { isCurrentBranchProbe } from '../context.js';
 import { looksLikeBranchId } from './formats.js';
-import { Branch, Database } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+import { Branch, Database } from '@neon/sdk';
+import { isNeonApiError, messageFromBody } from '../api.js';
 
 export const branchIdResolve = async ({
   branch,
@@ -207,9 +207,9 @@ export const fillSingleProject = async (
   } catch (error) {
     // If the API error is about missing org_id, provide a user-friendly message
     if (
-      isAxiosError(error) &&
-      error.response?.status === 400 &&
-      error.response?.data?.message?.includes('org_id is required')
+      isNeonApiError(error) &&
+      error.status === 400 &&
+      messageFromBody(error.data)?.includes('org_id is required')
     ) {
       throw new Error(
         'Multiple projects found, please provide one with the --project-id option',

--- a/packages/cli/src/utils/point_in_time.ts
+++ b/packages/cli/src/utils/point_in_time.ts
@@ -1,4 +1,4 @@
-import { Api } from '@neondatabase/api-client';
+import type { NeonApiClient } from '../api.js';
 import { looksLikeLSN, looksLikeTimestamp } from './formats.js';
 import { branchIdResolve } from './enrichers.js';
 
@@ -26,7 +26,7 @@ export type PointInTimeProps = {
   targetBranchId: string;
   pointInTime: string;
   projectId: string;
-  api: Api<unknown>;
+  api: NeonApiClient;
 };
 
 export class PointInTimeParseError extends Error {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -15,7 +15,13 @@
     // the bare `neon-init/bootstrap` specifier untouched).
     "baseUrl": ".",
     "paths": {
-      "neon-init/bootstrap": ["node_modules/neon-init/dist/lib/bootstrap"]
+      "neon-init/bootstrap": ["node_modules/neon-init/dist/lib/bootstrap"],
+      // `@neon/sdk` ships its raw layer via the `@neon/sdk/raw` subpath export.
+      // Classic ("node") module resolution ignores package `exports`, so map the
+      // specifiers to their shipped types here for the type-checker; Node honors
+      // the export map at runtime (the emitted JS keeps the bare specifiers).
+      "@neon/sdk": ["node_modules/@neon/sdk/dist/index"],
+      "@neon/sdk/raw": ["node_modules/@neon/sdk/dist/raw"]
     },
     "resolveJsonModule": true,
     "noImplicitAny": true,

--- a/packages/config-runtime/e2e/helpers.ts
+++ b/packages/config-runtime/e2e/helpers.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { createApiClient } from "@neondatabase/api-client";
+import { createNeonClient } from "@neon/sdk";
+import {
+	deleteProject as rawDeleteProject,
+	getProject as rawGetProject,
+	listProjects as rawListProjects,
+} from "@neon/sdk/raw";
 import { createRealNeonApi, type NeonApi } from "@neondatabase/config";
 import { test } from "vitest";
 
@@ -56,8 +61,24 @@ export async function bootstrapProject(
 }
 
 /** Lower-level Neon client. Used by cleanup and a few setup helpers. */
-function makeRawClient(): ReturnType<typeof createApiClient> {
-	return createApiClient({ apiKey: requireApiKey() });
+function makeRawClient(): ReturnType<typeof createNeonClient>["client"] {
+	return createNeonClient({ apiKey: requireApiKey() }).client;
+}
+
+/**
+ * Unwrap a `@neon/sdk` raw `{ data, error, response }` result into the bare body, throwing
+ * `{ response: { status } }` on a non-2xx so the status-based catches below keep working.
+ */
+function unwrap<T>(result: {
+	data?: T;
+	error?: unknown;
+	response?: Response;
+}): T {
+	const response = result.response;
+	if (!response || !response.ok) {
+		throw { response: { status: response?.status, data: result.error } };
+	}
+	return result.data as T;
 }
 
 /**
@@ -77,7 +98,7 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
 	if (cachedScope) return cachedScope;
 	const client = makeRawClient();
 	try {
-		await client.listProjects({ limit: 1 });
+		unwrap(await rawListProjects({ client, query: { limit: 1 } }));
 		cachedScope = { kind: "org-or-user", canCreate: true };
 		return cachedScope;
 	} catch (err) {
@@ -107,16 +128,22 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
  */
 async function deleteProject(projectId: string): Promise<void> {
 	const client = makeRawClient();
-	const project = await client.getProject(projectId).catch((err: unknown) => {
-		const status = (err as { response?: { status?: number } } | undefined)
-			?.response?.status;
-		if (status === 404 || status === 410) return null;
-		throw err;
-	});
+	const project = await rawGetProject({
+		client,
+		path: { project_id: projectId },
+	})
+		.then(unwrap)
+		.catch((err: unknown) => {
+			const status = (
+				err as { response?: { status?: number } } | undefined
+			)?.response?.status;
+			if (status === 404 || status === 410) return null;
+			throw err;
+		});
 	if (!project) return;
-	if (!project.data.project.name.startsWith(PROJECT_PREFIX)) {
+	if (!project.project.name.startsWith(PROJECT_PREFIX)) {
 		throw new Error(
-			`Refusing to delete project ${projectId} ("${project.data.project.name}"): does not match the e2e prefix.`,
+			`Refusing to delete project ${projectId} ("${project.project.name}"): does not match the e2e prefix.`,
 		);
 	}
 	// Retry on 423 (locked while a previous mutation is in flight) so cleanup is robust.
@@ -124,7 +151,12 @@ async function deleteProject(projectId: string): Promise<void> {
 	let delay = 500;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
-			await client.deleteProject(projectId);
+			unwrap(
+				await rawDeleteProject({
+					client,
+					path: { project_id: projectId },
+				}),
+			);
 			return;
 		} catch (err) {
 			const status = (
@@ -149,17 +181,19 @@ export async function sweepOrphans(): Promise<{ swept: string[] }> {
 	const swept: string[] = [];
 	let cursor: string | undefined;
 	while (true) {
-		const res = await client.listProjects({
-			limit: 100,
-			...(cursor ? { cursor } : {}),
-		});
-		for (const project of res.data.projects) {
+		const body = unwrap(
+			await rawListProjects({
+				client,
+				query: { limit: 100, ...(cursor ? { cursor } : {}) },
+			}),
+		);
+		for (const project of body.projects) {
 			if (project.name.startsWith(PROJECT_PREFIX)) {
 				await deleteProject(project.id);
 				swept.push(project.id);
 			}
 		}
-		const next = (res.data as { pagination?: { next?: string } }).pagination
+		const next = (body as { pagination?: { next?: string } }).pagination
 			?.next;
 		if (!next || next === cursor) break;
 		cursor = next;

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -49,7 +49,7 @@
 		"tsc": "tsc"
 	},
 	"devDependencies": {
-		"@neondatabase/api-client": "^2.7.1",
+		"@neon/sdk": "workspace:*",
 		"@types/node": "catalog:",
 		"@vitest/coverage-v8": "3.0.9",
 		"console-fail-test": "0.5.0",

--- a/packages/config/e2e/helpers.ts
+++ b/packages/config/e2e/helpers.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { createApiClient } from "@neondatabase/api-client";
+import { createNeonClient } from "@neon/sdk";
+import {
+	deleteProject as rawDeleteProject,
+	getProject as rawGetProject,
+	listProjects as rawListProjects,
+} from "@neon/sdk/raw";
 import { test } from "vitest";
 import type { NeonApi } from "../src/lib/neon-api.js";
 import { createRealNeonApi } from "../src/lib/neon-api-real.js";
@@ -57,8 +62,24 @@ export async function bootstrapProject(
 }
 
 /** Lower-level Neon client. Used by cleanup and a few setup helpers. */
-function makeRawClient(): ReturnType<typeof createApiClient> {
-	return createApiClient({ apiKey: requireApiKey() });
+function makeRawClient(): ReturnType<typeof createNeonClient>["client"] {
+	return createNeonClient({ apiKey: requireApiKey() }).client;
+}
+
+/**
+ * Unwrap a `@neon/sdk` raw `{ data, error, response }` result into the bare body, throwing
+ * `{ response: { status } }` on a non-2xx so the status-based catches below keep working.
+ */
+function unwrap<T>(result: {
+	data?: T;
+	error?: unknown;
+	response?: Response;
+}): T {
+	const response = result.response;
+	if (!response || !response.ok) {
+		throw { response: { status: response?.status, data: result.error } };
+	}
+	return result.data as T;
 }
 
 /**
@@ -78,7 +99,7 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
 	if (cachedScope) return cachedScope;
 	const client = makeRawClient();
 	try {
-		await client.listProjects({ limit: 1 });
+		unwrap(await rawListProjects({ client, query: { limit: 1 } }));
 		cachedScope = { kind: "org-or-user", canCreate: true };
 		return cachedScope;
 	} catch (err) {
@@ -108,16 +129,22 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
  */
 async function deleteProject(projectId: string): Promise<void> {
 	const client = makeRawClient();
-	const project = await client.getProject(projectId).catch((err) => {
-		const status = (err as { response?: { status?: number } } | undefined)
-			?.response?.status;
-		if (status === 404 || status === 410) return null;
-		throw err;
-	});
+	const project = await rawGetProject({
+		client,
+		path: { project_id: projectId },
+	})
+		.then(unwrap)
+		.catch((err) => {
+			const status = (
+				err as { response?: { status?: number } } | undefined
+			)?.response?.status;
+			if (status === 404 || status === 410) return null;
+			throw err;
+		});
 	if (!project) return;
-	if (!project.data.project.name.startsWith(PROJECT_PREFIX)) {
+	if (!project.project.name.startsWith(PROJECT_PREFIX)) {
 		throw new Error(
-			`Refusing to delete project ${projectId} ("${project.data.project.name}"): does not match the e2e prefix.`,
+			`Refusing to delete project ${projectId} ("${project.project.name}"): does not match the e2e prefix.`,
 		);
 	}
 	// Retry on 423 (locked while a previous mutation is in flight) so cleanup is robust.
@@ -125,7 +152,12 @@ async function deleteProject(projectId: string): Promise<void> {
 	let delay = 500;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
-			await client.deleteProject(projectId);
+			unwrap(
+				await rawDeleteProject({
+					client,
+					path: { project_id: projectId },
+				}),
+			);
 			return;
 		} catch (err) {
 			const status = (
@@ -150,17 +182,19 @@ export async function sweepOrphans(): Promise<{ swept: string[] }> {
 	const swept: string[] = [];
 	let cursor: string | undefined;
 	while (true) {
-		const res = await client.listProjects({
-			limit: 100,
-			...(cursor ? { cursor } : {}),
-		});
-		for (const project of res.data.projects) {
+		const body = unwrap(
+			await rawListProjects({
+				client,
+				query: { limit: 100, ...(cursor ? { cursor } : {}) },
+			}),
+		);
+		for (const project of body.projects) {
 			if (project.name.startsWith(PROJECT_PREFIX)) {
 				await deleteProject(project.id);
 				swept.push(project.id);
 			}
 		}
-		const next = (res.data as { pagination?: { next?: string } }).pagination
+		const next = (body as { pagination?: { next?: string } }).pagination
 			?.next;
 		if (!next || next === cursor) break;
 		cursor = next;

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -57,7 +57,7 @@
 		"vitest": "catalog:"
 	},
 	"dependencies": {
-		"@neondatabase/api-client": "^2.7.1",
+		"@neon/sdk": "workspace:*",
 		"jiti": "^2.7.0",
 		"zod": "^4.4.3"
 	},

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1,24 +1,41 @@
+import type {
+	DataApiSettings as ApiDataApiSettings,
+	Branch,
+	BranchCreateRequest,
+	BranchCreateRequestEndpointOptions,
+	BranchUpdateRequest,
+	DataApiCreateRequest,
+	DataApiReponse,
+	Database,
+	DefaultEndpointSettings,
+	Endpoint,
+	EndpointUpdateRequest,
+	PgVersion,
+	Project,
+	ProjectCreateRequest,
+	ProjectListItem,
+	ProjectUpdateRequest,
+	Role,
+} from "@neon/sdk";
+import { createNeonClient } from "@neon/sdk";
 import {
-	type Branch,
-	type BranchCreateRequest,
-	type BranchCreateRequestEndpointOptions,
-	type BranchUpdateRequest,
-	createApiClient,
-	type DataAPICreateRequest,
-	type DataAPIReponse,
-	type DataAPISettings,
-	type Database,
-	type DefaultEndpointSettings,
-	type Endpoint,
-	EndpointType,
-	type EndpointUpdateRequest,
-	type PgVersion,
-	type Project,
-	type ProjectCreateRequest,
-	type ProjectListItem,
-	type ProjectUpdateRequest,
-	type Role,
-} from "@neondatabase/api-client";
+	createProject as rawCreateProject,
+	createProjectBranch as rawCreateProjectBranch,
+	createProjectBranchDataApi as rawCreateProjectBranchDataApi,
+	getConnectionUri as rawGetConnectionUri,
+	getNeonAuth as rawGetNeonAuth,
+	getProject as rawGetProject,
+	getProjectBranchDataApi as rawGetProjectBranchDataApi,
+	listProjectBranchDatabases as rawListProjectBranchDatabases,
+	listProjectBranches as rawListProjectBranches,
+	listProjectBranchRoles as rawListProjectBranchRoles,
+	listProjectEndpoints as rawListProjectEndpoints,
+	listProjects as rawListProjects,
+	updateProject as rawUpdateProject,
+	updateProjectBranch as rawUpdateProjectBranch,
+	updateProjectBranchDataApi as rawUpdateProjectBranchDataApi,
+	updateProjectEndpoint as rawUpdateProjectEndpoint,
+} from "@neon/sdk/raw";
 import { z } from "zod";
 import { formatSuspendTimeout, parseSuspendTimeout } from "./duration.js";
 import { ErrorCode, PlatformError } from "./errors.js";
@@ -53,8 +70,31 @@ import type {
 } from "./types.js";
 import { wrapNeonError } from "./wrap-neon-error.js";
 
-type ApiClient = ReturnType<typeof createApiClient>;
+type ApiClient = ReturnType<typeof createNeonClient>["client"];
 const DEFAULT_NEON_API_BASE_URL = "https://console.neon.tech/api/v2";
+
+/**
+ * Unwrap a `@neon/sdk` raw `{ data, error, response }` result into the bare body, throwing
+ * on a non-2xx response. The thrown shape (`{ response: { status, data } }`) deliberately
+ * matches what the package's REST fallbacks already throw, so {@link wrapNeonError} and the
+ * 423 {@link retryOnLocked} retry keep working unchanged across both transports.
+ */
+function unwrap<T>(result: {
+	data?: T;
+	error?: unknown;
+	response?: Response;
+}): T {
+	const response = result.response;
+	if (!response || !response.ok) {
+		throw {
+			response: {
+				status: response?.status,
+				data: result.error,
+			},
+		};
+	}
+	return result.data as T;
+}
 
 const neonAuthResponseSchema = z.object({
 	auth_provider_project_id: z.string(),
@@ -67,8 +107,8 @@ const neonAuthResponseSchema = z.object({
 // ─── Data API mapping (camelCase neon.ts ↔ snake_case Neon API) ───────────────
 
 /** Map our camelCase {@link DataApiSettings} onto the Neon API's snake_case `DataAPISettings`. */
-function dataApiSettingsToApi(settings: DataApiSettings): DataAPISettings {
-	const out: DataAPISettings = {};
+function dataApiSettingsToApi(settings: DataApiSettings): ApiDataApiSettings {
+	const out: ApiDataApiSettings = {};
 	if (settings.dbAggregatesEnabled !== undefined)
 		out.db_aggregates_enabled = settings.dbAggregatesEnabled;
 	if (settings.dbAnonRole !== undefined)
@@ -101,7 +141,7 @@ function normalizeOpenapiMode(
 
 /** Map the Neon API's snake_case `DataAPISettings` back to our camelCase {@link DataApiSettings}. */
 function dataApiSettingsFromApi(
-	settings: DataAPISettings | null | undefined,
+	settings: ApiDataApiSettings | null | undefined,
 ): DataApiSettings | undefined {
 	if (!settings) return undefined;
 	const out: DataApiSettings = {};
@@ -132,8 +172,8 @@ function dataApiSettingsFromApi(
 /** Build the Neon API `DataAPICreateRequest` from our {@link EnableDataApiInput}. */
 function dataApiCreateRequest(
 	input: EnableDataApiInput | undefined,
-): DataAPICreateRequest {
-	const req: DataAPICreateRequest = {};
+): DataApiCreateRequest {
+	const req: DataApiCreateRequest = {};
 	if (!input) return req;
 	if (input.authProvider !== undefined)
 		req.auth_provider =
@@ -151,7 +191,7 @@ function dataApiCreateRequest(
 
 /** Map a `DataAPIReponse` (GET) onto our {@link NeonDataApiSnapshot}. */
 function dataApiSnapshotFromResponse(
-	data: DataAPIReponse,
+	data: DataApiReponse,
 ): NeonDataApiSnapshot {
 	const snapshot: NeonDataApiSnapshot = { url: data.url };
 	if (data.status !== undefined) snapshot.status = data.status;
@@ -242,7 +282,7 @@ interface RestConfig {
 }
 
 /**
- * Adapt `@neondatabase/api-client` to the narrow {@link NeonApi} façade used by the rest of
+ * Adapt `@neon/sdk` (raw layer) to the narrow {@link NeonApi} façade used by the rest of
  * this package. Constructs are restricted to whole-object read/write of just the fields we
  * model in {@link Config}; anything else stays untouched on the remote.
  */
@@ -270,10 +310,13 @@ export function createRealNeonApi(options: {
 		);
 	}
 
-	const client = createApiClient({
+	// The SDK runs its own retries by default; this adapter does its own 423-aware
+	// `retryOnLocked`, so disable the SDK's to avoid compounding backoff.
+	const client = createNeonClient({
 		apiKey: options.apiKey,
-		...(options.baseUrl ? { baseURL: options.baseUrl } : {}),
-	});
+		retries: 0,
+		...(options.baseUrl ? { baseUrl: options.baseUrl } : {}),
+	}).client;
 
 	return new RealNeonApi(
 		client,
@@ -372,15 +415,21 @@ class RealNeonApi implements NeonApi {
 				const projects: ProjectListItem[] = [];
 				let cursor: string | undefined;
 				while (true) {
-					const res = await this.client.listProjects({
-						...(filter.orgId ? { org_id: filter.orgId } : {}),
-						...(cursor ? { cursor } : {}),
-						limit: 100,
-					});
-					projects.push(...res.data.projects);
-					const next = (
-						res.data as { pagination?: { next?: string } }
-					).pagination?.next;
+					const body = unwrap(
+						await rawListProjects({
+							client: this.client,
+							query: {
+								...(filter.orgId
+									? { org_id: filter.orgId }
+									: {}),
+								...(cursor ? { cursor } : {}),
+								limit: 100,
+							},
+						}),
+					);
+					projects.push(...body.projects);
+					const next = (body as { pagination?: { next?: string } })
+						.pagination?.next;
 					if (!next || next === cursor) break;
 					cursor = next;
 				}
@@ -393,8 +442,13 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`getProject(${projectId})`,
 			async () => {
-				const res = await this.client.getProject(projectId);
-				return projectToSnapshot(res.data.project);
+				const body = unwrap(
+					await rawGetProject({
+						client: this.client,
+						path: { project_id: projectId },
+					}),
+				);
+				return projectToSnapshot(body.project);
 			},
 			{ projectId },
 		);
@@ -427,8 +481,10 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`createProject(${input.name})`,
 			async () => {
-				const res = await this.client.createProject(body);
-				return projectToSnapshot(res.data.project);
+				const data = unwrap(
+					await rawCreateProject({ client: this.client, body }),
+				);
+				return projectToSnapshot(data.project);
 			},
 			{ mutating: true },
 		);
@@ -454,8 +510,14 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`updateProject(${projectId})`,
 			async () => {
-				const res = await this.client.updateProject(projectId, body);
-				return projectToSnapshot(res.data.project);
+				const data = unwrap(
+					await rawUpdateProject({
+						client: this.client,
+						path: { project_id: projectId },
+						body,
+					}),
+				);
+				return projectToSnapshot(data.project);
 			},
 			{ projectId, mutating: true },
 		);
@@ -468,15 +530,19 @@ class RealNeonApi implements NeonApi {
 				const branches: Branch[] = [];
 				let cursor: string | undefined;
 				while (true) {
-					const res = await this.client.listProjectBranches({
-						projectId,
-						limit: 100,
-						...(cursor ? { cursor } : {}),
-					});
-					branches.push(...(res.data.branches as Branch[]));
-					const next = (
-						res.data as { pagination?: { next?: string } }
-					).pagination?.next;
+					const body = unwrap(
+						await rawListProjectBranches({
+							client: this.client,
+							path: { project_id: projectId },
+							query: {
+								limit: 100,
+								...(cursor ? { cursor } : {}),
+							},
+						}),
+					);
+					branches.push(...(body.branches as Branch[]));
+					const next = (body as { pagination?: { next?: string } })
+						.pagination?.next;
 					if (!next || next === cursor) break;
 					cursor = next;
 				}
@@ -496,12 +562,12 @@ class RealNeonApi implements NeonApi {
 		const endpointOptions: BranchCreateRequestEndpointOptions | undefined =
 			input.computeSettings
 				? {
-						type: EndpointType.ReadWrite,
+						type: "read_write",
 						...computeSettingsToEndpointOptions(
 							input.computeSettings,
 						),
 					}
-				: { type: EndpointType.ReadWrite };
+				: { type: "read_write" };
 
 		const body: BranchCreateRequest = {
 			branch: {
@@ -517,15 +583,16 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`createBranch(${projectId}/${input.name})`,
 			async () => {
-				const res = await this.client.createProjectBranch(
-					projectId,
-					body,
+				const data = unwrap(
+					await rawCreateProjectBranch({
+						client: this.client,
+						path: { project_id: projectId },
+						body,
+					}),
 				);
 				return {
-					branch: branchToSnapshot(res.data.branch),
-					endpoints: (res.data.endpoints ?? []).map(
-						endpointToSnapshot,
-					),
+					branch: branchToSnapshot(data.branch),
+					endpoints: (data.endpoints ?? []).map(endpointToSnapshot),
 				};
 			},
 			{ projectId, mutating: true },
@@ -544,12 +611,14 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`updateBranch(${projectId}/${branchId})`,
 			async () => {
-				const res = await this.client.updateProjectBranch(
-					projectId,
-					branchId,
-					{ branch },
+				const data = unwrap(
+					await rawUpdateProjectBranch({
+						client: this.client,
+						path: { project_id: projectId, branch_id: branchId },
+						body: { branch },
+					}),
 				);
-				return branchToSnapshot(res.data.branch);
+				return branchToSnapshot(data.branch);
 			},
 			{ projectId, mutating: true },
 		);
@@ -559,10 +628,13 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`listEndpoints(${projectId})`,
 			async () => {
-				const res = await this.client.listProjectEndpoints(projectId);
-				return (res.data.endpoints as Endpoint[]).map(
-					endpointToSnapshot,
+				const data = unwrap(
+					await rawListProjectEndpoints({
+						client: this.client,
+						path: { project_id: projectId },
+					}),
 				);
+				return (data.endpoints as Endpoint[]).map(endpointToSnapshot);
 			},
 			{ projectId },
 		);
@@ -578,12 +650,17 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`updateEndpoint(${projectId}/${endpointId})`,
 			async () => {
-				const res = await this.client.updateProjectEndpoint(
-					projectId,
-					endpointId,
-					{ endpoint },
+				const data = unwrap(
+					await rawUpdateProjectEndpoint({
+						client: this.client,
+						path: {
+							project_id: projectId,
+							endpoint_id: endpointId,
+						},
+						body: { endpoint },
+					}),
 				);
-				return endpointToSnapshot(res.data.endpoint);
+				return endpointToSnapshot(data.endpoint);
 			},
 			{ projectId, mutating: true },
 		);
@@ -596,11 +673,13 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`listBranchRoles(${projectId}/${branchId})`,
 			async () => {
-				const res = await this.client.listProjectBranchRoles(
-					projectId,
-					branchId,
+				const data = unwrap(
+					await rawListProjectBranchRoles({
+						client: this.client,
+						path: { project_id: projectId, branch_id: branchId },
+					}),
 				);
-				return (res.data.roles as Role[]).map(roleToSnapshot);
+				return (data.roles as Role[]).map(roleToSnapshot);
 			},
 			{ projectId },
 		);
@@ -613,13 +692,13 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			`listBranchDatabases(${projectId}/${branchId})`,
 			async () => {
-				const res = await this.client.listProjectBranchDatabases(
-					projectId,
-					branchId,
+				const data = unwrap(
+					await rawListProjectBranchDatabases({
+						client: this.client,
+						path: { project_id: projectId, branch_id: branchId },
+					}),
 				);
-				return (res.data.databases as Database[]).map(
-					databaseToSnapshot,
-				);
+				return (data.databases as Database[]).map(databaseToSnapshot);
 			},
 			{ projectId },
 		);
@@ -637,17 +716,24 @@ class RealNeonApi implements NeonApi {
 		return this.call(
 			op,
 			async () => {
-				const res = await this.client.getConnectionUri({
-					projectId,
-					database_name: input.databaseName,
-					role_name: input.roleName,
-					...(input.branchId ? { branch_id: input.branchId } : {}),
-					...(input.endpointId
-						? { endpoint_id: input.endpointId }
-						: {}),
-					pooled,
-				});
-				return { uri: res.data.uri };
+				const data = unwrap(
+					await rawGetConnectionUri({
+						client: this.client,
+						path: { project_id: projectId },
+						query: {
+							database_name: input.databaseName,
+							role_name: input.roleName,
+							...(input.branchId
+								? { branch_id: input.branchId }
+								: {}),
+							...(input.endpointId
+								? { endpoint_id: input.endpointId }
+								: {}),
+							pooled,
+						},
+					}),
+				);
+				return { uri: data.uri };
 			},
 			{ projectId },
 		);
@@ -663,11 +749,18 @@ class RealNeonApi implements NeonApi {
 			return await this.call(
 				`getNeonAuth(${projectId}/${branchId})`,
 				async () => {
-					const res = await this.client.getNeonAuth(
-						projectId,
-						branchId,
+					const data = unwrap(
+						await rawGetNeonAuth({
+							client: this.client,
+							path: {
+								project_id: projectId,
+								branch_id: branchId,
+							},
+						}),
 					);
-					return neonAuthResponseToSnapshot(res.data);
+					return neonAuthResponseToSnapshot(
+						neonAuthResponseSchema.parse(data),
+					);
 				},
 				{ projectId },
 			);
@@ -690,8 +783,8 @@ class RealNeonApi implements NeonApi {
 			return await this.call(
 				`enableNeonAuth(${projectId}/${branchId})`,
 				async () => {
-					// TODO: switch back to `this.client.createNeonAuth` once
-					// @neondatabase/api-client narrows this branch endpoint to `better_auth`.
+					// The generated `createNeonAuth` doesn't narrow this branch
+					// endpoint to `better_auth`, so post the REST body directly.
 					const data = await this.postJson(
 						`/projects/${encodeURIComponent(projectId)}/branches/${encodeURIComponent(branchId)}/auth`,
 						createNeonAuthRestInput(input),
@@ -780,13 +873,16 @@ class RealNeonApi implements NeonApi {
 				`getNeonDataApi(${projectId}/${branchId}/${databaseName})`,
 				async () =>
 					dataApiSnapshotFromResponse(
-						await this.client
-							.getProjectBranchDataApi(
-								projectId,
-								branchId,
-								databaseName,
-							)
-							.then((res) => res.data),
+						unwrap(
+							await rawGetProjectBranchDataApi({
+								client: this.client,
+								path: {
+									project_id: projectId,
+									branch_id: branchId,
+									database_name: databaseName,
+								},
+							}),
+						),
 					),
 				{ projectId },
 			);
@@ -809,15 +905,20 @@ class RealNeonApi implements NeonApi {
 			return await this.call(
 				`enableProjectBranchDataApi(${projectId}/${branchId}/${databaseName})`,
 				async () => {
-					const res = await this.client.createProjectBranchDataApi(
-						projectId,
-						branchId,
-						databaseName,
-						dataApiCreateRequest(input),
+					const data = unwrap(
+						await rawCreateProjectBranchDataApi({
+							client: this.client,
+							path: {
+								project_id: projectId,
+								branch_id: branchId,
+								database_name: databaseName,
+							},
+							body: dataApiCreateRequest(input),
+						}),
 					);
 					// The create response only carries `url`; settings/status come from a
 					// follow-up GET, which we leave to the caller when it needs them.
-					return { url: res.data.url };
+					return { url: data.url };
 				},
 				{ projectId, mutating: true },
 			);
@@ -846,20 +947,30 @@ class RealNeonApi implements NeonApi {
 		return await this.call(
 			`updateProjectBranchDataApi(${projectId}/${branchId}/${databaseName})`,
 			async () => {
-				await this.client.updateProjectBranchDataApi(
-					projectId,
-					branchId,
-					databaseName,
-					{ settings: dataApiSettingsToApi(settings) },
+				unwrap(
+					await rawUpdateProjectBranchDataApi({
+						client: this.client,
+						path: {
+							project_id: projectId,
+							branch_id: branchId,
+							database_name: databaseName,
+						},
+						body: { settings: dataApiSettingsToApi(settings) },
+					}),
 				);
 				// The PATCH returns an empty body; re-fetch so the caller sees the
 				// post-update url/status/settings.
-				const res = await this.client.getProjectBranchDataApi(
-					projectId,
-					branchId,
-					databaseName,
+				const data = unwrap(
+					await rawGetProjectBranchDataApi({
+						client: this.client,
+						path: {
+							project_id: projectId,
+							branch_id: branchId,
+							database_name: databaseName,
+						},
+					}),
 				);
-				return dataApiSnapshotFromResponse(res.data);
+				return dataApiSnapshotFromResponse(data);
 			},
 			{ projectId, mutating: true },
 		);
@@ -1445,10 +1556,7 @@ function endpointToSnapshot(endpoint: Endpoint): NeonEndpointSnapshot {
 	return {
 		id: endpoint.id,
 		branchId: endpoint.branch_id,
-		type:
-			endpoint.type === EndpointType.ReadOnly
-				? "read_only"
-				: "read_write",
+		type: endpoint.type === "read_only" ? "read_only" : "read_write",
 		autoscalingLimitMinCu:
 			endpoint.autoscaling_limit_min_cu as ComputeSettings["autoscalingLimitMinCu"],
 		autoscalingLimitMaxCu:

--- a/packages/env/e2e/helpers.ts
+++ b/packages/env/e2e/helpers.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from "node:crypto";
-import { createApiClient } from "@neondatabase/api-client";
+import { createNeonClient } from "@neon/sdk";
+import {
+	deleteProject as rawDeleteProject,
+	getProject as rawGetProject,
+	listProjects as rawListProjects,
+} from "@neon/sdk/raw";
 import { createRealNeonApi, type NeonApi } from "@neondatabase/config/v1";
 import { test } from "vitest";
 
@@ -53,8 +58,24 @@ export async function bootstrapProject(
 }
 
 /** Lower-level Neon client. Used by cleanup and a few setup helpers. */
-function makeRawClient(): ReturnType<typeof createApiClient> {
-	return createApiClient({ apiKey: requireApiKey() });
+function makeRawClient(): ReturnType<typeof createNeonClient>["client"] {
+	return createNeonClient({ apiKey: requireApiKey() }).client;
+}
+
+/**
+ * Unwrap a `@neon/sdk` raw `{ data, error, response }` result into the bare body, throwing
+ * `{ response: { status } }` on a non-2xx so the status-based catches below keep working.
+ */
+function unwrap<T>(result: {
+	data?: T;
+	error?: unknown;
+	response?: Response;
+}): T {
+	const response = result.response;
+	if (!response || !response.ok) {
+		throw { response: { status: response?.status, data: result.error } };
+	}
+	return result.data as T;
 }
 
 /**
@@ -70,7 +91,7 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
 	if (cachedScope) return cachedScope;
 	const client = makeRawClient();
 	try {
-		await client.listProjects({ limit: 1 });
+		unwrap(await rawListProjects({ client, query: { limit: 1 } }));
 		cachedScope = { kind: "org-or-user", canCreate: true };
 		return cachedScope;
 	} catch (err) {
@@ -100,23 +121,34 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
  */
 async function deleteProject(projectId: string): Promise<void> {
 	const client = makeRawClient();
-	const project = await client.getProject(projectId).catch((err) => {
-		const status = (err as { response?: { status?: number } } | undefined)
-			?.response?.status;
-		if (status === 404 || status === 410) return null;
-		throw err;
-	});
+	const project = await rawGetProject({
+		client,
+		path: { project_id: projectId },
+	})
+		.then(unwrap)
+		.catch((err) => {
+			const status = (
+				err as { response?: { status?: number } } | undefined
+			)?.response?.status;
+			if (status === 404 || status === 410) return null;
+			throw err;
+		});
 	if (!project) return;
-	if (!project.data.project.name.startsWith(PROJECT_PREFIX)) {
+	if (!project.project.name.startsWith(PROJECT_PREFIX)) {
 		throw new Error(
-			`Refusing to delete project ${projectId} ("${project.data.project.name}"): does not match the e2e prefix.`,
+			`Refusing to delete project ${projectId} ("${project.project.name}"): does not match the e2e prefix.`,
 		);
 	}
 	const maxAttempts = 12;
 	let delay = 500;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
-			await client.deleteProject(projectId);
+			unwrap(
+				await rawDeleteProject({
+					client,
+					path: { project_id: projectId },
+				}),
+			);
 			return;
 		} catch (err) {
 			const status = (
@@ -140,17 +172,19 @@ export async function sweepOrphans(): Promise<{ swept: string[] }> {
 	const swept: string[] = [];
 	let cursor: string | undefined;
 	while (true) {
-		const res = await client.listProjects({
-			limit: 100,
-			...(cursor ? { cursor } : {}),
-		});
-		for (const project of res.data.projects) {
+		const body = unwrap(
+			await rawListProjects({
+				client,
+				query: { limit: 100, ...(cursor ? { cursor } : {}) },
+			}),
+		);
+		for (const project of body.projects) {
 			if (project.name.startsWith(PROJECT_PREFIX)) {
 				await deleteProject(project.id);
 				swept.push(project.id);
 			}
 		}
-		const next = (res.data as { pagination?: { next?: string } }).pagination
+		const next = (body as { pagination?: { next?: string } }).pagination
 			?.next;
 		if (!next || next === cursor) break;
 		cursor = next;

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -47,7 +47,7 @@
 		"tsc": "tsc"
 	},
 	"devDependencies": {
-		"@neondatabase/api-client": "^2.7.1",
+		"@neon/sdk": "workspace:*",
 		"@types/node": "catalog:",
 		"@types/yargs": "^17.0.35",
 		"@vitest/coverage-v8": "3.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -206,9 +206,9 @@ importers:
       '@hono/node-server':
         specifier: 2.0.4
         version: 2.0.4(hono@4.12.25)
-      '@neondatabase/api-client':
-        specifier: 2.7.1
-        version: 2.7.1
+      '@neon/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@neondatabase/config':
         specifier: 0.8.0
         version: 0.8.0
@@ -221,12 +221,6 @@ importers:
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
-      axios:
-        specifier: 1.7.2
-        version: 1.7.2
-      axios-debug-log:
-        specifier: 1.0.0
-        version: 1.0.0(axios@1.7.2)
       chalk:
         specifier: 5.3.0
         version: 5.3.0
@@ -260,6 +254,9 @@ importers:
       prompts:
         specifier: 2.4.2
         version: 2.4.2
+      undici:
+        specifier: ^8.5.0
+        version: 8.5.0
       which:
         specifier: 3.0.1
         version: 3.0.1
@@ -3092,16 +3089,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios-debug-log@1.0.0:
-    resolution: {integrity: sha512-ZjMaEBEij9w+Vbk2Uc3XflchTT7j9rZdYD/snN+XQ5FRDq1QjZNhh0Izb3KSyarU5vTkiCvJyg1xDiQBHZZB9w==}
-    peerDependencies:
-      axios: '>=1.0.0'
-
   axios@1.16.1:
     resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
-
-  axios@1.7.2:
-    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
 
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
@@ -5462,9 +5451,6 @@ packages:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -6216,13 +6202,13 @@ packages:
   undici-types@7.10.0:
     resolution: {integrity: sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==}
 
-  undici@7.16.0:
-    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.5.0:
+    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
+    engines: {node: '>=22.19.0'}
 
   unenv@1.10.0:
     resolution: {integrity: sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==}
@@ -8732,6 +8718,7 @@ snapshots:
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+    optional: true
 
   '@types/diff@5.2.1': {}
 
@@ -8775,7 +8762,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/ms@2.1.0': {}
+  '@types/ms@2.1.0':
+    optional: true
 
   '@types/node@12.20.55': {}
 
@@ -9309,14 +9297,6 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios-debug-log@1.0.0(axios@1.7.2):
-    dependencies:
-      '@types/debug': 4.1.13
-      axios: 1.7.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
@@ -9326,14 +9306,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  axios@1.7.2:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   b4a@1.6.7: {}
 
@@ -9633,7 +9605,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.16.0
+      undici: 7.28.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -11880,8 +11852,6 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-from-env@1.1.0: {}
-
   proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
@@ -12726,9 +12696,9 @@ snapshots:
   undici-types@7.10.0:
     optional: true
 
-  undici@7.16.0: {}
-
   undici@7.28.0: {}
+
+  undici@8.5.0: {}
 
   unenv@1.10.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,9 +364,9 @@ importers:
 
   packages/config:
     dependencies:
-      '@neondatabase/api-client':
-        specifier: ^2.7.1
-        version: 2.7.1
+      '@neon/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
@@ -405,9 +405,9 @@ importers:
         specifier: ^0.8.2
         version: 0.8.3
     devDependencies:
-      '@neondatabase/api-client':
-        specifier: ^2.7.1
-        version: 2.7.1
+      '@neon/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.17
@@ -439,9 +439,9 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
-      '@neondatabase/api-client':
-        specifier: ^2.7.1
-        version: 2.7.1
+      '@neon/sdk':
+        specifier: workspace:*
+        version: link:../sdk
       '@types/node':
         specifier: 'catalog:'
         version: 20.19.17


### PR DESCRIPTION
## Summary

Phase 1 of replacing the deprecated **`@neondatabase/api-client`** (axios) with the new fetch-based, zero-dependency **`@neon/sdk`** across the `neon-pkgs` monorepo — dogfooding the SDK we just published.

This PR migrates the **`config` family** (`@neondatabase/config`, plus the `config-runtime` / `env` e2e helpers). The big **`neonctl` CLI** migration (122 call sites, ~60 methods, multipart function deploys, snapshot tests) is intentionally a **separate follow-up PR** so it gets its own focused review.

### What changed
- **`@neondatabase/config` — `createRealNeonApi` adapter** (`src/lib/neon-api-real.ts`): the ~17 standard project/branch/endpoint/role/database/data-api calls now go through `@neon/sdk/raw` (path/query/body + `{ data, error }`) instead of the axios `Api` client. A small `unwrap()` re-throws non-2xx responses in the **same `{ response: { status, data } }` shape** the existing `wrap-neon-error.ts` and 423 `retryOnLocked` already consume — so error handling and retries needed **zero** changes.
- The `NeonApi` façade is **unchanged** — this is a pure transport swap, invisible to consumers.
- The preview REST fallbacks (buckets / functions / credentials / neon-auth / storage) already used raw `fetch`; untouched.
- **e2e helpers** for `config` / `config-runtime` / `env` migrated off `createApiClient` to a raw `@neon/sdk` client (same status-based cleanup logic).
- **Dependencies:** dropped `@neondatabase/api-client` (runtime dep of `config`; devDep of `env` / `config-runtime`) in favor of `@neon/sdk` (`workspace:*`).
- Type-name deltas handled: `DataAPI*` → `DataApi*`, and `EndpointType` is now a string union (`"read_write"` / `"read_only"`) rather than an enum.

### Why no changeset for env / config-runtime
Their only change is in `e2e/` (not shipped), so no version bump — only `@neondatabase/config` gets a `patch` changeset (its runtime dep tree changed).

## Test plan
- [x] `tsc` clean for `config`, `config-runtime`, `env` (incl. `e2e/`)
- [x] Unit tests pass: **223** `config` (incl. `neon-api-real.test.ts`, `wrap-neon-error.test.ts`), **49** `config-runtime`, **93** `env`
- [x] Biome lint/format clean
- [ ] e2e suites (`test:e2e`) — require a live `NEON_API_KEY`; please run in CI / locally with creds
- [ ] Follow-up PR: migrate `neonctl` (`packages/cli`) off `@neondatabase/api-client`