### PR TITLE
docs: reference `neon` CLI over `neonctl` in user-facing output

### DIFF
--- a/.changeset/neon-cli-rename.md
+++ b/.changeset/neon-cli-rename.md
@@ -1,0 +1,13 @@
+---
+"neon-init": patch
+"@neon/env": patch
+"@neon/config": patch
+"@neon/sdk": patch
+---
+
+Reference the `neon` CLI over `neonctl` in user-facing output and docs. The CLI
+ships both the `neon` and `neonctl` binaries; `neonctl` keeps working as an
+alias, but `neon init` now emits `neon …` commands, status messages, and
+agent-facing prompts using the cleaner `neon` name, and the package READMEs
+document `neon`. Internal package install/version checks and the
+`~/.config/neonctl/` config path are unchanged.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -2,7 +2,7 @@
 
 Config-as-Code for the Neon Platform. A repo-local `neon.ts` exports a TypeScript policy function describing a branch's desired state. This package exposes **functions** to inspect, diff, and deploy that policy against the Neon API.
 
-> No CLI commands ship here, and the package is **filesystem- and env-agnostic**: it never reads `.neon` files or `NEON_*` environment variables. You pass `projectId` and the target branch explicitly (resolve them in your CLI, e.g. neonctl). This package is functions only.
+> No CLI commands ship here, and the package is **filesystem- and env-agnostic**: it never reads `.neon` files or `NEON_*` environment variables. You pass `projectId` and the target branch explicitly (resolve them in your CLI, e.g. neon). This package is functions only.
 
 ## Install
 

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -82,7 +82,7 @@ Flags (both commands): `--config <path>`, `--project-id`, `--branch`, `--api-key
 
 ## Env vars produced
 
-These are the OS-level vars `fetchEnv` / `parseEnv` read and `toEntries` (so `neon-env run` / `neon-env export` / `neonctl env pull`) emit. Which ones appear depends on what your `neon.ts` policy enables — grouped by service below.
+These are the OS-level vars `fetchEnv` / `parseEnv` read and `toEntries` (so `neon-env run` / `neon-env export` / `neon env pull`) emit. Which ones appear depends on what your `neon.ts` policy enables — grouped by service below.
 
 **Branch identity + Postgres** (always present):
 
@@ -125,4 +125,4 @@ These are the OS-level vars `fetchEnv` / `parseEnv` read and `toEntries` (so `ne
 
 The **CLI** (`neon-env run`) resolves project + branch itself: `--project-id` / `--branch` flag → `NEON_PROJECT_ID` / `NEON_BRANCH` (name) / `NEON_BRANCH_ID` (legacy id) env → `.neon[/project.json]` walked up from the working directory (its `branch` field, name or id; legacy `branchId` still read). The API key resolves via `--api-key` → `NEON_API_KEY` → `~/.config/neonctl/credentials.json`.
 
-The **library functions** do none of this — pass `projectId` / `branch` explicitly. This keeps `.neon` parsing in one place (the CLI / neonctl) and the functions pure.
+The **library functions** do none of this — pass `projectId` / `branch` explicitly. This keeps `.neon` parsing in one place (the CLI / neon) and the functions pure.

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -53,7 +53,7 @@ Then:
 
 The tool automatically detects which editors are installed on your system and you'll be prompted to choose which one(s) to configure.
 
-**Authentication:** Uses OAuth via `neonctl` and creates an API key for you - opens your browser, no manual API keys needed.
+**Authentication:** Uses OAuth via the Neon CLI (`neon`) and creates an API key for you - opens your browser, no manual API keys needed.
 
 **Agent Guidelines:** The Neon MCP Server includes built-in agent guidelines as an MCP resource. Your AI assistant will automatically have access to:
 

