### PR TITLE
chore: release neonctl@2.28.0

### DIFF
--- a/.changeset/neon-status-current-branch.md
+++ b/.changeset/neon-status-current-branch.md
@@ -1,9 +1,0 @@
----
-"neonctl": minor
----
-
-Add `neon status` and the `--current-branch` flag for `config status`.
-
-`neon status` is a top-level alias for `neon config status` (it mirrors all of its options and delegates to the same handler).
-
-`config status --current-branch` (also `neon status --current-branch`) prints only the branch pinned in the local `.neon` file with no network request, no login, and no analytics — cheap enough to drive a shell prompt (e.g. starship). It prints the branch name to stdout and exits 0; when no branch is pinned it prints nothing to stdout, writes a `neonctl checkout <branch>` hint to stderr, and exits non-zero (grep-style) so a prompt can guard on the command directly.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # neonctl
 
+## 2.28.0
+
+### Minor Changes
+
+- f13ce14: Add `neon status` and the `--current-branch` flag for `config status`.
+
+  `neon status` is a top-level alias for `neon config status` (it mirrors all of its options and delegates to the same handler).
+
+  `config status --current-branch` (also `neon status --current-branch`) prints only the branch pinned in the local `.neon` file with no network request, no login, and no analytics — cheap enough to drive a shell prompt (e.g. starship). It prints the branch name to stdout and exits 0; when no branch is pinned it prints nothing to stdout, writes a `neonctl checkout <branch>` hint to stderr, and exits non-zero (grep-style) so a prompt can guard on the command directly.
+
+### Patch Changes
+
+- Migrate neonctl off the deprecated axios-based `@neondatabase/api-client` to a fetch-native client over `@neon/sdk`. `axios` and `axios-debug-log` are removed; API failures now surface as a single `NeonApiError`; `HTTP(S)_PROXY` / `NO_PROXY` support is preserved (via undici) and the per-request timeout + 423 retry are unchanged. Also bumps the bundled `@neondatabase/config`, `@neondatabase/config-runtime`, and `@neondatabase/env` to 0.8.1 (the @neon/sdk-based releases). Requires Node >=22.
+
 ## 2.27.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,9 +48,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neon/sdk": "workspace:*",
-    "@neondatabase/config": "0.8.1",
-    "@neondatabase/config-runtime": "0.8.1",
-    "@neondatabase/env": "0.8.1",
+    "@neondatabase/config": "workspace:*",
+    "@neondatabase/config-runtime": "workspace:*",
+    "@neondatabase/env": "workspace:*",
     "@segment/analytics-node": "1.3.0",
     "chalk": "5.3.0",
     "chokidar": "5.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.27.1",
