### PR TITLE
fix(neonctl): reuse branches after create conflicts

### DIFF
--- a/.changeset/idempotent-branch-create.md
+++ b/.changeset/idempotent-branch-create.md
@@ -1,0 +1,5 @@
+---
+"neonctl": patch
+---
+
+Treat a branch-create conflict as a successful reuse of the existing branch when the requested name matches.

--- a/packages/cli/src/commands/branches.ts
+++ b/packages/cli/src/commands/branches.ts
@@ -1,6 +1,6 @@
 import type { Branch } from "@neon/sdk";
 import type yargs from "yargs";
-import { retryOnLock } from "../api.js";
+import { isNeonApiError, retryOnLock } from "../api.js";
 
 import { contextBranch, readContextFile } from "../context.js";
 import { log } from "../log.js";
@@ -407,39 +407,69 @@ const create = async (
 		}
 	}
 
-	const { data } = await retryOnLock(() =>
-		props.apiClient.createProjectBranch(props.projectId, {
-			branch: {
-				name: props.name,
-				...parentProps,
-				...(props.schemaOnly ? { init_source: "schema-only" } : {}),
-				...(props["expires-at"]
-					? {
-							expires_at: new Date(
-								props["expires-at"],
-							).toISOString(),
-						}
-					: {}),
-			},
-			endpoints: props.compute
-				? [
-						{
-							type: props.type,
-							suspend_timeout_seconds:
-								props.suspendTimeout === 0
-									? undefined
-									: props.suspendTimeout,
-							...(props.cu
-								? getComputeUnits(props.cu)
-								: undefined),
-						},
-					]
-				: [],
-			annotation_value: props.annotation
-				? JSON.parse(props.annotation)
-				: undefined,
-		}),
-	);
+	let data: Awaited<
+		ReturnType<typeof props.apiClient.createProjectBranch>
+	>["data"];
+	try {
+		({ data } = await retryOnLock(() =>
+			props.apiClient.createProjectBranch(props.projectId, {
+				branch: {
+					name: props.name,
+					...parentProps,
+					...(props.schemaOnly ? { init_source: "schema-only" } : {}),
+					...(props["expires-at"]
+						? {
+								expires_at: new Date(
+									props["expires-at"],
+								).toISOString(),
+							}
+						: {}),
+				},
+				endpoints: props.compute
+					? [
+							{
+								type: props.type,
+								suspend_timeout_seconds:
+									props.suspendTimeout === 0
+										? undefined
+										: props.suspendTimeout,
+								...(props.cu
+									? getComputeUnits(props.cu)
+									: undefined),
+							},
+						]
+					: [],
+				annotation_value: props.annotation
+					? JSON.parse(props.annotation)
+					: undefined,
+			}),
+		));
+	} catch (err) {
+		if (!isNeonApiError(err) || err.status !== 409) {
+			throw err;
+		}
+
+		const { data: latest } = await props.apiClient.listProjectBranches({
+			projectId: props.projectId,
+		});
+		const existing = latest.branches.find(
+			(branch: Branch) => branch.name === props.name,
+		);
+		if (!existing) {
+			throw err;
+		}
+		if (props.psql) {
+			throw new Error(
+				`Branch "${props.name}" already exists. Use \`neon branches get ${props.name}\` or rerun without --psql.`,
+			);
+		}
+
+		log.info('Branch "%s" already exists; using it.', props.name);
+		writer(props).end(existing, {
+			fields: BRANCH_FIELDS,
+		});
+		return;
+	}
 
 	const parent = branches.find((b: Branch) => b.id === data.branch.parent_id);
 	if (parent?.protected) {


### PR DESCRIPTION
## Why

In the latest seven days of production CLI telemetry (July 10–16), `neonctl` reported **22,415 API 409 conflicts** affecting **215 users**. The dominant cause is a branch name already being present:

- **20,823** `branch already exists` errors (**92.9%** of 409s; 130 users)
- 1,104 generic 409 responses (74 users)
- 249 database-already-exists errors (9 users)
- 233 read-write-endpoint-already-exists errors (3 users)
- 6 other conflicts (5 users)

A duplicate branch name commonly happens when a CI job is rerun or concurrent work attempts to create the same named branch. Today the API 409 bubbles out as a failed CLI command even when the requested branch is already usable.

## What this changes

- On `neon branches create`, catch a 409 and re-read the project branches.
- If a branch with the requested name now exists, treat the operation as an idempotent success: print and return that existing branch.
- Re-throw the original 409 when no matching branch is found, so unrelated conflicts are never hidden.
- Keep `--psql` explicit: an already-existing branch has no newly returned connection URI, so the command explains how to inspect it or rerun without `--psql`.

This directly addresses the 20.8k known duplicate-branch conflicts. Database and endpoint conflicts are intentionally left for follow-up PRs because their safe idempotency keys differ.

## Real smoke test

Using a throwaway project in the Neon smoke org, then deleting that project afterward:

```console
$ neon branches create --project-id patient-violet-49916922 --name smoke-conflict --no-compute --output json
{
  "id": "br-ancient-glade-aj3bineq",
  "name": "smoke-conflict",
  "current_state": "init"
}

$ neon branches create --project-id patient-violet-49916922 --name smoke-conflict --no-compute --output json
INFO: Branch "smoke-conflict" already exists; using it.
{
  "id": "br-ancient-glade-aj3bineq",
  "name": "smoke-conflict",
  "current_state": "ready"
}
```

## Test plan

- [x] `pnpm --filter neonctl test`
- [x] `pnpm --filter neonctl lint`
- [x] Live smoke: created a branch, reran the same command, verified it returned the same branch, then deleted the smoke project