### PR TITLE
fix(env): resolve branch by name or id, not id only

### DIFF
--- a/.changeset/env-resolve-branch-by-name-or-id.md
+++ b/.changeset/env-resolve-branch-by-name-or-id.md
@@ -1,0 +1,5 @@
+---
+"@neon/env": minor
+---
+
+Resolve branches by name or id, not id only. `fetchEnv` now accepts a `branch` option holding either a branch name (e.g. `main`) or an id (`br-…`); the legacy id-only `branchId` option still works. The `neon-env` CLI reads the `branch` field from the flat `.neon` file written by `neonctl link` (falling back to legacy `branchId`), and honors `NEON_BRANCH` in addition to `NEON_BRANCH_ID`. This fixes `neon-env run`/`export` failing to resolve a branch pinned by name.

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -235,7 +235,7 @@ const fetchAndProject = async (
 ): Promise<Record<string, string>> => {
 	const env = await fetchEnv(config, {
 		projectId: ctx.projectId as string,
-		branchId: ctx.branchId as string,
+		branch: ctx.branchId as string,
 		...apiOptions(ctx),
 		...(ctx.env ? { env: ctx.env } : {}),
 	});

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -12,7 +12,7 @@ npm install @neon/env
 
 ## Functions
 
-The library functions are **filesystem- and env-agnostic**: `fetchEnv` requires an explicit `projectId` + `branchId`. (The `neon-env` CLI does the `.neon`/`NEON_*` resolution and passes these in.)
+The library functions are **filesystem- and env-agnostic**: `fetchEnv` requires an explicit `projectId` + `branch` (a branch **name** like `main`, or a `br-…` id). (The `neon-env` CLI does the `.neon`/`NEON_*` resolution and passes these in.)
 
 > `parseEnv` takes **no branch name**: the secret set is static (top-level `config.auth` / `config.dataApi`), so it reads those toggles directly without evaluating the per-branch closure. Its optional second argument is a **scope** _or_ a **key filter** — omit it for the full external (app/build) env, pass a **function slug** when running inside that deployed function (adds a typed `function` namespace of its declared env keys), or pass an **array of OS-level env-var keys** to require + return only that subset.
 
@@ -21,7 +21,7 @@ import config from "../neon";
 import { fetchEnv, parseEnv } from "@neon/env";
 
 // Async — calls the Neon API for live connection strings. Use in build scripts / top-level await.
-const env = await fetchEnv(config, { projectId: "patient-art-12345", branchId: "br-…" });
+const env = await fetchEnv(config, { projectId: "patient-art-12345", branch: "main" });
 const db = drizzle(neon(env.postgres.databaseUrl), { schema });
 
 // Sync — reads already-injected process.env and validates it (no network).
@@ -43,7 +43,7 @@ Both return the same namespaced `NeonEnv` shape: `postgres` is always present; `
 
 | Function | Description |
 | --- | --- |
-| `fetchEnv(config, { projectId, branchId, ... })` | Async. Calls the Neon API for the given project + branch and returns live connection strings (and Auth/Data API values when enabled). `projectId` and `branchId` are required (`branchId` is a `br-…` id). |
+| `fetchEnv(config, { projectId, branch, ... })` | Async. Calls the Neon API for the given project + branch and returns live connection strings (and Auth/Data API values when enabled). `projectId` and `branch` are required; `branch` accepts a branch **name** (e.g. `main`) or a `br-…` id. (The legacy id-only `branchId` option still works.) |
 | `parseEnv(config)` / `parseEnv(config, slug)` / `parseEnv(config, keys)` | Sync. Reads/validates the Neon env vars already present in `process.env` against the static policy toggles. With a function `slug`, also returns a typed `function` namespace of that function's declared env keys. With a `keys` array (e.g. `["DATABASE_URL"]`), only those vars are required and returned, as a narrowed namespaced shape — the keys are typesafe against the policy. Throws `PlatformError(EnvNotInjected)` listing missing vars when the env isn't populated. |
 | `toEntries(env)` | Project a resolved `NeonEnv` into `{ KEY: value }` pairs for cross-process transport (named after the web `.entries()` convention; returns a `Record`). |
 
@@ -58,7 +58,7 @@ neon-env run -- npm run dev
 neon-env run -- pnpm dev
 ```
 
-`run` loads `neon.ts`, resolves the branch (via `--branch`, `NEON_BRANCH_ID`, or `.neon[/project.json]`), fetches the connection strings from Neon, and spawns the command with `NEON_BRANCH` / `DATABASE_URL` / `DATABASE_URL_UNPOOLED` (and `NEON_AUTH_BASE_URL` / `NEON_AUTH_JWKS_URL` / `NEON_DATA_API_URL` when the policy enables them) injected on top of the inherited environment. Stdio is inherited so interactive dev servers keep working, and the parent exits with the child's exit code.
+`run` loads `neon.ts`, resolves the branch (via `--branch`, `NEON_BRANCH` / `NEON_BRANCH_ID`, or the `branch` field in `.neon[/project.json]` — by name or id), fetches the connection strings from Neon, and spawns the command with `NEON_BRANCH` / `DATABASE_URL` / `DATABASE_URL_UNPOOLED` (and `NEON_AUTH_BASE_URL` / `NEON_AUTH_JWKS_URL` / `NEON_DATA_API_URL` when the policy enables them) injected on top of the inherited environment. Stdio is inherited so interactive dev servers keep working, and the parent exits with the child's exit code.
 
 ### `export` — print env to stdout
 
@@ -91,6 +91,6 @@ Flags (both commands): `--config <path>`, `--project-id`, `--branch`, `--api-key
 
 ## Resolution
 
-The **CLI** (`neon-env run`) resolves project + branch itself: `--project-id` / `--branch` flag → `NEON_PROJECT_ID` / `NEON_BRANCH_ID` env → `.neon[/project.json]` walked up from the working directory. The API key resolves via `--api-key` → `NEON_API_KEY` → `~/.config/neonctl/credentials.json`.
+The **CLI** (`neon-env run`) resolves project + branch itself: `--project-id` / `--branch` flag → `NEON_PROJECT_ID` / `NEON_BRANCH` (name) / `NEON_BRANCH_ID` (legacy id) env → `.neon[/project.json]` walked up from the working directory (its `branch` field, name or id; legacy `branchId` still read). The API key resolves via `--api-key` → `NEON_API_KEY` → `~/.config/neonctl/credentials.json`.
 
-The **library functions** do none of this — pass `projectId` / `branchId` explicitly. This keeps `.neon` parsing in one place (the CLI / neonctl) and the functions pure.
+The **library functions** do none of this — pass `projectId` / `branch` explicitly. This keeps `.neon` parsing in one place (the CLI / neonctl) and the functions pure.

--- a/packages/env/src/cli.ts
+++ b/packages/env/src/cli.ts
@@ -39,7 +39,7 @@ const argv = yargs(hideBin(process.argv))
 				.option("branch", {
 					type: "string",
 					describe:
-						"Override the .neon/project.json branchId / NEON_BRANCH_ID",
+						"Branch name or id to target (overrides .neon / NEON_BRANCH / NEON_BRANCH_ID)",
 				})
 				.option("api-key", {
 					type: "string",
@@ -68,7 +68,7 @@ const argv = yargs(hideBin(process.argv))
 				.option("branch", {
 					type: "string",
 					describe:
-						"Override the .neon/project.json branchId / NEON_BRANCH_ID",
+						"Branch name or id to target (overrides .neon / NEON_BRANCH / NEON_BRANCH_ID)",
 				})
 				.option("api-key", {
 					type: "string",

--- a/packages/env/src/lib/cli/commands.test.ts
+++ b/packages/env/src/lib/cli/commands.test.ts
@@ -44,13 +44,15 @@ export default defineConfig({});`;
 }
 
 describe("runEnvRun", () => {
-	test("injects DATABASE_URL into the spawned command", async () => {
+	// Regression: `neonctl link` writes a flat `.neon` pinning the branch *name*
+	// (`branch: "main"`), not a `br-…` id. fetchEnv must resolve that to the branch.
+	test("injects DATABASE_URL when .neon pins the branch by name", async () => {
 		const { api, projectId } = seededFake();
 		const root = setup({
 			"package.json": "{}",
-			".neon/project.json": JSON.stringify({
+			".neon": JSON.stringify({
 				projectId,
-				branchId: "br-main",
+				branch: "main",
 			}),
 			"neon.ts": policy(),
 		});

--- a/packages/env/src/lib/cli/commands.ts
+++ b/packages/env/src/lib/cli/commands.ts
@@ -182,7 +182,7 @@ function formatDotenvLine(key: string, value: string): string {
 async function loadConfigAndFetchEnv(
 	options: EnvResolveOptions,
 	ctx: CommandEnv,
-	resolved: { projectId: string; branchId: string },
+	resolved: { projectId: string; branch: string },
 ): Promise<Awaited<ReturnType<typeof fetchEnv>>> {
 	const { config, resolvedPath } = await loadConfigFromFile({
 		...(options.configPath ? { path: options.configPath } : {}),
@@ -194,7 +194,7 @@ async function loadConfigAndFetchEnv(
 		: {};
 	return fetchEnv(config, {
 		projectId: resolved.projectId,
-		branchId: resolved.branchId,
+		branch: resolved.branch,
 		env: { ...process.env, ...fileEnv },
 		...(ctx.api ? { api: ctx.api } : {}),
 		...(options.apiKey ? { apiKey: options.apiKey } : {}),

--- a/packages/env/src/lib/cli/resolve-context.test.ts
+++ b/packages/env/src/lib/cli/resolve-context.test.ts
@@ -36,7 +36,7 @@ describe("resolveContext — precedence", () => {
 		});
 		expect(result).toEqual({
 			ok: true,
-			context: { projectId: "proj-opt", branchId: "br-opt" },
+			context: { projectId: "proj-opt", branch: "br-opt" },
 		});
 	});
 
@@ -57,11 +57,29 @@ describe("resolveContext — precedence", () => {
 		});
 		expect(result).toMatchObject({
 			ok: true,
-			context: { projectId: "proj-env", branchId: "br-env" },
+			context: { projectId: "proj-env", branch: "br-env" },
 		});
 	});
 
-	test("falls back to .neon/project.json when no option or env", () => {
+	test("NEON_BRANCH (name) resolves and wins over the file", () => {
+		const root = setup({
+			"package.json": "{}",
+			".neon": JSON.stringify({
+				projectId: "proj-file",
+				branch: "br-file",
+			}),
+		});
+		const result = resolveContext({
+			cwd: root,
+			env: { NEON_PROJECT_ID: "proj-env", NEON_BRANCH: "feature-x" },
+		});
+		expect(result).toMatchObject({
+			ok: true,
+			context: { projectId: "proj-env", branch: "feature-x" },
+		});
+	});
+
+	test("falls back to the legacy `branchId` field in the .neon file", () => {
 		const root = setup({
 			"package.json": "{}",
 			".neon/project.json": JSON.stringify({
@@ -74,25 +92,42 @@ describe("resolveContext — precedence", () => {
 			ok: true,
 			context: {
 				projectId: "proj-file",
-				branchId: "br-file",
+				branch: "br-file",
 			},
+		});
+	});
+
+	test("prefers the `branch` field over the legacy `branchId`", () => {
+		const root = setup({
+			"package.json": "{}",
+			".neon": JSON.stringify({
+				projectId: "proj-file",
+				branch: "main",
+				branchId: "br-legacy",
+			}),
+		});
+		const result = resolveContext({ cwd: root, env: EMPTY_ENV });
+		expect(result).toEqual({
+			ok: true,
+			context: { projectId: "proj-file", branch: "main" },
 		});
 	});
 });
 
 describe("resolveContext — .neon file discovery", () => {
-	test("reads the bare `.neon` neonctl-convention file", () => {
+	test("reads the bare `.neon` neonctl-convention file (branch name)", () => {
+		// `neonctl link` writes a flat `.neon` with `branch` holding the branch *name*.
 		const root = setup({
 			"package.json": "{}",
 			".neon": JSON.stringify({
 				projectId: "p-bare",
-				branchId: "br-bare",
+				branch: "main",
 			}),
 		});
 		const result = resolveContext({ cwd: root, env: EMPTY_ENV });
 		expect(result).toMatchObject({
 			ok: true,
-			context: { projectId: "p-bare", branchId: "br-bare" },
+			context: { projectId: "p-bare", branch: "main" },
 		});
 	});
 
@@ -128,7 +163,7 @@ describe("resolveContext — .neon file discovery", () => {
 		});
 		expect(result).toMatchObject({
 			ok: true,
-			context: { projectId: "p-root", branchId: "br-root" },
+			context: { projectId: "p-root", branch: "br-root" },
 		});
 	});
 

--- a/packages/env/src/lib/cli/resolve-context.ts
+++ b/packages/env/src/lib/cli/resolve-context.ts
@@ -9,7 +9,8 @@ import { dirname, resolve } from "node:path";
  */
 export interface ResolvedContext {
 	projectId: string;
-	branchId: string;
+	/** Branch ref — a name (preferred for readability) or an id (`br-…`). */
+	branch: string;
 }
 
 export interface ResolveContextOptions {
@@ -37,33 +38,38 @@ export function resolveContext(
 		nonEmpty(env.NEON_PROJECT_ID) ??
 		file?.projectId;
 
-	const branchId =
+	// A branch ref — name (preferred) or id. `NEON_BRANCH` carries the name; `NEON_BRANCH_ID`
+	// is the legacy id-only var. The `.neon` file pins `branch` (name) via `neonctl link`,
+	// with legacy `branchId` still honored. fetchEnv resolves either form by name or id.
+	const branch =
 		nonEmpty(options.branch) ??
+		nonEmpty(env.NEON_BRANCH) ??
 		nonEmpty(env.NEON_BRANCH_ID) ??
-		file?.branchId;
+		file?.branch;
 
 	const missing: string[] = [];
 	if (!projectId) {
 		missing.push(
-			"project id — pass `--project-id`, set `NEON_PROJECT_ID`, or add `projectId` to `.neon/project.json` (run `npx neonctl link`).",
+			"project id — pass `--project-id`, set `NEON_PROJECT_ID`, or add `projectId` to `.neon` (run `npx neonctl link`).",
 		);
 	}
-	if (!branchId) {
+	if (!branch) {
 		missing.push(
-			"branch — pass `--branch`, set `NEON_BRANCH_ID`, or add `branchId` to `.neon/project.json` (run `npx neonctl checkout <branch>`).",
+			"branch — pass `--branch`, set `NEON_BRANCH`/`NEON_BRANCH_ID`, or add `branch` to `.neon` (run `npx neonctl link` / `neonctl checkout <branch>`).",
 		);
 	}
-	if (!projectId || !branchId) return { ok: false, missing };
+	if (!projectId || !branch) return { ok: false, missing };
 
 	return {
 		ok: true,
-		context: { projectId, branchId },
+		context: { projectId, branch },
 	};
 }
 
 interface NeonFile {
 	projectId?: string;
-	branchId?: string;
+	/** Branch ref — name (preferred) or id. Reads `branch`, falling back to legacy `branchId`. */
+	branch?: string;
 }
 
 /**
@@ -111,8 +117,15 @@ function readNeonFileAt(path: string): NeonFile | null {
 	const out: NeonFile = {};
 	if (typeof obj.projectId === "string" && obj.projectId !== "")
 		out.projectId = obj.projectId;
-	if (typeof obj.branchId === "string" && obj.branchId !== "")
-		out.branchId = obj.branchId;
+	// Prefer the `branch` field (name or id, written by `neonctl link`); fall back to the
+	// legacy id-only `branchId`.
+	const branch =
+		typeof obj.branch === "string" && obj.branch !== ""
+			? obj.branch
+			: typeof obj.branchId === "string" && obj.branchId !== ""
+				? obj.branchId
+				: undefined;
+	if (branch) out.branch = branch;
 	return out;
 }
 

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -89,6 +89,42 @@ describe("fetchEnv", () => {
 		expect(env.postgres.databaseUrl).toContain("-pooler");
 	});
 
+	test("resolves the branch by name via `branch`", async () => {
+		const { api, projectId } = seededFake();
+		const env = await fetchEnv(defineConfig({}), {
+			api,
+			projectId,
+			branch: "main",
+		});
+		expect(env.branch?.name).toBe("main");
+		expect(env.postgres.databaseUrl).toContain("postgresql://");
+	});
+
+	test("`branch` (id) wins over the legacy `branchId`", async () => {
+		const { api, projectId } = seededFake();
+		const env = await fetchEnv(defineConfig({}), {
+			api,
+			projectId,
+			branch: "main",
+			branchId: "br-does-not-exist",
+		});
+		expect(env.branch?.name).toBe("main");
+	});
+
+	test("throws a clear error for an unknown branch name or id", async () => {
+		const { api, projectId } = seededFake();
+		await expect(
+			fetchEnv(defineConfig({}), { api, projectId, branch: "nope" }),
+		).rejects.toMatchObject({ code: ErrorCode.BranchNotFound });
+	});
+
+	test("throws when no branch is provided", async () => {
+		const { api, projectId } = seededFake();
+		await expect(
+			fetchEnv(defineConfig({}), { api, projectId }),
+		).rejects.toMatchObject({ code: ErrorCode.BranchNotFound });
+	});
+
 	test("surfaces the branch name as NEON_BRANCH", async () => {
 		const { api, projectId } = seededFake();
 		const env = await fetchEnv(defineConfig({}), {

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -387,8 +387,18 @@ export interface FetchEnvOptions {
 	 * project. Resolve it in your CLI (e.g. neonctl) and pass it in.
 	 */
 	projectId: string;
-	/** Neon branch id (`br-…`). **Required.** Resolve names to ids before calling. */
-	branchId: string;
+	/**
+	 * Neon branch — its **name** (e.g. `main`) or its id (`br-…`). **Required** (or pass the
+	 * legacy {@link FetchEnvOptions.branchId}). Resolved against the project's branches by
+	 * id first, then by name, so either form works.
+	 */
+	branch?: string;
+	/**
+	 * @deprecated Legacy id-only field. Prefer {@link FetchEnvOptions.branch}, which accepts
+	 * a branch name or id. Still honored for backward compatibility; ignored when `branch`
+	 * is set.
+	 */
+	branchId?: string;
 	/**
 	 * Neon API key. Resolved via the standard chain (option → `NEON_API_KEY` →
 	 * `~/.config/neonctl/credentials.json`) when omitted. Ignored when a custom `api`
@@ -436,14 +446,14 @@ export interface FetchEnvOptions {
  * {@link parseEnv} instead — same {@link NeonEnv} shape, but a sync call against
  * `process.env`.
  *
- * Filesystem- and env-agnostic: pass `projectId` and the target `branchId` explicitly
- * (resolve them in your CLI, e.g. neonctl).
+ * Filesystem- and env-agnostic: pass `projectId` and the target `branch` (name or id)
+ * explicitly (resolve them in your CLI, e.g. neonctl).
  *
  * ```ts
  * import config from "../neon";
  * import { fetchEnv } from "@neon/env";
  *
- * const env = await fetchEnv(config, { projectId: "patient-art-12345", branchId: "br-…" });
+ * const env = await fetchEnv(config, { projectId: "patient-art-12345", branch: "main" });
  * const db = drizzle(neon(env.postgres.databaseUrl), { schema });
  * ```
  *
@@ -468,7 +478,18 @@ export async function fetchEnv<const C extends Config>(
 		);
 	}
 
-	const branch = resolveBranch(options.branchId, branches);
+	const branchRef = options.branch ?? options.branchId;
+	if (!branchRef) {
+		throw new PlatformError(
+			ErrorCode.BranchNotFound,
+			[
+				"fetchEnv: no branch provided.",
+				"Pass `branch` with a branch name (e.g. `main`) or id (`br-…`).",
+			].join(" "),
+			{ details: { projectId } },
+		);
+	}
+	const branch = resolveBranch(branchRef, branches);
 	const desired = resolveConfig(config, {
 		name: branch.name,
 		id: branch.id,
@@ -763,22 +784,30 @@ function createApiFromOptions(options: FetchEnvOptions): NeonApi {
 	});
 }
 
+/**
+ * Resolve a branch ref — a name or an id — to a concrete branch. Matches by id first
+ * (exact `br-…`), then by name; both are unique within a project, so the lookup is
+ * unambiguous. This lets `.neon` files written by `neonctl` (which pin the branch *name*)
+ * and explicit `br-…` ids both work.
+ */
 function resolveBranch(
-	branchId: string,
+	branch: string,
 	branches: NeonBranchSnapshot[],
 ): NeonBranchSnapshot {
-	const match = branches.find((b) => b.id === branchId);
+	const match =
+		branches.find((b) => b.id === branch) ??
+		branches.find((b) => b.name === branch);
 	if (match) return match;
 	throw new PlatformError(
 		ErrorCode.BranchNotFound,
 		[
-			`fetchEnv: branch id ${JSON.stringify(branchId)} not found on project.`,
+			`fetchEnv: branch ${JSON.stringify(branch)} not found on project (matched by id or name).`,
 			`Existing branches: ${branches.map((b) => `${b.name} (${b.id})`).join(", ")}.`,
 		].join(" "),
 		{
 			details: {
-				branchId,
-				available: branches.map((b) => b.id),
+				branch,
+				available: branches.map((b) => `${b.name} (${b.id})`),
 			},
 		},
 	);

--- a/packages/env/src/lib/test-utils.ts
+++ b/packages/env/src/lib/test-utils.ts
@@ -12,6 +12,7 @@ import { vi } from "vitest";
 const NEON_AND_RELATED_ENV_KEYS = [
 	"NEON_API_KEY",
 	"NEON_PROJECT_ID",
+	"NEON_BRANCH",
 	"NEON_BRANCH_ID",
 	"NEON_ORG_ID",
 	"NEON_AUTH_BASE_URL",


### PR DESCRIPTION
## Summary

`@neon/env` only resolved a branch by its `br-…` **id**, so `neon-env run` / `export` (and `fetchEnv`) failed when the branch was pinned by **name** — which is exactly what `neonctl link` writes to the flat `.neon` file (`"branch": "main"`).

This makes `branch` (a name **or** an id) the primary field everywhere, with `branchId` kept as a legacy id-only alias:

- **`fetchEnv`** gains a `branch?: string` option (name or id). `resolveBranch` now matches by id first, then by name (both unique per project). The legacy `branchId?` option is still honored; passing neither now throws a clear `BranchNotFound`.
- **CLI context resolution** (`resolveContext` / `.neon` reader) reads the `branch` field (falling back to legacy `branchId`) and honors `NEON_BRANCH` (name) in addition to `NEON_BRANCH_ID` (legacy id). `ResolvedContext.branchId` → `ResolvedContext.branch`.
- The `neonctl dev` caller now passes `branch` instead of `branchId`.
- README + `--branch` flag help + a changeset (`minor`) updated.

### Convention
- `branchName` → name only
- `branchId` → id only (legacy)
- `branch` → id **or** name (name preferred for readability)

## Test plan
- [x] `pnpm --filter @neon/env test:ci` — 99 passed. New coverage: resolve-by-name, `branch` wins over legacy `branchId`, unknown-branch error, no-branch error, flat `.neon` pinned by name (end-to-end through `runEnvRun`), `NEON_BRANCH` env, `branch`-field-preferred-over-`branchId`.
- [x] `pnpm --filter @neon/env build` (tsc --noEmit && tsdown) — clean.
- [x] `pnpm --filter neonctl typecheck` — clean.
- [x] Biome check — clean.