### PR TITLE
feat(ai-sdk-provider): route through cleaned-up gateway paths (/v1, /openai/v1, /anthropic/v1)

### DIFF
--- a/.changeset/provider-clean-gateway-paths.md
+++ b/.changeset/provider-clean-gateway-paths.md
@@ -1,0 +1,5 @@
+---
+"@neon/ai-sdk-provider": minor
+---
+
+Route models through the Neon AI Gateway's cleaned-up top-level paths. `createNeon()` now targets `${NEON_AI_GATEWAY_BASE_URL}/v1` for unified Chat Completions, `/openai/v1` for the OpenAI Responses dialect (Codex, GPT-5), and `/anthropic/v1` for native Anthropic Messages — instead of the older `/ai-gateway/{mlflow,openai,anthropic}/v1` prefixes. Behavior is unchanged (the gateway serves both), verified end-to-end across Anthropic, OpenAI, Codex, Gemini, Llama, and the image-generation tool.

--- a/packages/ai-sdk-provider/src/lib/neon-anthropic-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-anthropic-language-model.ts
@@ -8,7 +8,7 @@ import type {
 
 /**
  * Language model for Anthropic models served via the Neon AI Gateway's native
- * Messages API (`/ai-gateway/anthropic/v1/messages`). Unlocks streaming
+ * Messages API (`/anthropic/v1/messages`). Unlocks streaming
  * structured output and native reasoning for Claude.
  *
  * The shared Anthropic model defaults to fine-grained tool-input streaming

--- a/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-responses-language-model.ts
@@ -8,7 +8,7 @@ import type {
 
 /**
  * Language model for OpenAI models served via the Neon AI Gateway's native
- * Responses API (`/ai-gateway/openai/v1/responses`). This route is required for
+ * Responses API (`/openai/v1/responses`). This route is required for
  * models that are only served natively (e.g. Codex) and unlocks native
  * reasoning and the image-generation tool.
  *

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -3,7 +3,7 @@
  *
  * `createNeon()` returns a provider that routes each model to the best gateway
  * endpoint based on its id (Anthropic → native Messages, OpenAI → native
- * Responses incl. Codex, everything else → unified MLflow), so a single
+ * Responses incl. Codex, everything else → unified Chat Completions), so a single
  * `neon('claude-...')` call (same base URL + token) reaches the whole catalog.
  * Ids use the canonical Neon (unprefixed) form; the legacy `databricks-` prefix
  * is also accepted. Configure with the branch-scoped `NEON_AI_GATEWAY_BASE_URL` +
@@ -155,7 +155,7 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 	const createAnthropicModel = (modelId: NeonChatModelId) =>
 		new NeonAnthropicLanguageModel(modelId, {
 			provider: "neon.anthropic",
-			baseURL: `${getHost()}/ai-gateway/anthropic/v1`,
+			baseURL: `${getHost()}/anthropic/v1`,
 			headers: () => getHeaders({ "anthropic-version": "2023-06-01" }),
 			fetch: options.fetch,
 			generateId,
@@ -165,18 +165,18 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 	const createOpenAIModel = (modelId: NeonChatModelId) =>
 		new NeonResponsesLanguageModel(modelId, {
 			provider: "neon.openai.responses",
-			url: ({ path }) => `${getHost()}/ai-gateway/openai/v1${path}`,
+			url: ({ path }) => `${getHost()}/openai/v1${path}`,
 			headers: getHeaders,
 			fetch: options.fetch,
 			fileIdPrefixes: ["file-"],
 		});
 
-	// Everything else (Gemini, Llama, Qwen, gpt-oss, ...) -> unified MLflow
-	// endpoint. Gemini is here because its native endpoint can't stream.
+	// Everything else (Gemini, Llama, Qwen, gpt-oss, ...) -> unified Chat
+	// Completions endpoint. Gemini is here because its native endpoint can't stream.
 	const createChatModel = (modelId: NeonChatModelId) =>
 		new NeonChatLanguageModel(modelId, {
 			provider: "neon.chat",
-			url: ({ path }) => `${getHost()}/ai-gateway/mlflow/v1${path}`,
+			url: ({ path }) => `${getHost()}/v1${path}`,
 			headers: getHeaders,
 			fetch: options.fetch,
 			errorStructure: neonErrorStructure,

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -80,7 +80,7 @@ export const NEON_ENV_VAR_KEYS = {
 	 * runtime injects: `apiKey` is the minted credential's bearer (`NEON_AI_GATEWAY_TOKEN`)
 	 * and `baseUrl` is the bare branch gateway host (`NEON_AI_GATEWAY_BASE_URL`,
 	 * `scheme://host`, no path). Clients like `@neon/ai-sdk-provider` read these and append the
-	 * `/ai-gateway/<dialect>/…` routes themselves (https://github.com/vercel/ai/pull/15997).
+	 * dialect route (`/v1`, `/openai/v1`, `/anthropic/v1`) themselves (https://github.com/vercel/ai/pull/15997).
 	 */
 	aiGateway: {
 		apiKey: "NEON_AI_GATEWAY_TOKEN",
@@ -159,7 +159,7 @@ export interface NeonStorageEnv {
  * `baseUrl` is the bare branch-scoped gateway host
  * (`https://<branchId>-api.ai.<region>.…`, no path). Projects to the Neon-branded env
  * (`NEON_AI_GATEWAY_TOKEN`, `NEON_AI_GATEWAY_BASE_URL`); clients like `@neon/ai-sdk-provider`
- * append the `/ai-gateway/<dialect>/…` routes themselves.
+ * append the dialect route (`/v1`, `/openai/v1`, `/anthropic/v1`) themselves.
  */
 export interface NeonAiGatewayEnv {
 	apiKey: string;
@@ -634,7 +634,7 @@ export async function fetchEnv<const C extends Config>(
 				apiKey: secrets.apiToken,
 				// Bare branch-scoped gateway host derived from the branch's connection URI —
 				// not the control-plane API origin (which doesn't serve the gateway). Clients
-				// append the /ai-gateway/<dialect>/… routes themselves.
+				// append the dialect route (/v1, /openai/v1, /anthropic/v1) themselves.
 				baseUrl: aiGatewayBaseUrl(branch.id, unpooled.uri),
 			} satisfies NeonAiGatewayEnv;
 		}
@@ -1327,7 +1327,7 @@ export function toEntries(env: NeonEnv<Config>): Record<string, string> {
 		const ai = withAiGateway.aiGateway;
 		// Neon-branded vars only: the bearer and the bare branch gateway host
 		// (scheme://host, no path) — the @neon/ai-sdk-provider appends the
-		// /ai-gateway/<dialect>/… routes itself (https://github.com/vercel/ai/pull/15997).
+		// dialect route (/v1, /openai/v1, /anthropic/v1) itself (https://github.com/vercel/ai/pull/15997).
 		out[keys.apiKey] = ai.apiKey;
 		out[keys.baseUrl] = ai.baseUrl;
 	}


### PR DESCRIPTION
## Summary

Follow-up to the Neon AI Gateway path cleanup. `@neon/ai-sdk-provider`'s `createNeon()` now targets the gateway's tidier **top-level** routes instead of the older `/ai-gateway/…` prefixes:

| Route kind | Before | After |
| --- | --- | --- |
| Unified Chat Completions (Gemini/Llama/Qwen/gpt-oss/…) | `${host}/ai-gateway/mlflow/v1` | `${host}/v1` |
| OpenAI Responses (GPT-5, Codex) | `${host}/ai-gateway/openai/v1` | `${host}/openai/v1` |
| Native Anthropic Messages (Claude) | `${host}/ai-gateway/anthropic/v1` | `${host}/anthropic/v1` |

Also refreshes the now-stale `/ai-gateway/<dialect>/…` wording in `@neon/env` doc comments (env already emits the bare `NEON_AI_GATEWAY_BASE_URL` host — no code change there; the base-URL-without-`/v1` behavior shipped in #285).

> Note: `@neon/env` needs no functional change — it writes the bare gateway host and clients append the dialect path. Gemini keeps routing via unified Chat Completions (`/v1`), not the native `/ai-gateway/gemini/v1beta` route (that dialect isn't cleaned up and the provider never used it).

## Test plan

- [x] `@neon/ai-sdk-provider` typecheck + unit tests (9 passed)
- [x] biome clean on all changed files
- [x] **Live e2e against the gateway** — 23 checks pass through the new routes: Anthropic (`/anthropic/v1`), OpenAI + Codex (`/openai/v1` Responses), Gemini + Llama (`/v1` chat), and the `neon.tools.imageGeneration` tool
- [x] Independently curled `/v1/chat/completions`, `/openai/v1/responses`, `/anthropic/v1/messages` → all 200

Pairs with models.dev anomalyco/models.dev#3198 and agent-skills neondatabase/agent-skills#46.