### PR TITLE
fix(neonctl): stop context walk at Windows roots

### DIFF
--- a/.changeset/warm-cats-stop.md
+++ b/.changeset/warm-cats-stop.md
@@ -1,0 +1,5 @@
+---
+"neonctl": patch
+---
+
+Prevent the CLI context-file walk from looping indefinitely at Windows drive roots.

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -6,7 +6,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
@@ -14,6 +14,7 @@ import {
 	currentContextFile,
 	ensureGitignored,
 	isCurrentBranchProbe,
+	walkContextFile,
 } from "./context.js";
 
 describe("isCurrentBranchProbe", () => {
@@ -69,6 +70,70 @@ describe("isCurrentBranchProbe", () => {
 		expect(
 			isCurrentBranchProbe({ _: ["config"], currentBranch: true }),
 		).toBe(false);
+	});
+});
+
+const boundedWindowsResolver = () => {
+	let terminalParentResolutions = 0;
+	return {
+		resolvePath: (...paths: string[]) => {
+			const resolved = win32.resolve(...paths);
+			if (paths.at(-1) === ".." && resolved === paths[0]) {
+				terminalParentResolutions += 1;
+				if (terminalParentResolutions > 1) {
+					throw new Error(
+						"context walk did not stop at the filesystem root",
+					);
+				}
+			}
+			return resolved;
+		},
+		terminalParentResolutions: () => terminalParentResolutions,
+	};
+};
+
+describe("walkContextFile with Windows path semantics", () => {
+	const root = win32.normalize("/");
+	const home = "C:\\Users\\test-user";
+
+	test("terminates at a drive root when no context exists in any ancestor", () => {
+		const cwd = "C:\\workspace\\nested";
+		const { resolvePath, terminalParentResolutions } =
+			boundedWindowsResolver();
+
+		expect(walkContextFile(cwd, root, home, resolvePath, () => false)).toBe(
+			win32.resolve(cwd, ".neon"),
+		);
+		expect(terminalParentResolutions()).toBe(1);
+	});
+
+	test("returns a context file found in a normal ancestor", () => {
+		const cwd = "C:\\workspace\\nested";
+		const contextFile = "C:\\workspace\\.neon";
+		const { resolvePath, terminalParentResolutions } =
+			boundedWindowsResolver();
+
+		expect(
+			walkContextFile(
+				cwd,
+				root,
+				home,
+				resolvePath,
+				(file) => file === contextFile,
+			),
+		).toBe(contextFile);
+		expect(terminalParentResolutions()).toBe(0);
+	});
+
+	test("terminates at a UNC share root", () => {
+		const cwd = "\\\\server\\share\\workspace\\nested";
+		const { resolvePath, terminalParentResolutions } =
+			boundedWindowsResolver();
+
+		expect(walkContextFile(cwd, root, home, resolvePath, () => false)).toBe(
+			win32.resolve(cwd, ".neon"),
+		);
+		expect(terminalParentResolutions()).toBe(1);
 	});
 });
 

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -63,7 +63,44 @@ export const isConfigInit = (args: { _: (string | number)[] }): boolean =>
 const CONTEXT_FILE = ".neon";
 const GITIGNORE_FILE = ".gitignore";
 
