### PR TITLE
feat(sdk): refresh Neon OpenAPI spec + surface snapshot expiresAt on update

### DIFF
--- a/.changeset/sdk-spec-refresh-snapshot-expires-at.md
+++ b/.changeset/sdk-spec-refresh-snapshot-expires-at.md
@@ -1,0 +1,8 @@
+---
+"@neon/sdk": minor
+---
+
+Refresh the vendored Neon OpenAPI spec and regenerated client, and surface the new snapshot expiration control ergonomically.
+
+- `snapshots.update(projectId, snapshotId, input)` now accepts `expiresAt` (ISO 8601). Omit it to leave the current expiration unchanged, pass a future timestamp to set an absolute expiration, or pass `null` to clear it so the snapshot never expires — matching the camelCase `expiresAt` already used by `snapshots.create`.
+- Regenerated types pick up the renamed `ProjectPermissionLevel` values (`VIEWER` / `EDITOR` / `ADMIN`, previously `CAN_VIEW` / `CAN_EDIT` / `CAN_MANAGE`) to track the live API.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -318,7 +318,7 @@ Branch-scoped AI Gateway endpoint metadata (beta).
 | --- | --- | --- |
 | `list(projectId)` | `Snapshot[]` | |
 | `create(projectId, branchId, input?)` | `Snapshot` | `input`: `{ name?, timestamp?, lsn?, expiresAt? }` (point-in-time) |
-| `update(projectId, snapshotId, { name? })` | `Snapshot` | |
+| `update(projectId, snapshotId, input)` | `Snapshot` | `input`: `{ name?, expiresAt? }` — pass `expiresAt: null` to clear the expiration |
 | `delete(projectId, snapshotId)` | **→void** | |
 | `restore(projectId, snapshotId, input?)` | `Branch` | see below |
 | `getSchedule(projectId, branchId)` | `BackupSchedule` | |

--- a/packages/sdk/spec/neon-openapi.json
+++ b/packages/sdk/spec/neon-openapi.json
@@ -10818,11 +10818,11 @@
             "ProjectPermissionLevel": {
                 "type": "string",
                 "enum": [
-                    "CAN_VIEW",
-                    "CAN_EDIT",
-                    "CAN_MANAGE"
+                    "VIEWER",
+                    "EDITOR",
+                    "ADMIN"
                 ],
-                "description": "The caller's effective permission for a project when\nper-project permissions are enabled. Values correspond to viewer,\neditor, and admin/manage project access levels. Omitted for personal\nprojects, flag-off organizations, and non-user subjects.\n"
+                "description": "The caller's effective permission for a project when\nper-project permissions are enabled. `VIEWER` grants read access,\n`EDITOR` adds update access, and `ADMIN` grants full management.\nOmitted for personal projects, flag-off organizations, and non-user\nsubjects.\n"
             },
             "ConsumptionHistoryPerProjectResponse": {
                 "type": "object",
@@ -15128,6 +15128,13 @@
                         "properties": {
                             "name": {
                                 "type": "string"
+                            },
+                            "expires_at": {
+                                "description": "The date and time when the snapshot will expire.\n\nOmit to leave the current expiration unchanged. Send `null` to\nclear the expiration so the snapshot never expires. A future\ntimestamp sets the absolute expiration.\n",
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "example": "2030-06-09T18:02:16Z"
                             }
                         }
                     }

