### PR TITLE
chore: release @neon/ai-sdk-provider@0.7.0

### DIFF
--- a/.changeset/provider-clean-gateway-paths.md
+++ b/.changeset/provider-clean-gateway-paths.md
@@ -1,5 +1,0 @@
----
-"@neon/ai-sdk-provider": minor
----
-
-Route models through the Neon AI Gateway's cleaned-up top-level paths. `createNeon()` now targets `${NEON_AI_GATEWAY_BASE_URL}/v1` for unified Chat Completions, `/openai/v1` for the OpenAI Responses dialect (Codex, GPT-5), and `/anthropic/v1` for native Anthropic Messages — instead of the older `/ai-gateway/{mlflow,openai,anthropic}/v1` prefixes. Behavior is unchanged (the gateway serves both), verified end-to-end across Anthropic, OpenAI, Codex, Gemini, Llama, and the image-generation tool.

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/ai-sdk-provider
 
+## 0.7.0
+
+### Minor Changes
+
+- d1e06fe: Route models through the Neon AI Gateway's cleaned-up top-level paths. `createNeon()` now targets `${NEON_AI_GATEWAY_BASE_URL}/v1` for unified Chat Completions, `/openai/v1` for the OpenAI Responses dialect (Codex, GPT-5), and `/anthropic/v1` for native Anthropic Messages — instead of the older `/ai-gateway/{mlflow,openai,anthropic}/v1` prefixes. Behavior is unchanged (the gateway serves both), verified end-to-end across Anthropic, OpenAI, Codex, Gemini, Llama, and the image-generation tool.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/ai-sdk-provider",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Version bump from the pending changeset (merged in #287).

## Bumped
- `@neon/ai-sdk-provider` 0.6.0 → **0.7.0** (minor)

### Changes
Route models through the Neon AI Gateway's cleaned-up top-level paths — `/v1` (unified Chat Completions), `/openai/v1` (OpenAI Responses), `/anthropic/v1` (native Anthropic Messages) — replacing the older `/ai-gateway/{mlflow,openai,anthropic}/v1` prefixes. Behavior unchanged; verified end-to-end.

After merge: dispatch `neon-pkgs.yml` publish for `ai-sdk-provider`, then verify on npm.