### PR TITLE
chore: sync lockfile for neon-init@0.20.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.20.1
-        version: 0.20.1
+        specifier: 0.20.2
+        version: 0.20.2
       open:
         specifier: ^10.2.0
         version: 10.2.0
@@ -3248,8 +3248,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.20.1:
-    resolution: {integrity: sha512-m7zQg5+Y7WQiCU6hcDv+BjGVwV2xlLagxehjQzZ+tQkLYmwZsIqrv2cdsMa4CAo4mAcM6ukfOidvWCMHBpWqaQ==}
+  neon-init@0.20.2:
+    resolution: {integrity: sha512-iaY/+UjVxejVpgXhLoaqOi6OBR3zZanEfCrtyc00QaOafE0BAj9qx7GBDo+XQ/VnJjQkxz5faV250CvFUQKBtg==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -6978,7 +6978,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.20.1:
+  neon-init@0.20.2:
     dependencies:
       '@clack/core': 0.4.2
       '@clack/prompts': 0.10.1


### PR DESCRIPTION
Syncs pnpm-lock.yaml to neon-init@0.20.2 (published to npm) after the release bump in #302. Unblocks frozen-lockfile install for the publish workflow and CI.