### PR TITLE
feat(cli): point `config init` at the @neon/* package names

### DIFF
--- a/packages/cli/src/commands/config.init.test.ts
+++ b/packages/cli/src/commands/config.init.test.ts
@@ -27,7 +27,7 @@ describe("config init", () => {
 
 		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
 		expect(content).toContain(
-			'import { defineConfig } from "@neondatabase/config/v1"',
+			'import { defineConfig } from "@neon/config/v1"',
 		);
 		expect(content).toContain("export default defineConfig({");
 		expect(content).toContain("auth: false");
@@ -59,10 +59,7 @@ describe("config init", () => {
 		// npm spells it `install`, pnpm/yarn/bun use `add` — assert on the packages,
 		// which are the same regardless of the resolved package manager.
 		expect(calls[0].args).toEqual(
-			expect.arrayContaining([
-				"@neondatabase/config",
-				"@neondatabase/env",
-			]),
+			expect.arrayContaining(["@neon/config", "@neon/env"]),
 		);
 		expect(calls[0].cwd).toBe(workspace);
 	});
@@ -71,7 +68,7 @@ describe("config init", () => {
 		writeFileSync(
 			join(workspace, "package.json"),
 			JSON.stringify({
-				dependencies: { "@neondatabase/config": "^0.8.1" },
+				dependencies: { "@neon/config": "^0.8.1" },
 			}),
 		);
 		const calls: string[][] = [];
@@ -86,8 +83,8 @@ describe("config init", () => {
 		});
 
 		expect(calls).toHaveLength(1);
-		expect(calls[0]).toContain("@neondatabase/env");
-		expect(calls[0]).not.toContain("@neondatabase/config");
+		expect(calls[0]).toContain("@neon/env");
+		expect(calls[0]).not.toContain("@neon/config");
 	});
 
 	test("does nothing to install when both packages are already declared", async () => {
@@ -95,8 +92,8 @@ describe("config init", () => {
 			join(workspace, "package.json"),
 			JSON.stringify({
 				dependencies: {
-					"@neondatabase/config": "^0.8.1",
-					"@neondatabase/env": "^0.8.1",
+					"@neon/config": "^0.8.1",
+					"@neon/env": "^0.8.1",
 				},
 			}),
 		);
@@ -155,6 +152,6 @@ describe("config init", () => {
 		});
 
 		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
-		expect(content).toContain("@neondatabase/config/v1");
+		expect(content).toContain("@neon/config/v1");
 	});
 });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -144,12 +144,14 @@ export const envPullFlag = {
 // ── `config init` ─────────────────────────────────────────────────────────────
 
 /**
- * The published npm packages a `neon.ts` project needs. The library sources live
- * under the `@neon/*` org now, but those aren't on npm yet — consumers install the
- * still-published `@neondatabase/*` names. Flip these to `@neon/*` once published.
+ * The published npm packages a `neon.ts` project needs — the `@neon/*` org names.
+ *
+ * ⚠️ DO NOT MERGE until `@neon/config` and `@neon/env` are actually published to
+ * npm. Until then `config init` must keep installing the `@neondatabase/*` names
+ * (see main), or it would try to install packages that don't exist yet.
  */
-const CONFIG_PACKAGE = "@neondatabase/config";
-const ENV_PACKAGE = "@neondatabase/env";
+const CONFIG_PACKAGE = "@neon/config";
+const ENV_PACKAGE = "@neon/env";
 const REQUIRED_PACKAGES = [CONFIG_PACKAGE, ENV_PACKAGE] as const;
 
 /** package.json fields a dependency can be declared in. */
@@ -359,7 +361,7 @@ export const builder = (argv: yargs.Argv) =>
 				yargs.options({
 					install: {
 						describe:
-							"Install @neondatabase/config and @neondatabase/env if they're missing. " +
+							"Install @neon/config and @neon/env if they're missing. " +
 							"On by default; use --no-install to just print the command.",
 						type: "boolean",
 						default: true,

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -146,9 +146,11 @@ export const envPullFlag = {
 /**
  * The published npm packages a `neon.ts` project needs — the `@neon/*` org names.
  *
- * ⚠️ DO NOT MERGE until `@neon/config` and `@neon/env` are actually published to
- * npm. Until then `config init` must keep installing the `@neondatabase/*` names
- * (see main), or it would try to install packages that don't exist yet.
+ * ⚠️ These ship to users the next time `neonctl` is released, so do NOT release
+ * neonctl until `@neon/config` and `@neon/env` are published to npm — otherwise
+ * `config init` would install packages that don't exist yet. (The libraries are
+ * mid-migration from `@neondatabase/*`; track their publish before cutting a CLI
+ * release.)
  */
 const CONFIG_PACKAGE = "@neon/config";
 const ENV_PACKAGE = "@neon/env";


### PR DESCRIPTION
Switches what `neon config init` scaffolds and installs from the old `@neondatabase/*` names to the new `@neon/*` org names:
- scaffolded `neon.ts` import: `@neondatabase/config/v1` → `@neon/config/v1`
- installed packages: `@neondatabase/config` + `@neondatabase/env` → `@neon/config` + `@neon/env`

(Driven by the `CONFIG_PACKAGE` / `ENV_PACKAGE` constants in `config.ts`; tests updated to match.)

## Safe to merge now — release is the gate, not the merge
This only changes what the **next `neonctl` release** ships. We're holding the `neonctl` release anyway until the `@neon/*` libraries are published to npm, so landing this on `main` now just keeps everything ready to go together. A code comment marks the release gate.

⚠️ Do not cut a `neonctl` release until `@neon/config` + `@neon/env` are live on npm (see the dual-publish pipeline `databricks/secure-public-registry-releases-eng#160` + npm trusted-publishing setup).