### PR TITLE
ci(sdk-spec-refresh): fail on spec drift instead of opening a PR

### DIFF
--- a/.github/workflows/sdk-spec-refresh.yml
+++ b/.github/workflows/sdk-spec-refresh.yml
@@ -1,9 +1,16 @@
-name: SDK Spec Refresh
+name: SDK Spec Drift
 
-# Maintainer signal: pull the live Neon OpenAPI spec, regenerate @neon/sdk,
-# and open a PR when the vendored spec or generated client drifts.
-# The PR is a starting point — coverage.test.ts will fail until someone
-# updates packages/sdk/src/neon/coverage.ts (EXPECTED_OPERATIONS / WRAPPED).
+# Maintainer signal: pull the live Neon OpenAPI spec, regenerate @neon/sdk, and
+# FAIL when the vendored spec or generated client drifts from what's committed.
+# This job intentionally does NOT open a PR (the org IP allow list blocks the
+# GitHub-hosted runner from pushing a branch). A red run is the signal to run
+# the refresh locally and open the PR by hand:
+#
+#   pnpm --filter @neon/sdk spec:pull
+#   pnpm --filter @neon/sdk generate
+#   pnpm --filter @neon/sdk build
+#   # review + update packages/sdk/src/neon/coverage.ts, add a changeset, open a PR
+#
 # Runs on a GitHub-hosted runner because it must reach neon.com; the protected
 # runner group has no public egress.
 
@@ -13,12 +20,11 @@ on:
     workflow_dispatch: ~
 
 permissions:
-    contents: write
-    pull-requests: write
+    contents: read
 
 jobs:
-    refresh:
-        name: Refresh @neon/sdk from live spec
+    drift:
+        name: Detect @neon/sdk spec drift
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -41,24 +47,17 @@ jobs:
             - name: Build (typecheck + bundle)
               run: pnpm --filter @neon/sdk build
 
-            - name: Open PR when spec or generated client changed
-              uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
-              with:
-                  branch: bot/sdk-spec-refresh
-                  commit-message: "chore(@neon/sdk): refresh OpenAPI spec"
-                  title: "chore(@neon/sdk): refresh OpenAPI spec"
-                  body: |
-                      Automated refresh from https://neon.com/api_spec/release/v2.json
-
-                      ## Follow-up before merge
-
-                      - [ ] Review added/removed operations in `packages/sdk/src/client/sdk.gen.ts`
-                      - [ ] Update `packages/sdk/src/neon/coverage.ts` (`EXPECTED_OPERATIONS`; wrap new ops in `WRAPPED` where ergonomic treatment is warranted)
-                      - [ ] Update `packages/sdk/README.md` API reference for any new ergonomic wrappers
-                      - [ ] Run `pnpm --filter @neon/sdk test:ci` locally
-                      - [ ] Add a changeset if this should ship a new `@neon/sdk` version
-
-                      CI is expected to fail on `coverage.test.ts` until `coverage.ts` is updated.
-                  labels: |
-                      dependencies
-                  delete-branch: true
+            - name: Fail when spec or generated client drifted
+              run: |
+                  # Stage so the diff also catches newly added / removed generated files.
+                  git add -A -- packages/sdk/spec packages/sdk/src/client
+                  if ! git diff --cached --exit-code -- packages/sdk/spec packages/sdk/src/client; then
+                      echo "::error::@neon/sdk is stale — the live Neon OpenAPI spec drifted from the committed spec/generated client."
+                      echo "Refresh it locally and open a PR:"
+                      echo "  pnpm --filter @neon/sdk spec:pull"
+                      echo "  pnpm --filter @neon/sdk generate"
+                      echo "  pnpm --filter @neon/sdk build"
+                      echo "Then review packages/sdk/src/neon/coverage.ts (EXPECTED_OPERATIONS / WRAPPED), add a changeset, and open the PR."
+                      exit 1
+                  fi
+                  echo "@neon/sdk is up to date with the live Neon OpenAPI spec."


### PR DESCRIPTION
## Summary

The **SDK Spec Refresh** workflow has failed every day since Jul 4. The regeneration steps all succeed; it dies on the final `peter-evans/create-pull-request` step when it tries to push `bot/sdk-spec-refresh`:

```
remote: The repository owner has an IP allow list enabled, and 52.159.243.168 is not permitted to access this repository.
fatal: unable to access 'https://github.com/neondatabase/neon-pkgs/': The requested URL returned error: 403
```

The `neondatabase` org has an IP allow list, and GitHub-hosted runner IPs aren't on it — so the bot can never push a branch from `ubuntu-latest`. Since the workflow *must* use a GitHub-hosted runner (it needs public egress to reach `neon.com`; the protected runner group has none), auto-opening a PR isn't viable here.

## What this changes

- **Drops the `create-pull-request` step.** No more branch push, no more 403.
- The job now **fails when the live spec or generated client drifts** from what's committed (`git diff` after `spec:pull` + `generate` + `build`), and **passes when everything is up to date**.
- A red run is the maintainer signal to refresh locally and open the PR by hand.
- Narrows workflow permissions to `contents: read` (no longer needs `pull-requests: write`).
- Renames the workflow to **SDK Spec Drift** to reflect the new detect-only behavior.

## Manual refresh flow (documented in the workflow header)

```bash
pnpm --filter @neon/sdk spec:pull
pnpm --filter @neon/sdk generate
pnpm --filter @neon/sdk build
# review packages/sdk/src/neon/coverage.ts (EXPECTED_OPERATIONS / WRAPPED), add a changeset, open a PR
```

## Test plan

- [ ] `workflow_dispatch` run on this branch reaches the drift step and **fails** (spec is currently drifted), proving detection works.