### PR TITLE
chore: release neonctl@2.32.0

### DIFF
--- a/.changeset/neat-config-diff.md
+++ b/.changeset/neat-config-diff.md
@@ -1,5 +1,0 @@
----
-"neonctl": minor
----
-
-`neon config plan` / `apply` (and `deploy`) now render their output as a git-style diff instead of tables. Service changes (Neon Auth, Data API, buckets, functions) list as green `+` additions; branch setting changes (TTL, `protected`, compute) group under a `~ <branch>` header as sorted `field → value` lines. A bare `apply` that hits drift on settings already present remotely now prints those as a sorted before→after diff (`current → desired`, old in red / new in green) — matching the `neon diff` styling — before exiting non-zero with the `--update-existing` hint. Colors honor `--no-color` and non-TTY pipes; `--output json|yaml` is unchanged.

--- a/.changeset/tidy-diff-command.md
+++ b/.changeset/tidy-diff-command.md
@@ -1,5 +1,0 @@
----
-"neonctl": minor
----
-
-Add a top-level `neon diff [compare-branch]` command that prints a git-style schema diff between the branch you're on (pinned in `.neon`, or `--branch`) and another branch. Omitting the argument compares the current branch against its parent ("what did I change since branching?"). Supports `--database`/`--db` to scope to one database (all databases by default), `--output json|yaml` for a structured per-database result, and colorized `git diff`-style output (red `---` / green `+++` / cyan `@@`, honoring `--no-color` and non-TTY pipes). The summary goes to stderr and the diff body to stdout, so `neon diff main > changes.patch` captures just the diff. For history-aware comparisons (a branch against its own past state at a timestamp/LSN), continue to use `branches schema-diff`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 2.32.0
+
+### Minor Changes
+
+- fe98464: `neon config plan` / `apply` (and `deploy`) now render their output as a git-style diff instead of tables. Service changes (Neon Auth, Data API, buckets, functions) list as green `+` additions; branch setting changes (TTL, `protected`, compute) group under a `~ <branch>` header as sorted `field → value` lines. A bare `apply` that hits drift on settings already present remotely now prints those as a sorted before→after diff (`current → desired`, old in red / new in green) — matching the `neon diff` styling — before exiting non-zero with the `--update-existing` hint. Colors honor `--no-color` and non-TTY pipes; `--output json|yaml` is unchanged.
+- 5cfbf6a: Add a top-level `neon diff [compare-branch]` command that prints a git-style schema diff between the branch you're on (pinned in `.neon`, or `--branch`) and another branch. Omitting the argument compares the current branch against its parent ("what did I change since branching?"). Supports `--database`/`--db` to scope to one database (all databases by default), `--output json|yaml` for a structured per-database result, and colorized `git diff`-style output (red `---` / green `+++` / cyan `@@`, honoring `--no-color` and non-TTY pipes). The summary goes to stderr and the diff body to stdout, so `neon diff main > changes.patch` captures just the diff. For history-aware comparisons (a branch against its own past state at a timestamp/LSN), continue to use `branches schema-diff`.
+
 ## 2.31.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.31.1",
+  "version": "2.32.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
Version bump via Changesets for the Neon CLI.

## Bumped
- `neonctl`: **2.31.1 → 2.32.0** (minor)

Consumes two pending changesets (both merged to `main`):
- **#294** — `neon diff [compare-branch]`: top-level git-style branch **schema diff**.
- **#295** — git-style diff for `neon config plan` / `apply` / `deploy` (service `+` list + sorted branch-setting before→after; conflict diff on bare `apply`).

No dependent cascade (the CLI is a leaf package); no other packages had pending changesets.

## After merge
This only lands the version + CHANGELOG on `main`. Publishing is a manual dispatch of `neon-pkgs.yml` in `databricks/secure-public-registry-releases-eng` with `-f package=neonctl -f ref=main` (also republishes the `neon` alias + standalone binaries + GitHub release).