### PR TITLE
chore: release @neon/sdk@1.1.0

### DIFF
--- a/.changeset/sdk-spec-refresh-snapshot-expires-at.md
+++ b/.changeset/sdk-spec-refresh-snapshot-expires-at.md
@@ -1,8 +1,0 @@
----
-"@neon/sdk": minor
----
-
-Refresh the vendored Neon OpenAPI spec and regenerated client, and surface the new snapshot expiration control ergonomically.
-
-- `snapshots.update(projectId, snapshotId, input)` now accepts `expiresAt` (ISO 8601). Omit it to leave the current expiration unchanged, pass a future timestamp to set an absolute expiration, or pass `null` to clear it so the snapshot never expires — matching the camelCase `expiresAt` already used by `snapshots.create`.
-- Regenerated types pick up the renamed `ProjectPermissionLevel` values (`VIEWER` / `EDITOR` / `ADMIN`, previously `CAN_VIEW` / `CAN_EDIT` / `CAN_MANAGE`) to track the live API.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neonctl
 
+## 2.31.1
+
+### Patch Changes
+
+- Updated dependencies [dba7d3f]
+  - @neon/sdk@1.1.0
+  - @neon/config@0.9.2
+  - @neon/config-runtime@0.9.2
+  - @neon/env@0.11.1
+
 ## 2.31.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 0.9.2
+
+### Patch Changes
+
+- @neon/config@0.9.2
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 0.9.2
+
+### Patch Changes
+
+- Updated dependencies [dba7d3f]
+  - @neon/sdk@1.1.0
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 0.11.1
+
+### Patch Changes
+
+- @neon/config@0.9.2
+
 ## 0.11.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "0.11.0",
+	"version": "0.11.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @neon/sdk
 
+## 1.1.0
+
+### Minor Changes
+
+- dba7d3f: Refresh the vendored Neon OpenAPI spec and regenerated client, and surface the new snapshot expiration control ergonomically.
+
+  - `snapshots.update(projectId, snapshotId, input)` now accepts `expiresAt` (ISO 8601). Omit it to leave the current expiration unchanged, pass a future timestamp to set an absolute expiration, or pass `null` to clear it so the snapshot never expires — matching the camelCase `expiresAt` already used by `snapshots.create`.
+  - Regenerated types pick up the renamed `ProjectPermissionLevel` values (`VIEWER` / `EDITOR` / `ADMIN`, previously `CAN_VIEW` / `CAN_EDIT` / `CAN_MANAGE`) to track the live API.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Summary

Consumes the pending changeset from #292 (`changeset version`) to release **`@neon/sdk@1.1.0`** — the snapshot `expiresAt`-on-update ergonomic + refreshed OpenAPI spec.

## Bumped packages

| Package | From → To | Why |
|---|---|---|
| **`@neon/sdk`** | 1.0.0 → **1.1.0** | minor — the actual change (snapshot `expiresAt`, spec refresh, `ProjectPermissionLevel` rename) |
| `neonctl` | 2.31.0 → 2.31.1 | patch — `workspace:*` dependent of `@neon/sdk` |
| `@neon/config` | 0.9.1 → 0.9.2 | patch — depends on `@neon/sdk` |
| `@neon/config-runtime` | 0.9.1 → 0.9.2 | patch — depends on `@neon/config` |
| `@neon/env` | 0.11.0 → 0.11.1 | patch — depends on `@neon/config` |

The four patch bumps are automatic Changesets cascades (`updateInternalDependencies: "patch"`) — their CHANGELOG entries are just "Updated dependencies". No source changes.

## After merge

Publish is a manual `workflow_dispatch` in `databricks/secure-public-registry-releases-eng` (`neon-pkgs.yml`), one package per run. Plan: publish **`@neon/sdk`** first; confirm publish scope for the cascaded dependents (esp. `neonctl`, which also builds binaries + a GitHub release).