### PR TITLE
fix(config): beta-region error messaging for neon.ts platform features

### DIFF
--- a/.changeset/platform-beta-region-errors.md
+++ b/.changeset/platform-beta-region-errors.md
@@ -1,0 +1,11 @@
+---
+"@neon/config": patch
+"neon-init": patch
+---
+
+Update platform-feature-unavailable errors for the public beta: drop outdated
+"private preview" / "Preview feature" wording, name `aws-us-east-2` explicitly,
+and treat API bodies that say a feature is unavailable for the project/region as
+a region gate (not a transient incident) even when the status is 503. `neon-init`
+getting-started prompts now describe the public-beta region requirement the same
+way.

--- a/.changeset/platform-beta-region-errors.md
+++ b/.changeset/platform-beta-region-errors.md
@@ -3,9 +3,9 @@
 "neon-init": patch
 ---
 
-Update platform-feature-unavailable errors for the public beta: drop outdated
-"private preview" / "Preview feature" wording, name `aws-us-east-2` explicitly,
-and treat API bodies that say a feature is unavailable for the project/region as
-a region gate (not a transient incident) even when the status is 503. `neon-init`
-getting-started prompts now describe the public-beta region requirement the same
-way.
+Update platform-feature-unavailable errors for the beta rollout: drop outdated
+"private preview" / "Preview feature" wording, say features are currently in
+beta and only in `aws-us-east-2` (more regions coming shortly), and treat API
+bodies that say a feature is unavailable for the project/region as a region gate
+(not a transient incident) even when the status is 503. `neon-init`
+getting-started prompts use the same wording.

