### PR TITLE
Add daily @neon/sdk OpenAPI spec refresh workflow

### DIFF
--- a/.github/workflows/sdk-spec-refresh.yml
+++ b/.github/workflows/sdk-spec-refresh.yml
@@ -1,0 +1,63 @@
+name: SDK Spec Refresh
+
+# Maintainer signal: pull the live Neon OpenAPI spec, regenerate @neon/sdk,
+# and open a PR when the vendored spec or generated client drifts.
+# The PR is a starting point — coverage.test.ts will fail until someone
+# updates packages/sdk/src/neon/coverage.ts (EXPECTED_OPERATIONS / WRAPPED).
+# Runs on a GitHub-hosted runner because it must reach neon.com; the protected
+# runner group has no public egress.
+
+on:
+    schedule:
+        - cron: "0 9 * * *" # daily 09:00 UTC
+    workflow_dispatch: ~
+
+permissions:
+    contents: write
+    pull-requests: write
+
+jobs:
+    refresh:
+        name: Refresh @neon/sdk from live spec
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              with:
+                  cache: pnpm
+                  node-version-file: .node-version
+
+            - run: pnpm install --frozen-lockfile
+
+            - name: Pull live OpenAPI spec
+              run: pnpm --filter @neon/sdk spec:pull
+
+            - name: Regenerate client
+              run: pnpm --filter @neon/sdk generate
+
+            - name: Build (typecheck + bundle)
+              run: pnpm --filter @neon/sdk build
+
+            - name: Open PR when spec or generated client changed
+              uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
+              with:
+                  branch: bot/sdk-spec-refresh
+                  commit-message: "chore(@neon/sdk): refresh OpenAPI spec"
+                  title: "chore(@neon/sdk): refresh OpenAPI spec"
+                  body: |
+                      Automated refresh from https://neon.com/api_spec/release/v2.json
+
+                      ## Follow-up before merge
+
+                      - [ ] Review added/removed operations in `packages/sdk/src/client/sdk.gen.ts`
+                      - [ ] Update `packages/sdk/src/neon/coverage.ts` (`EXPECTED_OPERATIONS`; wrap new ops in `WRAPPED` where ergonomic treatment is warranted)
+                      - [ ] Run `pnpm --filter @neon/sdk test:ci` locally
+                      - [ ] Add a changeset if this should ship a new `@neon/sdk` version
+
+                      CI is expected to fail on `coverage.test.ts` until `coverage.ts` is updated.
+                  labels: |
+                      dependencies
+                  delete-branch: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,51 @@ and `@neon/functions`.
 -   **Conformance tests** (`tests/psql-conformance`) need Docker/testcontainers and are excluded from the default Vitest run; run them explicitly with `pnpm --filter <name> test:conformance`.
 -   **Sibling deps**: `@neondatabase/*` + `neon-init` are currently pinned to published versions (not `workspace:*`); switching to `workspace:*` is a planned follow-up.
 
+### The SDK package (`packages/sdk`)
+
+`@neon/sdk` is the official TypeScript SDK for the Neon API — a Fetch-based client
+generated from Neon's OpenAPI spec, with a hand-authored ergonomic layer on top. See
+`packages/sdk/README.md` for the public API.
+
+**Regenerating the client (local):**
+
+```bash
+pnpm --filter @neon/sdk spec:pull   # refresh vendored spec from neon.com
+pnpm --filter @neon/sdk generate    # regenerate packages/sdk/src/client
+pnpm --filter @neon/sdk build       # typecheck + bundle
+pnpm --filter @neon/sdk test:ci     # coverage guard — see below
+```
+
+The vendored spec lives at `packages/sdk/spec/neon-openapi.json`. Codegen is
+`@hey-api/openapi-ts` (`packages/sdk/openapi-ts.config.ts`).
+
+**Automated spec refresh (`.github/workflows/sdk-spec-refresh.yml`):**
+
+The live spec at https://neon.com/api_spec/release/v2.json can drift ahead of the
+vendored copy on `main`. A scheduled workflow keeps maintainers aware:
+
+| | |
+| --- | --- |
+| **When** | Daily at 09:00 UTC; also `workflow_dispatch` |
+| **What** | `spec:pull` → `generate` → `build` on `@neon/sdk` |
+| **Output** | Opens or updates a PR on branch `bot/sdk-spec-refresh` titled `chore(@neon/sdk): refresh OpenAPI spec` — **only when something changed** |
+| **Runner** | `ubuntu-latest` (public egress to `neon.com`). CI uses the protected runner group + JFrog mirror and **cannot** reach the public spec URL — same constraint as `catalog-drift.yml` |
+
+**The bot PR is a starting point, not merge-ready.** The workflow deliberately does
+not run `test:ci`. CI will fail on `packages/sdk/src/neon/coverage.test.ts` until
+someone updates `packages/sdk/src/neon/coverage.ts`:
+
+1. Review added/removed operations in `sdk.gen.ts`.
+2. Wrap new ops in the ergonomic layer where warranted (and add them to `WRAPPED`),
+   or accept them as raw-only.
+3. Update `EXPECTED_OPERATIONS` to match the new generated set.
+4. Run `pnpm --filter @neon/sdk test:ci` locally.
+5. Add a changeset if the refresh should ship a new `@neon/sdk` version.
+
+`hey-api` does not treat Neon's `x-stability-level` (alpha/beta) differently — beta
+and private-preview endpoints are generated identically to stable ones. Access
+control stays on the API side.
+
 ### Key Implementation Details
 
 -   `neon-new` (CLI) and `vite-plugin-neon-new` (plugin) both support SQL seeding via the `--seed` flag (CLI) or `seed.path` option (plugin)


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Action (`SDK Spec Refresh`) that runs daily at 09:00 UTC
- Pulls the live spec from https://neon.com/api_spec/release/v2.json, regenerates `@neon/sdk`, and builds
- Opens or updates a PR on `bot/sdk-spec-refresh` when the vendored spec or generated client changes
- PR is intentionally a starting point — `coverage.test.ts` will fail until `coverage.ts` is updated manually

## Test plan
- [ ] Merge and verify `workflow_dispatch` runs successfully
- [ ] Confirm a drift PR is opened when the live spec differs from `main`