### PR TITLE
docs(sdk): fix required params in README examples

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -379,6 +379,7 @@ for await (const project of neon.consumption.perProject({
   from: "2026-06-01T00:00:00Z",
   to: "2026-06-30T00:00:00Z",
   granularity: "daily",
+  org_id: "org-...", // the org to report on; consumption requires a Scale plan or above
 })) {
   console.log(project);
 }
@@ -413,6 +414,7 @@ import { raw } from "@neon/sdk";
 const { data, error } = await raw.getProjectBranchSchema({
   client: neon.client,
   path: { project_id, branch_id },
+  query: { db_name: "neondb" }, // db_name is required
 });
 ```
 


### PR DESCRIPTION
Two README examples omitted required parameters:

- `raw.getProjectBranchSchema` needs `query: { db_name }` (required in the generated type; the example would not typecheck).
- `consumption.perProject` needs `org_id` to resolve the target org.

Found while verifying every example against the live SDK for the neon-website Management SDK reference.

This pull request and its description were written by Isaac.