--- a/packages/config/src/lib/neon-api-real.test.ts
+++ b/packages/config/src/lib/neon-api-real.test.ts
@@ -205,7 +205,7 @@ describe("isPreviewFeatureUnavailable", () => {
 });
 
 describe("previewUnavailableError", () => {
-	test("503 with region-unavailable API body: points at aws-us-east-2 public beta", () => {
+	test("503 with region-unavailable API body: points at aws-us-east-2 beta rollout", () => {
 		const original = new PlatformError(ErrorCode.ServerError, "boom", {
 			details: {
 				status: 503,
@@ -229,7 +229,8 @@ describe("previewUnavailableError", () => {
 			/platform service not available for this region/,
 		);
 		expect(wrapped.message).toMatch(/request id req-503-region/);
-		expect(wrapped.message).toMatch(/public beta/);
+		expect(wrapped.message).toMatch(/currently in beta/);
+		expect(wrapped.message).toMatch(/more regions are coming shortly/);
 		expect(wrapped.message).toMatch(/aws-us-east-2/);
 		expect(wrapped.message).not.toMatch(/private preview/);
 		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
@@ -237,7 +238,7 @@ describe("previewUnavailableError", () => {
 		expect(wrapped.details.requestId).toBe("req-503-region");
 	});
 
-	test("503 with project-unavailable API body: points at aws-us-east-2 public beta", () => {
+	test("503 with project-unavailable API body: points at aws-us-east-2 beta rollout", () => {
 		const original = new PlatformError(ErrorCode.ServerError, "boom", {
 			details: {
 				status: 503,
@@ -258,7 +259,8 @@ describe("previewUnavailableError", () => {
 			/platform functions not available for this project/,
 		);
 		expect(wrapped.message).toMatch(/request id req-503/);
-		expect(wrapped.message).toMatch(/public beta/);
+		expect(wrapped.message).toMatch(/currently in beta/);
+		expect(wrapped.message).toMatch(/more regions are coming shortly/);
 		expect(wrapped.message).toMatch(/aws-us-east-2/);
 		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
 		expect(wrapped.details.status).toBe(503);
@@ -280,7 +282,7 @@ describe("previewUnavailableError", () => {
 		expect(wrapped.message).not.toMatch(/aws-us-east-2/);
 	});
 
-	test("404: points at aws-us-east-2 public beta", () => {
+	test("404: points at aws-us-east-2 beta rollout", () => {
 		const original = new PlatformError(ErrorCode.NotFound, "boom", {
 			details: { status: 404, neonMessage: "this route does not exist" },
 		});
@@ -291,7 +293,8 @@ describe("previewUnavailableError", () => {
 		if (!(wrapped instanceof PlatformError)) throw new Error("not wrapped");
 		expect(wrapped.code).toBe(ErrorCode.FeatureUnavailable);
 		expect(wrapped.message).toMatch(/HTTP 404 Not Found/);
-		expect(wrapped.message).toMatch(/public beta/);
+		expect(wrapped.message).toMatch(/currently in beta/);
+		expect(wrapped.message).toMatch(/more regions are coming shortly/);
 		expect(wrapped.message).toMatch(/aws-us-east-2/);
 		expect(wrapped.message).not.toMatch(/private preview/);
 		expect(wrapped.message).not.toMatch(/neonstatus\.com/);

--- a/packages/config/src/lib/neon-api-real.test.ts
+++ b/packages/config/src/lib/neon-api-real.test.ts
@@ -205,7 +205,39 @@ describe("isPreviewFeatureUnavailable", () => {
 });
 
 describe("previewUnavailableError", () => {
-	test("503: FeatureUnavailable with status line, API message, request id, and incident guidance", () => {
+	test("503 with region-unavailable API body: points at aws-us-east-2 public beta", () => {
+		const original = new PlatformError(ErrorCode.ServerError, "boom", {
+			details: {
+				status: 503,
+				neonMessage:
+					'platform service not available for this region; cell_id:"aws-us-east-1-cell-9"',
+				requestId: "req-503-region",
+			},
+		});
+		const wrapped = previewUnavailableError(
+			original,
+			"Object storage (buckets)",
+		);
+		expect(wrapped).toBeInstanceOf(PlatformError);
+		if (!(wrapped instanceof PlatformError)) throw new Error("not wrapped");
+		expect(wrapped.code).toBe(ErrorCode.FeatureUnavailable);
+		expect(wrapped.message).toMatch(
+			/Object storage \(buckets\) isn't available for this Neon project/,
+		);
+		expect(wrapped.message).toMatch(/HTTP 503 Service Unavailable/);
+		expect(wrapped.message).toMatch(
+			/platform service not available for this region/,
+		);
+		expect(wrapped.message).toMatch(/request id req-503-region/);
+		expect(wrapped.message).toMatch(/public beta/);
+		expect(wrapped.message).toMatch(/aws-us-east-2/);
+		expect(wrapped.message).not.toMatch(/private preview/);
+		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
+		expect(wrapped.details.status).toBe(503);
+		expect(wrapped.details.requestId).toBe("req-503-region");
+	});
+
+	test("503 with project-unavailable API body: points at aws-us-east-2 public beta", () => {
 		const original = new PlatformError(ErrorCode.ServerError, "boom", {
 			details: {
 				status: 503,
@@ -218,28 +250,37 @@ describe("previewUnavailableError", () => {
 		expect(wrapped).toBeInstanceOf(PlatformError);
 		if (!(wrapped instanceof PlatformError)) throw new Error("not wrapped");
 		expect(wrapped.code).toBe(ErrorCode.FeatureUnavailable);
-		expect(wrapped.message).toMatch(/Functions is a Preview feature/);
 		expect(wrapped.message).toMatch(
-			/isn't available for this Neon project/,
+			/Functions isn't available for this Neon project/,
 		);
-		// One short status line + the raw API message + request id (never a stack trace).
 		expect(wrapped.message).toMatch(/HTTP 503 Service Unavailable/);
 		expect(wrapped.message).toMatch(
 			/platform functions not available for this project/,
 		);
 		expect(wrapped.message).toMatch(/request id req-503/);
-		// 503 → still coming up, or a transient incident: retry / status page / support.
-		expect(wrapped.message).toMatch(/incident/);
-		expect(wrapped.message).toMatch(/neonstatus\.com/);
-		// Escape hatch + structured details for programmatic consumers.
-		expect(wrapped.message).toMatch(
-			/remove the corresponding feature from the `preview`/,
-		);
+		expect(wrapped.message).toMatch(/public beta/);
+		expect(wrapped.message).toMatch(/aws-us-east-2/);
+		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
 		expect(wrapped.details.status).toBe(503);
 		expect(wrapped.details.requestId).toBe("req-503");
 	});
 
-	test("404: points at region availability / private-preview access", () => {
+	test("503 without region signal: incident guidance", () => {
+		const original = new PlatformError(ErrorCode.ServerError, "boom", {
+			details: {
+				status: 503,
+				neonMessage: "service not available",
+				requestId: "req-503-transient",
+			},
+		});
+		const wrapped = previewUnavailableError(original, "Functions");
+		if (!(wrapped instanceof PlatformError)) throw new Error("not wrapped");
+		expect(wrapped.message).toMatch(/incident/);
+		expect(wrapped.message).toMatch(/neonstatus\.com/);
+		expect(wrapped.message).not.toMatch(/aws-us-east-2/);
+	});
+
+	test("404: points at aws-us-east-2 public beta", () => {
 		const original = new PlatformError(ErrorCode.NotFound, "boom", {
 			details: { status: 404, neonMessage: "this route does not exist" },
 		});
@@ -250,8 +291,9 @@ describe("previewUnavailableError", () => {
 		if (!(wrapped instanceof PlatformError)) throw new Error("not wrapped");
 		expect(wrapped.code).toBe(ErrorCode.FeatureUnavailable);
 		expect(wrapped.message).toMatch(/HTTP 404 Not Found/);
-		expect(wrapped.message).toMatch(/region/);
-		expect(wrapped.message).toMatch(/access to the preview/);
+		expect(wrapped.message).toMatch(/public beta/);
+		expect(wrapped.message).toMatch(/aws-us-east-2/);
+		expect(wrapped.message).not.toMatch(/private preview/);
 		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
 		expect(wrapped.details.status).toBe(404);
 	});

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1357,8 +1357,16 @@ const HTTP_STATUS_TEXT: Record<number, string> = {
 	503: "Service Unavailable",
 };
 
-/** AWS region where Neon platform features are available during the public beta. */
+/** AWS region where Neon platform features are currently available in beta. */
 const PLATFORM_BETA_REGION_ID = "aws-us-east-2";
+
+const PLATFORM_BETA_REGION_GUIDANCE =
+	"Neon platform features (Functions, object storage, and the AI Gateway) are currently in beta and only available in the AWS US East (Ohio) region " +
+	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Create a project in that region — e.g. \`neon link --org-id <org> --project-name <name> --region-id ${PLATFORM_BETA_REGION_ID}\`.`;
+
+const PLATFORM_BETA_REGION_GUIDANCE_SHORT =
+	"Neon platform features are currently in beta and only available in the AWS US East (Ohio) region " +
+	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Create a project in that region to use it.`;
 
 /**
  * True when the Neon API body indicates the feature isn't deployed for this project's
@@ -1378,8 +1386,8 @@ function isRegionUnavailableNeonMessage(
 }
 
 /**
- * Per-status guidance for a platform feature that came back "unavailable". During the
- * public beta these features roll out region by region — today only in
+ * Per-status guidance for a platform feature that came back "unavailable". These features
+ * are currently in beta and rolling out region by region — today only in
  * {@link PLATFORM_BETA_REGION_ID} — so we tailor the next step instead of emitting one
  * catch-all:
  *
@@ -1387,7 +1395,7 @@ function isRegionUnavailableNeonMessage(
  *   isn't deployed for this project's region: create a project in `aws-us-east-2`.
  * - 503 without a region-unavailable body — the route exists but is refusing right now;
  *   Neon may be having a transient incident. Retry; if it persists check neonstatus.com.
- * - anything else — point at the public-beta region requirement.
+ * - anything else — point at the beta region requirement.
  *
  * Only statuses {@link isPreviewFeatureUnavailable} accepts (404/501/503) actually reach
  * this, so there is intentionally no 401/403 branch — those never classify as "unavailable".
@@ -1401,18 +1409,12 @@ function platformFeatureUnavailableHint(
 		status === 404 ||
 		status === 501
 	) {
-		return (
-			"During the public beta, Neon platform features (Functions, object storage, and the AI Gateway) are only available in the AWS US East (Ohio) region " +
-			`(\`${PLATFORM_BETA_REGION_ID}\`). Create a project in that region — e.g. \`neon link --org-id <org> --project-name <name> --region-id ${PLATFORM_BETA_REGION_ID}\`.`
-		);
+		return PLATFORM_BETA_REGION_GUIDANCE;
 	}
 	if (status === 503) {
 		return "The endpoint is reachable but refused the request — Neon may be having a transient incident. Retry shortly; if it keeps failing, check https://neonstatus.com and contact Neon support.";
 	}
-	return (
-		"During the public beta, this feature is only available in the AWS US East (Ohio) region " +
-		`(\`${PLATFORM_BETA_REGION_ID}\`). Create a project in that region to use it.`
-	);
+	return PLATFORM_BETA_REGION_GUIDANCE_SHORT;
 }
 
 /**

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1362,11 +1362,11 @@ const PLATFORM_BETA_REGION_ID = "aws-us-east-2";
 
 const PLATFORM_BETA_REGION_GUIDANCE =
 	"Neon platform features (Functions and Object Storage) are currently in beta and only available in the AWS US East (Ohio) region " +
-	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to create a new project in that region.`;
+	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to link or create a new project in that region.`;
 
 const PLATFORM_BETA_REGION_GUIDANCE_SHORT =
 	"Neon platform features are currently in beta and only available in the AWS US East (Ohio) region " +
-	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to create a new project in that region.`;
+	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to link or create a new project in that region.`;
 
 /**
  * True when the Neon API body indicates the feature isn't deployed for this project's

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1357,43 +1357,62 @@ const HTTP_STATUS_TEXT: Record<number, string> = {
 	503: "Service Unavailable",
 };
 
+/** AWS region where Neon platform features are available during the public beta. */
+const PLATFORM_BETA_REGION_ID = "aws-us-east-2";
+
 /**
- * Per-status guidance for a Preview feature that came back "unavailable". A preview can be
- * gated several different ways and the HTTP status is the best signal for which, so we tailor
- * the next step instead of emitting one catch-all — valuable while these features are in
- * preview and rolling out region by region:
+ * True when the Neon API body indicates the feature isn't deployed for this project's
+ * region (as opposed to a transient 503 incident).
+ */
+function isRegionUnavailableNeonMessage(
+	neonMessage: string | undefined,
+): boolean {
+	if (!neonMessage) return false;
+	const lower = neonMessage.toLowerCase();
+	return (
+		lower.includes("not available for this region") ||
+		lower.includes("not available for this project") ||
+		lower.includes("platform functions not available") ||
+		lower.includes("platform service not available")
+	);
+}
+
+/**
+ * Per-status guidance for a platform feature that came back "unavailable". During the
+ * public beta these features roll out region by region — today only in
+ * {@link PLATFORM_BETA_REGION_ID} — so we tailor the next step instead of emitting one
+ * catch-all:
  *
- * - 404 / 501 — the route isn't deployed for this project's region (or the account isn't in
- *   the private preview): create a project in a region where the preview is enabled, and
- *   confirm your account has preview access.
- * - 503 — the route exists but is refusing right now: either the preview is still coming up,
- *   or Neon is having a transient incident. Retry; if it persists it's likely an incident.
- * - anything else — generic "not enabled for your account/region; request access".
+ * - 404 / 501, or an API message that names region/project unavailability — the route
+ *   isn't deployed for this project's region: create a project in `aws-us-east-2`.
+ * - 503 without a region-unavailable body — the route exists but is refusing right now;
+ *   Neon may be having a transient incident. Retry; if it persists check neonstatus.com.
+ * - anything else — point at the public-beta region requirement.
  *
  * Only statuses {@link isPreviewFeatureUnavailable} accepts (404/501/503) actually reach
  * this, so there is intentionally no 401/403 branch — those never classify as "unavailable".
  */
-function previewUnavailableHint(status: number | undefined): string {
-	switch (status) {
-		case 404:
-		case 501:
-			return (
-				"This usually means the preview isn't available in your project's region yet, or " +
-				"your Neon account isn't in the private preview: create a project in a region where " +
-				"the preview is enabled, and make sure your account has access to the preview."
-			);
-		case 503:
-			return (
-				"The endpoint is reachable but refused the request — the preview may still be " +
-				"coming up, or Neon may be having a transient incident. Retry shortly; if it keeps " +
-				"failing, check https://neonstatus.com and report it to Neon support."
-			);
-		default:
-			return (
-				"This usually means the preview isn't enabled for your Neon account or the project's " +
-				"region. Request access to the preview, or use a project in a region where it's available."
-			);
+function platformFeatureUnavailableHint(
+	status: number | undefined,
+	neonMessage: string | undefined,
+): string {
+	if (
+		isRegionUnavailableNeonMessage(neonMessage) ||
+		status === 404 ||
+		status === 501
+	) {
+		return (
+			"During the public beta, Neon platform features (Functions, object storage, and the AI Gateway) are only available in the AWS US East (Ohio) region " +
+			`(\`${PLATFORM_BETA_REGION_ID}\`). Create a project in that region — e.g. \`neon link --org-id <org> --project-name <name> --region-id ${PLATFORM_BETA_REGION_ID}\`.`
+		);
 	}
+	if (status === 503) {
+		return "The endpoint is reachable but refused the request — Neon may be having a transient incident. Retry shortly; if it keeps failing, check https://neonstatus.com and contact Neon support.";
+	}
+	return (
+		"During the public beta, this feature is only available in the AWS US East (Ohio) region " +
+		`(\`${PLATFORM_BETA_REGION_ID}\`). Create a project in that region to use it.`
+	);
 }
 
 /**
@@ -1403,8 +1422,8 @@ function previewUnavailableHint(status: number | undefined): string {
  *
  * The message names the failing feature, summarizes the response in one short
  * `HTTP <status> <reason>` line, includes the raw Neon API message + request id (valuable
- * signal while the feature is in preview), gives status-specific guidance (see
- * {@link previewUnavailableHint}), and offers removing the feature from the policy as an
+ * signal while the feature is in beta), gives status-specific guidance (see
+ * {@link platformFeatureUnavailableHint}), and offers removing the feature from the policy as an
  * escape hatch. `status`/`requestId` are also kept on `details` for programmatic consumers.
  */
 export function previewUnavailableError(
@@ -1436,8 +1455,8 @@ export function previewUnavailableError(
 	return new PlatformError(
 		ErrorCode.FeatureUnavailable,
 		[
-			`${featureLabel} is a Preview feature and isn't available for this Neon project${apiContext}.`,
-			previewUnavailableHint(status),
+			`${featureLabel} isn't available for this Neon project${apiContext}.`,
+			platformFeatureUnavailableHint(status, neonMessage),
 			"If you don't need it, remove the corresponding feature from the `preview` block of your neon.ts and re-run.",
 		].join(" "),
 		{

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1361,12 +1361,12 @@ const HTTP_STATUS_TEXT: Record<number, string> = {
 const PLATFORM_BETA_REGION_ID = "aws-us-east-2";
 
 const PLATFORM_BETA_REGION_GUIDANCE =
-	"Neon platform features (Functions, Object Storage, and AI Gateway) are currently in beta and only available in the AWS US East (Ohio) region " +
-	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Create a project in that region — e.g. \`neon link --org-id <org> --project-name <name> --region-id ${PLATFORM_BETA_REGION_ID}\`.`;
+	"Neon platform features (Functions and Object Storage) are currently in beta and only available in the AWS US East (Ohio) region " +
+	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to create a new project in that region.`;
 
 const PLATFORM_BETA_REGION_GUIDANCE_SHORT =
 	"Neon platform features are currently in beta and only available in the AWS US East (Ohio) region " +
-	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Create a project in that region to use it.`;
+	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to create a new project in that region.`;
 
 /**
  * True when the Neon API body indicates the feature isn't deployed for this project's

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1361,7 +1361,7 @@ const HTTP_STATUS_TEXT: Record<number, string> = {
 const PLATFORM_BETA_REGION_ID = "aws-us-east-2";
 
 const PLATFORM_BETA_REGION_GUIDANCE =
-	"Neon platform features (Functions, object storage, and the AI Gateway) are currently in beta and only available in the AWS US East (Ohio) region " +
+	"Neon platform features (Functions, Object Storage, and AI Gateway) are currently in beta and only available in the AWS US East (Ohio) region " +
 	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Create a project in that region — e.g. \`neon link --org-id <org> --project-name <name> --region-id ${PLATFORM_BETA_REGION_ID}\`.`;
 
 const PLATFORM_BETA_REGION_GUIDANCE_SHORT =

--- a/packages/init/src/lib/phases/getting-started.ts
+++ b/packages/init/src/lib/phases/getting-started.ts
@@ -33,7 +33,7 @@ export async function handleGettingStartedPhase(
 
 	if (!options.hasConnectionString) {
 		if (options.preview) {
-			// Preview mode: new project in AWS us-east-2, or existing eligible project
+			// Public beta: platform features are only in AWS us-east-2 for now
 			steps.push(
 				{
 					id: "select_org",
@@ -49,7 +49,7 @@ export async function handleGettingStartedPhase(
 					id: "select_or_create_project",
 					description: [
 						"List existing Neon projects in the selected organization using the CLI command below (replace <org-id> with the selected org ID).",
-						"IMPORTANT: Preview features require a project in the AWS us-east-2 region created on or after 2026-06-15.",
+						"IMPORTANT: During the public beta, Neon platform features (Functions, object storage, AI Gateway) require a project in the AWS us-east-2 region created on or after 2026-06-15.",
 						"Filter the project list to ONLY show projects where region_id is 'aws-us-east-2' AND created_at is on or after '2026-06-15'.",
 						"If eligible projects exist, present them alongside a 'Create new project' option.",
 						"If no eligible projects exist, tell the user and proceed directly to creating a new one.",

--- a/packages/init/src/lib/phases/getting-started.ts
+++ b/packages/init/src/lib/phases/getting-started.ts
@@ -49,7 +49,7 @@ export async function handleGettingStartedPhase(
 					id: "select_or_create_project",
 					description: [
 						"List existing Neon projects in the selected organization using the CLI command below (replace <org-id> with the selected org ID).",
-						"IMPORTANT: Neon platform features (Functions, object storage, AI Gateway) are currently in beta and only available in the AWS us-east-2 region (more regions coming shortly). Projects must have region_id 'aws-us-east-2' and be created on or after 2026-06-15.",
+						"IMPORTANT: Neon platform features (Functions, Object Storage, and AI Gateway) are currently in beta and only available in the AWS us-east-2 region (more regions coming shortly). Projects must have region_id 'aws-us-east-2' and be created on or after 2026-06-15.",
 						"Filter the project list to ONLY show projects where region_id is 'aws-us-east-2' AND created_at is on or after '2026-06-15'.",
 						"If eligible projects exist, present them alongside a 'Create new project' option.",
 						"If no eligible projects exist, tell the user and proceed directly to creating a new one.",

--- a/packages/init/src/lib/phases/getting-started.ts
+++ b/packages/init/src/lib/phases/getting-started.ts
@@ -49,7 +49,7 @@ export async function handleGettingStartedPhase(
 					id: "select_or_create_project",
 					description: [
 						"List existing Neon projects in the selected organization using the CLI command below (replace <org-id> with the selected org ID).",
-						"IMPORTANT: During the public beta, Neon platform features (Functions, object storage, AI Gateway) require a project in the AWS us-east-2 region created on or after 2026-06-15.",
+						"IMPORTANT: Neon platform features (Functions, object storage, AI Gateway) are currently in beta and only available in the AWS us-east-2 region (more regions coming shortly). Projects must have region_id 'aws-us-east-2' and be created on or after 2026-06-15.",
 						"Filter the project list to ONLY show projects where region_id is 'aws-us-east-2' AND created_at is on or after '2026-06-15'.",
 						"If eligible projects exist, present them alongside a 'Create new project' option.",
 						"If no eligible projects exist, tell the user and proceed directly to creating a new one.",


### PR DESCRIPTION
## Summary

Updates the "feature unavailable" errors from `neon config plan` / `neon deploy` (and `env pull`) when a `neon.ts` declares a platform feature outside the beta region.

- Drops outdated **"Preview feature" / "private preview"** copy; says features are **currently in beta**, only in **`aws-us-east-2`** (AWS US East / Ohio), with **more regions coming shortly**.
- Treats Neon API bodies that say a feature is unavailable for the project/region (e.g. `"platform service not available for this region"`) as a **region gate** even on HTTP 503, instead of misclassifying it as a transient incident that points at neonstatus.com.
- Points users at plain **`neon link`** (interactive: creates a project and defaults the region to `aws-us-east-2`) rather than a long flag form.
- Lists only the features that actually produce this error — **Functions and Object Storage**. The AI Gateway is credential-gated with no control-plane route, so `previewUnavailableError` is never thrown for it (verified via smoke test: AI Gateway `plan` succeeds in us-east-1; only `deploy` is Free-plan gated).
- `neon-init` getting-started prompts use the same "currently in beta / us-east-2 / more regions soon" wording.

## Verified against smoke test (us-east-1 project, smoke org)

| Feature | plan/deploy status | Neon API message |
|---|---|---|
| Functions | HTTP 404 | `platform functions not available for this project` |
| Object Storage | HTTP 503 | `platform service not available for this region` |
| AI Gateway | plan OK; deploy blocked by Free plan | (no region error) |

### Before (functions, us-east-1)

```
Functions is a Preview feature and isn't available for this Neon project (HTTP 404 …). This usually means the preview isn't available in your project's region yet, or your Neon account isn't in the private preview…
```

### After

```
Functions isn't available for this Neon project (HTTP 404 …). Neon platform features (Functions and Object Storage) are currently in beta and only available in the AWS US East (Ohio) region (`aws-us-east-2`); more regions are coming shortly. Run `neon link` to create a new project in that region. If you don't need it, remove the corresponding feature from the `preview` block of your neon.ts and re-run.
```

## Test plan

- [x] `bunx vitest run src/lib/neon-api-real.test.ts` in `packages/config` (22 passing)
- [ ] Manual: `neon config plan` / `neon deploy` on a non–`aws-us-east-2` project with `preview.functions` / `preview.buckets` — shows beta + `aws-us-east-2` guidance and `neon link` (no private-preview / neonstatus.com copy for region-gated 503s)