-const wrapWithContextFile = (dir: string) => resolve(dir, CONTEXT_FILE);
+type ResolvePath = (...paths: string[]) => string;
+
+const canAccess = (file: string): boolean => {
+	try {
+		accessSync(file);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Walk toward the filesystem root looking for an accessible context file.
+ * Path resolution and access are injectable so platform-specific traversal
+ * semantics can be exercised on every CI host.
+ */
+export const walkContextFile = (
+	cwd: string,
+	root: string,
+	home: string,
+	resolvePath: ResolvePath,
+	canAccessFile: (file: string) => boolean,
+): string => {
+	let currentDir = cwd;
+	while (currentDir !== root && currentDir !== home) {
+		const contextFile = resolvePath(currentDir, CONTEXT_FILE);
+		if (canAccessFile(contextFile)) {
+			return contextFile;
+		}
+		const parentDir = resolvePath(currentDir, "..");
+		if (parentDir === currentDir) {
+			break;
+		}
+		currentDir = parentDir;
+	}
+
+	return resolvePath(cwd, CONTEXT_FILE);
+};
 
 /**
  * Resolve the default `.neon` path for the current working directory.
@@ -84,20 +121,7 @@ const wrapWithContextFile = (dir: string) => resolve(dir, CONTEXT_FILE);
  * `process.cwd()` (which would race with other tests running in parallel).
  */
 export const currentContextFile = (cwd: string = process.cwd()) => {
-	let currentDir = cwd;
-	const root = normalize("/");
-	const home = homedir();
-	while (currentDir !== root && currentDir !== home) {
-		try {
-			accessSync(resolve(currentDir, CONTEXT_FILE));
-			return wrapWithContextFile(currentDir);
-		} catch {
-			// ignore
-		}
-		currentDir = resolve(currentDir, "..");
-	}
-
-	return wrapWithContextFile(cwd);
+	return walkContextFile(cwd, normalize("/"), homedir(), resolve, canAccess);
 };
 
 export const readContextFile = (file: string): Context => {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #289
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/neondatabase/neon-pkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/neondatabase/neon-pkgs/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR fixes a Windows-specific infinite loop in the Neon CLI's `.neon` context-file discovery. Before this change, every CLI invocation that initialized the global context middleware?including fast-path invocations such as `neon --version` and `neon --help`?could hang indefinitely with no stdout or stderr when run outside the user's home directory and no `.neon` file existed in the current directory or its ancestors.

The fix makes termination depend on whether walking to the parent directory actually advances, rather than relying only on a POSIX-shaped root sentinel. It also extracts the traversal into a small testable helper with injected path resolution and file-access behavior. That lets the Linux-only CI exercise real Windows drive and UNC path semantics through `node:path.win32`, so the regression is covered without requiring a Windows runner.

## User impact

On affected Windows installations, the CLI could become unusable from otherwise ordinary working directories:

- a directory on a drive different from the user's home drive;
- the root of the home drive, such as `C:\`;
- any directory on the home drive that is outside the user's home tree;
- a UNC share when no ancestor contains a `.neon` context file.

The failure happened before command dispatch, so even commands that should return immediately appeared completely frozen. A timed-out parent process could also leave the CLI's `node.exe` process running.

After this change, the context walk terminates at drive roots and UNC share roots, and the CLI falls back to `<cwd>/.neon` exactly as it does when no context is found on other platforms.

## Root cause

`currentContextFile()` walks upward from the current working directory looking for an accessible `.neon` file. Its previous loop used `normalize("/")` as the filesystem-root sentinel:

```ts
const root = normalize("/");
while (currentDir !== root && currentDir !== home) {
  // ...
  currentDir = resolve(currentDir, "..");
}
```

On Windows, `normalize("/")` evaluates to `"\\"`, while real terminal paths retain their drive or share prefix:

```text
normalize("/")            -> "\\"
resolve("C:\\", "..")     -> "C:\\"
resolve("\\\\server\\share\\", "..") -> "\\\\server\\share\\"
```

Once the walk reached `C:\` or a UNC share root, resolving `..` returned the same directory. That directory matched neither `"\\"` nor the user's home, so the loop could never make progress or terminate.

## Implementation

### Progress-based termination

The traversal now resolves the next parent into `parentDir` and stops when it is identical to `currentDir`:

```ts
const parentDir = resolvePath(currentDir, "..");
if (parentDir === currentDir) {
  break;
}
currentDir = parentDir;
```

This condition is portable because it describes the filesystem behavior directly. It does not need to know whether a root is represented as `/`, `C:\`, `D:\`, or `\\server\share\`.

### Testable traversal helper

The directory walk was extracted into `walkContextFile()`. The helper receives:

- the starting directory;
- the existing root and home stopping boundaries;
- a path resolver;
- a context-file accessibility predicate.

`currentContextFile()` delegates to it with Node's native `resolve`, `normalize`, `homedir`, and `accessSync` behavior. The helper is internal to the CLI implementation and is not added to the package's public entrypoint.

This separation preserves production behavior while allowing tests to inject `node:path.win32` on Linux.

### Release metadata

A patch changeset for `neonctl` is included with the user-facing summary:

> Prevent the CLI context-file walk from looping indefinitely at Windows drive roots.

## Regression coverage

The new tests execute the actual extracted traversal with Windows path semantics on every host, including Linux CI. They cover:

1. A normal Windows path with no accessible `.neon` file in any ancestor, terminating at `C:\` and falling back to `<cwd>/.neon`.
2. A normal Windows path with a valid `.neon` file in a parent directory, returning that context without reaching the root.
3. A UNC path with no context in its ancestors, terminating at the share root and falling back to `<cwd>/.neon`.

The injected resolver is deliberately bounded: after reporting the same terminal parent once, a second attempt throws `context walk did not stop at the filesystem root`. This prevents a broken implementation from hanging the Vitest worker and makes the old behavior fail quickly in Linux CI.

As a mutation check, the new `parentDir === currentDir` guard was temporarily removed locally. The focused suite then failed in 109 ms in both termination cases:

```text
walkContextFile with Windows path semantics
  ? terminates at a drive root when no context exists in any ancestor
  ? terminates at a UNC share root

Error: context walk did not stop at the filesystem root
2 failed | 16 passed
```

Restoring the guard returned the suite to 18/18 passing tests.

Existing coverage continues to verify the unchanged semantics:

- fallback to `<cwd>/.neon` when no context is found;
- discovery of an existing `.neon` file in a normal parent directory;
- ignoring unrelated `package.json` and `.git` project markers;
- preserving the existing home-directory stopping boundary;
- retaining the offline current-branch fast path.

## Validation

The following validation was completed locally on Windows 11 with Node.js 22.14.0 and the repository-pinned pnpm 10.30.3:

- `corepack pnpm --filter neonctl typecheck` ? passed;
- `vitest run src/context.test.ts` ? 18/18 passed;
- `vitest run src/current_branch_fast_path.test.ts` ? 5/5 passed;
- Biome check on `context.ts` and `context.test.ts` ? passed;
- Windows-native CLI build equivalent (`generateParams`, `tsc -p tsconfig.build.json`, and copying `callback.html`) ? passed;
- `git diff --check` ? passed;
- corrected local build: `neon --version` from `C:\` returned `2.33.2` and exited normally;
- corrected npm-linked CLI: `neon --version` and `neon --help` from a working directory outside the user home both exited normally;
- no relevant orphaned Node processes remained after the decisive tests.

The full Windows command suite was also attempted locally, but exceeded the configured 244-second local timeout without reporting an assertion failure. Its process tree was cleaned up, so this PR does not represent that broad local run as completed; the focused regression, typecheck, formatting, build, and manual Windows validations above all completed successfully.

## Compatibility and scope

This change intentionally does not alter:

- CLI commands, options, output formats, or authentication behavior;
- the `.neon` schema;
- how a valid ancestor context is selected;
- the existing home-directory stopping boundary;
- fallback behavior when no context exists;
- build scripts or Windows shell portability of the build command;
- public package exports.

No public documentation update is required because the change restores the already-documented ancestor lookup behavior on Windows rather than introducing a new user-facing workflow. The changeset provides the appropriate release note.

## References

- Closes [neondatabase/neon-pkgs#289](https://github.com/neondatabase/neon-pkgs/issues/289) ? canonical report containing the exact Windows drive-root diagnosis and reproduction.
- Related historical report: [neondatabase/neonctl#471](https://github.com/neondatabase/neonctl/issues/471) ? originally reported against the standalone Windows binary and traced to CLI initialization before command dispatch.

