### PR TITLE
feat(cli): add `neon api` passthrough command

### DIFF
--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -321,6 +321,12 @@ export type RequestParams = {
 	type?: ContentType;
 	format?: "json" | "stream";
 	secure?: boolean;
+	/**
+	 * Extra request headers, merged on top of the defaults (`User-Agent`,
+	 * `Authorization`, and `Content-Type`). Later keys win, so callers can
+	 * override any default when they need to.
+	 */
+	headers?: Record<string, string>;
 };
 
 export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) => {
@@ -385,6 +391,13 @@ export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) => {
 		} else if (params.body !== undefined) {
 			headers["Content-Type"] = ContentType.Json;
 			payload = JSON.stringify(params.body);
+		}
+
+		// Caller-supplied headers win over the defaults set above.
+		if (params.headers) {
+			for (const [key, value] of Object.entries(params.headers)) {
+				headers[key] = value;
+			}
 		}
 
 		let response: Response;

--- a/packages/cli/src/commands/__snapshots__/api.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`api command (e2e passthrough) > GET single resource by path 1`] = `
+"{
+  "project": {
+    "id": "test",
+    "name": "test_project",
+    "created_at": "2019-01-01T00:00:00Z",
+    "settings": {
+      "allowed_ips": {
+        "ips": [
+          "192.168.1.1"
+        ],
+        "protected_branches_only": false
+      }
+    }
+  }
+}
+"
+`;
+
+exports[`api command (e2e passthrough) > GET with query params 1`] = `
+"{
+  "projects": [
+    {
+      "id": 1,
+      "name": "Project_1",
+      "created_at": "2019-01-01T00:00:00.000Z",
+      "updated_at": "2019-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "name": "Project_2",
+      "created_at": "2019-01-01T00:00:00.000Z",
+      "updated_at": "2019-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "name": "Project_3",
+      "created_at": "2019-01-01T00:00:00.000Z",
+      "updated_at": "2019-01-01T00:00:00.000Z"
+    }
+  ]
+}
+"
+`;
+
+exports[`api command (e2e passthrough) > POST with -F body fields 1`] = `
+"{
+  "project": {
+    "id": "new-project-123456",
+    "name": "test_project",
+    "created_at": "2021-01-01T00:00:00.000Z"
+  },
+  "connection_uris": [
+    {
+      "connection_uri": "postgres://localhost:5432/test_project"
+    }
+  ],
+  "branch": {
+    "id": "br-test-branch-123456",
+    "name": "test_branch",
+    "created_at": "2021-01-01T00:00:00.000Z"
+  }
+}
+"
+`;
+
+exports[`api command (e2e passthrough) > rejects paths without a leading slash 1`] = `""`;

