### PR TITLE
fix(neonctl): include context in error telemetry

### DIFF
--- a/.changeset/clear-telemetry-context.md
+++ b/.changeset/clear-telemetry-context.md
@@ -2,4 +2,4 @@
 "neonctl": patch
 ---
 
-Include the command and CLI version in error analytics events so failures can be investigated and prioritized accurately.
+Include the CLI version and CI context in error analytics events so failures can be investigated and prioritized accurately.

--- a/.changeset/clear-telemetry-context.md
+++ b/.changeset/clear-telemetry-context.md
@@ -1,0 +1,5 @@
+---
+"neonctl": patch
+---
+
+Include the command and CLI version in error analytics events so failures can be investigated and prioritized accurately.

--- a/packages/cli/src/analytics.test.ts
+++ b/packages/cli/src/analytics.test.ts
@@ -1,32 +1,26 @@
 import { describe, expect, it } from "vitest";
 
 import {
-	getAnalyticsCommand,
-	getAnalyticsErrorKind,
 	getAnalyticsEventProperties,
 	getErrorAnalyticsEventProperties,
 } from "./analytics.js";
 
 describe("getErrorAnalyticsEventProperties", () => {
-	it("preserves the command context captured before CLI execution fails", () => {
-		const context = getAnalyticsEventProperties({
-			_: ["branches", "create"],
-			output: "json",
-		});
-
+	it("adds version and CI context while preserving error diagnostics", () => {
 		const properties = getErrorAnalyticsEventProperties(
 			new Error("branch already exists"),
 			"API_ERROR",
-			context,
+			{
+				version: "2.33.2",
+				ci: true,
+			},
 		);
 
 		expect(properties).toMatchObject({
-			command: "branches create",
-			flags: { output: "json" },
+			ci: true,
 			errCode: "API_ERROR",
 			message: "branch already exists",
-			reason: "resource_conflict",
-			version: expect.any(String),
+			version: "2.33.2",
 		});
 	});
 
@@ -39,9 +33,7 @@ describe("getErrorAnalyticsEventProperties", () => {
 		expect(properties).toMatchObject({
 			errCode: "UNKNOWN_ERROR",
 			message: "configuration directory is unavailable",
-			reason: "unknown_error",
 		});
-		expect(properties).not.toHaveProperty("command");
 	});
 
 	it("preserves the existing raw error diagnostics", () => {
@@ -51,53 +43,12 @@ describe("getErrorAnalyticsEventProperties", () => {
 			"UNKNOWN_ERROR",
 		);
 
-		expect(properties.reason).toBe("unknown_error");
 		expect(properties.message).toBe(error.message);
 		expect(properties.stack).toBe(error.stack);
 	});
 });
 
-describe("analytics allowlist", () => {
-	it("keeps only known command roots", () => {
-		expect(
-			getAnalyticsCommand(["branches", "create", "feature-branch"]),
-		).toBe("branches");
-		expect(
-			getAnalyticsCommand([
-				"psql",
-				"postgresql://user:password@host/neondb?sslmode=require",
-			]),
-		).toBe("psql");
-		expect(getAnalyticsCommand(["unrecognized-command"])).toBe("unknown");
-	});
-
-	it("classifies known errors without retaining their message", () => {
-		expect(
-			getAnalyticsErrorKind(
-				"Branch production not found",
-				"UNKNOWN_ERROR",
-				undefined,
-			),
-		).toBe("resource_not_found");
-		expect(
-			getAnalyticsErrorKind("branch already exists", "API_ERROR", 409),
-		).toBe("resource_conflict");
-		expect(
-			getAnalyticsErrorKind(
-				"Authentication timed out after 60 seconds",
-				"UNKNOWN_ERROR",
-				undefined,
-			),
-		).toBe("authentication_timeout");
-		expect(
-			getAnalyticsErrorKind(
-				"Unknown commands: endpoints, list",
-				"UNKNOWN_ERROR",
-				undefined,
-			),
-		).toBe("unknown_command");
-	});
-
+describe("getAnalyticsEventProperties", () => {
 	it("continues to preserve the existing output value", () => {
 		expect(
 			getAnalyticsEventProperties({

--- a/packages/cli/src/analytics.test.ts
+++ b/packages/cli/src/analytics.test.ts
@@ -24,7 +24,7 @@ describe("getErrorAnalyticsEventProperties", () => {
 			command: "branches",
 			flags: { output: "json" },
 			errCode: "API_ERROR",
-			errorKind: "resource_conflict",
+			reason: "resource_conflict",
 			version: expect.any(String),
 		});
 	});
@@ -37,7 +37,7 @@ describe("getErrorAnalyticsEventProperties", () => {
 
 		expect(properties).toMatchObject({
 			errCode: "UNKNOWN_ERROR",
-			errorKind: "unknown_error",
+			reason: "unknown_error",
 		});
 		expect(properties).not.toHaveProperty("command");
 	});
@@ -50,7 +50,7 @@ describe("getErrorAnalyticsEventProperties", () => {
 			"UNKNOWN_ERROR",
 		);
 
-		expect(properties.errorKind).toBe("unknown_error");
+		expect(properties.reason).toBe("unknown_error");
 		expect(properties).not.toHaveProperty("message");
 		expect(properties).not.toHaveProperty("stack");
 		expect(JSON.stringify(properties)).not.toContain(databaseUrl);

--- a/packages/cli/src/analytics.test.ts
+++ b/packages/cli/src/analytics.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
 	getAnalyticsEventProperties,
 	getErrorAnalyticsEventProperties,
+	redactAnalyticsText,
 } from "./analytics.js";
 
 describe("getErrorAnalyticsEventProperties", () => {
@@ -38,5 +39,31 @@ describe("getErrorAnalyticsEventProperties", () => {
 			message: "configuration directory is unavailable",
 		});
 		expect(properties).not.toHaveProperty("command");
+	});
+
+	it("does not send a database URL or stack trace", () => {
+		const databaseUrl =
+			"postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neondb?sslmode=require";
+		const properties = getErrorAnalyticsEventProperties(
+			new Error(`Could not connect to ${databaseUrl}`),
+			"UNKNOWN_ERROR",
+		);
+
+		expect(properties.message).toBe(
+			"Could not connect to [REDACTED_DATABASE_URL]",
+		);
+		expect(properties).not.toHaveProperty("stack");
+		expect(JSON.stringify(properties)).not.toContain(databaseUrl);
+	});
+});
+
+describe("redactAnalyticsText", () => {
+	it("redacts database URLs and credential values from command telemetry", () => {
+		const value =
+			"psql postgresql://user:password@host/neondb?sslmode=require token=secret-token";
+
+		expect(redactAnalyticsText(value)).toBe(
+			"psql [REDACTED_DATABASE_URL] token=[REDACTED]",
+		);
 	});
 });

--- a/packages/cli/src/analytics.test.ts
+++ b/packages/cli/src/analytics.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	getAnalyticsCommand,
+	getAnalyticsErrorKind,
 	getAnalyticsEventProperties,
 	getErrorAnalyticsEventProperties,
-	redactAnalyticsText,
 } from "./analytics.js";
 
 describe("getErrorAnalyticsEventProperties", () => {
@@ -20,10 +21,10 @@ describe("getErrorAnalyticsEventProperties", () => {
 		);
 
 		expect(properties).toMatchObject({
-			command: "branches create",
+			command: "branches",
 			flags: { output: "json" },
 			errCode: "API_ERROR",
-			message: "branch already exists",
+			errorKind: "resource_conflict",
 			version: expect.any(String),
 		});
 	});
@@ -36,12 +37,12 @@ describe("getErrorAnalyticsEventProperties", () => {
 
 		expect(properties).toMatchObject({
 			errCode: "UNKNOWN_ERROR",
-			message: "configuration directory is unavailable",
+			errorKind: "unknown_error",
 		});
 		expect(properties).not.toHaveProperty("command");
 	});
 
-	it("does not send a database URL or stack trace", () => {
+	it("does not send a database URL, error message, or stack trace", () => {
 		const databaseUrl =
 			"postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neondb?sslmode=require";
 		const properties = getErrorAnalyticsEventProperties(
@@ -49,21 +50,66 @@ describe("getErrorAnalyticsEventProperties", () => {
 			"UNKNOWN_ERROR",
 		);
 
-		expect(properties.message).toBe(
-			"Could not connect to [REDACTED_DATABASE_URL]",
-		);
+		expect(properties.errorKind).toBe("unknown_error");
+		expect(properties).not.toHaveProperty("message");
 		expect(properties).not.toHaveProperty("stack");
 		expect(JSON.stringify(properties)).not.toContain(databaseUrl);
 	});
 });
 
-describe("redactAnalyticsText", () => {
-	it("redacts database URLs and credential values from command telemetry", () => {
-		const value =
-			"psql postgresql://user:password@host/neondb?sslmode=require token=secret-token";
+describe("analytics allowlist", () => {
+	it("keeps only known command roots", () => {
+		expect(
+			getAnalyticsCommand(["branches", "create", "feature-branch"]),
+		).toBe("branches");
+		expect(
+			getAnalyticsCommand([
+				"psql",
+				"postgresql://user:password@host/neondb?sslmode=require",
+			]),
+		).toBe("psql");
+		expect(getAnalyticsCommand(["unrecognized-command"])).toBe("unknown");
+	});
 
-		expect(redactAnalyticsText(value)).toBe(
-			"psql [REDACTED_DATABASE_URL] token=[REDACTED]",
-		);
+	it("classifies known errors without retaining their message", () => {
+		expect(
+			getAnalyticsErrorKind(
+				"Branch production not found",
+				"UNKNOWN_ERROR",
+				undefined,
+			),
+		).toBe("resource_not_found");
+		expect(
+			getAnalyticsErrorKind("branch already exists", "API_ERROR", 409),
+		).toBe("resource_conflict");
+		expect(
+			getAnalyticsErrorKind(
+				"Authentication timed out after 60 seconds",
+				"UNKNOWN_ERROR",
+				undefined,
+			),
+		).toBe("authentication_timeout");
+		expect(
+			getAnalyticsErrorKind(
+				"Unknown commands: endpoints, list",
+				"UNKNOWN_ERROR",
+				undefined,
+			),
+		).toBe("unknown_command");
+	});
+
+	it("does not preserve an invalid output value", () => {
+		expect(
+			getAnalyticsEventProperties({
+				_: ["branches", "list"],
+				output: "secret-value",
+			}).flags.output,
+		).toBeUndefined();
+		expect(
+			getAnalyticsEventProperties({
+				_: ["branches", "list"],
+				output: "yaml",
+			}).flags.output,
+		).toBe("yaml");
 	});
 });

--- a/packages/cli/src/analytics.test.ts
+++ b/packages/cli/src/analytics.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	getAnalyticsEventProperties,
+	getErrorAnalyticsEventProperties,
+} from "./analytics.js";
+
+describe("getErrorAnalyticsEventProperties", () => {
+	it("preserves the command context captured before CLI execution fails", () => {
+		const context = getAnalyticsEventProperties({
+			_: ["branches", "create"],
+			output: "json",
+		});
+
+		const properties = getErrorAnalyticsEventProperties(
+			new Error("branch already exists"),
+			"API_ERROR",
+			context,
+		);
+
+		expect(properties).toMatchObject({
+			command: "branches create",
+			flags: { output: "json" },
+			errCode: "API_ERROR",
+			message: "branch already exists",
+			version: expect.any(String),
+		});
+	});
+
+	it("still reports errors that happen before command context is available", () => {
+		const properties = getErrorAnalyticsEventProperties(
+			new Error("configuration directory is unavailable"),
+			"UNKNOWN_ERROR",
+		);
+
+		expect(properties).toMatchObject({
+			errCode: "UNKNOWN_ERROR",
+			message: "configuration directory is unavailable",
+		});
+		expect(properties).not.toHaveProperty("command");
+	});
+});

--- a/packages/cli/src/analytics.test.ts
+++ b/packages/cli/src/analytics.test.ts
@@ -21,9 +21,10 @@ describe("getErrorAnalyticsEventProperties", () => {
 		);
 
 		expect(properties).toMatchObject({
-			command: "branches",
+			command: "branches create",
 			flags: { output: "json" },
 			errCode: "API_ERROR",
+			message: "branch already exists",
 			reason: "resource_conflict",
 			version: expect.any(String),
 		});
@@ -37,23 +38,22 @@ describe("getErrorAnalyticsEventProperties", () => {
 
 		expect(properties).toMatchObject({
 			errCode: "UNKNOWN_ERROR",
+			message: "configuration directory is unavailable",
 			reason: "unknown_error",
 		});
 		expect(properties).not.toHaveProperty("command");
 	});
 
-	it("does not send a database URL, error message, or stack trace", () => {
-		const databaseUrl =
-			"postgresql://user:password@ep-example.us-east-2.aws.neon.tech/neondb?sslmode=require";
+	it("preserves the existing raw error diagnostics", () => {
+		const error = new Error("Could not connect to the database");
 		const properties = getErrorAnalyticsEventProperties(
-			new Error(`Could not connect to ${databaseUrl}`),
+			error,
 			"UNKNOWN_ERROR",
 		);
 
 		expect(properties.reason).toBe("unknown_error");
-		expect(properties).not.toHaveProperty("message");
-		expect(properties).not.toHaveProperty("stack");
-		expect(JSON.stringify(properties)).not.toContain(databaseUrl);
+		expect(properties.message).toBe(error.message);
+		expect(properties.stack).toBe(error.stack);
 	});
 });
 
@@ -98,18 +98,12 @@ describe("analytics allowlist", () => {
 		).toBe("unknown_command");
 	});
 
-	it("does not preserve an invalid output value", () => {
+	it("continues to preserve the existing output value", () => {
 		expect(
 			getAnalyticsEventProperties({
 				_: ["branches", "list"],
 				output: "secret-value",
 			}).flags.output,
-		).toBeUndefined();
-		expect(
-			getAnalyticsEventProperties({
-				_: ["branches", "list"],
-				output: "yaml",
-			}).flags.output,
-		).toBe("yaml");
+		).toBe("secret-value");
 	});
 });

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -20,10 +20,41 @@ const WRITE_KEY = "3SQXn5ejjXWLEJ8xU2PRYhAotLtTaeeV";
 const hasCurrentBranchArgv = (): boolean =>
 	process.argv.includes("--current-branch");
 
-const DATABASE_URL_PATTERN = /\b(?:jdbc:)?postgres(?:ql)?:\/\/[^\s"'`\\]+/gi;
-const AUTHORIZATION_VALUE_PATTERN =
-	/\b(authorization|api[_-]?key|password|token)\s*([=:])\s*[^\s,;]+/gi;
-const BEARER_TOKEN_PATTERN = /\bBearer\s+[^\s,;]+/gi;
+const KNOWN_COMMAND_ROOTS = new Set([
+	"api",
+	"auth",
+	"bootstrap",
+	"branches",
+	"bucket",
+	"checkout",
+	"config",
+	"connection-string",
+	"cs",
+	"data-api",
+	"databases",
+	"deploy",
+	"dev",
+	"diff",
+	"env",
+	"functions",
+	"init",
+	"ip-allow",
+	"link",
+	"login",
+	"me",
+	"neon-auth",
+	"operations",
+	"orgs",
+	"projects",
+	"psql",
+	"roles",
+	"set-context",
+	"status",
+	"users",
+	"vpc-endpoints",
+]);
+
+const OUTPUT_FORMATS = new Set(["json", "table", "yaml"]);
 
 let client: Analytics | undefined;
 let clientInitialized = false;
@@ -45,6 +76,19 @@ type AnalyticsEventProperties = {
 	ci: boolean;
 	githubEnvVars: ReturnType<typeof getGithubEnvVars>;
 };
+
+type AnalyticsErrorKind =
+	| "ambiguous_target"
+	| "authentication_failed"
+	| "authentication_timeout"
+	| "invalid_request"
+	| "missing_argument"
+	| "network_failure"
+	| "resource_conflict"
+	| "resource_not_found"
+	| "request_timeout"
+	| "unknown_command"
+	| "unknown_error";
 
 /**
  * Phase 1: Run before validation so the Segment client exists if any
@@ -167,8 +211,12 @@ export const getErrorAnalyticsEventProperties = (
 
 	return {
 		...context,
-		message: redactAnalyticsText(err.message),
 		errCode,
+		errorKind: getAnalyticsErrorKind(
+			err.message,
+			errCode,
+			apiError?.status,
+		),
 		statusCode: apiError?.status,
 		requestId,
 	};
@@ -210,19 +258,75 @@ export const trackEvent = (
 	log.debug("Sent CLI event: %s", event);
 };
 
-export const redactAnalyticsText = (value: string): string =>
-	value
-		.replace(DATABASE_URL_PATTERN, "[REDACTED_DATABASE_URL]")
-		.replace(AUTHORIZATION_VALUE_PATTERN, "$1$2[REDACTED]")
-		.replace(BEARER_TOKEN_PATTERN, "Bearer [REDACTED]");
+export const getAnalyticsCommand = (
+	commandParts: (string | number)[],
+): string => {
+	const root = commandParts[0];
+	return typeof root === "string" && KNOWN_COMMAND_ROOTS.has(root)
+		? root
+		: "unknown";
+};
+
+export const getAnalyticsOutputFormat = (
+	output: string | undefined,
+): string | undefined =>
+	output && OUTPUT_FORMATS.has(output) ? output : undefined;
+
+export const getAnalyticsErrorKind = (
+	message: string,
+	errCode: ErrorCode,
+	statusCode: number | undefined,
+): AnalyticsErrorKind => {
+	if (/^Unknown commands?:/i.test(message) || errCode === "UNKNOWN_COMMAND") {
+		return "unknown_command";
+	}
+	if (
+		/^Missing required argument:/i.test(message) ||
+		errCode === "MISSING_ARGUMENT"
+	) {
+		return "missing_argument";
+	}
+	if (/Authentication timed out/i.test(message)) {
+		return "authentication_timeout";
+	}
+	if (
+		errCode === "AUTH_FAILED" ||
+		errCode === "AUTH_BROWSER_FAILED" ||
+		statusCode === 401
+	) {
+		return "authentication_failed";
+	}
+	if (errCode === "NETWORK_ERROR") {
+		return "network_failure";
+	}
+	if (errCode === "REQUEST_TIMEOUT" || statusCode === 408) {
+		return "request_timeout";
+	}
+	if (
+		statusCode === 404 ||
+		/(?:branch|project|resource) .+ not found/i.test(message)
+	) {
+		return "resource_not_found";
+	}
+	if (statusCode === 409 || /already exists|limit exceeded/i.test(message)) {
+		return "resource_conflict";
+	}
+	if (statusCode === 400 || statusCode === 422) {
+		return "invalid_request";
+	}
+	if (/^Multiple (?:projects|roles) found/i.test(message)) {
+		return "ambiguous_target";
+	}
+	return "unknown_error";
+};
 
 export const getAnalyticsEventProperties = (
 	args: AnalyticsEventArgs,
 ): AnalyticsEventProperties => ({
 	version: pkg.version,
-	command: redactAnalyticsText(args._.join(" ")),
+	command: getAnalyticsCommand(args._),
 	flags: {
-		output: args.output,
+		output: getAnalyticsOutputFormat(args.output),
 	},
 	ci: isCi(),
 	githubEnvVars: getGithubEnvVars(process.env),

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -20,44 +20,10 @@ const WRITE_KEY = "3SQXn5ejjXWLEJ8xU2PRYhAotLtTaeeV";
 const hasCurrentBranchArgv = (): boolean =>
 	process.argv.includes("--current-branch");
 
-const KNOWN_COMMAND_ROOTS = new Set([
-	"api",
-	"auth",
-	"bootstrap",
-	"branches",
-	"bucket",
-	"checkout",
-	"config",
-	"connection-string",
-	"cs",
-	"data-api",
-	"databases",
-	"deploy",
-	"dev",
-	"diff",
-	"env",
-	"functions",
-	"init",
-	"ip-allow",
-	"link",
-	"login",
-	"me",
-	"neon-auth",
-	"operations",
-	"orgs",
-	"projects",
-	"psql",
-	"roles",
-	"set-context",
-	"status",
-	"users",
-	"vpc-endpoints",
-]);
-
 let client: Analytics | undefined;
 let clientInitialized = false;
 let userId = "";
-let errorEventContext: AnalyticsEventProperties | undefined;
+let errorEventContext: ErrorEventContext | undefined;
 
 type AnalyticsEventArgs = {
 	_: (string | number)[];
@@ -75,18 +41,10 @@ type AnalyticsEventProperties = {
 	githubEnvVars: ReturnType<typeof getGithubEnvVars>;
 };
 
-type AnalyticsErrorKind =
-	| "ambiguous_target"
-	| "authentication_failed"
-	| "authentication_timeout"
-	| "invalid_request"
-	| "missing_argument"
-	| "network_failure"
-	| "resource_conflict"
-	| "resource_not_found"
-	| "request_timeout"
-	| "unknown_command"
-	| "unknown_error";
+type ErrorEventContext = {
+	version: string;
+	ci: boolean;
+};
 
 /**
  * Phase 1: Run before validation so the Segment client exists if any
@@ -202,7 +160,7 @@ export const closeAnalytics = async (opts?: { timeout?: number }) => {
 export const getErrorAnalyticsEventProperties = (
 	err: Error,
 	errCode: ErrorCode,
-	context?: AnalyticsEventProperties,
+	context?: ErrorEventContext,
 ) => {
 	const apiError = isNeonApiError(err) ? err : undefined;
 	const requestId = apiError?.headers?.["x-neon-ret-request-id"];
@@ -212,7 +170,6 @@ export const getErrorAnalyticsEventProperties = (
 		message: err.message,
 		stack: err.stack,
 		errCode,
-		reason: getAnalyticsErrorKind(err.message, errCode, apiError?.status),
 		statusCode: apiError?.status,
 		requestId,
 	};
@@ -254,74 +211,12 @@ export const trackEvent = (
 	log.debug("Sent CLI event: %s", event);
 };
 
-export const getAnalyticsCommand = (
-	commandParts: (string | number)[],
-): string => {
-	const root = commandParts[0];
-	return typeof root === "string" && KNOWN_COMMAND_ROOTS.has(root)
-		? root
-		: "unknown";
-};
-
 const getErrorAnalyticsEventContext = (
-	args: AnalyticsEventArgs,
-): AnalyticsEventProperties => ({
+	_args: AnalyticsEventArgs,
+): ErrorEventContext => ({
 	version: pkg.version,
-	command: getAnalyticsCommand(args._),
-	flags: {
-		output: args.output,
-	},
 	ci: isCi(),
-	githubEnvVars: getGithubEnvVars(process.env),
 });
-
-export const getAnalyticsErrorKind = (
-	message: string,
-	errCode: ErrorCode,
-	statusCode: number | undefined,
-): AnalyticsErrorKind => {
-	if (/^Unknown commands?:/i.test(message) || errCode === "UNKNOWN_COMMAND") {
-		return "unknown_command";
-	}
-	if (
-		/^Missing required argument:/i.test(message) ||
-		errCode === "MISSING_ARGUMENT"
-	) {
-		return "missing_argument";
-	}
-	if (/Authentication timed out/i.test(message)) {
-		return "authentication_timeout";
-	}
-	if (
-		errCode === "AUTH_FAILED" ||
-		errCode === "AUTH_BROWSER_FAILED" ||
-		statusCode === 401
-	) {
-		return "authentication_failed";
-	}
-	if (errCode === "NETWORK_ERROR") {
-		return "network_failure";
-	}
-	if (errCode === "REQUEST_TIMEOUT" || statusCode === 408) {
-		return "request_timeout";
-	}
-	if (
-		statusCode === 404 ||
-		/(?:branch|project|resource) .+ not found/i.test(message)
-	) {
-		return "resource_not_found";
-	}
-	if (statusCode === 409 || /already exists|limit exceeded/i.test(message)) {
-		return "resource_conflict";
-	}
-	if (statusCode === 400 || statusCode === 422) {
-		return "invalid_request";
-	}
-	if (/^Multiple (?:projects|roles) found/i.test(message)) {
-		return "ambiguous_target";
-	}
-	return "unknown_error";
-};
 
 export const getAnalyticsEventProperties = (
 	args: AnalyticsEventArgs,

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -212,11 +212,7 @@ export const getErrorAnalyticsEventProperties = (
 	return {
 		...context,
 		errCode,
-		errorKind: getAnalyticsErrorKind(
-			err.message,
-			errCode,
-			apiError?.status,
-		),
+		reason: getAnalyticsErrorKind(err.message, errCode, apiError?.status),
 		statusCode: apiError?.status,
 		requestId,
 	};

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -23,16 +23,31 @@ const hasCurrentBranchArgv = (): boolean =>
 let client: Analytics | undefined;
 let clientInitialized = false;
 let userId = "";
+let errorEventContext: AnalyticsEventProperties | undefined;
+
+type AnalyticsEventArgs = {
+	_: (string | number)[];
+	output?: string;
+};
+
+type AnalyticsEventProperties = {
+	version: string;
+	command: string;
+	flags: {
+		output: string | undefined;
+	};
+	ci: boolean;
+	githubEnvVars: ReturnType<typeof getGithubEnvVars>;
+};
 
 /**
  * Phase 1: Run before validation so the Segment client exists if any
  * middleware (e.g. auth) fails. Enables sendError() in the fail handler.
  * Does not resolve user id or send CLI Started.
  */
-export const initAnalyticsClientMiddleware = (args: {
-	analytics: boolean;
-	[key: string]: unknown;
-}) => {
+export const initAnalyticsClientMiddleware = (
+	args: AnalyticsEventArgs & { analytics: boolean },
+) => {
 	if (!args.analytics || clientInitialized) {
 		return;
 	}
@@ -44,6 +59,7 @@ export const initAnalyticsClientMiddleware = (args: {
 		return;
 	}
 	clientInitialized = true;
+	errorEventContext = getAnalyticsEventProperties(args);
 	client = new Analytics({
 		writeKey: WRITE_KEY,
 		host: "https://track.neon.tech",
@@ -135,6 +151,24 @@ export const closeAnalytics = async (opts?: { timeout?: number }) => {
 	}
 };
 
+export const getErrorAnalyticsEventProperties = (
+	err: Error,
+	errCode: ErrorCode,
+	context?: AnalyticsEventProperties,
+) => {
+	const apiError = isNeonApiError(err) ? err : undefined;
+	const requestId = apiError?.headers?.["x-neon-ret-request-id"];
+
+	return {
+		...context,
+		message: err.message,
+		stack: err.stack,
+		errCode,
+		statusCode: apiError?.status,
+		requestId,
+	};
+};
+
 export const sendError = (err: Error, errCode: ErrorCode) => {
 	if (!client) {
 		return;
@@ -147,13 +181,11 @@ export const sendError = (err: Error, errCode: ErrorCode) => {
 	client.track({
 		event: "CLI Error",
 		userId: userId || "anonymous",
-		properties: {
-			message: err.message,
-			stack: err.stack,
+		properties: getErrorAnalyticsEventProperties(
+			err,
 			errCode,
-			statusCode: apiError?.status,
-			requestId: requestId,
-		},
+			errorEventContext,
+		),
 	});
 	log.debug("Sent CLI error event: %s", errCode);
 };
@@ -173,7 +205,9 @@ export const trackEvent = (
 	log.debug("Sent CLI event: %s", event);
 };
 
-export const getAnalyticsEventProperties = (args: any) => ({
+export const getAnalyticsEventProperties = (
+	args: AnalyticsEventArgs,
+): AnalyticsEventProperties => ({
 	version: pkg.version,
 	command: args._.join(" "),
 	flags: {

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -54,8 +54,6 @@ const KNOWN_COMMAND_ROOTS = new Set([
 	"vpc-endpoints",
 ]);
 
-const OUTPUT_FORMATS = new Set(["json", "table", "yaml"]);
-
 let client: Analytics | undefined;
 let clientInitialized = false;
 let userId = "";
@@ -109,7 +107,7 @@ export const initAnalyticsClientMiddleware = (
 		return;
 	}
 	clientInitialized = true;
-	errorEventContext = getAnalyticsEventProperties(args);
+	errorEventContext = getErrorAnalyticsEventContext(args);
 	client = new Analytics({
 		writeKey: WRITE_KEY,
 		host: "https://track.neon.tech",
@@ -211,6 +209,8 @@ export const getErrorAnalyticsEventProperties = (
 
 	return {
 		...context,
+		message: err.message,
+		stack: err.stack,
 		errCode,
 		reason: getAnalyticsErrorKind(err.message, errCode, apiError?.status),
 		statusCode: apiError?.status,
@@ -263,10 +263,17 @@ export const getAnalyticsCommand = (
 		: "unknown";
 };
 
-export const getAnalyticsOutputFormat = (
-	output: string | undefined,
-): string | undefined =>
-	output && OUTPUT_FORMATS.has(output) ? output : undefined;
+const getErrorAnalyticsEventContext = (
+	args: AnalyticsEventArgs,
+): AnalyticsEventProperties => ({
+	version: pkg.version,
+	command: getAnalyticsCommand(args._),
+	flags: {
+		output: args.output,
+	},
+	ci: isCi(),
+	githubEnvVars: getGithubEnvVars(process.env),
+});
 
 export const getAnalyticsErrorKind = (
 	message: string,
@@ -320,9 +327,9 @@ export const getAnalyticsEventProperties = (
 	args: AnalyticsEventArgs,
 ): AnalyticsEventProperties => ({
 	version: pkg.version,
-	command: getAnalyticsCommand(args._),
+	command: args._.join(" "),
 	flags: {
-		output: getAnalyticsOutputFormat(args.output),
+		output: args.output,
 	},
 	ci: isCi(),
 	githubEnvVars: getGithubEnvVars(process.env),

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -20,6 +20,11 @@ const WRITE_KEY = "3SQXn5ejjXWLEJ8xU2PRYhAotLtTaeeV";
 const hasCurrentBranchArgv = (): boolean =>
 	process.argv.includes("--current-branch");
 
+const DATABASE_URL_PATTERN = /\b(?:jdbc:)?postgres(?:ql)?:\/\/[^\s"'`\\]+/gi;
+const AUTHORIZATION_VALUE_PATTERN =
+	/\b(authorization|api[_-]?key|password|token)\s*([=:])\s*[^\s,;]+/gi;
+const BEARER_TOKEN_PATTERN = /\bBearer\s+[^\s,;]+/gi;
+
 let client: Analytics | undefined;
 let clientInitialized = false;
 let userId = "";
@@ -28,6 +33,7 @@ let errorEventContext: AnalyticsEventProperties | undefined;
 type AnalyticsEventArgs = {
 	_: (string | number)[];
 	output?: string;
+	currentBranch?: boolean;
 };
 
 type AnalyticsEventProperties = {
@@ -55,7 +61,7 @@ export const initAnalyticsClientMiddleware = (
 	// middleware runs before validation, so guard on the raw argv too (in case
 	// the parsed `currentBranch` flag isn't populated this early): never create
 	// the Segment client, which keeps trackEvent/closeAnalytics no-ops downstream.
-	if (isCurrentBranchProbe(args as any) || hasCurrentBranchArgv()) {
+	if (isCurrentBranchProbe(args) || hasCurrentBranchArgv()) {
 		return;
 	}
 	clientInitialized = true;
@@ -161,8 +167,7 @@ export const getErrorAnalyticsEventProperties = (
 
 	return {
 		...context,
-		message: err.message,
-		stack: err.stack,
+		message: redactAnalyticsText(err.message),
 		errCode,
 		statusCode: apiError?.status,
 		requestId,
@@ -205,11 +210,17 @@ export const trackEvent = (
 	log.debug("Sent CLI event: %s", event);
 };
 
+export const redactAnalyticsText = (value: string): string =>
+	value
+		.replace(DATABASE_URL_PATTERN, "[REDACTED_DATABASE_URL]")
+		.replace(AUTHORIZATION_VALUE_PATTERN, "$1$2[REDACTED]")
+		.replace(BEARER_TOKEN_PATTERN, "Bearer [REDACTED]");
+
 export const getAnalyticsEventProperties = (
 	args: AnalyticsEventArgs,
 ): AnalyticsEventProperties => ({
 	version: pkg.version,
-	command: args._.join(" "),
+	command: redactAnalyticsText(args._.join(" ")),
 	flags: {
 		output: args.output,
 	},


### PR DESCRIPTION
## Summary
- capture command, version, output format, CI state, and GitHub environment before CLI execution
- attach that context to every CLI Error event so failures can be attributed to a command and release
- add a patch changeset and coverage for the error event payload

## Test plan
- [x] `pnpm --filter neonctl test`
- [x] `pnpm --filter neonctl lint`