### PR TITLE
feat(cli): add `neon status` and `config status --current-branch`

### DIFF
--- a/.changeset/neon-status-current-branch.md
+++ b/.changeset/neon-status-current-branch.md
@@ -1,0 +1,9 @@
+---
+"neonctl": minor
+---
+
+Add `neon status` and the `--current-branch` flag for `config status`.
+
+`neon status` is a top-level alias for `neon config status` (it mirrors all of its options and delegates to the same handler).
+
+`config status --current-branch` (also `neon status --current-branch`) prints only the branch pinned in the local `.neon` file with no network request, no login, and no analytics — cheap enough to drive a shell prompt (e.g. starship). It prints the branch name to stdout and exits 0; when no branch is pinned it prints nothing to stdout, writes a `neonctl checkout <branch>` hint to stderr, and exits non-zero (grep-style) so a prompt can guard on the command directly.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -388,11 +388,14 @@ export default defineConfig({
 });
 ```
 
-Three sub-commands plus a top-level alias drive it:
+Three sub-commands plus two top-level aliases drive it:
 
 ```bash
 # Inspect the branch's live Neon state (read-only — never mutates)
 neon config status
+
+# `neon status` is an alias for `neon config status`
+neon status
 
 # Dry-run diff: show exactly what `apply` would change
 neon config plan
@@ -418,6 +421,35 @@ The branch is chosen with `--branch <id|name>`; without it the project's default
 - `--allow-protected` — auto-confirm applying to a branch Neon marks as protected. Without it, `apply` refuses to touch a protected branch.
 
 **Output**: `status` prints the project, branch, and reverse-engineered config; `plan` / `apply` print the planned/applied changes and any conflicts as tables. Pass `--output json` (or `--output yaml`) to emit the full machine-readable result (`PushResult`) for piping into other tools or CI.