--- a/packages/cli/src/commands/api.test.ts
+++ b/packages/cli/src/commands/api.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { test } from "../test_utils/fixtures";
+import {
+	buildBody,
+	buildQuery,
+	parseHeaders,
+	parseKeyValue,
+	parseTypedValue,
+	setDeep,
+} from "./api";
+
+describe("api arg mapping", () => {
+	it("types scalar and JSON values", () => {
+		expect(parseTypedValue("true")).toBe(true);
+		expect(parseTypedValue("false")).toBe(false);
+		expect(parseTypedValue("null")).toBeNull();
+		expect(parseTypedValue("42")).toBe(42);
+		expect(parseTypedValue("-3.14")).toBeCloseTo(-3.14);
+		expect(parseTypedValue("hello")).toBe("hello");
+		expect(parseTypedValue('["a","b"]')).toEqual(["a", "b"]);
+		expect(parseTypedValue('{"a":1}')).toEqual({ a: 1 });
+		// Invalid JSON falls back to the literal string.
+		expect(parseTypedValue("{oops")).toBe("{oops");
+	});
+
+	it("splits key=value on the first '='", () => {
+		expect(parseKeyValue("a=b=c")).toEqual({ key: "a", value: "b=c" });
+		expect(() => parseKeyValue("noequals")).toThrow(/key=value/);
+	});
+
+	it("assigns nested values by dot-path", () => {
+		const target: Record<string, unknown> = {};
+		setDeep(target, "branch.name", "dev");
+		setDeep(target, "branch.protected", true);
+		expect(target).toEqual({ branch: { name: "dev", protected: true } });
+	});
+
+	it("builds a typed body from -F and a raw body from -f", () => {
+		expect(
+			buildBody(
+				["branch.name=dev", "endpoints=[]", "count=2"],
+				["label=42"],
+			),
+		).toEqual({
+			branch: { name: "dev" },
+			endpoints: [],
+			count: 2,
+			label: "42",
+		});
+	});
+
+	it("builds a query map", () => {
+		expect(buildQuery(["limit=10", "search=foo"])).toEqual({
+			limit: "10",
+			search: "foo",
+		});
+	});
+
+	it("parses headers on the first ':'", () => {
+		expect(parseHeaders(["X-Trace: abc:def"])).toEqual({
+			"X-Trace": "abc:def",
+		});
+		expect(() => parseHeaders(["bad-header"])).toThrow(/key:value/);
+	});
+});
+
+describe("api command (e2e passthrough)", () => {
+	// Maps -Q pairs to the query string; the mock asserts limit=100 is forwarded.
+	test("GET with query params", async ({ testCliCommand }) => {
+		await testCliCommand(["api", "/projects", "-Q", "limit=100"], {
+			output: "json",
+		});
+	});
+
+	// Path passthrough to a nested resource returns the raw JSON body.
+	test("GET single resource by path", async ({ testCliCommand }) => {
+		await testCliCommand(["api", "/projects/test"], { output: "json" });
+	});
+
+	// -X selects the method and -F builds the (dot-nested) JSON body; the mock
+	// asserts { project: { name: "test_project" } } is received.
+	test("POST with -F body fields", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"api",
+				"/projects",
+				"-X",
+				"POST",
+				"-F",
+				"project.name=test_project",
+			],
+			{ output: "json" },
+		);
+	});
+
+	test("rejects paths without a leading slash", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["api", "projects"], {
+			code: 1,
+			stderr: 'ERROR: Invalid path "projects". API paths must start with "/". Run `neon api --list` to see available routes.',
+		});
+	});
+});

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -1,0 +1,347 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import YAML from "yaml";
+import type yargs from "yargs";
+
+import type { RequestParams } from "../api.js";
+import type { CommonProps } from "../types.js";
+import { DEFAULT_SPEC_URL, getEndpoints, loadSpec } from "../utils/openapi.js";
+import { writer } from "../writer.js";
+
+const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+type HttpMethod = (typeof HTTP_METHODS)[number];
+
+// ── Pure helpers (unit-tested) ───────────────────────────────────────────────
+
+/**
+ * Coerce a raw string into a typed JSON value: booleans, `null`, integers,
+ * floats, and JSON arrays/objects are parsed; everything else stays a string.
+ */
+export function parseTypedValue(raw: string): unknown {
+	if (raw === "true") return true;
+	if (raw === "false") return false;
+	if (raw === "null") return null;
+	if (/^-?\d+$/.test(raw)) return Number.parseInt(raw, 10);
+	if (/^-?\d*\.\d+$/.test(raw)) return Number.parseFloat(raw);
+	if (raw.startsWith("[") || raw.startsWith("{")) {
+		try {
+			return JSON.parse(raw);
+		} catch {
+			return raw;
+		}
+	}
+	return raw;
+}
+
+/** Split a `key=value` pair on the first `=`. */
+export function parseKeyValue(input: string): { key: string; value: string } {
+	const eq = input.indexOf("=");
+	if (eq === -1) {
+		throw new Error(`Invalid "key=value" pair: "${input}".`);
+	}
+	return { key: input.slice(0, eq), value: input.slice(eq + 1) };
+}
+
+/**
+ * Assign `value` into `target` at a dot-delimited path, creating intermediate
+ * objects as needed. Enables `-F branch.name=dev` → `{ branch: { name: "dev" } }`,
+ * matching the nested shape of Neon request bodies.
+ */
+export function setDeep(
+	target: Record<string, unknown>,
+	dottedKey: string,
+	value: unknown,
+): void {
+	const parts = dottedKey.split(".");
+	let node = target;
+	for (let i = 0; i < parts.length - 1; i++) {
+		const part = parts[i];
+		const next = node[part];
+		if (typeof next !== "object" || next === null || Array.isArray(next)) {
+			node[part] = {};
+		}
+		node = node[part] as Record<string, unknown>;
+	}
+	node[parts[parts.length - 1]] = value;
+}
+
+/** Build a JSON body object from typed `-F` and string `-f` field pairs. */
+export function buildBody(
+	fields: string[],
+	rawFields: string[],
+): Record<string, unknown> {
+	const body: Record<string, unknown> = {};
+	for (const field of fields) {
+		const { key, value } = parseKeyValue(field);
+		setDeep(body, key, parseTypedValue(value));
+	}
+	for (const field of rawFields) {
+		const { key, value } = parseKeyValue(field);
+		setDeep(body, key, value);
+	}
+	return body;
+}
+
+/** Build a query-string map from `-Q key=value` pairs. */
+export function buildQuery(pairs: string[]): Record<string, string> {
+	const query: Record<string, string> = {};
+	for (const pair of pairs) {
+		const { key, value } = parseKeyValue(pair);
+		query[key] = value;
+	}
+	return query;
+}
+
+/** Build a header map from `-H key:value` pairs. */
+export function parseHeaders(pairs: string[]): Record<string, string> {
+	const headers: Record<string, string> = {};
+	for (const pair of pairs) {
+		const idx = pair.indexOf(":");
+		if (idx === -1) {
+			throw new Error(`Invalid header "${pair}". Expected "key:value".`);
+		}
+		headers[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim();
+	}
+	return headers;
+}
+
+function assertMethod(method: string): asserts method is HttpMethod {
+	if (!(HTTP_METHODS as readonly string[]).includes(method)) {
+		throw new Error(
+			`Unsupported method "${method}". Use one of: ${HTTP_METHODS.join(", ")}.`,
+		);
+	}
+}
+
+// ── I/O helpers ──────────────────────────────────────────────────────────────
+
+async function readStdin(): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of process.stdin) {
+		chunks.push(Buffer.from(chunk));
+	}
+	return Buffer.concat(chunks as unknown as readonly Uint8Array[]).toString(
+		"utf8",
+	);
+}
+
+/** Resolve `--data`: `-` reads stdin, `@file` reads a file, else the literal string. Parsed as JSON when possible. */
+async function readData(data: string): Promise<unknown> {
+	let raw: string;
+	if (data === "-") {
+		raw = await readStdin();
+	} else if (data.startsWith("@")) {
+		raw = readFileSync(resolve(data.slice(1)), "utf8");
+	} else {
+		raw = data;
+	}
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return raw;
+	}
+}
+
+// ── yargs command ─────────────────────────────────────────────────────────────
+
+type ApiArgs = CommonProps & {
+	configDir: string;
+	path?: string;
+	method?: string;
+	field?: (string | number)[];
+	rawField?: (string | number)[];
+	data?: string;
+	query?: (string | number)[];
+	header?: (string | number)[];
+	include: boolean;
+	list: boolean;
+	refresh: boolean;
+	specUrl: string;
+};
+
+const toStrings = (values?: (string | number)[]): string[] =>
+	(values ?? []).map(String);
+
+async function listEndpoints(args: ApiArgs): Promise<void> {
+	const spec = await loadSpec({
+		configDir: args.configDir,
+		specUrl: args.specUrl,
+		refresh: args.refresh,
+	});
+	if (!spec) {
+		throw new Error(
+			`Could not load the Neon OpenAPI spec from ${args.specUrl}. ` +
+				"Check your network connection or pass --spec-url.",
+		);
+	}
+	const endpoints = getEndpoints(spec).map((endpoint) => ({
+		method: endpoint.method,
+		path: endpoint.path,
+		summary: endpoint.summary ?? "",
+	}));
+	writer(args).end(endpoints, {
+		fields: ["method", "path", "summary"],
+		title: `Neon API endpoints (${endpoints.length})`,
+		emptyMessage: "No endpoints found in the spec.",
+	});
+}
+
+async function runRequest(args: ApiArgs): Promise<void> {
+	const path = args.path;
+	if (!path) {
+		throw new Error(
+			"Missing API path. Usage: neon api <path> (e.g. neon api /projects). " +
+				"Run `neon api --list` to see available routes.",
+		);
+	}
+	if (!path.startsWith("/")) {
+		throw new Error(
+			`Invalid path "${path}". API paths must start with "/". ` +
+				"Run `neon api --list` to see available routes.",
+		);
+	}
+
+	const fields = toStrings(args.field);
+	const rawFields = toStrings(args.rawField);
+
+	let body: unknown;
+	if (args.data !== undefined) {
+		body = await readData(args.data);
+	} else if (fields.length > 0 || rawFields.length > 0) {
+		body = buildBody(fields, rawFields);
+	}
+
+	const hasBody = body !== undefined;
+	const method = String(
+		args.method ?? (hasBody ? "POST" : "GET"),
+	).toUpperCase();
+	assertMethod(method);
+
+	const query = buildQuery(toStrings(args.query));
+	const headers = parseHeaders(toStrings(args.header));
+
+	const params: RequestParams = {
+		path,
+		method,
+		...(Object.keys(query).length > 0 ? { query } : {}),
+		...(hasBody ? { body } : {}),
+		...(Object.keys(headers).length > 0 ? { headers } : {}),
+	};
+
+	const response = await args.apiClient.request(params);
+
+	const out = process.stdout;
+	if (args.include) {
+		out.write(`HTTP ${response.status} ${response.statusText}\n`);
+		for (const [key, value] of Object.entries(response.headers)) {
+			out.write(`${key}: ${value}\n`);
+		}
+		out.write("\n");
+	}
+
+	if (response.data === undefined) {
+		return;
+	}
+	if (args.output === "yaml") {
+		out.write(YAML.stringify(response.data));
+	} else {
+		out.write(`${JSON.stringify(response.data, null, 2)}\n`);
+	}
+}
+
+export const command = "api [path]";
+export const describe =
+	"Call any Neon API route directly (authenticated passthrough)";
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 api <path> [options]")
+		.positional("path", {
+			type: "string",
+			describe:
+				'API path beginning with "/" (e.g. /projects or ' +
+				"/projects/{project_id}/branches). Use `list` to list endpoints.",
+		})
+		.options({
+			method: {
+				alias: "X",
+				type: "string",
+				describe:
+					"HTTP method (GET, POST, PUT, PATCH, DELETE). " +
+					"Defaults to GET, or POST when a body is provided.",
+			},
+			field: {
+				alias: "F",
+				type: "array",
+				string: true,
+				describe:
+					"Body field key=value (repeatable). Dot-notation nests " +
+					"objects (e.g. -F branch.name=dev); values are typed " +
+					"(numbers, booleans, null, JSON).",
+			},
+			"raw-field": {
+				alias: "f",
+				type: "array",
+				string: true,
+				describe:
+					"Body field key=value with the value kept as a raw string.",
+			},
+			data: {
+				alias: "d",
+				type: "string",
+				describe:
+					"Raw request body: a JSON string, @file, or - for stdin. " +
+					"Overrides --field.",
+			},
+			query: {
+				alias: "Q",
+				type: "array",
+				string: true,
+				describe: "Query parameter key=value (repeatable).",
+			},
+			header: {
+				alias: "H",
+				type: "array",
+				string: true,
+				describe: "Extra request header key:value (repeatable).",
+			},
+			include: {
+				alias: "i",
+				type: "boolean",
+				default: false,
+				describe:
+					"Print the response status and headers before the body.",
+			},
+			list: {
+				type: "boolean",
+				default: false,
+				describe: "List available API endpoints from the OpenAPI spec.",
+			},
+			refresh: {
+				type: "boolean",
+				default: false,
+				describe: "Refresh the cached OpenAPI spec (used with --list).",
+			},
+			"spec-url": {
+				type: "string",
+				default: process.env.NEON_API_SPEC_URL ?? DEFAULT_SPEC_URL,
+				hidden: true,
+				describe: "OpenAPI spec URL used by --list.",
+			},
+		})
+		.example("$0 api /projects", "List your projects")
+		.example(
+			"$0 api /projects/{id}/branches -X POST -F branch.name=dev",
+			"Create a branch",
+		)
+		.example("$0 api --list", "List every available API route");
+
+export const handler = async (args: yargs.Arguments) => {
+	const apiArgs = args as unknown as ApiArgs;
+	if (apiArgs.list || apiArgs.path === "list" || apiArgs.path === "ls") {
+		await listEndpoints(apiArgs);
+		return;
+	}
+	await runRequest(apiArgs);
+};

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,3 +1,4 @@
+import * as api from "./api.js";
 import * as auth from "./auth.js";
 import * as bootstrap from "./bootstrap.js";
 import * as branches from "./branches.js";
