### PR TITLE
chore: release pending changesets

### DIFF
--- a/.changeset/ai-gateway-enabled-models-notice.md
+++ b/.changeset/ai-gateway-enabled-models-notice.md
@@ -1,8 +1,0 @@
----
-"neonctl": patch
----
-
-Fix AI Gateway "reduced model set" notices to consider only models with
-`enabled: true` from `/v1/models`. The gateway lists the full catalog but marks
-models the account cannot serve yet as `enabled: false`; previously the notice
-checked every listed id and could miss accounts on a trimmed catalog.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # neonctl
 
+## 2.33.2
+
+### Patch Changes
+
+- 6b415c7: Fix AI Gateway "reduced model set" notices to consider only models with
+  `enabled: true` from `/v1/models`. The gateway lists the full catalog but marks
+  models the account cannot serve yet as `enabled: false`; previously the notice
+  checked every listed id and could miss accounts on a trimmed catalog.
+
 ## 2.33.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.33.1",
+  "version": "2.33.2",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Summary

- **neonctl**: 2.33.1 → 2.33.2 (patch)
  - Fix AI Gateway "reduced model set" notices to consider only models with `enabled: true` from `/v1/models` (#304)

## Publish backlog (after merge)

| Package | npm | main (after merge) |
|---------|-----|-------------------|
| neonctl | 2.33.1 | 2.33.2 |

No `neon-init` bump — lockfile sync not required.

## Test plan

- [x] `pnpm changeset version`
- [x] `pnpm lint:ci`