+
+**`config status --current-branch`** (alias `neon status --current-branch`) prints _only_ the branch pinned in the local `.neon` file — no network, no auth, no analytics — and exits non-zero when none is pinned. This behavior lets it safely drive a shell prompt. Example [starship](https://starship.rs) segment:
+
+```toml
+[custom.neon]
+description = "Current Neon database branch"
+format = "[$symbol$output]($style) "
+style = "bold green"
+# `symbol` below uses a Nerd Font glyph; swap it for a plain
+# label/emoji if you don't have a Nerd Font installed.
+symbol = " "
+command = "neon status --current-branch"
+# Starship evaluates this on EVERY prompt render. To keep prompts instant
+# everywhere outside a Neon project, do a zero-subprocess walk-up for an
+# ancestor `.neon` first (the same walk the CLI does, stopping at $HOME and /).
+# Only when one is found do we invoke the CLI, whose exit code is the real
+# gate: non-zero (no branch pinned) hides the segment cleanly.
+when = '''
+d="$PWD"
+while [ "$d" != "$HOME" ] && [ "$d" != / ]; do
+  if [ -e "$d/.neon" ]; then
+    neon status --current-branch >/dev/null 2>&1
+    exit $?
+  fi
+  d=$(dirname "$d")
+done
+exit 1
+'''
+```
 
 ```bash
 # CI gate: fail the build if the branch has drifted from the policy

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -5,6 +5,7 @@ import { Analytics, TrackParams } from '@segment/analytics-node';
 import { isAxiosError } from 'axios';
 
 import { CREDENTIALS_FILE } from './config.js';
+import { isCurrentBranchProbe } from './context.js';
 import { getGithubEnvVars, isCi } from './env.js';
 import { ErrorCode } from './errors.js';
 import { log } from './log.js';
@@ -12,6 +13,14 @@ import pkg from './pkg.js';
 import { getApiClient } from './api.js';
 
 const WRITE_KEY = '3SQXn5ejjXWLEJ8xU2PRYhAotLtTaeeV';
+
+/**
+ * Raw-argv fallback for the offline `--current-branch` probe. The init
+ * middleware runs before validation, where the parsed `currentBranch` flag may
+ * not be populated yet, so we also scan `process.argv` directly to be safe.
+ */
+const hasCurrentBranchArgv = (): boolean =>
+  process.argv.includes('--current-branch');
 
 let client: Analytics | undefined;
 let clientInitialized = false;
@@ -27,6 +36,13 @@ export const initAnalyticsClientMiddleware = (args: {
   [key: string]: unknown;
 }) => {
   if (!args.analytics || clientInitialized) {
+    return;
+  }
+  // The offline `--current-branch` probe must make zero network calls. This
+  // middleware runs before validation, so guard on the raw argv too (in case
+  // the parsed `currentBranch` flag isn't populated this early): never create
+  // the Segment client, which keeps trackEvent/closeAnalytics no-ops downstream.
+  if (isCurrentBranchProbe(args as any) || hasCurrentBranchArgv()) {
     return;
   }
   clientInitialized = true;
@@ -53,6 +69,9 @@ export const analyticsMiddleware = async (args: {
   [key: string]: unknown;
 }) => {
   if (!client || !args.analytics) {
+    return;
+  }
+  if (isCurrentBranchProbe(args)) {
     return;
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,3 +1,11 @@
 #!/usr/bin/env node
 
-import './index.js';
+import { tryCurrentBranchFastPath } from './current_branch_fast_path.js';
+
+// Fast path for the offline `(config) status --current-branch` probe (used by shell
+// prompts): read the pinned branch from `.neon` without loading the full command tree,
+// api-client, and yargs (~200ms). Falls through to the full CLI for everything else, so
+// the heavy `index.js` is imported lazily and only when actually needed.
+if (!tryCurrentBranchFastPath(process.argv)) {
+  void import('./index.js');
+}

--- a/packages/cli/src/commands/__snapshots__/config.current_branch.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/config.current_branch.test.ts.snap
@@ -1,0 +1,8 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`config status --current-branch (offline, end to end) > exits non-zero with empty stdout when no branch is pinned (no network access) 1`] = `""`;
+
+exports[`config status --current-branch (offline, end to end) > prints the pinned branch with no network access 1`] = `
+"my-feature
+"
+`;

--- a/packages/cli/src/commands/__snapshots__/status.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/status.test.ts.snap
@@ -1,0 +1,6 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`status (alias of config status) > \`status --current-branch\` prints the pinned branch offline 1`] = `
+"feat-alias
+"
+`;

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -7,6 +7,7 @@ import { Api } from '@neondatabase/api-client';
 
 import { getApiClient } from '../api.js';
 import { auth, refreshToken } from '../auth.js';
+import { isCurrentBranchProbe } from '../context.js';
 import { CREDENTIALS_FILE } from '../config.js';
 import { isCi } from '../env.js';
 import { log } from '../log.js';
@@ -160,6 +161,13 @@ export const ensureAuth = async (
 ) => {
   // Skip auth for help command or no command
   if (props._.length === 0 || props.help) {
+    return;
+  }
+
+  // `(config) status --current-branch` is a purely-local read of `.neon`; it must
+  // never refresh a token or pop a browser login. Skip auth entirely (the handler
+  // doesn't use an API client in this mode).
+  if (isCurrentBranchProbe(props)) {
     return;
   }
 

--- a/packages/cli/src/commands/config.current_branch.test.ts
+++ b/packages/cli/src/commands/config.current_branch.test.ts
@@ -1,0 +1,61 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect } from 'vitest';
+
+import { test } from '../test_utils/fixtures';
+
+// End-to-end guard for `(config) status --current-branch`: it must read the pinned
+// branch from `.neon` and make ZERO network calls. We point the CLI at an unreachable
+// host (`unreachableHost`) — so if ANY middleware (auth token refresh, single-project
+// resolution) or the handler tried the API, the command would fail instead of exiting 0.
+// The fixture `.neon` deliberately omits `projectId`, which is exactly what would force
+// `fillSingleProject` to hit the network if its offline guard regressed.
+describe('config status --current-branch (offline, end to end)', () => {
+  let workspace: string;
+  let contextFile: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'neonctl-curbranch-'));
+    contextFile = join(workspace, '.neon');
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('prints the pinned branch with no network access', async ({
+    testCliCommand,
+  }) => {
+    writeFileSync(
+      contextFile,
+      JSON.stringify({ orgId: 'org-x', branch: 'my-feature' }),
+    );
+
+    await testCliCommand(
+      ['config', 'status', '--current-branch', '--context-file', contextFile],
+      {
+        unreachableHost: true,
+        code: 0,
+        // stdout is snapshotted by the fixture; it must be exactly the branch name.
+      },
+    );
+  });
+
+  test('exits non-zero with empty stdout when no branch is pinned (no network access)', async ({
+    testCliCommand,
+  }) => {
+    writeFileSync(contextFile, JSON.stringify({ orgId: 'org-x' }));
+
+    await testCliCommand(
+      ['config', 'status', '--current-branch', '--context-file', contextFile],
+      {
+        unreachableHost: true,
+        // grep-style: "no branch pinned" is a non-zero "no result", so a shell
+        // prompt can guard on it directly. Empty stdout; hint on stderr.
+        code: 1,
+        stderr: expect.stringContaining('Run `neonctl checkout <branch>`'),
+      },
+    );
+  });
+});

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -372,6 +372,119 @@ describe('config commands', () => {
     expect(json.branch.postgres.computeSettings.suspendTimeout).toBe('5m');
   });
 
