### PR TITLE
feat(cli): `neon config init` + offer it from `neon link`

### DIFF
--- a/packages/cli/src/commands/__snapshots__/config.init.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/config.init.test.ts.snap
@@ -1,0 +1,3 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`config init > runs offline end to end and scaffolds into the working directory 1`] = `""`;

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -8,7 +8,7 @@ import type { NeonApiClient } from "../api.js";
 import { getApiClient } from "../api.js";
 import { auth, refreshToken } from "../auth.js";
 import { CREDENTIALS_FILE } from "../config.js";
-import { isCurrentBranchProbe } from "../context.js";
+import { isConfigInit, isCurrentBranchProbe } from "../context.js";
 import { isCi } from "../env.js";
 import { log } from "../log.js";
 import type { ExtendedTokenSet } from "../types.js";
@@ -169,6 +169,12 @@ export const ensureAuth = async (
 	// never refresh a token or pop a browser login. Skip auth entirely (the handler
 	// doesn't use an API client in this mode).
 	if (isCurrentBranchProbe(props)) {
+		return;
+	}
+
+	// `config init` only scaffolds a neon.ts and installs npm packages locally; it
+	// never calls the Neon API, so skip auth entirely — no token refresh, no login.
+	if (isConfigInit(props)) {
 		return;
 	}
 

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
@@ -14,12 +13,17 @@ import {
 	templateIds,
 } from "neon-init/bootstrap";
 import prompts, { type InitialReturnValue } from "prompts";
-import which from "which";
 import type yargs from "yargs";
 
 import { isCi } from "../env.js";
 import { log } from "../log.js";
 import type { CommonProps } from "../types.js";
+import {
+	detectPackageManager,
+	installedPackageManagers,
+	type PackageManager,
+	runCommand,
+} from "../utils/package_manager.js";
 
 type BootstrapProps = CommonProps & {
 	directory?: string;
@@ -460,33 +464,6 @@ const confirm = async (message: string): Promise<boolean> => {
 	return value === true;
 };
 
-type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
-
-// npm first so it's the default/preselected choice; the rest follow in rough
-// popularity order.
-const PACKAGE_MANAGERS: PackageManager[] = ["npm", "pnpm", "yarn", "bun"];
-
-/**
- * The package manager the CLI was invoked through, read from the
- * `npm_config_user_agent` npm sets for `npm exec`/`npx`, `pnpm dlx`, `yarn
- * dlx`, and `bunx` (so `pnpm dlx neonctl bootstrap` installs with pnpm).
- * Returns undefined when there's nothing to infer from — e.g. a
- * globally-installed `neon`/`neonctl` — so the caller can ask instead of
- * silently assuming npm.
- */
-const detectPackageManager = (): PackageManager | undefined => {
-	const ua = process.env.npm_config_user_agent ?? "";
-	if (ua.startsWith("pnpm")) return "pnpm";
-	if (ua.startsWith("yarn")) return "yarn";
-	if (ua.startsWith("bun")) return "bun";
-	if (ua.startsWith("npm")) return "npm";
-	return undefined;
-};
-
-/** The package managers actually on PATH, in {@link PACKAGE_MANAGERS} order. */
-const installedPackageManagers = (): PackageManager[] =>
-	PACKAGE_MANAGERS.filter((pm) => which.sync(pm, { nothrow: true }) !== null);
-
 /**
  * Ask which package manager to install with when we couldn't infer one from the
  * invocation. Offers the managers actually installed (npm preselected); with
@@ -511,46 +488,6 @@ const selectPackageManager = async (): Promise<PackageManager> => {
 	});
 	return pm ?? "npm";
 };
-
-/**
- * Run a command inheriting our stdio so the user sees install / link output
- * live and can answer any prompts the child raises. Resolves to whether it
- * exited cleanly; a non-zero exit is reported but never aborts bootstrap — the
- * scaffold already succeeded, so we let the user retry the step by hand.
- */
-const runCommand = (
-	cmd: string,
-	args: string[],
-	cwd: string,
-): Promise<boolean> =>
-	new Promise((resolvePromise) => {
-		// npm/pnpm/yarn ship as .cmd shims on Windows, which need a shell to run.
-		const child = spawn(cmd, args, {
-			cwd,
-			stdio: "inherit",
-			shell: process.platform === "win32",
-		});
-		child.on("error", (err) => {
-			log.warning(
-				"Could not run `%s %s`: %s",
-				cmd,
-				args.join(" "),
-				err instanceof Error ? err.message : String(err),
-			);
-			resolvePromise(false);
-		});
-		child.on("close", (code) => {
-			if (code !== 0) {
-				log.warning(
-					"`%s %s` exited with code %d.",
-					cmd,
-					args.join(" "),
-					code,
-				);
-			}
-			resolvePromise(code === 0);
-		});
-	});
 
 /**
  * Re-invoke this same CLI as `neon link` inside the scaffolded directory, so the

--- a/packages/cli/src/commands/config.init.test.ts
+++ b/packages/cli/src/commands/config.init.test.ts
@@ -1,0 +1,148 @@
+import {
+	existsSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect } from "vitest";
+import { test } from "../test_utils/fixtures";
+import { initCmd } from "./config";
+
+describe("config init", () => {
+	let workspace: string;
+
+	beforeEach(() => {
+		workspace = mkdtempSync(join(tmpdir(), "neonctl-config-init-"));
+	});
+
+	afterEach(() => {
+		rmSync(workspace, { recursive: true, force: true });
+	});
+
+	test("creates a starter neon.ts when the project has none", async () => {
+		await initCmd({ cwd: workspace, install: false });
+
+		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
+		expect(content).toContain(
+			'import { defineConfig } from "@neondatabase/config/v1"',
+		);
+		expect(content).toContain("export default defineConfig({");
+		expect(content).toContain("auth: false");
+		expect(content).toContain('ttl: "7d"');
+	});
+
+	test("leaves an existing Neon config file untouched", async () => {
+		const original = "export default { auth: true };\n";
+		writeFileSync(join(workspace, "neon.ts"), original);
+
+		await initCmd({ cwd: workspace, install: false });
+
+		expect(readFileSync(join(workspace, "neon.ts"), "utf8")).toBe(original);
+	});
+
+	test("installs the missing config packages with the detected package manager", async () => {
+		const calls: { cmd: string; args: string[]; cwd: string }[] = [];
+
+		await initCmd({
+			cwd: workspace,
+			install: true,
+			run: (cmd, args, cwd) => {
+				calls.push({ cmd, args, cwd });
+				return Promise.resolve(true);
+			},
+		});
+
+		expect(calls).toHaveLength(1);
+		// npm spells it `install`, pnpm/yarn/bun use `add` — assert on the packages,
+		// which are the same regardless of the resolved package manager.
+		expect(calls[0].args).toEqual(
+			expect.arrayContaining([
+				"@neondatabase/config",
+				"@neondatabase/env",
+			]),
+		);
+		expect(calls[0].cwd).toBe(workspace);
+	});
+
+	test("only installs the packages that aren't already declared", async () => {
+		writeFileSync(
+			join(workspace, "package.json"),
+			JSON.stringify({
+				dependencies: { "@neondatabase/config": "^0.8.1" },
+			}),
+		);
+		const calls: string[][] = [];
+
+		await initCmd({
+			cwd: workspace,
+			install: true,
+			run: (_cmd, args) => {
+				calls.push(args);
+				return Promise.resolve(true);
+			},
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]).toContain("@neondatabase/env");
+		expect(calls[0]).not.toContain("@neondatabase/config");
+	});
+
+	test("does nothing to install when both packages are already declared", async () => {
+		writeFileSync(
+			join(workspace, "package.json"),
+			JSON.stringify({
+				dependencies: {
+					"@neondatabase/config": "^0.8.1",
+					"@neondatabase/env": "^0.8.1",
+				},
+			}),
+		);
+		const calls: string[][] = [];
+
+		await initCmd({
+			cwd: workspace,
+			run: (_cmd, args) => {
+				calls.push(args);
+				return Promise.resolve(true);
+			},
+		});
+
+		expect(calls).toHaveLength(0);
+	});
+
+	test("--no-install scaffolds but never runs an installer", async () => {
+		const calls: string[][] = [];
+
+		await initCmd({
+			cwd: workspace,
+			install: false,
+			run: (_cmd, args) => {
+				calls.push(args);
+				return Promise.resolve(true);
+			},
+		});
+
+		expect(calls).toHaveLength(0);
+		expect(existsSync(join(workspace, "neon.ts"))).toBe(true);
+	});
+
+	// End-to-end: `config init` must run with NO auth and NO network — it only
+	// scaffolds locally. Pointing the CLI at an unreachable host proves that
+	// neither the global auth middleware nor `fillSingleProject` reached out (a
+	// regression in either offline guard would turn this into a connection error).
+	test("runs offline end to end and scaffolds into the working directory", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["config", "init", "--no-install"], {
+			unreachableHost: true,
+			code: 0,
+			cwd: workspace,
+		});
+
+		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
+		expect(content).toContain("@neondatabase/config/v1");
+	});
+});

--- a/packages/cli/src/commands/config.init.test.ts
+++ b/packages/cli/src/commands/config.init.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect } from "vitest";
 import { test } from "../test_utils/fixtures";
-import { initCmd } from "./config";
+import { hasNeonConfigFile, initCmd } from "./config";
 
 describe("config init", () => {
 	let workspace: string;
@@ -127,6 +127,18 @@ describe("config init", () => {
 
 		expect(calls).toHaveLength(0);
 		expect(existsSync(join(workspace, "neon.ts"))).toBe(true);
+	});
+
+	test("hasNeonConfigFile detects each supported config filename", () => {
+		expect(hasNeonConfigFile(workspace)).toBe(false);
+		for (const name of ["neon.ts", "neon.mts", "neon.js", "neon.mjs"]) {
+			rmSync(join(workspace, "neon.ts"), { force: true });
+			rmSync(join(workspace, name), { force: true });
+			writeFileSync(join(workspace, name), "export default {};\n");
+			expect(hasNeonConfigFile(workspace)).toBe(true);
+			rmSync(join(workspace, name), { force: true });
+		}
+		expect(hasNeonConfigFile(workspace)).toBe(false);
 	});
 
 	// End-to-end: `config init` must run with NO auth and NO network — it only

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { resolveConfig } from "@neon/config";
 import {
 	apply,
@@ -23,6 +25,11 @@ import type { BranchScopeProps } from "../types.js";
 import { announceTargetBranch } from "../utils/branch_notice.js";
 import { fillSingleProject, resolveBranchRef } from "../utils/enrichers.js";
 import { bundleEntry } from "../utils/esbuild.js";
+import {
+	addDependenciesArgs,
+	resolvePackageManager,
+	runCommand,
+} from "../utils/package_manager.js";
 import { zipBundle } from "../utils/zip.js";
 import { writer } from "../writer.js";
 import { autoPullEnvAfterPin } from "./env.js";
@@ -134,6 +141,144 @@ export const envPullFlag = {
 	},
 } as const;
 
+// ── `config init` ─────────────────────────────────────────────────────────────
+
+/**
+ * The published npm packages a `neon.ts` project needs. The library sources live
+ * under the `@neon/*` org now, but those aren't on npm yet — consumers install the
+ * still-published `@neondatabase/*` names. Flip these to `@neon/*` once published.
+ */
+const CONFIG_PACKAGE = "@neondatabase/config";
+const ENV_PACKAGE = "@neondatabase/env";
+const REQUIRED_PACKAGES = [CONFIG_PACKAGE, ENV_PACKAGE] as const;
+
+/** package.json fields a dependency can be declared in. */
+const DEPENDENCY_FIELDS = [
+	"dependencies",
+	"devDependencies",
+	"peerDependencies",
+	"optionalDependencies",
+] as const;
+
+/** Config filenames the runtime loads (mirrors @neon/config's loader). */
+const NEON_CONFIG_FILENAMES = ["neon.ts", "neon.mts", "neon.js", "neon.mjs"];
+
+/** Starter `neon.ts` written by `config init` when a project has none. */
+const NEON_CONFIG_TEMPLATE = `import { defineConfig } from "${CONFIG_PACKAGE}/v1";
+
+export default defineConfig({
+  // Declare your Neon services here
+  auth: false,
+  // Branch policy: per-branch tuning
+  branch: (branch) => {
+    if (branch.isDefault) {
+      // Default branch: no overrides, uses project defaults
+      return {};
+    }
+    if (!branch.exists) {
+      // New non-default branches: auto-expire
+      // Run \`neon checkout <name>\` to create a new branch with these settings
+      return { ttl: "7d" };
+    }
+    // Existing branch: no changes
+    return {};
+  },
+});
+`;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null;
+
+/**
+ * The {@link REQUIRED_PACKAGES} not already declared in the project's package.json
+ * (any dependency field). A missing or malformed package.json means none are
+ * declared, so all are reported missing.
+ */
+const missingDependencies = (cwd: string): string[] => {
+	const declared = new Set<string>();
+	const pkgPath = join(cwd, "package.json");
+	if (existsSync(pkgPath)) {
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(readFileSync(pkgPath, "utf8"));
+		} catch {
+			parsed = undefined;
+		}
+		if (isRecord(parsed)) {
+			for (const field of DEPENDENCY_FIELDS) {
+				const deps = parsed[field];
+				if (isRecord(deps)) {
+					for (const name of Object.keys(deps)) declared.add(name);
+				}
+			}
+		}
+	}
+	return REQUIRED_PACKAGES.filter((pkg) => !declared.has(pkg));
+};
+
+export type ConfigInitProps = {
+	/** Directory to scaffold into / resolve package.json from. Defaults to cwd. */
+	cwd?: string;
+	/**
+	 * Install the missing config packages. On by default; `--no-install` just
+	 * prints the command to run by hand.
+	 */
+	install?: boolean;
+	/** Injected command runner (tests). Defaults to the real spawn-based runner. */
+	run?: typeof runCommand;
+};
+
+/**
+ * Scaffold a `neon.ts` policy and make sure the Neon config packages are
+ * installed, so a project can go straight to `neon config plan` / `apply`.
+ * Purely local — it never touches the Neon API (see {@link isConfigInit}).
+ */
+export const initCmd = async (props: ConfigInitProps): Promise<void> => {
+	const cwd = props.cwd ?? process.cwd();
+	const run = props.run ?? runCommand;
+
+	// 1. Scaffold neon.ts unless the project already has a Neon config file.
+	const existing = NEON_CONFIG_FILENAMES.find((name) =>
+		existsSync(join(cwd, name)),
+	);
+	if (existing) {
+		log.info("Found an existing %s — leaving it untouched.", existing);
+	} else {
+		writeFileSync(join(cwd, "neon.ts"), NEON_CONFIG_TEMPLATE);
+		log.info("Created neon.ts with a starter policy.");
+	}
+
+	// 2. Make sure the config packages are installed.
+	const missing = missingDependencies(cwd);
+	if (missing.length === 0) {
+		log.info("%s are already installed.", REQUIRED_PACKAGES.join(" and "));
+	} else {
+		const pm = resolvePackageManager();
+		const args = addDependenciesArgs(pm, missing);
+		if (props.install === false) {
+			log.info(
+				"Install the Neon config packages to use neon.ts: %s %s",
+				pm,
+				args.join(" "),
+			);
+		} else {
+			log.info("Installing %s with %s…", missing.join(", "), pm);
+			const ok = await run(pm, args, cwd);
+			if (!ok) {
+				log.warning(
+					"Could not install the config packages automatically. Run by hand: %s %s",
+					pm,
+					args.join(" "),
+				);
+			}
+		}
+	}
+
+	log.info(
+		"Next: edit neon.ts, then run `neon config plan` to preview and `neon config apply`.",
+	);
+};
+
 export const command = "config";
 export const describe = "Manage a branch with a neon.ts policy";
 export const builder = (argv: yargs.Argv) =>
@@ -202,6 +347,21 @@ export const builder = (argv: yargs.Argv) =>
 					...envPullFlag,
 				}),
 			(args) => applyCmd(args as any),
