### PR TITLE
fix(cli): pin undici to ^7.28.0 to restore Node 20 support

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.29.2
+
+### Patch Changes
+
+- Lower the Node requirement from `>=22` back to `>=20.18.1` by pinning `undici` to `^7.28.0` (undici 8 requires Node 22.19+). undici is only used for `HTTP(S)_PROXY` support via `EnvHttpProxyAgent`, which is available in undici 7, so there is no behavioral change — this just restores Node 20 compatibility for the CLI.
+
 ## 2.29.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.29.1",
+  "version": "2.29.2",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",
@@ -31,7 +31,7 @@
     "package.json"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=20.18.1"
   },
   "scripts": {
     "generateParams": "tsx generateOptionsFromSpec.ts",
@@ -63,7 +63,7 @@
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",
     "prompts": "2.4.2",
-    "undici": "^8.5.0",
+    "undici": "^7.28.0",
     "which": "3.0.1",
     "yaml": "2.4.5",
     "yargs": "17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,8 +255,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       undici:
-        specifier: ^8.5.0
-        version: 8.5.0
+        specifier: ^7.28.0
+        version: 7.28.0
       which:
         specifier: 3.0.1
         version: 3.0.1
@@ -6142,10 +6142,6 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
-
-  undici@8.5.0:
-    resolution: {integrity: sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==}
-    engines: {node: '>=22.19.0'}
 
   unenv@1.10.0:
     resolution: {integrity: sha512-wY5bskBQFL9n3Eca5XnhH6KbUo/tfvkwm9OpcdCvLaeA7piBNbavbOKJySEwQ1V0RH6HvNlSAFRTpvTqgKRQXQ==}
@@ -12557,8 +12553,6 @@ snapshots:
     optional: true
 
   undici@7.28.0: {}
-
-  undici@8.5.0: {}
 
   unenv@1.10.0:
     dependencies:


### PR DESCRIPTION
## Summary

`neonctl` currently requires **Node >=22** — but only because `undici@8.5.0` (added in #250 for `HTTP(S)_PROXY` support) declares `engines.node >=22.19.0`. undici is used *only* for `EnvHttpProxyAgent` + `setGlobalDispatcher` (see `packages/cli/src/api.ts`), and that API has existed since **undici 6.14**. So we can safely drop back to a Node-20-compatible undici with **zero code changes**.

- Pin `undici` `^8.5.0` → **`^7.28.0`** (latest 7.x; `engines.node >=20.18.1`).
- Lower CLI `engines.node` `>=22` → **`>=20.18.1`** to match undici 7.
- No behavioral change — same proxy support via `EnvHttpProxyAgent`.

### Context / semver note

The jump to `>=22` shipped in `2.28.0` as a *minor*, which (strictly) dropped Node 18/20/21 support and was arguably a breaking change. This PR is a compatibility **broadening** (widening the supported range), so it's correctly a **patch** (`2.29.2`). It restores Node 20 but does **not** restore Node 18 (that would need undici 6 + `>=18.17`).

## Test plan

- [x] `pnpm --filter neonctl typecheck` passes against undici 7
- [x] `pnpm format` (Biome) clean
- [x] Lockfile refreshed — resolves `undici@7.28.0`, `undici@8` gone
- [x] Changeset added (`neonctl` patch → `2.29.2`)