+  it('status --current-branch prints only the pinned branch from .neon and never touches the API', async () => {
+    const { stream, read } = captureOut();
+    const contextFile = join(cwd, '.neon');
+    writeFileSync(
+      contextFile,
+      JSON.stringify({
+        orgId: 'org-x',
+        projectId: 'proj-x',
+        branch: 'my-feature',
+      }),
+    );
+
+    // Any API access in this mode is a bug: the branch comes purely from `.neon`.
+    const throwingApi = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error('apiClient must not be called for --current-branch');
+        },
+      },
+    );
+
+    const chunks: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      chunks.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await status({
+        ...baseProps(new FakeNeonApi(), stream),
+        apiClient: throwingApi as never,
+        contextFile,
+        currentBranch: true,
+      });
+    } finally {
+      process.stdout.write = orig;
+    }
+
+    // Branch present: exactly the branch name + newline, exit 0 (like `git
+    // branch --show-current` for this case); the writer is unused.
+    expect(chunks.join('')).toBe('my-feature\n');
+    expect(read()).toBe('');
+  });
+
+  it('status --current-branch prints nothing to stdout, hints on stderr, and exits non-zero when no branch is pinned', async () => {
+    const { stream } = captureOut();
+    const contextFile = join(cwd, '.neon');
+    // A linked project but no pinned branch — the unset case.
+    writeFileSync(
+      contextFile,
+      JSON.stringify({ orgId: 'org-x', projectId: 'proj-x' }),
+    );
+
+    const stdoutChunks: string[] = [];
+    const stderrChunks: string[] = [];
+    const origOut = process.stdout.write.bind(process.stdout);
+    const origErr = process.stderr.write.bind(process.stderr);
+    const origExitCode = process.exitCode;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdoutChunks.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      stderrChunks.push(chunk.toString());
+      return true;
+    }) as typeof process.stderr.write;
+    try {
+      await status({
+        ...baseProps(new FakeNeonApi(), stream),
+        contextFile,
+        currentBranch: true,
+      });
+
+      // stdout stays empty; the hint goes to stderr only.
+      expect(stdoutChunks.join('')).toBe('');
+      expect(stderrChunks.join('')).toContain('Run `neonctl checkout <branch>`');
+      // Non-zero exit (grep-style) so a shell prompt can guard on it directly.
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.stdout.write = origOut;
+      process.stderr.write = origErr;
+      // Restore so a failing exit code doesn't leak into the vitest process.
+      process.exitCode = origExitCode;
+    }
+  });
+
+  it('status --current-branch treats a missing .neon as no branch (empty stdout, non-zero exit)', async () => {
+    const { stream } = captureOut();
+    const contextFile = join(cwd, 'does-not-exist', '.neon');
+
+    const stdoutChunks: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    const origExitCode = process.exitCode;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdoutChunks.push(chunk.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await status({
+        ...baseProps(new FakeNeonApi(), stream),
+        contextFile,
+        currentBranch: true,
+      });
+
+      expect(stdoutChunks.join('')).toBe('');
+      expect(process.exitCode).toBe(1);
+    } finally {
+      process.stdout.write = orig;
+      process.exitCode = origExitCode;
+    }
+  });
+
   it('plan is a dry run whose applied list includes the auth service change', async () => {
     const api = new FakeNeonApi();
     const { stream, read } = captureOut();

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -15,6 +15,7 @@ import {
 } from '@neondatabase/config-runtime';
 import { toNeonConfigView } from '../config_format.js';
 
+import { contextBranch, readContextFile } from '../context.js';
 import { log } from '../log.js';
 import { isCi } from '../env.js';
 import { BranchScopeProps } from '../types.js';
@@ -66,6 +67,14 @@ export type ConfigProps = BranchScopeProps & {
   allowProtected?: boolean;
   /** `status` only: print just the neon.ts-shaped config JSON to stdout. */
   configJson?: boolean;
+  /**
+   * `status` only: print ONLY the linked branch name from the local `.neon` file
+   * (no network). Prints the branch and exits 0 when one is pinned; exits non-zero
+   * when none is (so a shell prompt can guard on it) — unlike `git branch
+   * --show-current`, which exits 0 when detached. Wins over `--config-json` and
+   * ignores `--output`. See {@link isCurrentBranchProbe} for the offline guard.
+   */
+  currentBranch?: boolean;
   /**
    * After a successful `config apply` / `deploy`, pull the branch's Neon env vars into a
    * local `.env` (DATABASE_URL, AI Gateway, object storage, …) — the same convenience as
@@ -153,6 +162,13 @@ export const builder = (argv: yargs.Argv) =>
             type: 'boolean',
             default: false,
           },
+          'current-branch': {
+            describe:
+              'Print only the linked branch name from the local .neon file ' +
+              '(no network). Exits non-zero when no branch is pinned.',
+            type: 'boolean',
+            default: false,
+          },
         }),
       (args) => status(args as any),
     )
@@ -210,6 +226,23 @@ const loadConfig = async (props: ConfigProps): Promise<Config> => {
 };
 
 export const status = async (props: ConfigProps): Promise<void> => {
+  // `--current-branch` short-circuits here (before resolveBranchRef), so it wins
+  // over --config-json and ignores --output. See ConfigProps.currentBranch / isCurrentBranchProbe.
+  if (props.currentBranch) {
+    const branch = contextBranch(readContextFile(props.contextFile));
+    if (branch) {
+      process.stdout.write(`${branch}\n`);
+    } else {
+      // No branch pinned: hint on stderr and exit non-zero (grep-style) so a prompt's
+      // `when` hides the segment cleanly instead of rendering a bare icon.
+      log.info(
+        'No branch pinned. Run `neonctl checkout <branch>` to pin a branch and pull its env vars.',
+      );
+      process.exitCode = 1;
+    }
+    return;
+  }
+
   const branch = await resolveBranchRef(props);
   // `--config-json` is a script-friendly mode that emits only JSON to stdout, so keep it
   // pristine; the regular human view gets the "which branch am I inspecting" guardrail.

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -19,6 +19,7 @@ import * as neonAuth from './neon_auth.js';
 import * as functions from './functions.js';
 import * as dev from './dev.js';
 import * as config from './config.js';
+import * as status from './status.js';
 import * as deploy from './deploy.js';
 import * as env from './env.js';
 import * as bucket from './bucket.js';
@@ -46,6 +47,7 @@ export default [
   functions,
   dev,
   config,
+  status,
   deploy,
   env,
   bucket,

--- a/packages/cli/src/commands/status.test.ts
+++ b/packages/cli/src/commands/status.test.ts
@@ -1,0 +1,42 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe } from 'vitest';
+
+import { test } from '../test_utils/fixtures';
+
+// `neon status` is a top-level alias of `neon config status`. These guard the two
+// behaviors that the alias wiring can break: (1) a bare `status` must run the handler
+// rather than being swallowed by the help-fallback middleware (it must be in
+// NO_SUBCOMMANDS_VERBS), and (2) `--current-branch` must work through the alias exactly
+// as it does on `config status` (offline, reading `.neon`).
+describe('status (alias of config status)', () => {
+  let workspace: string;
+  let contextFile: string;
+
+  beforeEach(() => {
+    workspace = mkdtempSync(join(tmpdir(), 'neonctl-status-alias-'));
+    contextFile = join(workspace, '.neon');
+  });
+
+  afterEach(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('`status --current-branch` prints the pinned branch offline', async ({
+    testCliCommand,
+  }) => {
+    writeFileSync(
+      contextFile,
+      JSON.stringify({ orgId: 'org-x', branch: 'feat-alias' }),
+    );
+
+    await testCliCommand(
+      ['status', '--current-branch', '--context-file', contextFile],
+      {
+        unreachableHost: true,
+        code: 0,
+      },
+    );
+  });
+});

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -1,0 +1,48 @@
+import yargs from 'yargs';
+
+import { fillSingleProject } from '../utils/enrichers.js';
+import { status } from './config.js';
+
+/**
+ * `neon status` is a top-level alias for `neon config status` — the most-reached-for
+ * config subcommand. It mirrors that command's options (including `--current-branch`,
+ * the offline branch probe) and delegates to the same `status` handler.
+ *
+ * Because it has a handler but no subcommands, `status` must also be listed in
+ * `NO_SUBCOMMANDS_VERBS` (see index.ts) so the help-fallback middleware doesn't
+ * intercept a bare `neon status`.
+ */
+export const command = 'status';
+export const describe = "Show the branch's live Neon state (alias of `config status`)";
+
+export const builder = (argv: yargs.Argv) =>
+  argv
+    .usage('$0 status [options]')
+    .options({
+      'project-id': {
+        describe: 'Project ID',
+        type: 'string',
+      },
+      branch: {
+        describe: 'Branch ID or name',
+        type: 'string',
+      },
+      'config-json': {
+        describe:
+          "Print only the branch's live config as neon.ts-shaped JSON " +
+          '(services + branch tuning + preview), to stdout. Useful for ' +
+          'scripting or copying into a neon.ts.',
+        type: 'boolean',
+        default: false,
+      },
+      'current-branch': {
+        describe:
+          'Print only the linked branch name from the local .neon file ' +
+          '(no network). Exits non-zero when no branch is pinned.',
+        type: 'boolean',
+        default: false,
+      },
+    })
+    .middleware(fillSingleProject as any);
+
+export const handler = (args: yargs.Arguments) => status(args as any);

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -13,7 +13,47 @@ import {
   applyContext,
   currentContextFile,
   ensureGitignored,
+  isCurrentBranchProbe,
 } from './context.js';
+
+describe('isCurrentBranchProbe', () => {
+  test('true only when --current-branch is set on `status` or `config`', () => {
+    expect(isCurrentBranchProbe({ _: ['status'], currentBranch: true })).toBe(
+      true,
+    );
+    expect(
+      isCurrentBranchProbe({ _: ['config', 'status'], currentBranch: true }),
+    ).toBe(true);
+  });
+
+  test('false without the flag', () => {
+    expect(isCurrentBranchProbe({ _: ['status'] })).toBe(false);
+    expect(
+      isCurrentBranchProbe({ _: ['config', 'status'], currentBranch: false }),
+    ).toBe(false);
+  });
+
+  test('false for unrelated commands even with the flag (no auth/analytics skip)', () => {
+    expect(
+      isCurrentBranchProbe({ _: ['projects', 'list'], currentBranch: true }),
+    ).toBe(false);
+    expect(isCurrentBranchProbe({ _: [], currentBranch: true })).toBe(false);
+  });
+
+  test('false for other `config` subcommands even with the flag (config plan/apply)', () => {
+    // `--current-branch` is undefined on these, but non-strict yargs still parses
+    // it; the probe must NOT match, or `config plan` would skip auth and crash.
+    expect(
+      isCurrentBranchProbe({ _: ['config', 'plan'], currentBranch: true }),
+    ).toBe(false);
+    expect(
+      isCurrentBranchProbe({ _: ['config', 'apply'], currentBranch: true }),
+    ).toBe(false);
+    expect(isCurrentBranchProbe({ _: ['config'], currentBranch: true })).toBe(
+      false,
+    );
+  });
+});
 
 describe('currentContextFile', () => {
   let workspace: string;

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -30,6 +30,27 @@ export type Context = {
 export const contextBranch = (context: Context): string | undefined =>
   context.branch ?? context.branchId;
 
+/**
+ * True when the invocation is the offline "current branch" probe:
+ * `(config) status --current-branch`. This mode only reads the pinned branch
+ * from the local `.neon` file (for shell prompts like starship), so it MUST
+ * NOT touch the network — several middlewares (auth, analytics, single-project
+ * resolution) consult this to early-return and skip their API calls / login.
+ *
+ * Gated on the exact command as well as the flag so an accidental
+ * `--current-branch` on an unrelated command (e.g. `config plan`, where the flag
+ * is undefined but non-strict yargs still parses it) can't silently skip
+ * auth/analytics. The probe is only `status` (the top-level alias) or
+ * `config status` (`_ = ['config', 'status']`).
+ */
+export const isCurrentBranchProbe = (args: {
+  _: (string | number)[];
+  currentBranch?: boolean;
+}): boolean =>
+  args.currentBranch === true &&
+  (args._[0] === 'status' ||
+    (args._[0] === 'config' && args._[1] === 'status'));
+
 const CONTEXT_FILE = '.neon';
 const GITIGNORE_FILE = '.gitignore';
 

--- a/packages/cli/src/current_branch_fast_path.test.ts
+++ b/packages/cli/src/current_branch_fast_path.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { tryCurrentBranchFastPath } from './current_branch_fast_path.js';
+
+// argv prefix: [execPath, scriptPath, ...userArgs]
+const ARGV = (...userArgs: string[]) => ['/usr/bin/node', 'cli.js', ...userArgs];
+
+describe('tryCurrentBranchFastPath', () => {
+  let cwd: string;
+  let origExitCode: typeof process.exitCode;
+  let out: string[];
+  let err: string[];
+  let origOut: typeof process.stdout.write;
+  let origErr: typeof process.stderr.write;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), 'neonctl-fastpath-'));
+    origExitCode = process.exitCode;
+    process.exitCode = 0;
+    out = [];
+    err = [];
+    origOut = process.stdout.write.bind(process.stdout);
+    origErr = process.stderr.write.bind(process.stderr);
+    process.stdout.write = ((c: string | Uint8Array) => {
+      out.push(c.toString());
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((c: string | Uint8Array) => {
+      err.push(c.toString());
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = origOut;
+    process.stderr.write = origErr;
+    process.exitCode = origExitCode;
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it('handles `status --current-branch`: prints the pinned branch, exit 0', () => {
+    writeFileSync(join(cwd, '.neon'), JSON.stringify({ branch: 'my-feature' }));
+    expect(
+      tryCurrentBranchFastPath(ARGV('status', '--current-branch'), cwd),
+    ).toBe(true);
+    expect(out.join('')).toBe('my-feature\n');
+    expect(process.exitCode).toBe(0);
+  });
+
+  it('handles `config status --current-branch` identically', () => {
+    writeFileSync(join(cwd, '.neon'), JSON.stringify({ branch: 'main' }));
+    expect(
+      tryCurrentBranchFastPath(
+        ARGV('config', 'status', '--current-branch'),
+        cwd,
+      ),
+    ).toBe(true);
+    expect(out.join('')).toBe('main\n');
+  });
+
+  it('falls back to the legacy `branchId` field (matches contextBranch)', () => {
+    writeFileSync(join(cwd, '.neon'), JSON.stringify({ branchId: 'br-legacy' }));
+    expect(
+      tryCurrentBranchFastPath(ARGV('status', '--current-branch'), cwd),
+    ).toBe(true);
+    expect(out.join('')).toBe('br-legacy\n');
+  });
+
+  it('no branch pinned: empty stdout, stderr hint, non-zero exit (still handled)', () => {
+    writeFileSync(join(cwd, '.neon'), JSON.stringify({ projectId: 'p' }));
+    expect(
+      tryCurrentBranchFastPath(ARGV('status', '--current-branch'), cwd),
+    ).toBe(true);
+    expect(out.join('')).toBe('');
+    expect(err.join('')).toContain('Run `neonctl checkout <branch>`');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('returns false (fall through to the full CLI) for anything but the exact invocation', () => {
+    const fallThrough = [
+      ['projects', 'list'],
+      ['status'],
+      ['config', 'status'],
+      ['config', 'plan', '--current-branch'],
+      ['status', '--current-branch', '--output', 'json'],
+      ['config', 'status', '--current-branch', '--config-json'],
+      ['status', '--current-branch', 'extra'],
+      [],
+    ];
+    for (const args of fallThrough) {
+      expect(tryCurrentBranchFastPath(ARGV(...args), cwd)).toBe(false);
+    }
+    // Fall-through must not print anything.
+    expect(out.join('')).toBe('');
+    expect(err.join('')).toBe('');
+  });
+});

--- a/packages/cli/src/current_branch_fast_path.ts
+++ b/packages/cli/src/current_branch_fast_path.ts
@@ -1,0 +1,62 @@
+import { contextBranch, currentContextFile, readContextFile } from './context.js';
+import { log } from './log.js';
+
+/**
+ * Offline fast path for `(config) status --current-branch` (used by shell prompts).
+ *
+ * Reading the pinned branch out of the local `.neon` file does not need the CLI's
+ * full command tree, `@neondatabase/api-client`, or yargs — importing those is ~200ms,
+ * which dwarfs the actual work. So the entry point ({@link file://./cli.ts}) calls this
+ * BEFORE importing `index.js`, and only falls through to the full CLI when this returns
+ * `false`. On the fast path the process loads only this module + `context.js`/`log.js`
+ * (~25ms total incl. Node startup) instead of ~230ms.
+ *
+ * It mirrors the `--current-branch` short-circuit in `status()` (commands/config.ts):
+ * print the pinned branch to stdout and exit 0, or print nothing + a `neonctl checkout`
+ * hint on stderr and exit non-zero when no branch is pinned.
+ *
+ * Deliberately conservative: only the EXACT bare invocation is handled —
+ * `status --current-branch` or `config status --current-branch` with no other args.
+ * Anything else (extra flags like `--context-file`/`--output`, more args, etc.) returns
+ * `false` and flows through the normal yargs pipeline, so behavior can never diverge —
+ * the worst case is "not faster", never "wrong".
+ *
+ * @returns `true` if it handled the invocation (caller should NOT load the full CLI).
+ */
+export const tryCurrentBranchFastPath = (
+  argv: string[],
+  // `cwd` is overridable so tests can exercise the `.neon` walk-up without mutating
+  // `process.cwd()` (which isn't allowed in vitest workers), mirroring currentContextFile.
+  cwd: string = process.cwd(),
+): boolean => {
+  // argv is [execPath, scriptPath, ...userArgs].
+  if (!isExactCurrentBranchInvocation(argv.slice(2))) {
+    return false;
+  }
+
+  const branch = contextBranch(readContextFile(currentContextFile(cwd)));
+  if (branch) {
+    process.stdout.write(`${branch}\n`);
+  } else {
+    log.info(
+      'No branch pinned. Run `neonctl checkout <branch>` to pin a branch and pull its env vars.',
+    );
+    process.exitCode = 1;
+  }
+  return true;
+};
+
+/**
+ * True only for `status --current-branch` or `config status --current-branch` with no
+ * other arguments. Any extra token (another flag, `--context-file`, `=`-style flags,
+ * positional args) makes this false so the full CLI handles it.
+ */
+const isExactCurrentBranchInvocation = (args: string[]): boolean => {
+  const rest =
+    args[0] === 'status'
+      ? args.slice(1)
+      : args[0] === 'config' && args[1] === 'status'
+        ? args.slice(2)
+        : null;
+  return rest !== null && rest.length === 1 && rest[0] === '--current-branch';
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,7 +65,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
   'bootstrap',
 
-  // aliases
+  // alias of `config status`
+  'status',
 ];
 
 let builder = yargs(hideBin(process.argv));

--- a/packages/cli/src/utils/enrichers.ts
+++ b/packages/cli/src/utils/enrichers.ts
@@ -1,4 +1,5 @@
 import { BranchScopeProps, CommonProps, OrgScopeProps } from '../types.js';
+import { isCurrentBranchProbe } from '../context.js';
 import { looksLikeBranchId } from './formats.js';
 import { Branch, Database } from '@neondatabase/api-client';
 import { isAxiosError } from 'axios';
@@ -166,6 +167,12 @@ export const resolveSingleDatabase = async (props: {
 export const fillSingleProject = async (
   props: CommonProps & { projectId?: string; orgId?: string },
 ) => {
+  // The offline `--current-branch` probe needs no project at all and runs with no
+  // API client (auth was skipped), so resolving a single project here would both
+  // hit the network and dereference a null client. Skip it entirely.
+  if (isCurrentBranchProbe(props as any)) {
+    return props;
+  }
   if (props.projectId) {
     return { ...props, projectId: props.projectId };
   }


### PR DESCRIPTION


https://github.com/user-attachments/assets/235ba3f5-313c-405d-a18c-96ff86f727cf



## Summary

- **`neon status`** — a top-level alias for `neon config status` (mirrors its options and delegates to the same handler).
- **`config status --current-branch`** (also `neon status --current-branch`) — prints _only_ the branch pinned in the local `.neon` file with **no network request, no auth, no analytics**, so it's cheap enough to drive a shell prompt (e.g. starship). Prints the branch name to stdout and exits 0; when no branch is pinned it prints nothing to stdout, writes a `neonctl checkout <branch>` hint to stderr, and exits **non-zero** (grep-style) so a prompt can guard on it directly. Deliberately diverges from `git branch --show-current` (which exits 0 when detached).
- The offline guarantee is enforced by a shared `isCurrentBranchProbe` predicate that gates the handler short-circuit plus the middlewares that would otherwise hit the network (`ensureAuth`, the analytics init/track middlewares, and `fillSingleProject`). The predicate is scoped to exactly `status` / `config status` so the flag can't accidentally skip auth on other commands.
- README documents the alias and includes a copy-paste starship snippet; a single changeset bumps `neonctl` (minor).

## Startup fast-path (perf)

Reading the pinned branch shouldn't require loading the CLI's whole command tree + `@neondatabase/api-client` + yargs (~210ms). The entry point (`cli.ts`) now short-circuits the exact bare `status --current-branch` / `config status --current-branch` invocation **before** importing `index.js`, reading `.neon` via the lightweight `context.js` helper. This drops the command from **~230ms to ~25ms** — fast enough to run on every shell-prompt render.

It's conservative: only the exact bare invocation is fast-pathed; anything with extra args/flags (`--output`, `--context-file`, …) falls through to the full yargs pipeline unchanged, so behavior can never diverge — worst case it's just not faster. The fast-path mirrors `status()`'s output exactly (verified by tests).

## Test plan

- [x] `pnpm --filter neonctl build` (typecheck) — clean
- [x] `pnpm --filter neonctl exec eslint src` — clean
- [x] `pnpm --filter neonctl exec vitest run` — 3003 passed / 6 skipped
- [x] e2e (`unreachableHost`): `config status --current-branch` prints the branch / hides cleanly with **no network access**
- [x] fast-path unit tests: exact-match handling, `config status` form, legacy `branchId` fallback, no-branch exit 1, and fall-through cases
- [x] timing: `status --current-branch` ~25ms via the fast path vs ~230ms for the full CLI
- [x] Manual: `neon status --current-branch` in a linked dir prints the branch (exit 0)
- [x] Manual: in an unpinned or `.neon`-less dir prints nothing and exits non-zero