--- a/packages/init/src/cli.ts
+++ b/packages/init/src/cli.ts
@@ -549,12 +549,12 @@ const cli = yargs(hideBin(process.argv))
 				.option("orgs-result", {
 					type: "string",
 					description:
-						"JSON output from neonctl orgs list (agent passes back).",
+						"JSON output from neon orgs list (agent passes back).",
 				})
 				.option("projects-result", {
 					type: "string",
 					description:
-						"JSON output from neonctl projects list (agent passes back).",
+						"JSON output from neon projects list (agent passes back).",
 				})
 				.option("framework", {
 					type: "string",

--- a/packages/init/src/index.ts
+++ b/packages/init/src/index.ts
@@ -53,7 +53,7 @@ export interface InitOptions {
 }
 
 function getNeonctlCommands() {
-	const base = "npx neonctl";
+	const base = "npx neon";
 	return {
 		listOrgs: `${base} orgs list --output json`,
 		listProjects: `${base} projects list --output json`,
@@ -70,8 +70,8 @@ function getAuthInstructions(): string {
 	return [
 		"YOU (the agent) must handle authentication. Do NOT ask the user to run commands themselves.",
 		"Do NOT write wrapper scripts (Python, shell, etc.) — use simple shell commands only.",
-		"IMPORTANT: Unset the CI environment variable for all neonctl commands below,",
-		"otherwise neonctl will refuse to open the browser.",
+		"IMPORTANT: Unset the CI environment variable for all neon commands below,",
+		"otherwise the Neon CLI will refuse to open the browser.",
 		"",
 		'Step 1: Ask the user: "Do you already have a Neon account, or do you need to create one?"',
 		"",
@@ -98,7 +98,7 @@ function getAuthInstructions(): string {
 		"=== AFTER SUCCESSFUL AUTH ===",
 		`Step 5: Verify by running: ${cmd} me`,
 		"   This should print the user's account info and exit with code 0.",
-		"Step 6: Re-run neonctl init with the same --agent and --json flags to complete setup.",
+		"Step 6: Re-run neon init with the same --agent and --json flags to complete setup.",
 	].join("\n");
 }
 

--- a/packages/init/src/init.test.ts
+++ b/packages/init/src/init.test.ts
@@ -90,15 +90,15 @@ describe("init() with json mode", () => {
 			{ editor: "Claude CLI", status: "success", type: "mcp" },
 		]);
 		expect(result.neonctl.authenticated).toBe(true);
-		expect(result.neonctl.commands.listOrgs).toContain("neonctl orgs list");
+		expect(result.neonctl.commands.listOrgs).toContain("neon orgs list");
 		expect(result.neonctl.commands.listProjects).toContain(
-			"neonctl projects list",
+			"neon projects list",
 		);
 		expect(result.neonctl.commands.createProject).toContain(
-			"neonctl projects create",
+			"neon projects create",
 		);
 		expect(result.neonctl.commands.getConnectionString).toContain(
-			"neonctl connection-string",
+			"neon connection-string",
 		);
 		expect(result.mcpServer.configured).toBe(true);
 		expect(result.mcpServer.requiresRestart).toBe(true);
@@ -282,13 +282,13 @@ describe("init() with json mode", () => {
 		expect(result.authInstructions).toContain("NEW ACCOUNT");
 		expect(result.authInstructions).toContain("/signup");
 		expect(result.authInstructions).toContain("EXISTING ACCOUNT");
-		expect(result.authInstructions).toContain("neonctl auth");
+		expect(result.authInstructions).toContain("neon auth");
 		expect(result.authInstructions).toContain("email verification");
 		expect(result.authInstructions).toContain(
 			"Do NOT write wrapper scripts",
 		);
 		expect(result.authInstructions).toContain("exit code 2");
-		expect(result.authInstructions).toContain("Re-run neonctl init");
+		expect(result.authInstructions).toContain("Re-run neon init");
 		expect(mockInstallNeon).not.toHaveBeenCalled();
 	});
 

--- a/packages/init/src/interactive.ts
+++ b/packages/init/src/interactive.ts
@@ -413,7 +413,7 @@ async function interactiveInitInner(
 		if (isCancel(authResult) || authResult === "no") {
 			outro(
 				dim(
-					`Your project is configured with Neon. You can set up Neon Auth later by having your agent run: neonctl init --agent --data '{"step":"neon-auth"}'`,
+					`Your project is configured with Neon. You can set up Neon Auth later by having your agent run: neon init --agent --data '{"step":"neon-auth"}'`,
 				),
 			);
 			return;
@@ -646,30 +646,28 @@ async function interactiveInitInner(
 			authS.stop("Authenticated.");
 		}
 
-		// Ensure neonctl CLI is installed and up to date
+		// Ensure the Neon CLI is installed and up to date
 		const nctlS = spinner();
-		nctlS.start("Checking neonctl CLI...");
+		nctlS.start("Checking Neon CLI...");
 		const nctlResult = await ensureNeonctl();
 		switch (nctlResult.status) {
 			case "already_current":
 				nctlS.stop(
-					dim(`neonctl CLI is up to date (v${nctlResult.version}) ✓`),
+					dim(`Neon CLI is up to date (v${nctlResult.version}) ✓`),
 				);
 				break;
 			case "installed":
 				nctlS.stop(
-					dim(`Installed neonctl CLI (v${nctlResult.version}) ✓`),
+					dim(`Installed Neon CLI (v${nctlResult.version}) ✓`),
 				);
 				break;
 			case "updated":
-				nctlS.stop(
-					dim(`Updated neonctl CLI to v${nctlResult.version} ✓`),
-				);
+				nctlS.stop(dim(`Updated Neon CLI to v${nctlResult.version} ✓`));
 				break;
 			case "failed":
-				nctlS.stop("Failed to install neonctl CLI");
+				nctlS.stop("Failed to install Neon CLI");
 				log.warn(
-					"neonctl could not be installed automatically. The setup will continue using npx.",
+					"The Neon CLI could not be installed automatically. The setup will continue using npx.",
 				);
 				break;
 		}
@@ -775,7 +773,7 @@ async function interactiveInitInner(
 	if (options.preview) gettingStartedData.preview = true;
 
 	// Build a prompt for the user to paste into their agent chat
-	const cmd = `neonctl init --agent --data '${JSON.stringify({ step: "getting-started", ...gettingStartedData })}'`;
+	const cmd = `neon init --agent --data '${JSON.stringify({ step: "getting-started", ...gettingStartedData })}'`;
 	// Account for clack's "│  " prefix (3 chars) when wrapping
 	const cols = (process.stdout.columns || 80) - 3;
 	const promptText = `To finish setting up Neon using Neon's agent-guided onboarding experience, have your agent run this shell command: ${cmd}`;

--- a/packages/init/src/lib/auth.ts
+++ b/packages/init/src/lib/auth.ts
@@ -34,7 +34,7 @@ export async function ensureNeonctlAuth(
 		if (!quiet) {
 			if (msg.includes("interactive auth") || msg.includes("CI")) {
 				log.error(
-					"Auth requires an interactive terminal. Run neonctl init in your system terminal (outside the chat) to sign in.",
+					"Auth requires an interactive terminal. Run neon init in your system terminal (outside the chat) to sign in.",
 				);
 			} else {
 				log.error(`Authentication failed: ${msg}`);
@@ -86,7 +86,8 @@ export async function createApiKeyFromNeonctl(
 	try {
 		const accessToken = await getNeonctlAccessToken();
 		if (!accessToken) {
-			if (!quiet) log.error("Could not find OAuth token from neonctl");
+			if (!quiet)
+				log.error("Could not find OAuth token from the Neon CLI");
 			return null;
 		}
 

--- a/packages/init/src/lib/enrich-output.ts
+++ b/packages/init/src/lib/enrich-output.ts
@@ -1,6 +1,6 @@
 /**
  * Converts neon-init args (e.g. ["neon-auth", "--json", "--setup"]) to a
- * neonctl init --data command using the step routing pattern.
+ * neon init --data command using the step routing pattern.
  */
 function argsToCommand(args: string[]): string {
 	const data: Record<string, unknown> = {};
@@ -35,12 +35,12 @@ function argsToCommand(args: string[]): string {
 		}
 	}
 
-	return `neonctl init --agent --data '${JSON.stringify(data)}'`;
+	return `neon init --agent --data '${JSON.stringify(data)}'`;
 }
 
 /**
  * Walks a phase response object and:
- * 1. Replaces `args` arrays with `command` strings (neonctl init --data format)
+ * 1. Replaces `args` arrays with `command` strings (neon init --data format)
  * 2. Renames `run_neon_init` → `run_shell_command`
  * 3. Adds a description to finalize steps
  */
@@ -70,7 +70,7 @@ export function enrichResponse(obj: unknown): unknown {
 			result.command.includes('"step":"finalize"')
 		) {
 			result.description =
-				"Run this command to complete the setup. This is the final step — do not run any other neonctl init commands after this.";
+				"Run this command to complete the setup. This is the final step — do not run any other neon init commands after this.";
 		}
 	}
 

--- a/packages/init/src/lib/neonctl.ts
+++ b/packages/init/src/lib/neonctl.ts
@@ -2,15 +2,17 @@ import { lstatSync } from "node:fs";
 import { execa } from "execa";
 
 /**
- * Returns the neonctl command prefix: "CI= npx -y neonctl".
+ * Returns the Neon CLI command prefix: "CI= npx -y neon".
  *
- * neonctl reads NEON_API_HOST and NEON_OAUTH_HOST from the environment
- * directly, so no extra flags are needed.
+ * The CLI reads NEON_API_HOST and NEON_OAUTH_HOST from the environment
+ * directly, so no extra flags are needed. The `neon` package ships both the
+ * `neon` and `neonctl` binaries; we surface the cleaner `neon` command in the
+ * examples emitted to users and agents.
  *
  * Usage: `${neonctlCmd()} orgs list --output json`
  */
 export function neonctlCmd(): string {
-	return "CI= npx -y neonctl";
+	return "CI= npx -y neon";
 }
 
 /**

--- a/packages/init/src/lib/phases/auth.test.ts
+++ b/packages/init/src/lib/phases/auth.test.ts
@@ -72,7 +72,7 @@ describe("handleAuthPhase", () => {
 		expect(result.status).toBe("in_progress");
 		expect(result.nextAction.type).toBe("run_command");
 		if (result.nextAction.type === "run_command") {
-			expect(result.nextAction.command).toContain("neonctl auth");
+			expect(result.nextAction.command).toContain("neon auth");
 			expect(result.nextAction.timeout).toBe(120000);
 			expect(result.nextAction.onFailure).toHaveProperty("2");
 		}

--- a/packages/init/src/lib/phases/db.test.ts
+++ b/packages/init/src/lib/phases/db.test.ts
@@ -9,7 +9,7 @@ describe("handleDbPhase", () => {
 		expect(result.status).toBe("ready");
 		expect(result.nextAction.type).toBe("run_command");
 		if (result.nextAction.type === "run_command") {
-			expect(result.nextAction.command).toContain("neonctl orgs list");
+			expect(result.nextAction.command).toContain("neon orgs list");
 			expect(result.nextAction.onSuccess.args).toContain("--orgs-result");
 		}
 	});

--- a/packages/init/src/lib/phases/getting-started.test.ts
+++ b/packages/init/src/lib/phases/getting-started.test.ts
@@ -39,7 +39,7 @@ describe("getting-started phase", () => {
 			const orgStep = result.nextAction.steps.find(
 				(s) => s.id === "select_org",
 			);
-			expect(orgStep?.command).toContain("neonctl orgs list");
+			expect(orgStep?.command).toContain("neon orgs list");
 			expect(orgStep?.description).toContain("CLI");
 			// Create step should include --org-id
 			const createStep = result.nextAction.steps.find(

--- a/packages/init/src/lib/phases/getting-started.ts
+++ b/packages/init/src/lib/phases/getting-started.ts
@@ -20,7 +20,7 @@ export interface GettingStartedPhaseOptions {
  *
  * Steps are concrete and executable — each has a CLI command to run
  * or a specific file operation. The agent should attempt each step
- * in order and actually perform the action using the neonctl CLI.
+ * in order and actually perform the action using the Neon CLI.
  */
 export async function handleGettingStartedPhase(
 	options: GettingStartedPhaseOptions,
@@ -119,7 +119,7 @@ export async function handleGettingStartedPhase(
 			description: [
 				"Check if node_modules exists in the project root.",
 				"If not, install project dependencies using the appropriate package manager (check for pnpm-lock.yaml, yarn.lock, bun.lockb, or default to npm).",
-				"This must be done before `neonctl env pull` because the project's Neon config file may import packages that need to be installed first.",
+				"This must be done before `neon env pull` because the project's Neon config file may import packages that need to be installed first.",
 			].join(" "),
 			command: "npm install",
 		});
@@ -128,7 +128,7 @@ export async function handleGettingStartedPhase(
 		steps.push({
 			id: "pull_env",
 			description: [
-				"Now that the .neon context file is in place and dependencies are installed, run `neonctl env pull` to populate the project's environment variables.",
+				"Now that the .neon context file is in place and dependencies are installed, run `neon env pull` to populate the project's environment variables.",
 				"This automatically writes the database connection string (and any other Neon-managed env vars) to the correct env file.",
 				"It reads the .neon context file to determine the project, and writes to the appropriate env file for the project.",
 				"Ensure the target env file is listed in .gitignore.",
@@ -223,7 +223,7 @@ export async function handleGettingStartedPhase(
 		description: [
 			"Verify the database connection works by running a SQL query against the Neon database.",
 			"Write and run a short script that connects using DATABASE_URL from the project's env file and executes `SELECT 1` (or queries a table from the migration if migrations were run).",
-			"Do NOT use the neonctl CLI or MCP tools for this — use a direct database connection to verify end-to-end connectivity.",
+			"Do NOT use the Neon CLI or MCP tools for this — use a direct database connection to verify end-to-end connectivity.",
 		].join(" "),
 	});
 

--- a/packages/init/src/lib/phases/neon-auth.ts
+++ b/packages/init/src/lib/phases/neon-auth.ts
@@ -77,7 +77,7 @@ export async function handleNeonAuthPhase(
 					{
 						id: "provision",
 						description:
-							"Enable Neon Auth on the project using the neonctl CLI. " +
+							"Enable Neon Auth on the project using the Neon CLI. " +
 							`Run: \`${neonctlCmd()} neon-auth enable --project-id <project-id> --output json\`. ` +
 							`You can check current status with: \`${neonctlCmd()} neon-auth status --project-id <project-id> --output json\`.` +
 							(options.projectId

--- a/packages/init/src/lib/phases/setup.ts
+++ b/packages/init/src/lib/phases/setup.ts
@@ -225,7 +225,7 @@ async function buildBulkInspection(
 				{
 					id: "neonctl",
 					description:
-						"The neonctl CLI will be installed or updated automatically (no action needed from the agent)",
+						"The Neon CLI will be installed or updated automatically (no action needed from the agent)",
 					lookFor: [],
 				},
 				{
@@ -306,8 +306,8 @@ async function buildBulkInspection(
 								{
 									value: "defaults",
 									label: hasApp
-										? "Use defaults (neonctl CLI, MCP: global, skills: project-level, extension if applicable — already-configured components will be skipped)"
-										: "Use defaults (neonctl CLI, MCP: global, extension if applicable — skills included in template)",
+										? "Use defaults (Neon CLI, MCP: global, skills: project-level, extension if applicable — already-configured components will be skipped)"
+										: "Use defaults (Neon CLI, MCP: global, extension if applicable — skills included in template)",
 								},
 								{
 									value: "customize",
@@ -467,7 +467,7 @@ function _buildModeQuestion(options: SetupPhaseOptions): PhaseResponse {
 	const inspectionArgs = buildInspectionArgs(options);
 
 	// Build defaults label showing only what will be installed
-	const defaultsParts: string[] = ["neonctl CLI"];
+	const defaultsParts: string[] = ["Neon CLI"];
 	if (!options.mcpConfigured) defaultsParts.push("MCP global");
 	defaultsParts.push("skills in project");
 	if (options.isVscodeIde) defaultsParts.push("install extension");
@@ -675,34 +675,34 @@ async function executeBatchedInstallation(
 		}
 	}
 
-	// Step 1: Ensure neonctl CLI is installed and up to date
+	// Step 1: Ensure the Neon CLI is installed and up to date
 	const neonctlResult = await ensureNeonctl();
 	switch (neonctlResult.status) {
 		case "already_current":
 			results.push({
 				id: "neonctl",
-				description: `neonctl CLI is up to date (v${neonctlResult.version})`,
+				description: `Neon CLI is up to date (v${neonctlResult.version})`,
 				status: "success",
 			});
 			break;
 		case "installed":
 			results.push({
 				id: "neonctl",
-				description: `Installed neonctl CLI (v${neonctlResult.version})`,
+				description: `Installed Neon CLI (v${neonctlResult.version})`,
 				status: "success",
 			});
 			break;
 		case "updated":
 			results.push({
 				id: "neonctl",
-				description: `Updated neonctl CLI to v${neonctlResult.version}`,
+				description: `Updated Neon CLI to v${neonctlResult.version}`,
 				status: "success",
 			});
 			break;
 		case "failed":
 			results.push({
 				id: "neonctl",
-				description: "Failed to install neonctl CLI",
+				description: "Failed to install Neon CLI",
 				status: "failed",
 				error: neonctlResult.error,
 			});

--- a/packages/init/src/lib/phases/status.ts
+++ b/packages/init/src/lib/phases/status.ts
@@ -33,7 +33,7 @@ export async function handleStatusPhase(
 		recommendations.push({
 			priority: "high",
 			message: "Not authenticated with Neon",
-			command: `neonctl init --agent --data '{"step":"auth"}'`,
+			command: `neon init --agent --data '{"step":"auth"}'`,
 		});
 	}
 
@@ -41,7 +41,7 @@ export async function handleStatusPhase(
 		recommendations.push({
 			priority: "high",
 			message: "No DATABASE_URL found in .env",
-			command: `neonctl init --agent --data '{"step":"db"}'`,
+			command: `neon init --agent --data '{"step":"db"}'`,
 		});
 	}
 
@@ -49,7 +49,7 @@ export async function handleStatusPhase(
 		recommendations.push({
 			priority: "medium",
 			message: "Neon agent skills not detected in this project",
-			command: `neonctl init --agent --data '{"step":"skills","install":true}'`,
+			command: `neon init --agent --data '{"step":"skills","install":true}'`,
 		});
 	}
 
@@ -57,7 +57,7 @@ export async function handleStatusPhase(
 		recommendations.push({
 			priority: "medium",
 			message: `${migrationTool} detected but no migrations found`,
-			command: `neonctl init --agent --data '{"step":"migrations"}'`,
+			command: `neon init --agent --data '{"step":"migrations"}'`,
 		});
 	}
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -257,7 +257,7 @@ enabled and the branch S3 endpoint metadata; buckets and objects are nested unde
 | `presign(projectId, branchId, bucketName, objectKey, input)` | `PresignResponse` | `input`: `{ operation: "upload" \| "download", content_type?, expires_in_seconds? }` |
 
 ```ts
-// Upload via presigned PUT (same flow as neonctl bucket object put)
+// Upload via presigned PUT (same flow as neon bucket object put)
 const { data: presign } = await neon.storage.objects.presign(
   projectId, branchId, "avatars", "user-1.png",
   { operation: "upload", content_type: "image/png" },


### PR DESCRIPTION
## Summary

The Neon CLI ships both the `neon` and `neonctl` binaries, and both npm packages (`neon`, `neonctl`) publish in lockstep (same version). `neonctl` keeps working as an alias — nothing breaks, no migration needed — but this surfaces the cleaner `neon` command everywhere users and agents see it.

- **`neon init` emitted commands**: the shared command helper now emits `CI= npx -y neon …`, so all agent steps (orgs list, projects list/create, connection-string, env pull, auth, `me`) use `neon`.
- **Self-invocation hints**: status recommendations, interactive next-steps, and `enrich-output` now emit `neon init --agent --data …`.
- **User-facing messages/prose**: spinner + status text ("Neon CLI is up to date"), auth instructions, and CLI `--help` descriptions reference `neon`.
- **READMEs**: `neon-init`, `@neon/env`, `@neon/config`, `@neon/sdk` reference `neon`.
- **Changeset** added (patch) for the affected packages.

## Left unchanged (real identifiers, not command examples)

- Package install + version checks in `lib/neonctl.ts` still target the `neonctl` package (installs the CLI that provides both bins; both packages are in lockstep).
- `~/.config/neonctl/` config/credentials path (shared by both bins).
- The `neonctl-init-{timestamp}` API-key name the CLI generates.
- Structured response keys / step ids (`neonctl: { … }`, `id: "neonctl"`) — internal agent-protocol contract.
- `AGENTS.md` / release skill (accurately describe the current publish model).

## Test plan

- [x] `vitest run` for `neon-init` — 123 passed (updated emitted-command assertions to `neon`)
- [x] `tsc --noEmit` for `neon-init` — clean
- [x] `biome ci` on changed paths — clean
- [ ] Manual: `npx neon init --agent` emits `neon …` step commands end-to-end