+  "version": "2.28.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",
@@ -48,9 +48,9 @@
   "dependencies": {
     "@hono/node-server": "2.0.4",
     "@neon/sdk": "workspace:*",
-    "@neondatabase/config": "0.8.0",
-    "@neondatabase/config-runtime": "0.8.0",
-    "@neondatabase/env": "0.7.0",
+    "@neondatabase/config": "0.8.1",
+    "@neondatabase/config-runtime": "0.8.1",
+    "@neondatabase/env": "0.8.1",
     "@segment/analytics-node": "1.3.0",
     "chalk": "5.3.0",
     "chokidar": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,14 +210,14 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@neondatabase/config':
-        specifier: 0.8.1
-        version: 0.8.1
+        specifier: workspace:*
+        version: link:../config
       '@neondatabase/config-runtime':
-        specifier: 0.8.1
-        version: 0.8.1
+        specifier: workspace:*
+        version: link:../config-runtime
       '@neondatabase/env':
-        specifier: 0.8.1
-        version: 0.8.1
+        specifier: workspace:*
+        version: link:../env
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -1804,23 +1804,6 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
-
-  '@neon/sdk@0.1.0':
-    resolution: {integrity: sha512-PCm/flt3IfLsY7SddwwCu8hbid+xPaB5GiQYYcRBFCkHNUX52LwrciZECMz574O0QmmijY4f6WdTSpjS4SMaHw==}
-    engines: {node: '>=22'}
-
-  '@neondatabase/config-runtime@0.8.1':
-    resolution: {integrity: sha512-X6eBHsqjwcM0826kvRfyfK6iR1vMjXfdJJy+2q+DWPfP+WRmYgQtIXhQJ86oUNZVQP6TIV8k/kCs93y0l/Mrzw==}
-    engines: {node: '>=22'}
-
-  '@neondatabase/config@0.8.1':
-    resolution: {integrity: sha512-y0ZkTV5WTi1IzXDpfhsutAYkyRieNcbdvzyyTAKTf7CWc9M7BqjzpK/ez5POEZaIen1g07mIdED91F8294T8eA==}
-    engines: {node: '>=22'}
-
-  '@neondatabase/env@0.8.1':
-    resolution: {integrity: sha512-cKX+iu4y7cMe79edTD8qK4qZiQ2xDix896lKIJ7xxImZkyIEOG4kOX/C2k8rfFtBnLxOYT68we8cfm5/GUIHQg==}
-    engines: {node: '>=22'}
-    hasBin: true
 
   '@neondatabase/serverless@1.0.1':
     resolution: {integrity: sha512-O6yC5TT0jbw86VZVkmnzCZJB0hfxBl0JJz6f+3KHoZabjb/X08r9eFA+vuY06z1/qaovykvdkrXYq3SPUuvogA==}
@@ -7721,26 +7704,6 @@ snapshots:
       '@emnapi/runtime': 1.11.1
       '@tybys/wasm-util': 0.10.2
     optional: true
-
-  '@neon/sdk@0.1.0': {}
-
-  '@neondatabase/config-runtime@0.8.1':
-    dependencies:
-      '@neondatabase/config': 0.8.1
-      esbuild: 0.25.9
-      fflate: 0.8.3
-
-  '@neondatabase/config@0.8.1':
-    dependencies:
-      '@neon/sdk': 0.1.0
-      jiti: 2.7.0
-      zod: 4.4.3
-
-  '@neondatabase/env@0.8.1':
-    dependencies:
-      '@neondatabase/config': 0.8.1
-      yargs: 18.0.0
-      zod: 4.4.3
 
   '@neondatabase/serverless@1.0.1':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,14 +210,14 @@ importers:
         specifier: workspace:*
         version: link:../sdk
       '@neondatabase/config':
-        specifier: 0.8.0
-        version: 0.8.0
+        specifier: 0.8.1
+        version: 0.8.1
       '@neondatabase/config-runtime':
-        specifier: 0.8.0
-        version: 0.8.0
+        specifier: 0.8.1
+        version: 0.8.1
       '@neondatabase/env':
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 0.8.1
+        version: 0.8.1
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
@@ -1805,19 +1805,20 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@neondatabase/api-client@2.7.1':
-    resolution: {integrity: sha512-hEYOJ89xIa2eEXBu9HRKYTJc9lrmszhNc0SIxzJvNE/3Av4xK7vkXWQ3LWy0DTTFY4Kn6wfM2wAjRIjf/jOu6w==}
-
-  '@neondatabase/config-runtime@0.8.0':
-    resolution: {integrity: sha512-SVQ4t3UUuSs+SGqBPf8tXoCJHVx2nttCicH5UchYTdrTvaPKEczBWmw1hKYr4sTCbd04AwL6KK42VH9tbOkgMQ==}
+  '@neon/sdk@0.1.0':
+    resolution: {integrity: sha512-PCm/flt3IfLsY7SddwwCu8hbid+xPaB5GiQYYcRBFCkHNUX52LwrciZECMz574O0QmmijY4f6WdTSpjS4SMaHw==}
     engines: {node: '>=22'}
 
-  '@neondatabase/config@0.8.0':
-    resolution: {integrity: sha512-ReOBVC+9j7X81C6DKtT94wimyHHjPv/LRpGPI2VAcSWSHyT/yGrNSwvT9WwNW1GsUXQNYBJh/3gzUCGhQrTazg==}
+  '@neondatabase/config-runtime@0.8.1':
+    resolution: {integrity: sha512-X6eBHsqjwcM0826kvRfyfK6iR1vMjXfdJJy+2q+DWPfP+WRmYgQtIXhQJ86oUNZVQP6TIV8k/kCs93y0l/Mrzw==}
     engines: {node: '>=22'}
 
-  '@neondatabase/env@0.7.0':
-    resolution: {integrity: sha512-A5GsnHZm0e6mf9MTB3+Q1TWuNhiAsluOqCsG2M/u9WKMvk9pzRMzN38kZMQ1EKh05UJa7CNNA7bXTr9wtEWwog==}
+  '@neondatabase/config@0.8.1':
+    resolution: {integrity: sha512-y0ZkTV5WTi1IzXDpfhsutAYkyRieNcbdvzyyTAKTf7CWc9M7BqjzpK/ez5POEZaIen1g07mIdED91F8294T8eA==}
+    engines: {node: '>=22'}
+
+  '@neondatabase/env@0.8.1':
+    resolution: {integrity: sha512-cKX+iu4y7cMe79edTD8qK4qZiQ2xDix896lKIJ7xxImZkyIEOG4kOX/C2k8rfFtBnLxOYT68we8cfm5/GUIHQg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -3086,12 +3087,6 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
-
   b4a@1.6.7:
     resolution: {integrity: sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==}
 
@@ -3429,10 +3424,6 @@ packages:
     resolution: {integrity: sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==}
     engines: {node: '>=0.1.90'}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@10.0.1:
     resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
     engines: {node: '>=14'}
@@ -3670,10 +3661,6 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-
   denque@2.1.0:
     resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
     engines: {node: '>=0.10'}
@@ -3871,10 +3858,6 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
-    engines: {node: '>= 0.4'}
-
-  es-set-tostringtag@2.1.0:
-    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
@@ -4095,22 +4078,9 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.16.0:
-    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
 
   formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -4288,10 +4258,6 @@ packages:
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
-    engines: {node: '>= 0.4'}
-
-  has-tostringtag@1.0.2:
-    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
@@ -5450,10 +5416,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@2.1.0:
-    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
-    engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -7760,39 +7722,25 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
-  '@neondatabase/api-client@2.7.1':
-    dependencies:
-      axios: 1.16.1
-    transitivePeerDependencies:
-      - debug
-      - supports-color
+  '@neon/sdk@0.1.0': {}
 
-  '@neondatabase/config-runtime@0.8.0':
+  '@neondatabase/config-runtime@0.8.1':
     dependencies:
-      '@neondatabase/config': 0.8.0
+      '@neondatabase/config': 0.8.1
       esbuild: 0.25.9
       fflate: 0.8.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
-  '@neondatabase/config@0.8.0':
+  '@neondatabase/config@0.8.1':
     dependencies:
-      '@neondatabase/api-client': 2.7.1
+      '@neon/sdk': 0.1.0
       jiti: 2.7.0
       zod: 4.4.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
-  '@neondatabase/env@0.7.0':
+  '@neondatabase/env@0.8.1':
     dependencies:
-      '@neondatabase/config': 0.8.0
+      '@neondatabase/config': 0.8.1
       yargs: 18.0.0
       zod: 4.4.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
 
   '@neondatabase/serverless@1.0.1':
     dependencies:
@@ -9295,18 +9243,6 @@ snapshots:
 
   async@3.2.6: {}
 
-  asynckit@0.4.0: {}
-
-  axios@1.16.1:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      https-proxy-agent: 5.0.1
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   b4a@1.6.7: {}
 
   b4a@1.8.1:
@@ -9708,10 +9644,6 @@ snapshots:
 
   colors@1.0.3: {}
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@10.0.1: {}
 
   commander@13.1.0: {}
@@ -9880,8 +9812,6 @@ snapshots:
 
   defu@6.1.7: {}
 
-  delayed-stream@1.0.0: {}
-
   denque@2.1.0: {}
 
   depd@2.0.0: {}
@@ -10042,13 +9972,6 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
-
-  es-set-tostringtag@2.1.0:
-    dependencies:
-      es-errors: 1.3.0
-      get-intrinsic: 1.3.0
-      has-tostringtag: 1.0.2
-      hasown: 2.0.2
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -10437,20 +10360,10 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0: {}
-
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
 
   formdata-polyfill@4.0.10:
     dependencies:
@@ -10658,10 +10571,6 @@ snapshots:
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
-
-  has-tostringtag@1.0.2:
-    dependencies:
-      has-symbols: 1.1.0
 
   hasown@2.0.2:
     dependencies:
@@ -11851,8 +11760,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:


### PR DESCRIPTION
## Release: neonctl 2.27.1 → 2.28.0

Second of two release PRs (follows #256, which published config/config-runtime/env @ 0.8.1).

- **feat:** `neon status` and `config status --current-branch` (#253).
- **migration:** neonctl moved off the axios-based `@neondatabase/api-client` to a fetch-native client over `@neon/sdk`; `axios`/`axios-debug-log` removed; single `NeonApiError`; `HTTP(S)_PROXY` support preserved via undici; `engines` now `>=22`.
- Bundled `@neondatabase/config`, `@neondatabase/config-runtime`, `@neondatabase/env` pins bumped to **0.8.1** — this is what fully removes `@neondatabase/api-client` (and axios) from neonctl's published dependency tree.

Publish after merge: `gh workflow run neon-pkgs.yml -f package=neonctl -f ref=main` (also builds the standalone CLI binaries + GitHub release).