### PR TITLE
chore: release neonctl@2.30.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.30.0
+
+### Minor Changes
+
+- Add `neon api <path>`, a passthrough command for calling any Neon API route directly from the CLI. It reuses your existing authentication, so requests are automatically authorized, and maps flags to the request: `-X/--method`, `-F/--field` (typed, dot-notation nested body), `-f/--raw-field`, `-d/--data` (`@file`/stdin/JSON), `-Q/--query`, `-H/--header`, and `-i/--include`. Run `neon api --list` to browse every available endpoint from the Neon OpenAPI spec. Because request mode calls the API directly, newly added or updated endpoints work immediately.
+
 ## 2.29.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.29.3",
+  "version": "2.30.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
Release PR for **neonctl@2.30.0** (minor) — consumes the changeset for the new `neon api` command merged in #274.

## Minor Changes

- Add `neon api <path>`, a passthrough command for calling any Neon API route directly from the CLI. Reuses existing auth, maps flags to the request (`-X`, `-F` typed/dot-notation body, `-f`, `-d`, `-Q`, `-H`, `-i`), and `neon api --list` browses every endpoint from the Neon OpenAPI spec. Newly added/updated endpoints work immediately.

## After merge

Publish via `neon-pkgs.yml -f package=neonctl -f ref=main` in `databricks/secure-public-registry-releases-eng`, then verify `npm view neonctl version`.