### PR TITLE
fix(cli): clear "check your connection" message on network failures

### DIFF
--- a/packages/cli/src/errors.test.ts
+++ b/packages/cli/src/errors.test.ts
@@ -1,0 +1,71 @@
+import { AxiosError } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import { isNetworkError, matchErrorCode } from './errors.js';
+
+describe('matchErrorCode', () => {
+  it('maps known message shapes to their codes', () => {
+    expect(matchErrorCode('Unknown command: frobnicate')).toBe(
+      'UNKNOWN_COMMAND',
+    );
+    expect(matchErrorCode('Missing required argument: project-id')).toBe(
+      'MISSING_ARGUMENT',
+    );
+  });
+
+  it('falls back to UNKNOWN_ERROR for unmatched / empty messages', () => {
+    expect(matchErrorCode('something else entirely')).toBe('UNKNOWN_ERROR');
+    expect(matchErrorCode(undefined)).toBe('UNKNOWN_ERROR');
+  });
+});
+
+describe('isNetworkError', () => {
+  it('detects a Node fetch failure whose cause carries the socket code', () => {
+    // What `await fetch(...)` rejects with when the host is unreachable: a bare
+    // `TypeError: fetch failed` with the real code one level down on `cause`.
+    const cause = Object.assign(new Error('getaddrinfo ENOTFOUND'), {
+      code: 'ENOTFOUND',
+    });
+    const err = Object.assign(new TypeError('fetch failed'), { cause });
+    expect(isNetworkError(err)).toBe(true);
+  });
+
+  it('detects a browser-style "Failed to fetch" message', () => {
+    expect(isNetworkError(new TypeError('Failed to fetch'))).toBe(true);
+  });
+
+  it('detects an axios "Network Error"', () => {
+    expect(isNetworkError(new AxiosError('Network Error'))).toBe(true);
+  });
+
+  it('detects a top-level socket code without a wrapping message', () => {
+    expect(
+      isNetworkError(
+        Object.assign(new Error('connect failed'), { code: 'ECONNREFUSED' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does not treat an HTTP API error as a network error', () => {
+    // A real 4xx/5xx must still surface to the user, never be swallowed as "offline".
+    const apiError = {
+      response: { status: 404, data: { message: 'not found' } },
+    };
+    expect(isNetworkError(apiError)).toBe(false);
+    expect(isNetworkError(new Error('Project not found'))).toBe(false);
+  });
+
+  it('does not treat an axios timeout (ECONNABORTED) as a network error', () => {
+    // Timeouts have their own dedicated message in the CLI; keep them distinct.
+    const timeout = Object.assign(new Error('timeout of 60000ms exceeded'), {
+      code: 'ECONNABORTED',
+    });
+    expect(isNetworkError(timeout)).toBe(false);
+  });
+
+  it('returns false for non-error values', () => {
+    expect(isNetworkError(null)).toBe(false);
+    expect(isNetworkError(undefined)).toBe(false);
+    expect(isNetworkError('fetch failed')).toBe(false);
+  });
+});

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,5 +1,6 @@
 export type ErrorCode =
   | 'REQUEST_TIMEOUT'
+  | 'NETWORK_ERROR'
   | 'AUTH_FAILED'
   | 'AUTH_BROWSER_FAILED'
   | 'API_ERROR'
@@ -27,4 +28,79 @@ export const matchErrorCode = (message?: string): ErrorCode => {
     }
   }
   return 'UNKNOWN_ERROR';
+};
+
+/**
+ * The single, human-readable line shown when the CLI couldn't reach the Neon API because
+ * of a connection-level failure (DNS, refused/reset connection, offline). It replaces the
+ * cryptic `fetch failed` / empty axios message a network blip otherwise surfaces (see
+ * {@link isNetworkError}), pointing at the two things the user can actually check.
+ */
+export const NETWORK_ERROR_MESSAGE =
+  'Could not reach the Neon API. Please check your internet connection and try again. ' +
+  'If your connection is fine and this keeps happening, check https://neonstatus.com for ongoing incidents.';
+
+/**
+ * Node-level socket/DNS error codes that mean the request never reached the server — a
+ * genuine connectivity problem rather than an API response we should surface. Deliberately
+ * excludes `ECONNABORTED` (axios' timeout), which the CLI already reports as a timeout.
+ */
+const NETWORK_ERROR_CODES = new Set([
+  'ECONNREFUSED',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EPIPE',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'EHOSTDOWN',
+  'ENETDOWN',
+]);
+
+/**
+ * Message fragments that mark a connection-level failure across our two transports: the
+ * `@neon/sdk` / global `fetch` path (used by `env pull` / `config` / `deploy`, and `link`'s
+ * bundled env pull) throws a bare `TypeError: fetch failed` / "Failed to fetch", while the
+ * axios `api-client` path throws an `AxiosError` whose message is "Network Error".
+ */
+const NETWORK_ERROR_MESSAGE_PATTERN =
+  /fetch failed|failed to fetch|network error/i;
+
+const readErrorCode = (value: unknown): string | undefined => {
+  if (value === null || typeof value !== 'object') return undefined;
+  const code = (value as { code?: unknown }).code;
+  return typeof code === 'string' ? code : undefined;
+};
+
+/**
+ * Whether `err` is a connection-level failure (the network blip the user sees as a cryptic
+ * `fetch failed`, or no message at all on the axios path) rather than an actual API response.
+ *
+ * A Node `fetch` failure is a bare `TypeError: fetch failed` whose underlying `cause` carries
+ * the real socket `code` (e.g. `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`), so we walk the
+ * `cause` chain checking both the code and the message. This is what lets the CLI swap the
+ * confusing default for {@link NETWORK_ERROR_MESSAGE}. It matches only failures where no
+ * response was ever received, so it never masks a real 4xx/5xx the user needs to see.
+ */
+export const isNetworkError = (err: unknown): boolean => {
+  let current: unknown = err;
+  for (
+    let depth = 0;
+    depth < 6 && current !== null && current !== undefined;
+    depth++
+  ) {
+    const code = readErrorCode(current);
+    if (code !== undefined && NETWORK_ERROR_CODES.has(code)) {
+      return true;
+    }
+    if (
+      current instanceof Error &&
+      NETWORK_ERROR_MESSAGE_PATTERN.test(current.message)
+    ) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
 };

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,7 +31,11 @@ import {
   trackEvent,
 } from './analytics.js';
 import { isAxiosError } from 'axios';
-import { matchErrorCode } from './errors.js';
+import {
+  isNetworkError,
+  matchErrorCode,
+  NETWORK_ERROR_MESSAGE,
+} from './errors.js';
 import { showHelp } from './help.js';
 import { currentContextFile, enrichFromContext } from './context.js';
 
@@ -187,6 +191,19 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
   // Log stack trace if available
   if (err instanceof Error && err.stack) {
     log.debug('Stack: %s', err.stack);
+  }
+
+  // A connection-level failure (no response ever reached us) reads as a cryptic
+  // `fetch failed` on the @neon/sdk / fetch path (env pull / config / deploy and link's
+  // bundled env pull), or surfaces no user-facing message at all on the axios path. Detect
+  // it first — across either transport — and swap in one clear "check your connection" hint.
+  // We deliberately do not retry here: re-running the whole command could re-trigger a
+  // non-idempotent step (e.g. project create), so retries belong at the request layer.
+  if (isNetworkError(err)) {
+    log.error(NETWORK_ERROR_MESSAGE);
+    const error = err instanceof Error ? err : new Error(NETWORK_ERROR_MESSAGE);
+    sendError(error, 'NETWORK_ERROR');
+    return false;
   }
 
   if (isAxiosError(err)) {


### PR DESCRIPTION
## Summary

When a network blip kills a request, the CLI used to surface a cryptic `fetch failed` (the `@neon/sdk` / `fetch` path behind `neon env pull`, `neon config …`, `neon deploy`, and `neon link`'s bundled env pull) — or, on the axios `api-client` path, **no user-facing error at all** (there's no `response.data.message` for a connection error).

This adds a small, transport-agnostic detector and swaps that for one clear, human-readable line:

> Could not reach the Neon API. Please check your internet connection and try again. If your connection is fine and this keeps happening, check https://neonstatus.com for ongoing incidents.

- `isNetworkError(err)` (`errors.ts`) walks the error `cause` chain looking for socket/DNS codes (`ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, …) and the `fetch failed` / "Failed to fetch" / "Network Error" messages — covering both the fetch and axios transports.
- The CLI's top-level `handleError` checks it first and prints `NETWORK_ERROR_MESSAGE` (tracked under a new `NETWORK_ERROR` analytics code).
- It matches **only** failures where no HTTP response was received, so a genuine 4xx/5xx is never masked. `ECONNABORTED` (axios timeout) is intentionally excluded — it keeps its existing "Request timed out" message.

### On auto-retry

The original ask also floated auto-retrying twice on `failed to fetch`. I deliberately **did not** add a retry at the CLI command boundary: the only seam there re-runs the whole command, which could re-trigger a non-idempotent step (e.g. project create) — exactly the double-create we want to avoid. A safe retry belongs at the per-request transport layer (`@neondatabase/config`'s `createRealNeonApi`, where a `fetch` rejection provably means the request never reached the server). Happy to follow up with that as a separate, focused change if we want it.

## Test plan

- [x] `vitest run src/errors.test.ts` — new unit tests for `isNetworkError` (fetch-failed w/ `cause` code, browser `Failed to fetch`, axios `Network Error`, bare socket code, and negative cases: real 404, timeout `ECONNABORTED`, non-error values) and `matchErrorCode`.
- [x] `tsc --noEmit`, `eslint`, `prettier --check` (cli config) all clean.
- [ ] Manual: run any of `neon env pull` / `neon deploy` / `neon link` while offline → see the friendly message instead of `fetch failed`.