### PR TITLE
chore: release @neon/env@0.9.0

### DIFF
--- a/.changeset/env-resolve-branch-by-name-or-id.md
+++ b/.changeset/env-resolve-branch-by-name-or-id.md
@@ -1,5 +1,0 @@
----
-"@neon/env": minor
----
-
-Resolve branches by name or id, not id only. `fetchEnv` now accepts a `branch` option holding either a branch name (e.g. `main`) or an id (`br-…`); the legacy id-only `branchId` option still works. The `neon-env` CLI reads the `branch` field from the flat `.neon` file written by `neonctl link` (falling back to legacy `branchId`), and honors `NEON_BRANCH` in addition to `NEON_BRANCH_ID`. This fixes `neon-env run`/`export` failing to resolve a branch pinned by name.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 2.29.1
+
+### Patch Changes
+
+- Updated dependencies [b78ced2]
+  - @neon/env@0.9.0
+
 ## 2.29.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 0.9.0
+
+### Minor Changes
+
+- b78ced2: Resolve branches by name or id, not id only. `fetchEnv` now accepts a `branch` option holding either a branch name (e.g. `main`) or an id (`br-…`); the legacy id-only `branchId` option still works. The `neon-env` CLI reads the `branch` field from the flat `.neon` file written by `neonctl link` (falling back to legacy `branchId`), and honors `NEON_BRANCH` in addition to `NEON_BRANCH_ID`. This fixes `neon-env run`/`export` failing to resolve a branch pinned by name.
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Consumes the changeset from #264.

- `@neon/env` → **0.9.0** (minor): resolve branches by name **or** id.
- `neonctl` → **2.29.1** (cascade patch — it bundles `@neon/env`).

After merge: dispatch `neon-pkgs.yml` for `@neon/env`, then `neonctl`.