### PR TITLE
chore: release @neondatabase/config + config-runtime + env @ 0.8.1

### DIFF
--- a/.changeset/config-migrate-to-neon-sdk.md
+++ b/.changeset/config-migrate-to-neon-sdk.md
@@ -1,5 +1,0 @@
----
-"@neondatabase/config": patch
----
-
-Migrate the real Neon API adapter (`createRealNeonApi`) from the deprecated `@neondatabase/api-client` (axios) to the new fetch-based `@neon/sdk` raw layer. The `NeonApi` façade and all behavior are unchanged — the standard project/branch/endpoint/role/database/data-api calls now go through `@neon/sdk/raw`, and a small `unwrap` helper re-throws non-2xx responses in the same shape the existing error wrapper and 423 retry already consume. This drops `@neondatabase/api-client` from the package's runtime dependencies in favor of the zero-dependency `@neon/sdk`.

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config-runtime
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies [1f77d97]
+  - @neondatabase/config@0.8.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config-runtime",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Imperative runtime for @neondatabase/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config
 
+## 0.8.1
+
+### Patch Changes
+
+- 1f77d97: Migrate the real Neon API adapter (`createRealNeonApi`) from the deprecated `@neondatabase/api-client` (axios) to the new fetch-based `@neon/sdk` raw layer. The `NeonApi` façade and all behavior are unchanged — the standard project/branch/endpoint/role/database/data-api calls now go through `@neon/sdk/raw`, and a small `unwrap` helper re-throws non-2xx responses in the same shape the existing error wrapper and 423 retry already consume. This drops `@neondatabase/api-client` from the package's runtime dependencies in favor of the zero-dependency `@neon/sdk`.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/config",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/env
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies [1f77d97]
+  - @neondatabase/config@0.8.1
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/env",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Release: config / config-runtime / env → 0.8.1

Consumes the `@neondatabase/config` → `@neon/sdk` migration changeset.

- **@neondatabase/config 0.8.0 → 0.8.1** — real Neon API adapter (`createRealNeonApi`) migrated from the axios-based `@neondatabase/api-client` to the fetch-based `@neon/sdk` raw layer. Behavior unchanged; drops `@neondatabase/api-client` from runtime deps.
- **@neondatabase/config-runtime 0.8.0 → 0.8.1** — cascade (depends on config via `workspace:*`).
- **@neondatabase/env 0.8.0 → 0.8.1** — cascade.

First of two release PRs. Once these publish to npm, the follow-up **neonctl** release PR (which pins these at `0.8.1`) can resolve its lockfile and go ready.

Publish order after merge: `@neondatabase/config` → `@neondatabase/config-runtime` + `@neondatabase/env`.