### PR TITLE
chore: support Node.js >=20.19 across published packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ pnpm --filter neon-new dry:run
 -   Uses pnpm workspaces (`packages/*`); shared dependency versions are pinned via the pnpm catalog (`pnpm-workspace.yaml`)
 -   Uses Biome for linting/formatting instead of ESLint/Prettier
 -   Builds with `tsdown` for bundling and `tsc --noEmit` for type-checking (see each package's `build` script)
--   Package manager: pnpm@10.30.3, Node.js >=22
+-   Package manager: pnpm@10.30.3. **Node.js requirements are split** (see `CONTRIBUTING.md`): contributors need **Node >=22** (pnpm needs 22.13+; regenerating `@neon/sdk` via `@hey-api/openapi-ts` needs 22.18+), while every **published package** targets **Node >=20.19** at runtime (`engines.node: ">=20.19.0"` — the real floor of the dependency trees, driven by `chokidar@5`/`yargs@18`). The repo-root `package.json` keeps `engines.node: ">=22"` on purpose: it describes the contributor environment, not the shipped packages.
 -   **Dependency Installation**: Prefer `pnpm dedupe` over `pnpm install` - it deduplicates dependencies in node_modules, minimizing conflict issues and reducing filesystem space
 -   **Exception — `packages/cli`** (the Neon CLI): keeps its own upstream toolchain (`tsc` → `dist`, ESLint + Prettier, `@yao-pkg/pkg` binaries) rather than tsdown/Biome, so it is **excluded from root Biome** (`biome.json` `!packages/cli`). See "The CLI package" below.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+Thanks for contributing to Neon's JavaScript/TypeScript packages!
+
+## Node.js versions — the two floors
+
+This repo has **two distinct Node.js requirements**, and they are intentionally different:
+
+| Audience | Node.js | Why |
+| --- | --- | --- |
+| **Contributors** (developing in this repo) | **>= 22** | The toolchain needs it: `pnpm` (10.x) requires Node **22.13+** (it uses `node:sqlite`), and regenerating the `@neon/sdk` types with `@hey-api/openapi-ts` requires Node **22.18+**. |
+| **End users** (installing a published package) | **>= 20.19** | Every published package declares `engines.node: ">=20.19.0"`. That is the true floor of the runtime dependency trees (driven by `chokidar@5` / `yargs@18`); nothing published needs Node 22. |
+
+In short: **you build and test on Node 22+, but everything we ship runs on Node 20.19+.** The
+repo root `package.json` declares `engines.node: ">=22"` for exactly this reason — it describes
+the *contributor* environment, not the published packages.
+
+> Node 20 reached end-of-life on 2026-04-30. We continue to support it as a grace window for
+> users who haven't upgraded yet; expect the floor to move to Node 22 once Node 20 usage is
+> negligible.
+
+### Using nvm
+
+```bash
+nvm install 22 && nvm use 22   # contributor toolchain
+```
+
+To sanity-check that a build still runs on the published floor, you can run the built artifacts
+(not `pnpm`, which needs 22.13+) under Node 20.19+:
+
+```bash
+nvm install 20 && nvm exec 20 node packages/cli/dist/cli.js --version
+```
+
+## Development
+
+```bash
+pnpm install          # install all workspaces
+pnpm build            # build every package (tsc + tsdown)
+pnpm test:ci          # run the test suites (Vitest)
+pnpm lint:ci          # lint + format check (Biome)
+```
+
+Scope a command to a single package with a filter:
+
+```bash
+pnpm --filter @neon/env build
+pnpm --filter @neon/env test:ci
+```
+
+See [`AGENTS.md`](./AGENTS.md) for the deeper architecture and per-package notes (especially the
+CLI package, which keeps its own toolchain).
+
+## Changing the supported Node floor
+
+If you bump a dependency that raises the runtime floor, update **every published package's**
+`engines.node` accordingly, refresh the `> **Requirements:**` note in each package `README.md`,
+and update the table above. Don't lower a package's `engines` below what its dependency tree
+actually supports.
+
+## Changesets
+
+User-facing changes need a changeset:
+
+```bash
+pnpm changeset        # pick package(s) + bump + summary
+```
+
+Commit the generated `.changeset/*.md` with your PR. See the "Release Management" section of
+[`AGENTS.md`](./AGENTS.md) for how releases are cut and published.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This is a [pnpm workspace](https://pnpm.io/workspaces). Internal dependencies ar
 
 ## Development
 
-Requires Node.js >= 22 and [pnpm](https://pnpm.io). From the repo root:
+Contributing to this repo requires **Node.js >= 22** and [pnpm](https://pnpm.io) — pnpm itself needs Node 22.13+, and regenerating the `@neon/sdk` types needs Node 22.18+. The **published packages** support **Node.js >= 20.19** at runtime (see each package's README and `CONTRIBUTING.md`). From the repo root:
 
 ```bash
 pnpm install          # install all workspaces

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @neondatabase/ai-sdk-provider
 
+## 0.6.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -12,6 +12,8 @@ Model ids use the canonical Neon (unprefixed) form — `claude-sonnet-4-6`, `gpt
 npm install @neon/ai-sdk-provider ai@^6
 ```
 
+> **Requirements:** Node.js >= 20.19.
+
 ## Configuration
 
 The gateway URL is branch-scoped, so both values come from the Neon Console (your project → a branch → **AI Gateway** tab), or from `neon env pull` / `neon dev`:

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/ai-sdk-provider",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",
@@ -57,7 +57,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @neondatabase/config-runtime
 
+## 0.9.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @neon/config@0.9.0
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/config-runtime/README.md
+++ b/packages/config-runtime/README.md
@@ -10,6 +10,8 @@ Imperative runtime for [`@neon/config`](../config): run a `neon.ts` policy again
 npm install @neon/config-runtime
 ```
 
+> **Requirements:** Node.js >= 20.19.
+
 ## API
 
 - `inspect` / `plan` / `apply` — read the current branch state, diff a policy against it, and apply the changes.

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",
@@ -64,7 +64,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @neondatabase/config
 
+## 0.9.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @neon/sdk@0.2.0
+
 ## 0.8.1
 
 ### Patch Changes

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -10,6 +10,8 @@ Config-as-Code for the Neon Platform. A repo-local `neon.ts` exports a TypeScrip
 npm install @neon/config
 ```
 
+> **Requirements:** Node.js >= 20.19.
+
 ## Define a policy
 
 ```ts

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "0.8.1",
+	"version": "0.9.0",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",
@@ -63,7 +63,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @neondatabase/env
 
+## 0.10.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @neon/config@0.9.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -10,6 +10,8 @@ Builds on [`@neon/config`](../config) — it reuses the `Config` policy type and
 npm install @neon/env
 ```
 
+> **Requirements:** Node.js >= 20.19.
+
 ## Functions
 
 The library functions are **filesystem- and env-agnostic**: `fetchEnv` requires an explicit `projectId` + `branch` (a branch **name** like `main`, or a `br-…` id). (The `neon-env` CLI does the `.neon`/`NEON_*` resolution and passes these in.)

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",
@@ -63,7 +63,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @neondatabase/functions
 
+## 0.6.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -8,6 +8,8 @@ Runtime helpers for [Neon Functions](https://neon.com). Currently provides a `wa
 npm install @neon/functions
 ```
 
+> **Requirements:** Node.js >= 20.19.
+
 ## Usage
 
 The API mirrors [`@vercel/functions`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package): import `waitUntil` and call it directly with the promise you want to keep alive.

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/functions",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Runtime helpers for Neon Functions. Currently provides a `waitUntil` primitive for deferring async work past a response.",
 	"keywords": [
 		"neon",
@@ -51,7 +51,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/get-db/CHANGELOG.md
+++ b/packages/get-db/CHANGELOG.md
@@ -1,5 +1,12 @@
 # get-db
 
+## 0.14.1
+
+### Patch Changes
+
+- Updated dependencies
+  - neon-new@0.15.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/get-db/README.md
+++ b/packages/get-db/README.md
@@ -4,6 +4,8 @@
 > [`neon-new`](https://www.npmjs.com/package/neon-new). It still works as an alias but prints a
 > deprecation warning at runtime — please migrate.
 
+> **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
+
 ## Migration
 
 Update your dependency:

--- a/packages/get-db/package.json
+++ b/packages/get-db/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "get-db",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"description": "[DEPRECATED] This package has been renamed to 'neon-new'. Please use 'neon-new' instead.",
 	"keywords": [
 		"neon",
@@ -58,7 +58,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neon-init
 
+## 0.20.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
 ## 0.19.0
 
 ### Minor Changes

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -8,6 +8,8 @@ Set up Neon for AI-powered database operations in VS Code, Cursor, and Claude CL
 npm add neon-init
 ```
 
+> **Requirements:** Node.js >= 20.19.
+
 ## Usage
 
 ```ts

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.19.0",
+	"version": "0.20.0",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",
@@ -67,7 +67,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/neon-new/CHANGELOG.md
+++ b/packages/neon-new/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neon-new
 
+## 0.15.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/neon-new/README.md
+++ b/packages/neon-new/README.md
@@ -4,6 +4,8 @@
 
 ---
 
+> **Requirements:** Node.js >= 20.19.
+
 ## CLI Usage
 
 The CLI provides a default referrer value, so the `--ref` flag is optional.

--- a/packages/neon-new/package.json
+++ b/packages/neon-new/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-new",
-	"version": "0.14.0",
+	"version": "0.15.0",
 	"description": "create a claimable Neon database in seconds!",
 	"keywords": [
 		"neon",
@@ -63,7 +63,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/neondb/CHANGELOG.md
+++ b/packages/neondb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neondb
 
+## 0.14.1
+
+### Patch Changes
+
+- Updated dependencies
+  - neon-new@0.15.0
+
 ## 0.14.0
 
 ### Minor Changes

--- a/packages/neondb/README.md
+++ b/packages/neondb/README.md
@@ -4,6 +4,8 @@
 > [`neon-new`](https://www.npmjs.com/package/neon-new). It still works as an alias but prints a
 > deprecation warning at runtime — please migrate.
 
+> **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
+
 ## Migration
 
 Update your dependency:

--- a/packages/neondb/package.json
+++ b/packages/neondb/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neondb",
-	"version": "0.14.0",
+	"version": "0.14.1",
 	"description": "[DEPRECATED] This package has been renamed to 'neon-new'. Please use 'neon-new' instead.",
 	"keywords": [
 		"neon",
@@ -58,7 +58,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @neon/sdk
 
+## 0.2.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -15,7 +15,7 @@ Two layers, one package:
 npm install @neon/sdk
 ```
 
-Requires Node.js ≥ 22 (or any runtime with a global `fetch` — Bun, Deno, edge, browser).
+Requires Node.js ≥ 20.19 (or any runtime with a global `fetch` — Bun, Deno, edge, browser).
 
 ## Quick start
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",
@@ -67,7 +67,7 @@
 	},
 	"packageManager": "pnpm@10.4.0",
 	"engines": {
-		"node": ">=22"
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"provenance": false

--- a/packages/vite-plugin-db/CHANGELOG.md
+++ b/packages/vite-plugin-db/CHANGELOG.md
@@ -1,5 +1,12 @@
 # vite-plugin-db
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies
+  - vite-plugin-neon-new@0.9.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/vite-plugin-db/README.md
+++ b/packages/vite-plugin-db/README.md
@@ -4,6 +4,8 @@
 > [`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new). It still works as an
 > alias but prints a deprecation warning at runtime — please migrate.
 
+> **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
+
 ## Migration
 
 Update your dependency:

--- a/packages/vite-plugin-db/package.json
+++ b/packages/vite-plugin-db/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-db",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "[DEPRECATED] This package has been renamed to 'vite-plugin-neon-new'. Please use 'vite-plugin-neon-new' instead.",
 	"keywords": [
 		"neon",
@@ -34,6 +34,9 @@
 	},
 	"peerDependencies": {
 		"vite": "^6.0.0 || ^7.0.0"
+	},
+	"engines": {
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/vite-plugin-neon-new/CHANGELOG.md
+++ b/packages/vite-plugin-neon-new/CHANGELOG.md
@@ -1,5 +1,20 @@
 # vite-plugin-neon-new
 
+## 0.9.0
+
+### Minor Changes
+
+- Support Node.js >= 20.19 at runtime. Every published package now declares
+  `engines.node: ">=20.19.0"` — the real floor of its dependency tree — instead of `>=22`, so the
+  packages install and run cleanly on Node 20 without any dependency downgrades (`neonctl` moves
+  from `>=20.18.1` to `>=20.19.0` to match `chokidar@5`). Contributing to the repo still requires
+  Node 22 (pnpm + SDK codegen); see `CONTRIBUTING.md`.
+
+### Patch Changes
+
+- Updated dependencies
+  - neon-new@0.15.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/vite-plugin-neon-new/README.md
+++ b/packages/vite-plugin-neon-new/README.md
@@ -20,6 +20,8 @@ This Vite plugin instantly provisions a Postgres instance (via Neon) and injects
 | **bun**         | `bun add -D vite-plugin-neon-new`      |
 | **deno**        | `deno add -D npm:vite-plugin-neon-new` |
 
+> **Requirements:** Node.js >= 20.19.
+
 ## Usage
 
 > **BREAKING CHANGE in v3.0.0**: The `referrer` option is now **required**.

--- a/packages/vite-plugin-neon-new/package.json
+++ b/packages/vite-plugin-neon-new/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-neon-new",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"keywords": [
 		"neon",
 		"database",
@@ -35,6 +35,9 @@
 	},
 	"peerDependencies": {
 		"vite": "^6.0.0 || ^7.0.0"
+	},
+	"engines": {
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/vite-plugin-postgres/CHANGELOG.md
+++ b/packages/vite-plugin-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/vite-plugin-postgres
 
+## 0.8.1
+
+### Patch Changes
+
+- Updated dependencies
+  - vite-plugin-neon-new@0.9.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/vite-plugin-postgres/README.md
+++ b/packages/vite-plugin-postgres/README.md
@@ -4,6 +4,8 @@
 > [`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new). It still works as an
 > alias but prints a deprecation warning at runtime — please migrate.
 
+> **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
+
 ## Migration
 
 Update your dependency:

--- a/packages/vite-plugin-postgres/package.json
+++ b/packages/vite-plugin-postgres/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/vite-plugin-postgres",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "[DEPRECATED] This package has been renamed to 'vite-plugin-neon-new'. Please use 'vite-plugin-neon-new' instead.",
 	"keywords": [
 		"neon",
@@ -34,6 +34,9 @@
 	},
 	"peerDependencies": {
 		"vite": "^6.0.0 || ^7.0.0"
+	},
+	"engines": {
+		"node": ">=20.19.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
## Summary

Lower `engines.node` from `>=22` to **`>=20.19.0`** for all published library packages so they install and run on Node 20 **with zero dependency downgrades**. `20.19.0` is the true floor of the dependency trees (`chokidar@5`, `yargs@18`); nothing published needs Node 22.

Bumped (via Changesets):
- **minor:** `@neon/sdk`, `@neon/env`, `@neon/functions`, `@neon/config`, `@neon/config-runtime`, `@neon/ai-sdk-provider`, `neon-init`, `neon-new`, `vite-plugin-neon-new`
- **patch (cascade):** deprecated aliases `get-db`, `neondb`, `vite-plugin-db`, `@neondatabase/vite-plugin-postgres`

## Docs

- A `> **Requirements:** Node.js >= 20.19.` note in **every** package README (updated the stale `@neon/sdk` "≥ 22" line).
- New **`CONTRIBUTING.md`** documenting the two-floor split: contributors need **Node 22** (pnpm needs 22.13+; `@neon/sdk` codegen via `@hey-api/openapi-ts` needs 22.18+), while shipped packages run on **Node 20.19+**.
- `README.md` + `AGENTS.md` updated to explain why the repo-root `engines` stays `>=22` (contributor env) while packages ship `>=20.19`.

## Not in this PR — the CLI

`neonctl` pins the **published** `neon-init` version, so its Node-20 fix (engines + `neon-init` → `^0.20.0`, which is what removes the transitive `>=22` warning) can only land **after `neon-init@0.20.0` is published**. That lands in a follow-up PR.

## Validation (all on Node 20.20.2 via nvm)

- Built on Node 24 (contributor toolchain); **all unit suites green on Node 20.20** — env 99, functions 5, config 223, config-runtime 49, sdk 2, init 123, neon-new 116, ai-sdk-provider 9, CLI 3011.
- Real end-to-end against a personal Neon account on Node 20.20: project **create → connection-string → branches → delete**; and a full **Neon Function build → deploy → invoke** (`with-hono` example: `POST/GET /todos` returned 201/200). All test resources cleaned up.

## Test plan

- [ ] CI green (build, lint, tests) on the repo's Node matrix
- [ ] After merge: publish the 9 library packages (incl. `neon-init@0.20.0`) via `neon-pkgs.yml`
- [ ] Follow-up PR: `neonctl` engines + `neon-init@^0.20.0`