### PR TITLE
feat(cli): add `neon inspect db` diagnostic commands

### DIFF
--- a/packages/cli/src/commands/__snapshots__/inspect.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/inspect.test.ts.snap
@@ -1,0 +1,21 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`inspect db > bloat --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > cache-hit --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > calls --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > locks --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > outliers --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > replication-slots --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > seq-scans --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > subscriptions --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > table-sizes --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > vacuum-stats --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;

--- a/packages/cli/src/commands/__snapshots__/inspect.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/inspect.test.ts.snap
@@ -4,6 +4,8 @@ exports[`inspect db > bloat --db-url bypasses the API and reports a Postgres con
 
 exports[`inspect db > calls --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
 
+exports[`inspect db > lfc-hit-rate --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
 exports[`inspect db > locks --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
 
 exports[`inspect db > outliers --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
@@ -17,3 +19,5 @@ exports[`inspect db > subscriptions --db-url bypasses the API and reports a Post
 exports[`inspect db > table-sizes --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
 
 exports[`inspect db > vacuum-stats --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
+
+exports[`inspect db > working-set --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;

--- a/packages/cli/src/commands/__snapshots__/inspect.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/inspect.test.ts.snap
@@ -2,8 +2,6 @@
 
 exports[`inspect db > bloat --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
 
-exports[`inspect db > cache-hit --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
-
 exports[`inspect db > calls --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;
 
 exports[`inspect db > locks --db-url bypasses the API and reports a Postgres connection error 1`] = `""`;

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -14,6 +14,7 @@ import * as diff from "./diff.js";
 import * as env from "./env.js";
 import * as functions from "./functions.js";
 import * as init from "./init.js";
+import * as inspect from "./inspect.js";
 import * as ipAllow from "./ip_allow.js";
 import * as link from "./link.js";
 import * as neonAuth from "./neon_auth.js";
@@ -42,6 +43,7 @@ export default [
 	roles,
 	operations,
 	snapshots,
+	inspect,
 	cs,
 	psql,
 	setContext,

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect } from "vitest";
+import { test } from "../test_utils/fixtures";
+
+// `inspect db` opens a real Postgres connection with the embedded wire client,
+// so these tests drive the hermetic `--db-url` path: point at a port nothing is
+// listening on and assert the command (a) bypasses the Neon API entirely and
+// (b) fails with a clear Postgres-connection error rather than the Neon-API
+// "Could not reach the Neon API" hint. `127.0.0.1:1` refuses immediately.
+const UNREACHABLE_DB_URL = "postgresql://user:pass@127.0.0.1:1/postgres";
+
+describe("inspect db", () => {
+	test("table-sizes --db-url bypasses the API and reports a Postgres connection error", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["inspect", "db", "table-sizes", "--db-url", UNREACHABLE_DB_URL],
+			{
+				code: 1,
+				stderr: expect.stringMatching(
+					/Could not connect to Postgres at 127\.0\.0\.1:1/,
+				),
+			},
+		);
+	});
+
+	test("cache-hit --db-url bypasses the API and reports a Postgres connection error", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["inspect", "db", "cache-hit", "--db-url", UNREACHABLE_DB_URL],
+			{
+				code: 1,
+				stderr: expect.stringMatching(
+					/Could not connect to Postgres at 127\.0\.0\.1:1/,
+				),
+			},
+		);
+	});
+
+	test("locks --db-url bypasses the API and reports a Postgres connection error", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["inspect", "db", "locks", "--db-url", UNREACHABLE_DB_URL],
+			{
+				code: 1,
+				stderr: expect.stringMatching(
+					/Could not connect to Postgres at 127\.0\.0\.1:1/,
+				),
+			},
+		);
+	});
+
+	// Phase-2 subcommands. The extension-gated ones (`outliers`, `calls`) still
+	// fail at the connection step here — the `pg_stat_statements` guard only runs
+	// after a successful connect — so they share the same wiring assertion.
+	for (const sub of [
+		"seq-scans",
+		"vacuum-stats",
+		"bloat",
+		"outliers",
+		"calls",
+		"replication-slots",
+		"subscriptions",
+	] as const) {
+		test(`${sub} --db-url bypasses the API and reports a Postgres connection error`, async ({
+			testCliCommand,
+		}) => {
+			await testCliCommand(
+				["inspect", "db", sub, "--db-url", UNREACHABLE_DB_URL],
+				{
+					code: 1,
+					stderr: expect.stringMatching(
+						/Could not connect to Postgres at 127\.0\.0\.1:1/,
+					),
+				},
+			);
+		});
+	}
+});

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -46,6 +46,8 @@ describe("inspect db", () => {
 		"bloat",
 		"outliers",
 		"calls",
+		"lfc-hit-rate",
+		"working-set",
 		"replication-slots",
 		"subscriptions",
 	] as const) {

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -23,20 +23,6 @@ describe("inspect db", () => {
 		);
 	});
 
-	test("cache-hit --db-url bypasses the API and reports a Postgres connection error", async ({
-		testCliCommand,
-	}) => {
-		await testCliCommand(
-			["inspect", "db", "cache-hit", "--db-url", UNREACHABLE_DB_URL],
-			{
-				code: 1,
-				stderr: expect.stringMatching(
-					/Could not connect to Postgres at 127\.0\.0\.1:1/,
-				),
-			},
-		);
-	});
-
 	test("locks --db-url bypasses the API and reports a Postgres connection error", async ({
 		testCliCommand,
 	}) => {

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -1,0 +1,102 @@
+import type yargs from "yargs";
+import type { BranchScopeProps, CommonProps } from "../types.js";
+import { fillSingleProject } from "../utils/enrichers.js";
+import { resolveConnectionUri, runInspectQuery } from "../utils/inspect_db.js";
+import {
+	INSPECT_QUERIES,
+	type InspectQuery,
+	type InspectSubcommand,
+} from "../utils/inspect_queries.js";
+import { writer } from "../writer.js";
+
+export const command = "inspect";
+export const describe = "Inspect a database's health and configuration";
+export const aliases = ["inspection"];
+
+type InspectProps = BranchScopeProps & {
+	branch?: string;
+	roleName?: string;
+	databaseName?: string;
+	dbUrl?: string;
+};
+
+/**
+ * `fillSingleProject` hits the API to auto-resolve a project. When the user
+ * passes `--db-url` we bypass the Neon API entirely, so skip it.
+ */
+const fillSingleProjectUnlessDbUrl = async (
+	props: CommonProps & { projectId?: string; orgId?: string; dbUrl?: string },
+) => {
+	if (props.dbUrl) {
+		return props;
+	}
+	return fillSingleProject(props);
+};
+
+const runSubcommand = async (name: InspectSubcommand, props: InspectProps) => {
+	const query: InspectQuery = INSPECT_QUERIES[name];
+
+	const connectionUri =
+		props.dbUrl ?? (await resolveConnectionUri(props)).connectionUri;
+
+	const rows = await runInspectQuery(connectionUri, query.sql, {
+		requiresExtension: query.requiresExtension,
+	});
+	writer(props).end(rows, {
+		fields: query.fields as readonly (keyof (typeof rows)[number])[],
+		emptyMessage: query.emptyMessage,
+	});
+};
+
+const dbBuilder = (argv: yargs.Argv) => {
+	let builder = argv
+		.usage("$0 inspect db <sub-command> [options]")
+		.options({
+			"project-id": {
+				describe: "Project ID",
+				type: "string",
+			},
+			branch: {
+				describe: "Branch ID or name",
+				type: "string",
+			},
+			"database-name": {
+				describe: "Database name",
+				type: "string",
+			},
+			"role-name": {
+				describe: "Role name",
+				type: "string",
+			},
+			"db-url": {
+				describe:
+					"Inspect any Postgres via a connection string, bypassing the Neon API (project/branch resolution is skipped)",
+				type: "string",
+			},
+		})
+		.middleware(fillSingleProjectUnlessDbUrl as any);
+
+	for (const name of Object.keys(INSPECT_QUERIES) as InspectSubcommand[]) {
+		builder = builder.command(
+			name,
+			INSPECT_QUERIES[name].describe,
+			(yargs) => yargs,
+			(args) => runSubcommand(name, args as unknown as InspectProps),
+		);
+	}
+
+	return builder;
+};
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 inspect <sub-command> [options]")
+		.command(
+			"db",
+			"Run a diagnostic query against a branch's Postgres",
+			dbBuilder,
+		);
+
+export const handler = (args: yargs.Argv) => {
+	return args;
+};

--- a/packages/cli/src/utils/inspect_db.ts
+++ b/packages/cli/src/utils/inspect_db.ts
@@ -1,0 +1,245 @@
+import type { Database, Endpoint, Role } from "@neon/sdk";
+import { parseConnectionUri } from "../psql/index.js";
+import { PgConnection } from "../psql/wire/connection.js";
+import type { BranchScopeProps } from "../types.js";
+import { EndpointType } from "./api_enums.js";
+import { branchIdFromProps } from "./enrichers.js";
+import { parsePITBranch } from "./point_in_time.js";
+
+export const SSL_MODES = [
+	"require",
+	"verify-ca",
+	"verify-full",
+	"omit",
+] as const;
+
+export type SslMode = (typeof SSL_MODES)[number];
+
+export type ResolveConnectionProps = BranchScopeProps & {
+	branch?: string;
+	roleName?: string;
+	databaseName?: string;
+	pooled?: boolean;
+	prisma?: boolean;
+	endpointType?: EndpointType;
+	ssl?: SslMode;
+};
+
+export type ResolvedConnection = {
+	/** Fully-formed `postgresql://…` connection URI. */
+	connectionUri: string;
+	host: string;
+	role: string;
+	password: string;
+	database: string;
+	/** The encoded query-string (sslmode, options, …), for extended output. */
+	options: string;
+};
+
+/**
+ * Resolve a branch's live Postgres connection details via the Neon API
+ * (endpoint → role → password → database → URL, honoring point-in-time,
+ * pooling, prisma tuning, and SSL mode). Mirrors how `connection-string`
+ * resolves a branch so `inspect db` connects the same way.
+ */
+export const resolveConnectionUri = async (
+	props: ResolveConnectionProps,
+): Promise<ResolvedConnection> => {
+	const projectId = props.projectId;
+	const parsedPIT = props.branch
+		? parsePITBranch(props.branch)
+		: ({ tag: "head", branch: "" } as const);
+	if (props.branch) {
+		props.branch = parsedPIT.branch;
+	}
+	const branchId = await branchIdFromProps(props);
+
+	const {
+		data: { endpoints },
+	} = await props.apiClient.listProjectBranchEndpoints(projectId, branchId);
+	const matchEndpointType = props.endpointType ?? EndpointType.ReadWrite;
+	let endpoint = endpoints.find(
+		(e: Endpoint) => e.type === matchEndpointType,
+	);
+	if (!endpoint && props.endpointType == null) {
+		endpoint = endpoints[0];
+	}
+	if (!endpoint) {
+		throw new Error(
+			`No ${
+				props.endpointType ?? ""
+			} endpoint found for the branch: ${branchId}`,
+		);
+	}
+
+	const role: string =
+		props.roleName ||
+		(await props.apiClient
+			.listProjectBranchRoles(projectId, branchId)
+			.then(({ data }): string => {
+				if (data.roles.length === 0) {
+					throw new Error(
+						`No roles found for the branch: ${branchId}`,
+					);
+				}
+				if (data.roles.length === 1) {
+					return data.roles[0].name;
+				}
+				throw new Error(
+					`Multiple roles found for the branch, please provide one with the --role-name option: ${data.roles
+						.map((r: Role) => r.name)
+						.join(", ")}`,
+				);
+			}));
+
+	const {
+		data: { databases: branchDatabases },
+	} = await props.apiClient.listProjectBranchDatabases(projectId, branchId);
+
+	const database =
+		props.databaseName ||
+		(() => {
+			if (branchDatabases.length === 0) {
+				throw new Error(
+					`No databases found for the branch: ${branchId}`,
+				);
+			}
+			if (branchDatabases.length === 1) {
+				return branchDatabases[0].name;
+			}
+			throw new Error(
+				`Multiple databases found for the branch, please provide one with the --database-name option: ${branchDatabases
+					.map((d: Database) => d.name)
+					.join(", ")}`,
+			);
+		})();
+
+	if (!branchDatabases.find((d: Database) => d.name === database)) {
+		throw new Error(`Database not found: ${database}`);
+	}
+
+	const {
+		data: { password },
+	} = await props.apiClient.getProjectBranchRolePassword(
+		props.projectId,
+		endpoint.branch_id,
+		role,
+	);
+
+	let host = props.pooled
+		? endpoint.host.replace(endpoint.id, `${endpoint.id}-pooler`)
+		: endpoint.host;
+	if (parsedPIT.tag !== "head") {
+		host = endpoint.host.replace(endpoint.id, endpoint.branch_id);
+	}
+	const connectionString = new URL(`postgresql://${host}`);
+	connectionString.pathname = database;
+	connectionString.username = role;
+	connectionString.password = password;
+
+	if (props.prisma) {
+		connectionString.searchParams.set("connect_timeout", "30");
+		if (props.pooled) {
+			connectionString.searchParams.set("pool_timeout", "30");
+			connectionString.searchParams.set("pgbouncer", "true");
+		}
+	}
+
+	const ssl = props.ssl ?? "require";
+	if (ssl !== "omit") {
+		connectionString.searchParams.set("sslmode", ssl);
+		connectionString.searchParams.set("channel_binding", "require");
+	}
+
+	if (parsedPIT.tag === "lsn") {
+		connectionString.searchParams.set(
+			"options",
+			`neon_lsn:${parsedPIT.lsn}`,
+		);
+	} else if (parsedPIT.tag === "timestamp") {
+		connectionString.searchParams.set(
+			"options",
+			`neon_timestamp:${parsedPIT.timestamp}`,
+		);
+	}
+
+	return {
+		connectionUri: connectionString.toString(),
+		host,
+		role,
+		password,
+		database,
+		options: connectionString.searchParams.toString(),
+	};
+};
+
+const rowsFrom = (result: {
+	fields: { name: string }[];
+	rows: unknown[][];
+}): Record<string, unknown>[] => {
+	const names = result.fields.map((f) => f.name);
+	return result.rows.map((row) => {
+		const obj: Record<string, unknown> = {};
+		names.forEach((name, i) => {
+			obj[name] = row[i];
+		});
+		return obj;
+	});
+};
+
+export type RunInspectQueryOptions = {
+	/**
+	 * Extension the query depends on. When set, the runner checks
+	 * `pg_extension` first and throws an actionable error if it isn't installed.
+	 */
+	requiresExtension?: string;
+};
+
+/**
+ * Connect to `connectionUri` with the embedded wire client, run a single
+ * read-only `sql`, and return the rows as objects keyed by column name (so the
+ * shared `writer` can render them by field). The connection is always closed,
+ * even on error.
+ */
+export const runInspectQuery = async (
+	connectionUri: string,
+	sql: string,
+	options: RunInspectQueryOptions = {},
+): Promise<Record<string, unknown>[]> => {
+	const opts = parseConnectionUri(connectionUri);
+	let connection: PgConnection;
+	try {
+		connection = await PgConnection.connect(opts);
+	} catch (err) {
+		// Give the failure a Postgres-specific message. The raw socket error
+		// (e.g. ECONNREFUSED) would otherwise be mislabeled by the top-level
+		// `isNetworkError` handler as a "Could not reach the Neon API" hint —
+		// misleading for `inspect db`, which talks to Postgres, not the API.
+		// We intentionally do not chain `cause` so that classifier can't match
+		// the socket `code`; the underlying reason is preserved in the message.
+		const reason = err instanceof Error ? err.message : String(err);
+		throw new Error(
+			`Could not connect to Postgres at ${opts.host}:${opts.port}: ${reason}`,
+		);
+	}
+	try {
+		const ext = options.requiresExtension;
+		if (ext) {
+			// `ext` is an internal constant from INSPECT_QUERIES, never user input,
+			// so interpolating it into the literal is safe.
+			const check = await connection.query(
+				`SELECT 1 FROM pg_extension WHERE extname = '${ext}';`,
+			);
+			if (check.rows.length === 0) {
+				throw new Error(
+					`This query needs the "${ext}" extension, which is not installed. ` +
+						`Enable it with: CREATE EXTENSION ${ext};`,
+				);
+			}
+		}
+		const result = await connection.query(sql);
+		return rowsFrom(result);
+	} finally {
+		await connection.close();
+	}
+};

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -278,10 +278,11 @@ export const INSPECT_QUERIES = {
 	},
 	"replication-slots": {
 		describe:
-			"Replication slots: status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)",
+			"Replication slots: kind, status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)",
 		fields: [
 			"slot_name",
 			"slot_type",
+			"slot_kind",
 			"status",
 			"client_addr",
 			"restart_lsn",
@@ -293,6 +294,12 @@ export const INSPECT_QUERIES = {
 			SELECT
 				s.slot_name,
 				s.slot_type,
+				CASE
+					WHEN s.slot_type = 'physical' THEN 'physical'
+					WHEN s.slot_name LIKE 'pg_%_sync_%' THEN 'initial-sync (tablesync)'
+					WHEN s.slot_type = 'logical' THEN 'CDC (apply)'
+					ELSE 'other'
+				END AS slot_kind,
 				CASE
 					WHEN r.state IS NOT NULL THEN r.state
 					WHEN s.active THEN 'active (no walsender)'

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -1,0 +1,361 @@
+/**
+ * Diagnostic SQL for `neon inspect db`. Each entry is a read-only query against
+ * Postgres' own statistics/catalog views plus the output columns (in display
+ * order) the table/json/yaml formatter should show.
+ *
+ * Most queries need no extra extension. The few that do (currently `outliers`
+ * and `calls`, which read `pg_stat_statements`) declare it via
+ * `requiresExtension`; the runner checks for it and fails with an actionable
+ * hint when it's missing.
+ */
+
+export type InspectQuery = {
+	/** One-line description shown in `--help`. */
+	describe: string;
+	/** The read-only SQL to execute. */
+	sql: string;
+	/** Output columns, in display order (also the object keys after mapping). */
+	fields: readonly string[];
+	/** Friendly message when the result set is empty (table output only). */
+	emptyMessage?: string;
+	/**
+	 * Postgres extension the query needs (e.g. `pg_stat_statements`). When set,
+	 * the runner verifies the extension is installed first and fails with an
+	 * actionable "enable it with CREATE EXTENSION …" message if it isn't.
+	 */
+	requiresExtension?: string;
+};
+
+export const INSPECT_QUERIES = {
+	"cache-hit": {
+		describe:
+			"Buffer-cache hit rates for indexes and tables (pg_statio_user_*)",
+		fields: ["name", "ratio"],
+		sql: /* sql */ `
+			SELECT
+				'index hit rate' AS name,
+				sum(idx_blks_hit)::float
+					/ nullif(sum(idx_blks_hit + idx_blks_read), 0) AS ratio
+			FROM pg_statio_user_indexes
+			UNION ALL
+			SELECT
+				'table hit rate' AS name,
+				sum(heap_blks_hit)::float
+					/ nullif(sum(heap_blks_hit + heap_blks_read), 0) AS ratio
+			FROM pg_statio_user_tables;
+		`,
+	},
+	"table-sizes": {
+		describe:
+			"Size of each table (including TOAST), largest first (pg_table_size)",
+		fields: ["schema", "name", "size"],
+		emptyMessage: "No user tables found.",
+		sql: /* sql */ `
+			SELECT
+				n.nspname AS schema,
+				c.relname AS name,
+				pg_size_pretty(pg_table_size(c.oid)) AS size
+			FROM pg_class c
+			LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+				AND n.nspname !~ '^pg_toast'
+				AND c.relkind = 'r'
+			ORDER BY pg_table_size(c.oid) DESC;
+		`,
+	},
+	"index-sizes": {
+		describe: "Size of each index, largest first (pg_relation_size)",
+		fields: ["schema", "name", "size"],
+		emptyMessage: "No indexes found.",
+		sql: /* sql */ `
+			SELECT
+				n.nspname AS schema,
+				c.relname AS name,
+				pg_size_pretty(pg_relation_size(c.oid)) AS size
+			FROM pg_class c
+			LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+				AND n.nspname !~ '^pg_toast'
+				AND c.relkind = 'i'
+			ORDER BY pg_relation_size(c.oid) DESC;
+		`,
+	},
+	"unused-indexes": {
+		describe:
+			"Non-unique indexes with few scans — candidates for removal (pg_stat_user_indexes)",
+		fields: ["table", "index", "index_size", "index_scans"],
+		emptyMessage: "No unused indexes detected.",
+		sql: /* sql */ `
+			SELECT
+				s.schemaname || '.' || s.relname AS "table",
+				s.indexrelname AS index,
+				pg_size_pretty(pg_relation_size(s.indexrelid)) AS index_size,
+				s.idx_scan AS index_scans
+			FROM pg_stat_user_indexes s
+			JOIN pg_index i ON i.indexrelid = s.indexrelid
+			WHERE NOT i.indisunique
+				AND NOT i.indisprimary
+				AND s.idx_scan < 50
+			ORDER BY pg_relation_size(s.indexrelid) DESC, s.idx_scan ASC;
+		`,
+	},
+	"seq-scans": {
+		describe:
+			"Number of sequential scans recorded against each table (pg_stat_user_tables)",
+		fields: ["schema", "name", "count"],
+		emptyMessage: "No user tables found.",
+		sql: /* sql */ `
+			SELECT
+				schemaname AS schema,
+				relname AS name,
+				seq_scan AS count
+			FROM pg_stat_user_tables
+			ORDER BY seq_scan DESC;
+		`,
+	},
+	"long-running-queries": {
+		describe: "Queries running longer than 5 minutes (pg_stat_activity)",
+		fields: ["pid", "duration", "state", "query"],
+		emptyMessage: "No long-running queries.",
+		sql: /* sql */ `
+			SELECT
+				pid,
+				(now() - query_start)::text AS duration,
+				state,
+				query
+			FROM pg_stat_activity
+			WHERE state <> 'idle'
+				AND query NOT ILIKE '%pg_stat_activity%'
+				AND now() - query_start > interval '5 minutes'
+			ORDER BY now() - query_start DESC;
+		`,
+	},
+	locks: {
+		describe:
+			"Locks held with the acquiring query and its age (pg_locks + pg_stat_activity)",
+		fields: [
+			"pid",
+			"relname",
+			"mode",
+			"locktype",
+			"granted",
+			"age",
+			"query",
+		],
+		emptyMessage: "No locks held.",
+		sql: /* sql */ `
+			SELECT
+				a.pid,
+				c.relname,
+				l.mode,
+				l.locktype,
+				l.granted,
+				(now() - a.query_start)::text AS age,
+				a.query
+			FROM pg_locks l
+			JOIN pg_stat_activity a ON a.pid = l.pid
+			LEFT JOIN pg_class c ON c.oid = l.relation
+			WHERE a.query <> '<insufficient privilege>'
+				AND l.pid <> pg_backend_pid()
+			ORDER BY a.query_start;
+		`,
+	},
+	outliers: {
+		describe:
+			"Queries taking the most cumulative execution time (needs pg_stat_statements)",
+		fields: ["total_exec_time", "prop_exec_time", "ncalls", "query"],
+		emptyMessage: "No statements recorded yet.",
+		requiresExtension: "pg_stat_statements",
+		sql: /* sql */ `
+			SELECT
+				(interval '1 millisecond' * total_exec_time)::text AS total_exec_time,
+				to_char(
+					(total_exec_time / nullif(sum(total_exec_time) OVER (), 0)) * 100,
+					'FM990D0'
+				) || '%' AS prop_exec_time,
+				calls AS ncalls,
+				query
+			FROM pg_stat_statements s
+			JOIN pg_database d ON d.oid = s.dbid
+			WHERE d.datname = current_database()
+			ORDER BY total_exec_time DESC
+			LIMIT 25;
+		`,
+	},
+	calls: {
+		describe: "Most frequently called queries (needs pg_stat_statements)",
+		fields: ["ncalls", "total_exec_time", "prop_exec_time", "query"],
+		emptyMessage: "No statements recorded yet.",
+		requiresExtension: "pg_stat_statements",
+		sql: /* sql */ `
+			SELECT
+				calls AS ncalls,
+				(interval '1 millisecond' * total_exec_time)::text AS total_exec_time,
+				to_char(
+					(calls / nullif(sum(calls) OVER (), 0)::float) * 100,
+					'FM990D0'
+				) || '%' AS prop_exec_time,
+				query
+			FROM pg_stat_statements s
+			JOIN pg_database d ON d.oid = s.dbid
+			WHERE d.datname = current_database()
+			ORDER BY calls DESC
+			LIMIT 25;
+		`,
+	},
+	"vacuum-stats": {
+		describe:
+			"Autovacuum status per table: last (auto)vacuum, dead tuples, threshold",
+		fields: [
+			"schema",
+			"table",
+			"last_vacuum",
+			"last_autovacuum",
+			"rowcount",
+			"dead_rowcount",
+			"expect_autovacuum",
+		],
+		emptyMessage: "No user tables found.",
+		sql: /* sql */ `
+			SELECT
+				n.nspname AS schema,
+				c.relname AS "table",
+				to_char(psut.last_vacuum, 'YYYY-MM-DD HH24:MI') AS last_vacuum,
+				to_char(psut.last_autovacuum, 'YYYY-MM-DD HH24:MI') AS last_autovacuum,
+				c.reltuples::bigint AS rowcount,
+				psut.n_dead_tup AS dead_rowcount,
+				CASE
+					WHEN current_setting('autovacuum_vacuum_threshold')::bigint
+						+ current_setting('autovacuum_vacuum_scale_factor')::numeric
+							* c.reltuples
+						< psut.n_dead_tup
+					THEN 'yes'
+					ELSE 'no'
+				END AS expect_autovacuum
+			FROM pg_stat_user_tables psut
+			JOIN pg_class c ON psut.relid = c.oid
+			JOIN pg_namespace n ON c.relnamespace = n.oid
+			ORDER BY psut.n_dead_tup DESC;
+		`,
+	},
+	bloat: {
+		describe:
+			"Estimated table/index bloat (statistical estimate, no extension needed)",
+		fields: ["type", "schema", "object_name", "bloat", "waste"],
+		emptyMessage: "No bloat estimate available.",
+		sql: /* sql */ `
+			WITH constants AS (
+				SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 8 AS ma
+			),
+			bloat_info AS (
+				SELECT
+					ma, bs, schemaname, tablename,
+					(datawidth + (hdr + ma - (CASE WHEN hdr % ma = 0 THEN ma ELSE hdr % ma END)))::numeric AS datahdr,
+					(maxfracsum * (nullhdr + ma - (CASE WHEN nullhdr % ma = 0 THEN ma ELSE nullhdr % ma END))) AS nullhdr2
+				FROM (
+					SELECT
+						schemaname, tablename, hdr, ma, bs,
+						SUM((1 - null_frac) * avg_width) AS datawidth,
+						MAX(null_frac) AS maxfracsum,
+						hdr + (
+							SELECT 1 + count(*) / 8
+							FROM pg_stats s2
+							WHERE null_frac <> 0
+								AND s2.schemaname = s.schemaname
+								AND s2.tablename = s.tablename
+						) AS nullhdr
+					FROM pg_stats s, constants
+					GROUP BY 1, 2, 3, 4, 5
+				) AS foo
+			),
+			table_bloat AS (
+				SELECT
+					schemaname, tablename, cc.relpages, bs,
+					CEIL((cc.reltuples * ((datahdr + ma
+						- (CASE WHEN datahdr % ma = 0 THEN ma ELSE datahdr % ma END))
+						+ nullhdr2 + 4)) / (bs - 20::float)) AS otta
+				FROM bloat_info
+				JOIN pg_class cc ON cc.relname = bloat_info.tablename
+				JOIN pg_namespace nn ON cc.relnamespace = nn.oid
+					AND nn.nspname = bloat_info.schemaname
+					AND nn.nspname NOT IN ('information_schema', 'pg_catalog')
+				WHERE cc.relkind = 'r'
+			)
+			SELECT
+				'table' AS type,
+				schemaname AS schema,
+				tablename AS object_name,
+				round(CASE WHEN otta = 0 THEN 0.0 ELSE relpages::numeric / otta::numeric END, 1) AS bloat,
+				pg_size_pretty(
+					(CASE WHEN relpages < otta THEN 0 ELSE (bs * (relpages - otta))::bigint END)
+				) AS waste
+			FROM table_bloat
+			ORDER BY (CASE WHEN relpages < otta THEN 0 ELSE bs * (relpages - otta) END) DESC
+			LIMIT 25;
+		`,
+	},
+	"replication-slots": {
+		describe:
+			"Replication slots: status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)",
+		fields: [
+			"slot_name",
+			"slot_type",
+			"status",
+			"client_addr",
+			"restart_lsn",
+			"confirmed_flush_lsn",
+			"replication_lag",
+		],
+		emptyMessage: "No replication slots found.",
+		sql: /* sql */ `
+			SELECT
+				s.slot_name,
+				s.slot_type,
+				CASE
+					WHEN r.state IS NOT NULL THEN r.state
+					WHEN s.active THEN 'active (no walsender)'
+					ELSE 'inactive'
+				END AS status,
+				r.client_addr,
+				s.restart_lsn,
+				s.confirmed_flush_lsn,
+				pg_size_pretty(
+					pg_wal_lsn_diff(
+						CASE
+							WHEN pg_is_in_recovery() THEN pg_last_wal_receive_lsn()
+							ELSE pg_current_wal_lsn()
+						END,
+						COALESCE(s.confirmed_flush_lsn, s.restart_lsn)
+					)
+				) AS replication_lag
+			FROM pg_replication_slots s
+			LEFT JOIN pg_stat_replication r ON r.pid = s.active_pid
+			ORDER BY s.slot_name;
+		`,
+	},
+	subscriptions: {
+		describe:
+			"Per-table logical replication progress on this subscriber (pg_subscription_rel)",
+		fields: ["subscription", "table_name", "status", "lsn"],
+		emptyMessage: "No subscriptions found on this database.",
+		sql: /* sql */ `
+			SELECT
+				sub.subname AS subscription,
+				sr.srrelid::regclass::text AS table_name,
+				CASE sr.srsubstate
+					WHEN 'i' THEN 'initialize'
+					WHEN 'd' THEN 'data being copied'
+					WHEN 'f' THEN 'finished table copy'
+					WHEN 's' THEN 'synchronized'
+					WHEN 'r' THEN 'ready'
+					ELSE sr.srsubstate::text
+				END AS status,
+				sr.srsublsn AS lsn
+			FROM pg_subscription_rel sr
+			JOIN pg_subscription sub ON sub.oid = sr.srsubid
+			ORDER BY sub.subname, table_name;
+		`,
+	},
+} as const satisfies Record<string, InspectQuery>;
+
+export type InspectSubcommand = keyof typeof INSPECT_QUERIES;

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -185,6 +185,57 @@ export const INSPECT_QUERIES = {
 			LIMIT 25;
 		`,
 	},
+	"lfc-hit-rate": {
+		describe: "Local File Cache hit rate (needs neon extension)",
+		fields: ["name", "ratio"],
+		emptyMessage: "No LFC stats available.",
+		requiresExtension: "neon",
+		// Read the hit/miss counters from neon_get_lfc_stats() rather than the
+		// neon_lfc_stats / neon_stat_file_cache views: those views are owned by
+		// cloud_admin and are not always readable by end-user roles, whereas the
+		// function is EXECUTE-able by the default role.
+		sql: /* sql */ `
+			WITH lfc AS (
+				SELECT lfc_key AS k, lfc_value AS v
+				FROM neon_get_lfc_stats() t(lfc_key text, lfc_value bigint)
+			)
+			SELECT
+				'lfc hit rate' AS name,
+				max(v) FILTER (WHERE k = 'file_cache_hits')::float
+					/ nullif(
+						max(v) FILTER (WHERE k = 'file_cache_hits')
+						+ max(v) FILTER (WHERE k = 'file_cache_misses'),
+						0
+					) AS ratio
+			FROM lfc;
+		`,
+	},
+	"working-set": {
+		describe: "Estimated working set vs LFC size (needs neon extension)",
+		fields: ["window", "working_set", "lfc_size", "exceeds_lfc"],
+		emptyMessage: "No working-set estimate available.",
+		requiresExtension: "neon",
+		sql: /* sql */ `
+			SELECT
+				w.window,
+				pg_size_pretty(w.working_set_bytes) AS working_set,
+				pg_size_pretty(pg_size_bytes(current_setting('neon.file_cache_size_limit'))) AS lfc_size,
+				CASE
+					WHEN w.working_set_bytes
+						> pg_size_bytes(current_setting('neon.file_cache_size_limit'))
+					THEN 'yes' ELSE 'no'
+				END AS exceeds_lfc
+			FROM (
+				SELECT
+					x AS window,
+					approximate_working_set_size_seconds(
+						extract('epoch' from x::interval)::int
+					)::bigint * 8192 AS working_set_bytes
+				FROM (VALUES ('1m'), ('5m'), ('15m'), ('1h')) AS t(x)
+			) w
+			ORDER BY working_set_bytes;
+		`,
+	},
 	"vacuum-stats": {
 		describe:
 			"Autovacuum status per table: last (auto)vacuum, dead tuples, threshold",

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -27,24 +27,6 @@ export type InspectQuery = {
 };
 
 export const INSPECT_QUERIES = {
-	"cache-hit": {
-		describe:
-			"Buffer-cache hit rates for indexes and tables (pg_statio_user_*)",
-		fields: ["name", "ratio"],
-		sql: /* sql */ `
-			SELECT
-				'index hit rate' AS name,
-				sum(idx_blks_hit)::float
-					/ nullif(sum(idx_blks_hit + idx_blks_read), 0) AS ratio
-			FROM pg_statio_user_indexes
-			UNION ALL
-			SELECT
-				'table hit rate' AS name,
-				sum(heap_blks_hit)::float
-					/ nullif(sum(heap_blks_hit + heap_blks_read), 0) AS ratio
-			FROM pg_statio_user_tables;
-		`,
-	},
 	"table-sizes": {
 		describe:
 			"Size of each table (including TOAST), largest first (pg_table_size)",


### PR DESCRIPTION
## Description

Adds a `neon inspect db <subcommand>` command group to the CLI. A set of
read-only Postgres diagnostics for quickly checking a branch's database health.

### What's added

Fourteen diagnostic subcommands, each running one read-only query against
Postgres' built-in statistics/catalog views:

| Subcommand | What it reports | Source views | Needs extension |
| --- | --- | --- | --- |
| `table-sizes` | Size of each table (incl. TOAST), largest first | `pg_table_size` | — |
| `index-sizes` | Size of each index, largest first | `pg_relation_size` | — |
| `unused-indexes` | Non-unique, non-PK indexes with few scans | `pg_stat_user_indexes` | — |
| `seq-scans` | Sequential-scan count per table | `pg_stat_user_tables` | — |
| `long-running-queries` | Queries running longer than 5 minutes | `pg_stat_activity` | — |
| `locks` | Locks held, with the acquiring query and its age | `pg_locks` + `pg_stat_activity` | — |
| `vacuum-stats` | Last (auto)vacuum, dead tuples, autovacuum expectation | `pg_stat_user_tables` + `pg_class` | — |
| `bloat` | Statistical table-bloat estimate (ratio + wasted bytes) | `pg_stats` + `pg_class` | — |
| `replication-slots` | Slot kind, status, client, restart/confirmed-flush LSNs, lag | `pg_replication_slots` + `pg_stat_replication` | — |
| `subscriptions` | Per-table logical replication progress on a subscriber | `pg_subscription_rel` | — |
| `outliers` | Queries by cumulative execution time | `pg_stat_statements` | `pg_stat_statements` |
| `calls` | Most frequently called queries | `pg_stat_statements` | `pg_stat_statements` |
| `lfc-hit-rate` | Local File Cache hit rate (the effective cache on Neon) | `neon_get_lfc_stats()` | `neon` |
| `working-set` | Estimated working set vs LFC size across 1m/5m/15m/1h windows | `approximate_working_set_size_seconds()` | `neon` |

### How it works

- **Command wiring** (`commands/inspect.ts`): follows the existing nested-command
  pattern (`inspect` → `db` → one subcommand per query), registered in
  `commands/index.ts`. Results are printed through the existing
  `writer(props).end(rows, { fields })` helper, so `--output table|json|yaml`
  works unchanged, with a friendly empty-set message where a blank table would
  otherwise print.
- **Query definitions** (`utils/inspect_queries.ts`): each subcommand's SQL,
  output columns (display order), empty-set message, and optional
  `requiresExtension` live in one keyed table.
- **DB access + connection resolution** (`utils/inspect_db.ts`): a self-contained
  `resolveConnectionUri(props)` (endpoint → role → password → database → URL,
  honoring `--project-id`, `--branch`, `--role-name`, `--database-name`,
  point-in-time, pooling, and SSL mode) that mirrors how `connection-string`
  resolves a branch — so `inspect db` connects the same way, honoring the linked
  `.neon` context (`neon link` / `set-context`) via the CLI's global context
  middleware, without touching any existing file. The same module then runs the
  query over the CLI's **embedded Postgres wire client** (`PgConnection` +
  `parseConnectionUri`) — no new `pg` dependency — and maps each result row to an
  object keyed by column name for the writer. Connection failures surface a
  Postgres-specific error instead of being mislabeled as a Neon API network
  error. For gated queries it first checks `pg_extension` and fails with an
  actionable `CREATE EXTENSION …` hint if the extension is missing.
- **`--db-url`**: inspect any Postgres directly via a connection string,
  bypassing the Neon API entirely (project/branch resolution is skipped).

### Connecting

There are three ways to point `inspect db` at a database — it resolves
connections the same way the rest of the CLI does.

**1. Any Postgres via `--db-url`** — the inspection queries are Postgres-agnostic,
so you can run them against any database (not just Neon) by passing a connection
string. This bypasses the Neon API entirely:

```bash
neon inspect db bloat --db-url postgresql://postgres:postgres@localhost:5432/postgres
```

**2. A linked Neon project (`neon link` / set-context)** — once the project is
linked (or a context is set), the CLI connects automatically whenever you're in
the project folder, and you no longer need `--db-url`:

```bash
neon link                 # or: neon set-context --project-id <project-id>
neon inspect db bloat
```

**3. Explicit flags** — override resolution per-invocation:

```bash
neon inspect db bloat \
  --project-id <project-id> --branch <branch> \
  --role-name <role> --database-name <db>
```

Output format is controlled by the shared `--output table|json|yaml` flag, e.g.
`neon inspect db bloat --output json`.

### Notes on specific commands

- `outliers` / `calls` require the `pg_stat_statements` extension, and
  `lfc-hit-rate` / `working-set` require the `neon` extension; all four are
  guarded at runtime (an actionable `CREATE EXTENSION …` hint if missing).
  Everything else needs no extension.
- `lfc-hit-rate` / `working-set` are Neon-specific. `lfc-hit-rate` reads the
  hit/miss counters from `neon_get_lfc_stats()` rather than the
  `neon_stat_file_cache` / `neon_lfc_stats` views, because those views are owned
  by `cloud_admin` and are not always readable by end-user roles, whereas the
  function is `EXECUTE`-able by the default role. `working-set` compares
  `approximate_working_set_size_seconds()` at 1m/5m/15m/1h against
  `neon.file_cache_size_limit`; `exceeds_lfc = yes` is the signal to size compute up.
- `bloat` is a statistical estimate (from `pg_stats`), not an exact measurement.
- `replication-slots` lag is recovery-aware (`pg_last_wal_receive_lsn()` on a
  standby, `pg_current_wal_lsn()` otherwise) and falls back to `restart_lsn` when
  a slot has no `confirmed_flush_lsn` (physical slots). The `status` column is a
  single derived value: the `pg_stat_replication` WAL-sender state
  (`streaming`/`catchup`/…) when a live walsender is attached, else
  `active (no walsender)` for non-walsender consumers (logical decoding / Neon's
  internal slot), else `inactive`. The `slot_kind` column classifies each slot:
  `physical` (streaming replicas / Neon's internal slot), `initial-sync
  (tablesync)` for the temporary per-table slots Postgres creates during a
  subscription's first copy (named `pg_<subid>_sync_<relid>`), and `CDC (apply)`
  for the subscription's steady-state logical slot.
- `subscriptions` is subscriber-side: it only returns rows on a database that is
  itself a logical-replication **subscriber** (has `CREATE SUBSCRIPTION` set up).
  On a non-subscriber database it correctly prints "No subscriptions found." Full
  output (per-table `initialize`/`copying`/`ready` states) still needs to be
  verified on an actual subscriber — e.g. a Neon branch subscribed to an upstream
  publisher during a logical-replication migration.

### Scope

- **Purely additive.** The branch only adds new files under `packages/cli/src/`
  (`commands/inspect.ts`, `commands/inspect.test.ts`, `utils/inspect_queries.ts`,
  `utils/inspect_db.ts`). The single unavoidable edit to
  an existing file is the 2-line command registration in `commands/index.ts` —
  no other existing file is modified (`connection-string`, the test harness, etc.
  are untouched).
- No structural or dependency changes: no `package.json`, workspace, `biome.json`,
  or `tsconfig` changes; no new runtime deps.

### Testing

- `pnpm --filter neonctl build` and `pnpm --filter neonctl lint` pass.
- `commands/inspect.test.ts` added (hermetic `--db-url` cases for all subcommands).
- All subcommands verified against a live linked branch (and against a plain
  Postgres via `--db-url`), in table and JSON output; the `pg_stat_statements`
  guard verified both with and without the extension installed;
  `replication-slots` verified against real logical + physical slots.