@@ -27,6 +28,7 @@ import * as vpcEndpoints from "./vpc_endpoints.js";
 
 export default [
 	auth,
+	api,
 	users,
 	orgs,
 	projects,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -26,6 +26,10 @@ import pkg from "./pkg.js";
 import { fillInArgs } from "./utils/middlewares.js";
 
 const NO_SUBCOMMANDS_VERBS = [
+	// `api <path>` has a handler but no subcommands (like `status`), so the
+	// help-fallback middleware must not intercept a bare `neon api /projects`.
+	"api",
+
 	// aliases
 	"auth",
 	"login",

--- a/packages/cli/src/utils/openapi.ts
+++ b/packages/cli/src/utils/openapi.ts
@@ -1,0 +1,162 @@
+// Lightweight loader for the Neon OpenAPI spec, used by `neon api --list` to
+// enumerate the available routes. The `neon api <path>` request path does NOT
+// depend on this module — it is a pure passthrough — so a stale or unreachable
+// spec never blocks a real API call. Listing degrades gracefully: fresh cache →
+// live fetch → stale cache → clear error.
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { log } from "../log.js";
+
+/** Public URL of the released Neon OpenAPI v2 spec. */
+export const DEFAULT_SPEC_URL = "https://neon.com/api_spec/release/v2.json";
+
+const CACHE_FILE = "openapi-spec.json";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 10_000;
+
+const HTTP_METHODS = new Set([
+	"get",
+	"post",
+	"put",
+	"patch",
+	"delete",
+	"head",
+	"options",
+]);
+
+type Operation = {
+	operationId?: string;
+	summary?: string;
+	description?: string;
+	tags?: string[];
+};
+
+type PathItem = Record<string, unknown>;
+
+export type OpenApiSpec = {
+	paths?: Record<string, PathItem>;
+	servers?: { url: string }[];
+	info?: { version?: string };
+};
+
+/** A single (method, path) route flattened from the spec. */
+export type EndpointInfo = {
+	method: string;
+	path: string;
+	summary?: string;
+	operationId?: string;
+	tags: string[];
+};
+
+type CachedSpec = {
+	fetchedAt: number;
+	specUrl: string;
+	spec: OpenApiSpec;
+};
+
+async function fetchSpec(url: string): Promise<OpenApiSpec> {
+	const controller = new AbortController();
+	const timer = setTimeout(() => {
+		controller.abort();
+	}, FETCH_TIMEOUT_MS);
+	try {
+		const res = await fetch(url, {
+			signal: controller.signal,
+			headers: { Accept: "application/json" },
+		});
+		if (!res.ok) {
+			throw new Error(
+				`Failed to fetch OpenAPI spec (${res.status} ${res.statusText})`,
+			);
+		}
+		return (await res.json()) as OpenApiSpec;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+function readCache(cachePath: string): CachedSpec | null {
+	try {
+		return JSON.parse(readFileSync(cachePath, "utf8")) as CachedSpec;
+	} catch {
+		return null;
+	}
+}
+
+function writeCache(cachePath: string, data: CachedSpec): void {
+	try {
+		mkdirSync(dirname(cachePath), { recursive: true });
+		writeFileSync(cachePath, JSON.stringify(data));
+	} catch (err) {
+		log.debug("Failed to cache OpenAPI spec: %s", err);
+	}
+}
+
+/**
+ * Load the Neon OpenAPI spec, preferring a fresh on-disk cache, then a live
+ * fetch (which refreshes the cache), then a stale cache as a last resort.
+ * Returns `null` when no spec can be obtained.
+ */
+export async function loadSpec(opts: {
+	configDir: string;
+	specUrl: string;
+	refresh: boolean;
+}): Promise<OpenApiSpec | null> {
+	const { configDir, specUrl, refresh } = opts;
+	const cachePath = join(configDir, CACHE_FILE);
+
+	if (!refresh) {
+		const cached = readCache(cachePath);
+		if (
+			cached &&
+			cached.specUrl === specUrl &&
+			Date.now() - cached.fetchedAt < CACHE_TTL_MS
+		) {
+			log.debug("Using cached OpenAPI spec from %s", cachePath);
+			return cached.spec;
+		}
+	}
+
+	try {
+		log.debug("Fetching OpenAPI spec from %s", specUrl);
+		const spec = await fetchSpec(specUrl);
+		writeCache(cachePath, { fetchedAt: Date.now(), specUrl, spec });
+		return spec;
+	} catch (err) {
+		log.debug("Failed to fetch OpenAPI spec: %s", err);
+		const stale = readCache(cachePath);
+		if (stale && stale.specUrl === specUrl) {
+			log.debug("Falling back to stale cached OpenAPI spec");
+			return stale.spec;
+		}
+		return null;
+	}
+}
+
+/** Flatten a spec into a sorted list of routes (by path, then method). */
+export function getEndpoints(spec: OpenApiSpec): EndpointInfo[] {
+	const endpoints: EndpointInfo[] = [];
+	for (const [path, item] of Object.entries(spec.paths ?? {})) {
+		for (const [method, op] of Object.entries(item)) {
+			if (!HTTP_METHODS.has(method.toLowerCase())) {
+				continue;
+			}
+			const operation = (op ?? {}) as Operation;
+			endpoints.push({
+				method: method.toUpperCase(),
+				path,
+				summary: operation.summary,
+				operationId: operation.operationId,
+				tags: operation.tags ?? [],
+			});
+		}
+	}
+	endpoints.sort((a, b) =>
+		a.path === b.path
+			? a.method.localeCompare(b.method)
+			: a.path.localeCompare(b.path),
+	);
+	return endpoints;
+}


### PR DESCRIPTION
## Summary

Adds `neon api <path>` — a spec-agnostic escape hatch that calls **any** Neon API route directly from the CLI, modeled on `vercel api` but adapted to neonctl's yargs + `@neon/sdk` stack.

It reuses the CLI's existing HTTP layer (`getApiClient().request()`), so the API token (API key **or** OAuth credentials), proxy dispatcher, timeout, and error shaping all come for free. No new fetch/auth path.

```bash
neon api /projects
neon api /projects/{id}/branches -X POST -F branch.name=dev
neon api /projects -X POST -F project.name=my-app -F project.org_id=org-...
neon api /users/me -i
neon api --list            # enumerate every route from the live spec
```

### Flags (mirrors `vercel api` where it makes sense)

| Flag | Purpose |
|---|---|
| `-X, --method` | HTTP method (default `GET`, or `POST` when a body is present) |
| `-F, --field key=value` | Typed body field; **dot-notation nests** (`-F branch.name=dev`) to match Neon's nested request bodies; values parsed as number/bool/null/JSON |
| `-f, --raw-field key=value` | Body field kept as a raw string |
| `-d, --data` | Raw body: JSON string, `@file`, or `-` for stdin (overrides `--field`) |
| `-Q, --query key=value` | Query parameter |
| `-H, --header key:value` | Extra request header |
| `-i, --include` | Print response status + headers before the body |
| `--list` / `list` | List available endpoints from the OpenAPI spec |
| `--refresh`, `--spec-url` | Control spec fetch/cache (also `NEON_API_SPEC_URL`) |

### Do newly added/updated endpoints "just work"? Yes.

**Request mode never consults the spec** — it's a pure passthrough. Any route the API exposes (including brand-new or updated ones) works the moment it ships, with **no CLI release required** and **no DX regression** (no stale-spec validation can ever block a real call).

The spec is used **only for discovery** (`neon api --list`), fetched live from `https://neon.com/api_spec/release/v2.json` and cached for 24h with a stale-cache fallback. So listings stay current automatically, and listing failures never affect real requests. Today that's **163 endpoints** across 18 tags, enumerated dynamically.

### Also

- Extends the shared low-level `request()` escape hatch with an optional `headers` map (merged on top of the defaults; additive, existing callers unaffected).
- Registers `api` in `NO_SUBCOMMANDS_VERBS` so a bare `neon api /projects` isn't intercepted by the help-fallback middleware (same treatment as `status`).

## Test plan

- [x] `tsc --noEmit` + eslint/biome clean
- [x] Unit tests for arg→request mapping (typed values, dot-notation body, query, headers)
- [x] Fork-based e2e snapshot tests against the mock server: GET + `-Q` query, path passthrough, `POST` + `-F` body (asserts the mapped request shape reaches the server)
- [x] Command registration + help tests pass
- [x] **Live e2e** against the real Neon API (smoke org): `GET /users/me`, `GET /projects -Q org_id=… -Q limit=…`, `neon api --list` (163 endpoints), and a full **create → delete** project lifecycle via `-X POST -F project.*` then `-X DELETE`; 404/error path exits non-zero with a shaped message

> Note: `neonctl` versioning is handled by the automated release pipeline (`prepare-release.yml`), so this PR intentionally does not hand-bump `package.json` or add a changeset.