+		)
+		.command(
+			"init",
+			"Scaffold a neon.ts policy and install the Neon config packages",
+			(yargs) =>
+				yargs.options({
+					install: {
+						describe:
+							"Install @neondatabase/config and @neondatabase/env if they're missing. " +
+							"On by default; use --no-install to just print the command.",
+						type: "boolean",
+						default: true,
+					},
+				}),
+			(args) => initCmd(args as any),
 		);
 
 export const handler = (args: yargs.Argv) => {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -163,6 +163,10 @@ const DEPENDENCY_FIELDS = [
 /** Config filenames the runtime loads (mirrors @neon/config's loader). */
 const NEON_CONFIG_FILENAMES = ["neon.ts", "neon.mts", "neon.js", "neon.mjs"];
 
+/** Whether `dir` already has a Neon config file the runtime would load. */
+export const hasNeonConfigFile = (dir: string): boolean =>
+	NEON_CONFIG_FILENAMES.some((name) => existsSync(join(dir, name)));
+
 /** Starter `neon.ts` written by `config init` when a project has none. */
 const NEON_CONFIG_TEMPLATE = `import { defineConfig } from "${CONFIG_PACKAGE}/v1";
 

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -24,6 +24,7 @@ import {
 	createBranch,
 	pickBranchInteractively,
 } from "../utils/branch_picker.js";
+import { hasNeonConfigFile, initCmd } from "./config.js";
 import { autoPullEnvAfterPin, renderAgentPullNote } from "./env.js";
 import { REGIONS } from "./projects.js";
 
@@ -713,7 +714,7 @@ const runInteractive = async (props: LinkProps, inputs: Inputs) => {
 			projectId: created.project.id,
 			branch: created.branchName,
 		});
-		await finalizeLink(props, {
+		await finalizeInteractiveLink(props, {
 			contextFile: props.contextFile,
 			orgId,
 			projectId: created.project.id,
@@ -736,7 +737,7 @@ const runInteractive = async (props: LinkProps, inputs: Inputs) => {
 			projectId: action.projectId,
 			branch,
 		});
-		await finalizeLink(props, {
+		await finalizeInteractiveLink(props, {
 			contextFile: props.contextFile,
 			orgId,
 			projectId: action.projectId,
@@ -761,7 +762,7 @@ const runInteractive = async (props: LinkProps, inputs: Inputs) => {
 		projectId: created.project.id,
 		branch: created.branchName,
 	});
-	await finalizeLink(props, {
+	await finalizeInteractiveLink(props, {
 		contextFile: props.contextFile,
 		orgId,
 		projectId: created.project.id,
@@ -1391,6 +1392,64 @@ const finalizeLink = async (
 		branch: summary.branch,
 		envPull: props.envPull,
 	});
+};
+
+/**
+ * Interactive `link` finalize: the shared {@link finalizeLink} (summary + env
+ * pull), then — as the last step — offer to manage the project's Neon setup as
+ * code with a `neon.ts`. Kept out of {@link finalizeLink} so the non-interactive
+ * paths never prompt.
+ */
+const finalizeInteractiveLink = async (
+	props: LinkProps,
+	summary: HumanSummary,
+): Promise<void> => {
+	await finalizeLink(props, summary);
+	await maybeOfferConfigInit(props, summary);
+};
+
+/**
+ * Offer to set up infrastructure-as-code at the end of an interactive `link` —
+ * the natural moment, since the project is now linked. Skipped when the project
+ * already has a `neon.ts` (nothing to scaffold). On yes, `config init` writes the
+ * starter `neon.ts` and installs the config packages, then env is pulled again so
+ * the local `.env` reflects the policy — the same pull `link` runs when a project
+ * already ships a `neon.ts`.
+ */
+const maybeOfferConfigInit = async (
+	props: LinkProps,
+	summary: HumanSummary,
+): Promise<void> => {
+	const cwd = process.cwd();
+	if (hasNeonConfigFile(cwd)) {
+		return;
+	}
+
+	const { value } = await prompts({
+		onState: onPromptState,
+		type: "confirm",
+		name: "value",
+		message:
+			"Manage this project's Neon setup as code? Adds a neon.ts you can edit and apply with `neon config apply`.",
+		initial: true,
+	});
+	if (value !== true) {
+		return;
+	}
+
+	await initCmd({ cwd, install: true });
+
+	// The neon.ts (and its deps) now exist — pull env again so the local .env
+	// reflects the policy, matching how `link` pulls when a project already ships
+	// a neon.ts. Only meaningful when a branch was pinned (same guard as finalize).
+	if (summary.branch && summary.projectId) {
+		await autoPullEnvAfterPin({
+			...props,
+			projectId: summary.projectId,
+			branch: summary.branch,
+			envPull: props.envPull,
+		});
+	}
 };
 
 const onPromptState = (state: {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -51,6 +51,15 @@ export const isCurrentBranchProbe = (args: {
 	(args._[0] === "status" ||
 		(args._[0] === "config" && args._[1] === "status"));
 
+/**
+ * `config init` only scaffolds a local `neon.ts` and installs npm packages — it
+ * never calls the Neon API. Gated on the exact command path so the global auth
+ * middleware and the single-project resolver can skip it (it runs with no API
+ * client), mirroring {@link isCurrentBranchProbe}.
+ */
+export const isConfigInit = (args: { _: (string | number)[] }): boolean =>
+	args._[0] === "config" && args._[1] === "init";
+
 const CONTEXT_FILE = ".neon";
 const GITIGNORE_FILE = ".gitignore";
 

--- a/packages/cli/src/test_utils/fixtures.ts
+++ b/packages/cli/src/test_utils/fixtures.ts
@@ -20,6 +20,8 @@ type Fixtures = {
 			outputTable?: boolean;
 			output?: "json" | "yaml" | "table";
 			env?: Record<string, string>;
+			/** Working directory to run the forked CLI in (e.g. a temp dir a command scaffolds into). */
+			cwd?: string;
 			/**
 			 * Point the CLI at a port that is bound and then immediately released, so the
 			 * request fails with a genuine connection error (ECONNREFUSED) instead of a slow
@@ -123,8 +125,9 @@ export const test = originalTest.extend<Fixtures>({
 				],
 				{
 					stdio: "pipe",
+					...(options.cwd ? { cwd: options.cwd } : {}),
 					env: {
-						PATH: `mocks/bin:${process.env.PATH}`,
+						PATH: `${join(process.cwd(), "mocks/bin")}:${process.env.PATH}`,
 						...(options.env ?? {}),
 					},
 				},

--- a/packages/cli/src/utils/enrichers.ts
+++ b/packages/cli/src/utils/enrichers.ts
@@ -1,6 +1,6 @@
 import type { Branch, Database } from "@neon/sdk";
 import { isNeonApiError, messageFromBody } from "../api.js";
-import { isCurrentBranchProbe } from "../context.js";
+import { isConfigInit, isCurrentBranchProbe } from "../context.js";
 import type { BranchScopeProps, CommonProps, OrgScopeProps } from "../types.js";
 import { looksLikeBranchId } from "./formats.js";
 
@@ -171,6 +171,12 @@ export const fillSingleProject = async (
 	// API client (auth was skipped), so resolving a single project here would both
 	// hit the network and dereference a null client. Skip it entirely.
 	if (isCurrentBranchProbe(props as any)) {
+		return props;
+	}
+
+	// `config init` is purely local (scaffold + npm install) and runs with no API
+	// client, so resolving a single project here would dereference a null client.
+	if (isConfigInit(props as any)) {
 		return props;
 	}
 	if (props.projectId) {

--- a/packages/cli/src/utils/package_manager.ts
+++ b/packages/cli/src/utils/package_manager.ts
@@ -1,0 +1,92 @@
+import { spawn } from "node:child_process";
+import which from "which";
+import { log } from "../log.js";
+
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+
+// npm first so it's the default/preselected choice; the rest follow in rough
+// popularity order.
+export const PACKAGE_MANAGERS: PackageManager[] = [
+	"npm",
+	"pnpm",
+	"yarn",
+	"bun",
+];
+
+/**
+ * The package manager the CLI was invoked through, read from the
+ * `npm_config_user_agent` npm sets for `npm exec`/`npx`, `pnpm dlx`, `yarn
+ * dlx`, and `bunx` (so `pnpm dlx neonctl …` installs with pnpm). Returns
+ * undefined when there's nothing to infer from — e.g. a globally-installed
+ * `neon`/`neonctl` — so the caller can ask (or fall back) instead of silently
+ * assuming npm.
+ */
+export const detectPackageManager = (): PackageManager | undefined => {
+	const ua = process.env.npm_config_user_agent ?? "";
+	if (ua.startsWith("pnpm")) return "pnpm";
+	if (ua.startsWith("yarn")) return "yarn";
+	if (ua.startsWith("bun")) return "bun";
+	if (ua.startsWith("npm")) return "npm";
+	return undefined;
+};
+
+/** The package managers actually on PATH, in {@link PACKAGE_MANAGERS} order. */
+export const installedPackageManagers = (): PackageManager[] =>
+	PACKAGE_MANAGERS.filter((pm) => which.sync(pm, { nothrow: true }) !== null);
+
+/**
+ * Pick a package manager without prompting: the one the CLI was invoked through,
+ * else the first one installed, else npm. Used by non-interactive flows (e.g.
+ * `config init`) where there's no scaffold prompt to hang a picker off.
+ */
+export const resolvePackageManager = (): PackageManager =>
+	detectPackageManager() ?? installedPackageManagers()[0] ?? "npm";
+
+/**
+ * The argv that adds `packages` as runtime dependencies with `pm`. npm spells it
+ * `install`; pnpm/yarn/bun use `add`.
+ */
+export const addDependenciesArgs = (
+	pm: PackageManager,
+	packages: string[],
+): string[] => (pm === "npm" ? ["install", ...packages] : ["add", ...packages]);
+
+/**
+ * Run a command inheriting our stdio so the user sees install / link output
+ * live and can answer any prompts the child raises. Resolves to whether it
+ * exited cleanly; a non-zero exit is reported but never throws — the caller
+ * decides whether to treat it as fatal.
+ */
+export const runCommand = (
+	cmd: string,
+	args: string[],
+	cwd: string,
+): Promise<boolean> =>
+	new Promise((resolvePromise) => {
+		// npm/pnpm/yarn ship as .cmd shims on Windows, which need a shell to run.
+		const child = spawn(cmd, args, {
+			cwd,
+			stdio: "inherit",
+			shell: process.platform === "win32",
+		});
+		child.on("error", (err) => {
+			log.warning(
+				"Could not run `%s %s`: %s",
+				cmd,
+				args.join(" "),
+				err instanceof Error ? err.message : String(err),
+			);
+			resolvePromise(false);
+		});
+		child.on("close", (code) => {
+			if (code !== 0) {
+				log.warning(
+					"`%s %s` exited with code %d.",
+					cmd,
+					args.join(" "),
+					code,
+				);
+			}
+			resolvePromise(code === 0);
+		});
+	});


### PR DESCRIPTION
Two related additions for the declarative `neon.ts` config workflow.

## 1. `neon config init`
A one-shot setup. Run in a project, it:
1. **Scaffolds `neon.ts`** with a minimal starter policy when the project has no Neon config file (and leaves any existing `neon.ts`/`.mts`/`.js`/`.mjs` untouched):

```ts
import { defineConfig } from "@neondatabase/config/v1";

export default defineConfig({
  // Declare your Neon services here
  auth: false,
  // Branch policy: per-branch tuning
  branch: (branch) => {
    if (branch.isDefault) {
      return {};
    }
    if (!branch.exists) {
      // New non-default branches: auto-expire
      return { ttl: "7d" };
    }
    return {};
  },
});
```

2. **Ensures `@neondatabase/config` + `@neondatabase/env` are installed** — detects the package manager from the invocation (npm/pnpm/yarn/bun, falling back to the first installed / npm) and installs only the ones missing from `package.json`. `--no-install` just prints the command.

**Purely local** — it never calls the Neon API. The global auth middleware and `fillSingleProject` skip it via a new shared `isConfigInit` guard (mirrors the `--current-branch` offline probe). An end-to-end test pins the CLI at an unreachable host to prove no network/auth happens.

## 2. `neon link` offers it as the last step
After an interactive `link` finishes (summary + env pull), it asks whether to manage the project's Neon setup as code — unless the project already has a `neon.ts`. On yes, it runs `config init`, then pulls env again so the local `.env` reflects the new policy (the same pull `link` runs when a project already ships a `neon.ts`). Wired only into the interactive flow (new `finalizeInteractiveLink`); non-interactive / agent / CI paths never prompt.

## Notes
- Extracts the package-manager helpers (`detectPackageManager` / `installedPackageManagers` / `runCommand` + new `resolvePackageManager` / `addDependenciesArgs`) out of `bootstrap.ts` into `utils/package_manager.ts` so the commands share one implementation.
- Uses the **published `@neondatabase/*`** names (the `@neon/*` libraries aren't on npm yet); flip to `@neon/*` once they are.

## Tests
`pnpm test:ci` green — **3011 tests pass**, incl. new `config init` coverage (scaffold created/left untouched, deps detected/partially/fully installed, `--no-install`, `hasNeonConfigFile`, and the offline e2e). `link`'s suites are unaffected (its interactive prompt path has no existing tests; the new prompt is interactive-only).