### PR TITLE
chore: release neonctl@2.29.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.29.0
+
+### Minor Changes
+
+- Add `neon config init`: scaffold a starter `neon.ts` policy and install the Neon config packages (`@neon/config` + `@neon/env`), detecting the project's package manager. Also offer it as the final step of an interactive `neon link` (then pull env so the local `.env` reflects the new policy).
+
 ## 2.28.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.28.0",
+  "version": "2.29.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
Version bump for the `config init` work (now that the `@neon/*` libraries are published + allowlisted).

## 2.29.0 (minor)
- Add `neon config init` (scaffold `neon.ts` + install `@neon/config` + `@neon/env`).
- Offer `config init` as the final step of an interactive `neon link`.

Applies the Changeset for the already-merged #259 / #260. After merge, publish via `neon-pkgs.yml` (`package=neonctl`).