--- a/packages/sdk/src/client/types.gen.ts
+++ b/packages/sdk/src/client/types.gen.ts
@@ -824,12 +824,13 @@ export type GrantPermissionToProjectRequest = {
 
 /**
  * The caller's effective permission for a project when
- * per-project permissions are enabled. Values correspond to viewer,
- * editor, and admin/manage project access levels. Omitted for personal
- * projects, flag-off organizations, and non-user subjects.
+ * per-project permissions are enabled. `VIEWER` grants read access,
+ * `EDITOR` adds update access, and `ADMIN` grants full management.
+ * Omitted for personal projects, flag-off organizations, and non-user
+ * subjects.
  *
  */
-export type ProjectPermissionLevel = 'CAN_VIEW' | 'CAN_EDIT' | 'CAN_MANAGE';
+export type ProjectPermissionLevel = 'VIEWER' | 'EDITOR' | 'ADMIN';
 
 export type ConsumptionHistoryPerProjectResponse = {
     projects: Array<ConsumptionHistoryPerProject>;
@@ -3161,6 +3162,15 @@ export type Snapshot = {
 export type SnapshotUpdateRequest = {
     snapshot: {
         name?: string;
+        /**
+         * The date and time when the snapshot will expire.
+         *
+         * Omit to leave the current expiration unchanged. Send `null` to
+         * clear the expiration so the snapshot never expires. A future
+         * timestamp sets the absolute expiration.
+         *
+         */
+        expires_at?: string | null;
     };
 };
 

--- a/packages/sdk/src/neon/resources/snapshots.test.ts
+++ b/packages/sdk/src/neon/resources/snapshots.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "../client.js";
+
+/**
+ * Build a client whose only stub is the network boundary, capturing the
+ * outgoing request so we can assert the serialized body.
+ */
+function neonCapturing() {
+	const calls: Array<{ url: string; body: unknown }> = [];
+	const neon = createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		fetch: async (input, init) => {
+			const request = input instanceof Request ? input : undefined;
+			const url = request ? request.url : String(input);
+			const raw = request ? await request.clone().text() : init?.body;
+			calls.push({
+				url,
+				body:
+					typeof raw === "string" && raw.length > 0
+						? JSON.parse(raw)
+						: raw,
+			});
+			return new Response(
+				JSON.stringify({ snapshot: { id: "snap-1" } }),
+				{
+					status: 200,
+					headers: { "content-type": "application/json" },
+				},
+			);
+		},
+	});
+	return { neon, calls };
+}
+
+describe("snapshots.update maps the ergonomic input to the API body", () => {
+	it("sends camelCase expiresAt as snake_case expires_at", async () => {
+		const { neon, calls } = neonCapturing();
+		await neon.snapshots.update("p-1", "snap-1", {
+			name: "renamed",
+			expiresAt: "2030-01-01T00:00:00Z",
+		});
+		expect(calls[0]?.body).toEqual({
+			snapshot: { name: "renamed", expires_at: "2030-01-01T00:00:00Z" },
+		});
+	});
+
+	it("forwards an explicit null to clear the expiration", async () => {
+		const { neon, calls } = neonCapturing();
+		await neon.snapshots.update("p-1", "snap-1", { expiresAt: null });
+		expect(calls[0]?.body).toEqual({ snapshot: { expires_at: null } });
+	});
+
+	it("omits expires_at entirely when not provided", async () => {
+		const { neon, calls } = neonCapturing();
+		await neon.snapshots.update("p-1", "snap-1", { name: "renamed" });
+		expect(calls[0]?.body).toEqual({ snapshot: { name: "renamed" } });
+	});
+});

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -13,12 +13,9 @@ import type {
 	BackupSchedule,
 	Branch,
 	Snapshot,
-	SnapshotUpdateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
-
-type UpdateInput = SnapshotUpdateRequest["snapshot"];
 
 /**
  * Inspect a freshly restored (not-yet-finalized) branch and decide whether to commit.
@@ -36,6 +33,18 @@ export interface CreateSnapshotInput {
 	lsn?: string;
 	/** When the snapshot is automatically deleted (ISO 8601). */
 	expiresAt?: string;
+}
+
+/** Input for {@link Snapshots.update}. */
+export interface UpdateSnapshotInput {
+	/** Rename the snapshot. */
+	name?: string;
+	/**
+	 * Change when the snapshot expires (ISO 8601). Omit to leave the current
+	 * expiration unchanged, pass `null` to clear it so the snapshot never
+	 * expires, or a future timestamp to set an absolute expiration.
+	 */
+	expiresAt?: string | null;
 }
 
 /** Input for {@link Snapshots.restore}. */
@@ -131,18 +140,18 @@ export class Snapshots<DThrow extends boolean> {
 	update(
 		projectId: string,
 		snapshotId: string,
-		input: UpdateInput,
+		input: UpdateSnapshotInput,
 	): Promise<Outcome<Snapshot, DThrow>>;
 	update<Throw extends boolean = DThrow>(
 		projectId: string,
 		snapshotId: string,
-		input: UpdateInput,
+		input: UpdateSnapshotInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Snapshot, Throw>>;
 	update(
 		projectId: string,
 		snapshotId: string,
-		input: UpdateInput,
+		input: UpdateSnapshotInput,
 		opts?: CallOptions,
 	): Promise<Snapshot | NeonResult<Snapshot>> {
 		return this.#ctx.run(
@@ -151,7 +160,15 @@ export class Snapshots<DThrow extends boolean> {
 				updateSnapshot({
 					client,
 					path: { project_id: projectId, snapshot_id: snapshotId },
-					body: { snapshot: input },
+					// `undefined` fields are dropped by JSON serialization, so an
+					// omitted `expiresAt` leaves the expiration unchanged while an
+					// explicit `null` clears it.
+					body: {
+						snapshot: {
+							name: input.name,
+							expires_at: input.expiresAt,
+						},
+					},
 					throwOnError: false,
 				}),
 			(data) => data.snapshot,


### PR DESCRIPTION
## Summary

Manual run of the SDK spec refresh (the automated workflow now only *detects* drift — see #290). Regenerates `@neon/sdk` from the live Neon OpenAPI spec and applies the ergonomic follow-up.

Two upstream spec changes landed:

1. **`ProjectPermissionLevel` enum renamed** — `CAN_VIEW` / `CAN_EDIT` / `CAN_MANAGE` → `VIEWER` / `EDITOR` / `ADMIN`. Only referenced by generated types (`effective_project_permission`); no hand-written ergonomic code used the literals, so it flows through the regenerated `types.gen.ts`.
2. **`SnapshotUpdateRequest` gained optional `expires_at`** — lets you change or clear a snapshot's expiration on update.

## Ergonomic decision

`snapshots.update` previously passed the raw `SnapshotUpdateRequest["snapshot"]` shape straight through (snake_case, `name` only). I gave it a proper `UpdateSnapshotInput` with camelCase **`expiresAt`**, matching the `expiresAt` already exposed by `snapshots.create`:

```ts
// set / change expiration
await neon.snapshots.update(projectId, snapshotId, { expiresAt: "2030-01-01T00:00:00Z" });
// clear it (never expires)
await neon.snapshots.update(projectId, snapshotId, { expiresAt: null });
// leave expiration unchanged (omit)
await neon.snapshots.update(projectId, snapshotId, { name: "renamed" });
```

The tri-state is preserved because JSON serialization drops `undefined` keys: omitted → not sent (unchanged), `null` → sent (cleared), timestamp → sent (set).

## Changes

- `packages/sdk/spec/neon-openapi.json`, `packages/sdk/src/client/types.gen.ts` — regenerated.
- `packages/sdk/src/neon/resources/snapshots.ts` — new `UpdateSnapshotInput` (`{ name?, expiresAt? }`), maps camelCase → API body.
- `packages/sdk/src/neon/resources/snapshots.test.ts` — new no-mock tests (stub only the fetch network boundary) asserting the serialized body for set / clear / omit.
- `packages/sdk/README.md` — updated `snapshots.update` row.
- `.changeset/…` — **minor** bump for `@neon/sdk`.

## ⚠️ Needs your call: version bump

I set the changeset to **minor**. The `ProjectPermissionLevel` rename is a breaking change to the exported `ProjectPermissionLevel` type for anyone who typed against the old string literals — arguably a **major**. But it's a passthrough of an upstream API change (the old values no longer exist server-side regardless), so I didn't want to force a major without your sign-off per our release rules. **Tell me if you'd rather bump this to major** and I'll update the changeset.

## Coverage guard

No operations were added or removed (`raw.gen.ts` / `sdk.gen.ts` unchanged, 163 wrapped ops), so `coverage.ts` (`EXPECTED_OPERATIONS` / `WRAPPED`) needs no update. `coverage.test.ts` and the full suite pass (17/17).

## Test plan

- [x] `pnpm --filter @neon/sdk build` (tsc + tsdown)
- [x] `pnpm --filter @neon/sdk test:ci` — 17/17 pass
- [x] `pnpm lint:ci` — clean
- [ ] Reviewer: confirm minor vs major for the `ProjectPermissionLevel` rename