### PR TITLE
fix(ci+docs): update stale @neondatabase/* refs to @neon/*

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -161,8 +161,8 @@ gh workflow run neon-pkgs.yml --repo databricks/secure-public-registry-releases-
 > npm" mode**. Dispatching with no `-f package=` (or `package=dry-run`) runs a smoke-test that
 > **publishes nothing**: the run still goes green and shows a "Publish …" step (that's
 > `npm publish --dry-run`), so it *looks* successful while npm stays on the old version. So for a
-> multi-package release, **dispatch this once per bumped package** (e.g. `@neondatabase/env`, then
-> `@neondatabase/functions`, then `@neondatabase/ai-sdk-provider`). Valid `package` values are the
+> multi-package release, **dispatch this once per bumped package** (e.g. `@neon/env`, then
+> `@neon/functions`, then `@neon/ai-sdk-provider`). Valid `package` values are the
 > choices in the workflow's `workflow_dispatch` input (each maintained package, plus `dry-run`).
 
 After each run succeeds, confirm with `npm view <pkg> version` — if it still shows the old version,

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -1,6 +1,6 @@
 name: Catalog Drift
 
-# Maintainer guard: fails when @neondatabase/ai-sdk-provider's pinned model
+# Maintainer guard: fails when @neon/ai-sdk-provider's pinned model
 # catalog (NEON_MODELS_DEV_IDS) drifts from the live models.dev `neon` provider.
 # Runs on a GitHub-hosted runner because it must reach the public internet
 # (models.dev); the protected runner group has no public egress.
@@ -25,4 +25,4 @@ jobs:
                   cache: pnpm
                   node-version-file: .node-version
             - run: pnpm install --frozen-lockfile
-            - run: pnpm --filter @neondatabase/ai-sdk-provider test:drift
+            - run: pnpm --filter @neon/ai-sdk-provider test:drift

--- a/.github/workflows/dist-typecheck.yml
+++ b/.github/workflows/dist-typecheck.yml
@@ -23,15 +23,15 @@ jobs:
                       dir: neon-new
                     - name: vite-plugin-neon-new
                       dir: vite-plugin-neon-new
-                    - name: "@neondatabase/config"
+                    - name: "@neon/config"
                       dir: config
-                    - name: "@neondatabase/config-runtime"
+                    - name: "@neon/config-runtime"
                       dir: config-runtime
-                    - name: "@neondatabase/env"
+                    - name: "@neon/env"
                       dir: env
-                    - name: "@neondatabase/functions"
+                    - name: "@neon/functions"
                       dir: functions
-                    - name: "@neondatabase/ai-sdk-provider"
+                    - name: "@neon/ai-sdk-provider"
                       dir: ai-sdk-provider
         steps:
             - name: Harden the runner (Audit all outbound calls)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,11 +74,11 @@ pnpm --filter neon-new dry:run
 Each package documents its own purpose, entry points, and API in its `README.md` — read the
 relevant package's README rather than maintaining a duplicate (and drift-prone) inventory here.
 At a high level: `neon-new` is the CLI + SDK, and `vite-plugin-neon-new` builds on it; the Config-as-Code
-toolchain centers on `@neondatabase/config` (pure, side-effect-free policy types + diff engine),
-with `@neondatabase/config-runtime` (imperative `inspect`/`plan`/`apply` + function deploy; pulls in
-`esbuild`, so import it from CLIs/CI, never from a `neon.ts` policy) and `@neondatabase/env` (resolve
-+ inject a branch's env) both building on `config`; plus `neon-init`, `@neondatabase/ai-sdk-provider`,
-and `@neondatabase/functions`.
+toolchain centers on `@neon/config` (pure, side-effect-free policy types + diff engine),
+with `@neon/config-runtime` (imperative `inspect`/`plan`/`apply` + function deploy; pulls in
+`esbuild`, so import it from CLIs/CI, never from a `neon.ts` policy) and `@neon/env` (resolve
++ inject a branch's env) both building on `config`; plus `neon-init`, `@neon/ai-sdk-provider`,
+and `@neon/functions`.
 
 ### The CLI package (`packages/cli`)
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ If you're looking for a single package's docs, see its own `README.md` under `pa
 
 | Package | Description |
 | --- | --- |
-| `@neondatabase/config` | Config-as-Code for Neon: `defineConfig` types + the pure diff engine and Neon API adapter behind a `neon.ts` policy. |
-| `@neondatabase/config-runtime` | Runtime for `neon.ts` policies — `inspect` / `plan` / `apply` (push/pull) plus function bundling and deploy. |
-| `@neondatabase/env` | Resolve and inject a branch's Neon env (`fetchEnv` / `parseEnv`, `neon-env run`) from a `neon.ts` policy. |
+| `@neon/config` | Config-as-Code for Neon: `defineConfig` types + the pure diff engine and Neon API adapter behind a `neon.ts` policy. |
+| `@neon/config-runtime` | Runtime for `neon.ts` policies — `inspect` / `plan` / `apply` (push/pull) plus function bundling and deploy. |
+| `@neon/env` | Resolve and inject a branch's Neon env (`fetchEnv` / `parseEnv`, `neon-env run`) from a `neon.ts` policy. |
 
 ### API & integrations
 
 | Package | Description |
 | --- | --- |
 | `@neon/sdk` | The official TypeScript SDK for the Neon API — a modern, Fetch-based client generated from Neon's OpenAPI spec (successor to `@neondatabase/api-client`). |
-| `@neondatabase/functions` | Runtime helpers for Neon Functions (e.g. a `waitUntil` primitive for deferring work past a response). |
-| `@neondatabase/ai-sdk-provider` | Community [Vercel AI SDK](https://ai-sdk.dev) provider for the Neon AI Gateway. |
+| `@neon/functions` | Runtime helpers for Neon Functions (e.g. a `waitUntil` primitive for deferring work past a response). |
+| `@neon/ai-sdk-provider` | Community [Vercel AI SDK](https://ai-sdk.dev) provider for the Neon AI Gateway. |
 
 A few renamed packages are still published as deprecated aliases (`get-db` / `neondb` → `neon-new`; `vite-plugin-db` / `@neondatabase/vite-plugin-postgres` → `vite-plugin-neon-new`); they re-export the new package and print a deprecation warning.
 
@@ -55,8 +55,8 @@ pnpm lint:ci          # lint + format check (Biome)
 Scope a command to a single package with a filter, e.g.:
 
 ```bash
-pnpm --filter @neondatabase/env build
-pnpm --filter @neondatabase/env test:ci
+pnpm --filter @neon/env build
+pnpm --filter @neon/env test:ci
 ```
 
 ## Releasing


### PR DESCRIPTION
Follow-up to the `@neondatabase/* → @neon/*` library rename (#258): a few in-repo refs still pointed at the old names. Most importantly, **two CI filters were silently broken**.

## CI (the important bit)
- **`catalog-drift.yml`** — `pnpm --filter @neondatabase/ai-sdk-provider test:drift` matched **no** workspace package, so the model-drift maintainer guard was a **silent no-op**. → `--filter @neon/ai-sdk-provider`.
- **`dist-typecheck.yml`** — the matrix `name` (`@neondatabase/config`, …) feeds `pnpm --filter ${name}... build`, which matched nothing. `attw` still ran (it uses `dir`), so the check stayed green but the targeted pre-build was dead. → names are now `@neon/*`.

## Docs
- `README.md` (package table + `pnpm --filter @neon/env build|test:ci`), `AGENTS.md` (package descriptions), `.claude/skills/release/SKILL.md` (dispatch examples).

## Untouched
`@neondatabase/serverless`, `@neondatabase/api-client`, repo URLs, and changelogs. Pure 1:1 rename (21 lines), no behavioral code changes.