### PR TITLE
fix(ai-sdk-provider): normalize gpt-oss harmony response shape

### DIFF
--- a/.changeset/gpt-oss-harmony-normalize.md
+++ b/.changeset/gpt-oss-harmony-normalize.md
@@ -1,0 +1,5 @@
+---
+"@neon/ai-sdk-provider": patch
+---
+
+Support `gpt-oss-*` models on the unified endpoint. The Neon AI Gateway returns gpt-oss responses in a non-OpenAI-compliant "harmony" shape (`message.content` as an array of reasoning/text parts instead of a string), which caused `generateText`/`streamText` to fail with `AI_APICallError: Invalid JSON response`. The provider now normalizes this to the OpenAI Chat Completions contract (string `content` + `reasoning_content`) before validation, so gpt-oss works end-to-end and its reasoning is surfaced. The transform is a no-op for every already-compliant model.

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -88,7 +88,7 @@ for await (const part of result.fullStream) {
 ## Limitations
 
 - `generateImage()` and embeddings (`embed` / `embedMany`) are not offered by the gateway and throw `NoSuchModelError`.
-- `gpt-oss-*` models return a non-standard ("harmony") response shape on the unified endpoint and are not fully supported.
+- `gpt-oss-*` models return a non-standard ("harmony") response shape on the unified endpoint (`message.content` as an array of reasoning/text parts instead of a string). The provider normalizes this to the OpenAI Chat Completions contract (string `content` + `reasoning_content`) so `generateText`/`streamText` work and reasoning is surfaced. See neondatabase/neon-pkgs#308.
 - OpenAI Responses multi-turn tool flows (`generateText` + `stepCountIs`) can return 502 from the gateway; tool calling is covered on Anthropic/Google/Meta in e2e.
 
 ## End-to-end tests

--- a/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
@@ -163,11 +163,34 @@ describe.skipIf(!hasGatewayEnv())(
 			}, 120_000);
 		});
 
-		describe("known gateway limitations", () => {
-			it.skip("gpt-oss harmony response shape is not OpenAI-compatible on MLflow", () => {
-				// Documented limitation — see README.
+		describe("gpt-oss harmony normalization (#308)", () => {
+			// The gateway returns gpt-oss `message.content` as a harmony parts
+			// array; the provider normalizes it to the OpenAI Chat Completions
+			// contract. Verify text comes through for both generate and stream.
+			it("generateText works and does not throw on the harmony shape", async () => {
+				const result = await generateText({
+					model: neon("gpt-oss-120b"),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+				});
+				expect(result.text.trim().length).toBeGreaterThan(0);
 			});
 
+			it("streamText works without an invalid-JSON error flood", async () => {
+				const result = streamText({
+					model: neon("gpt-oss-120b"),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+				});
+				let text = "";
+				for await (const part of result.textStream) {
+					text += part;
+				}
+				expect(text.trim().length).toBeGreaterThan(0);
+			});
+		});
+
+		describe("known gateway limitations", () => {
 			it.skip("OpenAI Responses multi-turn tool follow-up can 502 on the gateway", () => {
 				// gpt-5-mini tool calling works for the first step but follow-up requests can 502.
 			});

--- a/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import {
+	extractHarmonyContent,
+	normalizeChunkBody,
+	normalizeCompletionBody,
+} from "./neon-harmony-normalize.js";
+
+describe("extractHarmonyContent", () => {
+	it("returns null for a compliant string content (no rewrite needed)", () => {
+		expect(extractHarmonyContent("Hi there")).toBeNull();
+		expect(extractHarmonyContent(null)).toBeNull();
+		expect(extractHarmonyContent(undefined)).toBeNull();
+	});
+
+	it("flattens text parts and hoists reasoning from summary_text", () => {
+		const content = [
+			{
+				type: "reasoning",
+				summary: [
+					{ type: "summary_text", text: "Think about the greeting." },
+				],
+			},
+			{ type: "text", text: "Hi! 👋" },
+		];
+		expect(extractHarmonyContent(content)).toEqual({
+			text: "Hi! 👋",
+			reasoning: "Think about the greeting.",
+		});
+	});
+
+	it("joins multiple text parts and reasoning sources", () => {
+		const content = [
+			{
+				type: "reasoning",
+				text: "raw cot",
+				summary: [{ text: "summary cot" }],
+			},
+			{
+				type: "reasoning",
+				content: [{ type: "reasoning_text", text: "more cot" }],
+			},
+			{ type: "text", text: "Hello " },
+			{ type: "text", text: "world" },
+		];
+		expect(extractHarmonyContent(content)).toEqual({
+			text: "Hello world",
+			reasoning: "raw cot\nsummary cot\nmore cot",
+		});
+	});
+});
+
+describe("normalizeCompletionBody", () => {
+	it("rewrites gpt-oss array content to string + reasoning_content", () => {
+		const body = {
+			object: "chat.completion",
+			choices: [
+				{
+					index: 0,
+					message: {
+						role: "assistant",
+						content: [
+							{
+								type: "reasoning",
+								summary: [
+									{ type: "summary_text", text: "why" },
+								],
+							},
+							{ type: "text", text: "Hi" },
+						],
+					},
+					finish_reason: "stop",
+				},
+			],
+		};
+		const out = normalizeCompletionBody(body);
+		expect(out).toEqual({
+			object: "chat.completion",
+			choices: [
+				{
+					index: 0,
+					message: {
+						role: "assistant",
+						content: "Hi",
+						reasoning_content: "why",
+					},
+					finish_reason: "stop",
+				},
+			],
+		});
+	});
+
+	it("leaves a compliant string-content body untouched", () => {
+		const body = {
+			choices: [{ message: { role: "assistant", content: "Hi there" } }],
+		};
+		expect(normalizeCompletionBody(structuredClone(body))).toEqual(body);
+	});
+
+	it("does not overwrite an existing reasoning field", () => {
+		const body = {
+			choices: [
+				{
+					message: {
+						role: "assistant",
+						reasoning: "already here",
+						content: [{ type: "text", text: "Hi" }],
+					},
+				},
+			],
+		};
+		const out = normalizeCompletionBody(body);
+		const choice = (
+			out as { choices: Array<{ message: Record<string, unknown> }> }
+		).choices[0];
+		expect(choice.message.content).toBe("Hi");
+		expect(choice.message.reasoning).toBe("already here");
+		expect(choice.message.reasoning_content).toBeUndefined();
+	});
+});
+
+describe("normalizeChunkBody", () => {
+	it("rewrites a reasoning-only delta to reasoning_content and drops empty text", () => {
+		const chunk = {
+			object: "chat.completion.chunk",
+			choices: [
+				{
+					index: 0,
+					delta: {
+						content: [
+							{
+								type: "reasoning",
+								summary: [
+									{ type: "summary_text", text: "thinking" },
+								],
+							},
+						],
+					},
+					finish_reason: null,
+				},
+			],
+		};
+		const out = normalizeChunkBody(chunk);
+		const delta = (
+			out as { choices: Array<{ delta: Record<string, unknown> }> }
+		).choices[0].delta;
+		expect(delta.content).toBeUndefined();
+		expect(delta.reasoning_content).toBe("thinking");
+	});
+
+	it("rewrites a text delta to a string", () => {
+		const chunk = {
+			choices: [
+				{ delta: { content: [{ type: "text", text: "Hello" }] } },
+			],
+		};
+		const out = normalizeChunkBody(chunk);
+		const delta = (
+			out as { choices: Array<{ delta: Record<string, unknown> }> }
+		).choices[0].delta;
+		expect(delta.content).toBe("Hello");
+	});
+});

--- a/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.test.ts
@@ -16,7 +16,9 @@ describe("extractHarmonyContent", () => {
 		const content = [
 			{
 				type: "reasoning",
-				summary: [{ type: "summary_text", text: "Think about the greeting." }],
+				summary: [
+					{ type: "summary_text", text: "Think about the greeting." },
+				],
 			},
 			{ type: "text", text: "Hi! 👋" },
 		];
@@ -28,8 +30,15 @@ describe("extractHarmonyContent", () => {
 
 	it("joins multiple text parts and reasoning sources", () => {
 		const content = [
-			{ type: "reasoning", text: "raw cot", summary: [{ text: "summary cot" }] },
-			{ type: "reasoning", content: [{ type: "reasoning_text", text: "more cot" }] },
+			{
+				type: "reasoning",
+				text: "raw cot",
+				summary: [{ text: "summary cot" }],
+			},
+			{
+				type: "reasoning",
+				content: [{ type: "reasoning_text", text: "more cot" }],
+			},
 			{ type: "text", text: "Hello " },
 			{ type: "text", text: "world" },
 		];
@@ -50,7 +59,12 @@ describe("normalizeCompletionBody", () => {
 					message: {
 						role: "assistant",
 						content: [
-							{ type: "reasoning", summary: [{ type: "summary_text", text: "why" }] },
+							{
+								type: "reasoning",
+								summary: [
+									{ type: "summary_text", text: "why" },
+								],
+							},
 							{ type: "text", text: "Hi" },
 						],
 					},
@@ -80,7 +94,9 @@ describe("normalizeCompletionBody", () => {
 		const body = {
 			choices: [{ message: { role: "assistant", content: "Hi there" } }],
 		};
-		const { body: out, changed } = normalizeCompletionBody(structuredClone(body));
+		const { body: out, changed } = normalizeCompletionBody(
+			structuredClone(body),
+		);
 		expect(changed).toBe(false);
 		expect(out).toEqual(body);
 	});
@@ -99,8 +115,9 @@ describe("normalizeCompletionBody", () => {
 		};
 		const { body: out, changed } = normalizeCompletionBody(body);
 		expect(changed).toBe(true);
-		const choice = (out as { choices: Array<{ message: Record<string, unknown> }> })
-			.choices[0];
+		const choice = (
+			out as { choices: Array<{ message: Record<string, unknown> }> }
+		).choices[0];
 		expect(choice.message.content).toBe("Hi");
 		expect(choice.message.reasoning).toBe("already here");
 		expect(choice.message.reasoning_content).toBeUndefined();
@@ -116,7 +133,12 @@ describe("normalizeChunkBody", () => {
 					index: 0,
 					delta: {
 						content: [
-							{ type: "reasoning", summary: [{ type: "summary_text", text: "thinking" }] },
+							{
+								type: "reasoning",
+								summary: [
+									{ type: "summary_text", text: "thinking" },
+								],
+							},
 						],
 					},
 					finish_reason: null,
@@ -125,26 +147,32 @@ describe("normalizeChunkBody", () => {
 		};
 		const { body: out, changed } = normalizeChunkBody(chunk);
 		expect(changed).toBe(true);
-		const delta = (out as { choices: Array<{ delta: Record<string, unknown> }> })
-			.choices[0].delta;
+		const delta = (
+			out as { choices: Array<{ delta: Record<string, unknown> }> }
+		).choices[0].delta;
 		expect(delta.content).toBeUndefined();
 		expect(delta.reasoning_content).toBe("thinking");
 	});
 
 	it("rewrites a text delta to a string", () => {
 		const chunk = {
-			choices: [{ delta: { content: [{ type: "text", text: "Hello" }] } }],
+			choices: [
+				{ delta: { content: [{ type: "text", text: "Hello" }] } },
+			],
 		};
 		const { body: out, changed } = normalizeChunkBody(chunk);
 		expect(changed).toBe(true);
-		const delta = (out as { choices: Array<{ delta: Record<string, unknown> }> })
-			.choices[0].delta;
+		const delta = (
+			out as { choices: Array<{ delta: Record<string, unknown> }> }
+		).choices[0].delta;
 		expect(delta.content).toBe("Hello");
 	});
 
 	it("leaves a compliant string delta untouched (changed=false)", () => {
 		const chunk = { choices: [{ delta: { content: "Hello" } }] };
-		const { body: out, changed } = normalizeChunkBody(structuredClone(chunk));
+		const { body: out, changed } = normalizeChunkBody(
+			structuredClone(chunk),
+		);
 		expect(changed).toBe(false);
 		expect(out).toEqual(chunk);
 	});

--- a/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.test.ts
@@ -16,9 +16,7 @@ describe("extractHarmonyContent", () => {
 		const content = [
 			{
 				type: "reasoning",
-				summary: [
-					{ type: "summary_text", text: "Think about the greeting." },
-				],
+				summary: [{ type: "summary_text", text: "Think about the greeting." }],
 			},
 			{ type: "text", text: "Hi! 👋" },
 		];
@@ -30,15 +28,8 @@ describe("extractHarmonyContent", () => {
 
 	it("joins multiple text parts and reasoning sources", () => {
 		const content = [
-			{
-				type: "reasoning",
-				text: "raw cot",
-				summary: [{ text: "summary cot" }],
-			},
-			{
-				type: "reasoning",
-				content: [{ type: "reasoning_text", text: "more cot" }],
-			},
+			{ type: "reasoning", text: "raw cot", summary: [{ text: "summary cot" }] },
+			{ type: "reasoning", content: [{ type: "reasoning_text", text: "more cot" }] },
 			{ type: "text", text: "Hello " },
 			{ type: "text", text: "world" },
 		];
@@ -59,12 +50,7 @@ describe("normalizeCompletionBody", () => {
 					message: {
 						role: "assistant",
 						content: [
-							{
-								type: "reasoning",
-								summary: [
-									{ type: "summary_text", text: "why" },
-								],
-							},
+							{ type: "reasoning", summary: [{ type: "summary_text", text: "why" }] },
 							{ type: "text", text: "Hi" },
 						],
 					},
@@ -72,7 +58,8 @@ describe("normalizeCompletionBody", () => {
 				},
 			],
 		};
-		const out = normalizeCompletionBody(body);
+		const { body: out, changed } = normalizeCompletionBody(body);
+		expect(changed).toBe(true);
 		expect(out).toEqual({
 			object: "chat.completion",
 			choices: [
@@ -89,11 +76,13 @@ describe("normalizeCompletionBody", () => {
 		});
 	});
 
-	it("leaves a compliant string-content body untouched", () => {
+	it("leaves a compliant string-content body untouched (changed=false)", () => {
 		const body = {
 			choices: [{ message: { role: "assistant", content: "Hi there" } }],
 		};
-		expect(normalizeCompletionBody(structuredClone(body))).toEqual(body);
+		const { body: out, changed } = normalizeCompletionBody(structuredClone(body));
+		expect(changed).toBe(false);
+		expect(out).toEqual(body);
 	});
 
 	it("does not overwrite an existing reasoning field", () => {
@@ -108,10 +97,10 @@ describe("normalizeCompletionBody", () => {
 				},
 			],
 		};
-		const out = normalizeCompletionBody(body);
-		const choice = (
-			out as { choices: Array<{ message: Record<string, unknown> }> }
-		).choices[0];
+		const { body: out, changed } = normalizeCompletionBody(body);
+		expect(changed).toBe(true);
+		const choice = (out as { choices: Array<{ message: Record<string, unknown> }> })
+			.choices[0];
 		expect(choice.message.content).toBe("Hi");
 		expect(choice.message.reasoning).toBe("already here");
 		expect(choice.message.reasoning_content).toBeUndefined();
@@ -127,36 +116,36 @@ describe("normalizeChunkBody", () => {
 					index: 0,
 					delta: {
 						content: [
-							{
-								type: "reasoning",
-								summary: [
-									{ type: "summary_text", text: "thinking" },
-								],
-							},
+							{ type: "reasoning", summary: [{ type: "summary_text", text: "thinking" }] },
 						],
 					},
 					finish_reason: null,
 				},
 			],
 		};
-		const out = normalizeChunkBody(chunk);
-		const delta = (
-			out as { choices: Array<{ delta: Record<string, unknown> }> }
-		).choices[0].delta;
+		const { body: out, changed } = normalizeChunkBody(chunk);
+		expect(changed).toBe(true);
+		const delta = (out as { choices: Array<{ delta: Record<string, unknown> }> })
+			.choices[0].delta;
 		expect(delta.content).toBeUndefined();
 		expect(delta.reasoning_content).toBe("thinking");
 	});
 
 	it("rewrites a text delta to a string", () => {
 		const chunk = {
-			choices: [
-				{ delta: { content: [{ type: "text", text: "Hello" }] } },
-			],
+			choices: [{ delta: { content: [{ type: "text", text: "Hello" }] } }],
 		};
-		const out = normalizeChunkBody(chunk);
-		const delta = (
-			out as { choices: Array<{ delta: Record<string, unknown> }> }
-		).choices[0].delta;
+		const { body: out, changed } = normalizeChunkBody(chunk);
+		expect(changed).toBe(true);
+		const delta = (out as { choices: Array<{ delta: Record<string, unknown> }> })
+			.choices[0].delta;
 		expect(delta.content).toBe("Hello");
+	});
+
+	it("leaves a compliant string delta untouched (changed=false)", () => {
+		const chunk = { choices: [{ delta: { content: "Hello" } }] };
+		const { body: out, changed } = normalizeChunkBody(structuredClone(chunk));
+		expect(changed).toBe(false);
+		expect(out).toEqual(chunk);
 	});
 });

--- a/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.ts
@@ -1,5 +1,11 @@
 import type { FetchFunction } from "@ai-sdk/provider-utils";
 
+// TODO(#308): Temporary workaround. Remove this whole module (and its wiring in
+// provider.ts) once the Neon AI Gateway returns Chat Completions-compliant
+// gpt-oss responses (string `content` + `reasoning_content`). The wrapper is a
+// transparent pass-through for any already-compliant response, so it is safe to
+// leave in place until the gateway fix ships — but it should be deleted then.
+
 /**
  * Normalize the Neon AI Gateway's non-OpenAI-compliant `gpt-oss` ("harmony")
  * response shape into the OpenAI Chat Completions contract before it reaches
@@ -19,9 +25,11 @@ import type { FetchFunction } from "@ai-sdk/provider-utils";
  * `reasoning_content` (which `@ai-sdk/openai-compatible` already surfaces as an
  * AI SDK reasoning part).
  *
- * The transform only rewrites when `content` is an array, so it is a no-op for
- * every spec-compliant model (Llama, Gemini, Qwen, …) and self-retires if the
- * gateway is fixed to return a compliant shape.
+ * The transform only rewrites when `content` is an array, and the fetch wrapper
+ * returns the response untouched when nothing was rewritten. So it is a true
+ * no-op / pass-through for every spec-compliant model (Llama, Gemini, Qwen, …)
+ * and self-retires the moment the gateway starts returning a compliant shape —
+ * it will not double-transform or otherwise interfere with the downstream fix.
  *
  * See neondatabase/neon-pkgs#308.
  */
@@ -35,14 +43,18 @@ interface ExtractedHarmony {
 	reasoning: string;
 }
 
+/** The result of a normalization pass, flagging whether anything was rewritten. */
+interface NormalizeResult {
+	body: unknown;
+	changed: boolean;
+}
+
 /**
  * Pull the text and reasoning out of a harmony `content` array. Returns `null`
  * when `content` is not an array (i.e. an already-compliant string response),
  * signalling that no rewrite is needed.
  */
-export function extractHarmonyContent(
-	content: unknown,
-): ExtractedHarmony | null {
+export function extractHarmonyContent(content: unknown): ExtractedHarmony | null {
 	if (!Array.isArray(content)) {
 		return null;
 	}
@@ -86,11 +98,15 @@ export function extractHarmonyContent(
 	return { text: texts.join(""), reasoning: reasonings.join("\n") };
 }
 
-/** Rewrite a non-streaming `chat.completion` body in place. Returns the body. */
-export function normalizeCompletionBody(body: unknown): unknown {
+/**
+ * Rewrite a non-streaming `chat.completion` body in place. `changed` is false
+ * when the body was already compliant (no harmony array found).
+ */
+export function normalizeCompletionBody(body: unknown): NormalizeResult {
 	if (!isRecord(body) || !Array.isArray(body.choices)) {
-		return body;
+		return { body, changed: false };
 	}
+	let changed = false;
 	for (const choice of body.choices) {
 		if (!isRecord(choice)) {
 			continue;
@@ -104,6 +120,7 @@ export function normalizeCompletionBody(body: unknown): unknown {
 			continue;
 		}
 		message.content = extracted.text;
+		changed = true;
 		if (
 			extracted.reasoning.length > 0 &&
 			message.reasoning_content == null &&
@@ -112,14 +129,18 @@ export function normalizeCompletionBody(body: unknown): unknown {
 			message.reasoning_content = extracted.reasoning;
 		}
 	}
-	return body;
+	return { body, changed };
 }
 
-/** Rewrite a streaming `chat.completion.chunk` body in place. Returns the body. */
-export function normalizeChunkBody(body: unknown): unknown {
+/**
+ * Rewrite a streaming `chat.completion.chunk` body in place. `changed` is false
+ * when the chunk was already compliant (no harmony array found).
+ */
+export function normalizeChunkBody(body: unknown): NormalizeResult {
 	if (!isRecord(body) || !Array.isArray(body.choices)) {
-		return body;
+		return { body, changed: false };
 	}
+	let changed = false;
 	for (const choice of body.choices) {
 		if (!isRecord(choice)) {
 			continue;
@@ -132,6 +153,7 @@ export function normalizeChunkBody(body: unknown): unknown {
 		if (extracted === null) {
 			continue;
 		}
+		changed = true;
 		// Drop empty text so reasoning-only chunks don't emit spurious text deltas.
 		if (extracted.text.length > 0) {
 			delta.content = extracted.text;
@@ -146,10 +168,13 @@ export function normalizeChunkBody(body: unknown): unknown {
 			delta.reasoning_content = extracted.reasoning;
 		}
 	}
-	return body;
+	return { body, changed };
 }
 
-/** Rewrite each `data:` frame of an SSE stream. */
+/**
+ * Rewrite each `data:` frame of an SSE stream. Compliant frames pass through
+ * verbatim; only harmony frames are re-serialized.
+ */
 function normalizeEventStream(
 	body: ReadableStream<Uint8Array>,
 ): ReadableStream<Uint8Array> {
@@ -158,8 +183,7 @@ function normalizeEventStream(
 	let buffer = "";
 
 	const rewriteLine = (line: string): string => {
-		const trimmed = line.startsWith("data:") ? line : null;
-		if (trimmed === null) {
+		if (!line.startsWith("data:")) {
 			return line;
 		}
 		const payload = line.slice("data:".length).trim();
@@ -172,7 +196,9 @@ function normalizeEventStream(
 		} catch {
 			return line;
 		}
-		return `data: ${JSON.stringify(normalizeChunkBody(parsed))}`;
+		const { body: normalized, changed } = normalizeChunkBody(parsed);
+		// Pass compliant frames through unchanged so we don't reshape a fixed gateway.
+		return changed ? `data: ${JSON.stringify(normalized)}` : line;
 	};
 
 	return body.pipeThrough(
@@ -182,9 +208,7 @@ function normalizeEventStream(
 				const lines = buffer.split("\n");
 				buffer = lines.pop() ?? "";
 				for (const line of lines) {
-					controller.enqueue(
-						encoder.encode(`${rewriteLine(line)}\n`),
-					);
+					controller.enqueue(encoder.encode(`${rewriteLine(line)}\n`));
 				}
 			},
 			flush(controller) {
@@ -208,6 +232,10 @@ function headersWithout(source: Headers, ...names: string[]): Headers {
  * Wrap a fetch implementation so gpt-oss harmony responses are normalized to
  * the OpenAI Chat Completions shape before the caller parses them. Composes
  * with a user-supplied `fetch` (falls back to the global `fetch`).
+ *
+ * When the response is already compliant, the original response is returned
+ * untouched — a transparent pass-through that will not interfere once the
+ * gateway is fixed.
  */
 export function wrapFetchWithHarmonyNormalization(
 	baseFetch?: FetchFunction,
@@ -223,10 +251,12 @@ export function wrapFetchWithHarmonyNormalization(
 		const contentType = response.headers.get("content-type") ?? "";
 
 		if (contentType.includes("text/event-stream")) {
+			// Streaming is inspected frame-by-frame; compliant frames pass through
+			// verbatim (see normalizeEventStream).
 			return new Response(normalizeEventStream(response.body), {
 				status: response.status,
 				statusText: response.statusText,
-				// content-length/encoding no longer match the rewritten body.
+				// content-length/encoding no longer describe the (possibly) rewritten body.
 				headers: headersWithout(
 					response.headers,
 					"content-length",
@@ -236,29 +266,33 @@ export function wrapFetchWithHarmonyNormalization(
 		}
 
 		if (contentType.includes("application/json")) {
-			const text = await response.text();
+			// Inspect a clone so the original body stays intact for the pass-through case.
+			let text: string;
+			try {
+				text = await response.clone().text();
+			} catch {
+				return response;
+			}
 			let parsed: unknown;
 			try {
 				parsed = JSON.parse(text);
 			} catch {
-				return new Response(text, {
-					status: response.status,
-					statusText: response.statusText,
-					headers: response.headers,
-				});
+				return response;
 			}
-			return new Response(
-				JSON.stringify(normalizeCompletionBody(parsed)),
-				{
-					status: response.status,
-					statusText: response.statusText,
-					headers: headersWithout(
-						response.headers,
-						"content-length",
-						"content-encoding",
-					),
-				},
-			);
+			const { body: normalized, changed } = normalizeCompletionBody(parsed);
+			if (!changed) {
+				// Already compliant: return the original response untouched.
+				return response;
+			}
+			return new Response(JSON.stringify(normalized), {
+				status: response.status,
+				statusText: response.statusText,
+				headers: headersWithout(
+					response.headers,
+					"content-length",
+					"content-encoding",
+				),
+			});
 		}
 
 		return response;

--- a/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.ts
@@ -54,7 +54,9 @@ interface NormalizeResult {
  * when `content` is not an array (i.e. an already-compliant string response),
  * signalling that no rewrite is needed.
  */
-export function extractHarmonyContent(content: unknown): ExtractedHarmony | null {
+export function extractHarmonyContent(
+	content: unknown,
+): ExtractedHarmony | null {
 	if (!Array.isArray(content)) {
 		return null;
 	}
@@ -208,7 +210,9 @@ function normalizeEventStream(
 				const lines = buffer.split("\n");
 				buffer = lines.pop() ?? "";
 				for (const line of lines) {
-					controller.enqueue(encoder.encode(`${rewriteLine(line)}\n`));
+					controller.enqueue(
+						encoder.encode(`${rewriteLine(line)}\n`),
+					);
 				}
 			},
 			flush(controller) {
@@ -279,7 +283,8 @@ export function wrapFetchWithHarmonyNormalization(
 			} catch {
 				return response;
 			}
-			const { body: normalized, changed } = normalizeCompletionBody(parsed);
+			const { body: normalized, changed } =
+				normalizeCompletionBody(parsed);
 			if (!changed) {
 				// Already compliant: return the original response untouched.
 				return response;

--- a/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-harmony-normalize.ts
@@ -1,0 +1,266 @@
+import type { FetchFunction } from "@ai-sdk/provider-utils";
+
+/**
+ * Normalize the Neon AI Gateway's non-OpenAI-compliant `gpt-oss` ("harmony")
+ * response shape into the OpenAI Chat Completions contract before it reaches
+ * the AI SDK's schema validation.
+ *
+ * For `gpt-oss-*` the gateway returns `message.content` (and streaming
+ * `delta.content`) as an array of Responses-style parts:
+ *
+ *   "content": [
+ *     { "type": "reasoning", "summary": [{ "type": "summary_text", "text": "…" }] },
+ *     { "type": "text", "text": "…" }
+ *   ]
+ *
+ * The Chat Completions spec requires `content` to be a string, so any strict
+ * OpenAI-compatible client (incl. the Vercel AI SDK) rejects it. We flatten the
+ * `text` parts into the string `content` and hoist reasoning into
+ * `reasoning_content` (which `@ai-sdk/openai-compatible` already surfaces as an
+ * AI SDK reasoning part).
+ *
+ * The transform only rewrites when `content` is an array, so it is a no-op for
+ * every spec-compliant model (Llama, Gemini, Qwen, …) and self-retires if the
+ * gateway is fixed to return a compliant shape.
+ *
+ * See neondatabase/neon-pkgs#308.
+ */
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+interface ExtractedHarmony {
+	text: string;
+	reasoning: string;
+}
+
+/**
+ * Pull the text and reasoning out of a harmony `content` array. Returns `null`
+ * when `content` is not an array (i.e. an already-compliant string response),
+ * signalling that no rewrite is needed.
+ */
+export function extractHarmonyContent(
+	content: unknown,
+): ExtractedHarmony | null {
+	if (!Array.isArray(content)) {
+		return null;
+	}
+
+	const texts: string[] = [];
+	const reasonings: string[] = [];
+
+	for (const part of content) {
+		if (!isRecord(part)) {
+			continue;
+		}
+		if (part.type === "text") {
+			if (typeof part.text === "string") {
+				texts.push(part.text);
+			}
+			continue;
+		}
+		if (part.type === "reasoning") {
+			// Reasoning items can carry the raw CoT in `text`, a `summary[]` of
+			// `summary_text` parts, and/or a `content[]` of `reasoning_text` parts.
+			if (typeof part.text === "string") {
+				reasonings.push(part.text);
+			}
+			if (Array.isArray(part.summary)) {
+				for (const entry of part.summary) {
+					if (isRecord(entry) && typeof entry.text === "string") {
+						reasonings.push(entry.text);
+					}
+				}
+			}
+			if (Array.isArray(part.content)) {
+				for (const entry of part.content) {
+					if (isRecord(entry) && typeof entry.text === "string") {
+						reasonings.push(entry.text);
+					}
+				}
+			}
+		}
+	}
+
+	return { text: texts.join(""), reasoning: reasonings.join("\n") };
+}
+
+/** Rewrite a non-streaming `chat.completion` body in place. Returns the body. */
+export function normalizeCompletionBody(body: unknown): unknown {
+	if (!isRecord(body) || !Array.isArray(body.choices)) {
+		return body;
+	}
+	for (const choice of body.choices) {
+		if (!isRecord(choice)) {
+			continue;
+		}
+		const message = choice.message;
+		if (!isRecord(message)) {
+			continue;
+		}
+		const extracted = extractHarmonyContent(message.content);
+		if (extracted === null) {
+			continue;
+		}
+		message.content = extracted.text;
+		if (
+			extracted.reasoning.length > 0 &&
+			message.reasoning_content == null &&
+			message.reasoning == null
+		) {
+			message.reasoning_content = extracted.reasoning;
+		}
+	}
+	return body;
+}
+
+/** Rewrite a streaming `chat.completion.chunk` body in place. Returns the body. */
+export function normalizeChunkBody(body: unknown): unknown {
+	if (!isRecord(body) || !Array.isArray(body.choices)) {
+		return body;
+	}
+	for (const choice of body.choices) {
+		if (!isRecord(choice)) {
+			continue;
+		}
+		const delta = choice.delta;
+		if (!isRecord(delta)) {
+			continue;
+		}
+		const extracted = extractHarmonyContent(delta.content);
+		if (extracted === null) {
+			continue;
+		}
+		// Drop empty text so reasoning-only chunks don't emit spurious text deltas.
+		if (extracted.text.length > 0) {
+			delta.content = extracted.text;
+		} else {
+			delta.content = undefined;
+		}
+		if (
+			extracted.reasoning.length > 0 &&
+			delta.reasoning_content == null &&
+			delta.reasoning == null
+		) {
+			delta.reasoning_content = extracted.reasoning;
+		}
+	}
+	return body;
+}
+
+/** Rewrite each `data:` frame of an SSE stream. */
+function normalizeEventStream(
+	body: ReadableStream<Uint8Array>,
+): ReadableStream<Uint8Array> {
+	const decoder = new TextDecoder();
+	const encoder = new TextEncoder();
+	let buffer = "";
+
+	const rewriteLine = (line: string): string => {
+		const trimmed = line.startsWith("data:") ? line : null;
+		if (trimmed === null) {
+			return line;
+		}
+		const payload = line.slice("data:".length).trim();
+		if (payload === "" || payload === "[DONE]") {
+			return line;
+		}
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(payload);
+		} catch {
+			return line;
+		}
+		return `data: ${JSON.stringify(normalizeChunkBody(parsed))}`;
+	};
+
+	return body.pipeThrough(
+		new TransformStream<Uint8Array, Uint8Array>({
+			transform(chunk, controller) {
+				buffer += decoder.decode(chunk, { stream: true });
+				const lines = buffer.split("\n");
+				buffer = lines.pop() ?? "";
+				for (const line of lines) {
+					controller.enqueue(
+						encoder.encode(`${rewriteLine(line)}\n`),
+					);
+				}
+			},
+			flush(controller) {
+				if (buffer.length > 0) {
+					controller.enqueue(encoder.encode(rewriteLine(buffer)));
+				}
+			},
+		}),
+	);
+}
+
+function headersWithout(source: Headers, ...names: string[]): Headers {
+	const copy = new Headers(source);
+	for (const name of names) {
+		copy.delete(name);
+	}
+	return copy;
+}
+
+/**
+ * Wrap a fetch implementation so gpt-oss harmony responses are normalized to
+ * the OpenAI Chat Completions shape before the caller parses them. Composes
+ * with a user-supplied `fetch` (falls back to the global `fetch`).
+ */
+export function wrapFetchWithHarmonyNormalization(
+	baseFetch?: FetchFunction,
+): FetchFunction {
+	const doFetch: FetchFunction =
+		baseFetch ?? ((input, init) => globalThis.fetch(input, init));
+
+	return async (input, init) => {
+		const response = await doFetch(input, init);
+		if (!response.ok || response.body === null) {
+			return response;
+		}
+		const contentType = response.headers.get("content-type") ?? "";
+
+		if (contentType.includes("text/event-stream")) {
+			return new Response(normalizeEventStream(response.body), {
+				status: response.status,
+				statusText: response.statusText,
+				// content-length/encoding no longer match the rewritten body.
+				headers: headersWithout(
+					response.headers,
+					"content-length",
+					"content-encoding",
+				),
+			});
+		}
+
+		if (contentType.includes("application/json")) {
+			const text = await response.text();
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(text);
+			} catch {
+				return new Response(text, {
+					status: response.status,
+					statusText: response.statusText,
+					headers: response.headers,
+				});
+			}
+			return new Response(
+				JSON.stringify(normalizeCompletionBody(parsed)),
+				{
+					status: response.status,
+					statusText: response.statusText,
+					headers: headersWithout(
+						response.headers,
+						"content-length",
+						"content-encoding",
+					),
+				},
+			);
+		}
+
+		return response;
+	};
+}

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -29,6 +29,7 @@ import { z } from "zod/v4";
 import { NeonAnthropicLanguageModel } from "./neon-anthropic-language-model.js";
 import { NeonChatLanguageModel } from "./neon-chat-language-model.js";
 import type { NeonChatModelId } from "./neon-chat-options.js";
+import { wrapFetchWithHarmonyNormalization } from "./neon-harmony-normalize.js";
 import { getNeonModelRoute } from "./neon-model-capabilities.js";
 import { NeonResponsesLanguageModel } from "./neon-responses-language-model.js";
 import { VERSION } from "./version.js";
@@ -173,12 +174,15 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 
 	// Everything else (Gemini, Llama, Qwen, gpt-oss, ...) -> unified Chat
 	// Completions endpoint. Gemini is here because its native endpoint can't stream.
+	// The fetch wrapper normalizes gpt-oss's non-compliant "harmony" content-array
+	// shape into the OpenAI Chat Completions contract (a no-op for every compliant
+	// model); see neon-harmony-normalize.ts and neondatabase/neon-pkgs#308.
 	const createChatModel = (modelId: NeonChatModelId) =>
 		new NeonChatLanguageModel(modelId, {
 			provider: "neon.chat",
 			url: ({ path }) => `${getHost()}/v1${path}`,
 			headers: getHeaders,
-			fetch: options.fetch,
+			fetch: wrapFetchWithHarmonyNormalization(options.fetch),
 			errorStructure: neonErrorStructure,
 			transformRequestBody: transformNeonRequestBody,
 			supportsStructuredOutputs: true,

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -174,14 +174,16 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 
 	// Everything else (Gemini, Llama, Qwen, gpt-oss, ...) -> unified Chat
 	// Completions endpoint. Gemini is here because its native endpoint can't stream.
-	// The fetch wrapper normalizes gpt-oss's non-compliant "harmony" content-array
-	// shape into the OpenAI Chat Completions contract (a no-op for every compliant
-	// model); see neon-harmony-normalize.ts and neondatabase/neon-pkgs#308.
 	const createChatModel = (modelId: NeonChatModelId) =>
 		new NeonChatLanguageModel(modelId, {
 			provider: "neon.chat",
 			url: ({ path }) => `${getHost()}/v1${path}`,
 			headers: getHeaders,
+			// TODO(#308): Temporary workaround for gpt-oss. The gateway returns a
+			// non-compliant "harmony" content-array shape; this wrapper normalizes it
+			// to the Chat Completions contract and is a transparent pass-through for
+			// every compliant response. Remove it (and neon-harmony-normalize.ts) once
+			// the gateway returns spec-compliant gpt-oss responses.
 			fetch: wrapFetchWithHarmonyNormalization(options.fetch),
 			errorStructure: neonErrorStructure,
 			transformRequestBody: transformNeonRequestBody,


### PR DESCRIPTION
## Summary

`gpt-oss-*` models fail through `@neon/ai-sdk-provider` (and any strict OpenAI-compatible AI SDK client) with `AI_APICallError: Invalid JSON response` on an HTTP 200. Root cause: the Neon AI Gateway returns gpt-oss responses on the unified `/v1/chat/completions` endpoint in a non-OpenAI-compliant **"harmony"** shape — `message.content` (and streaming `delta.content`) is an **array of Responses-style parts** instead of a string:

```jsonc
"message": {
  "role": "assistant",
  "content": [
    { "type": "reasoning", "summary": [ { "type": "summary_text", "text": "…" } ] },
    { "type": "text", "text": "Hi" }
  ]
}
```

The OpenAI Chat Completions spec requires `content` to be a `string`, so the AI SDK's Zod validation rejects it (`cause: AI_TypeValidationError`, `expected string, received array`). This is not provider-specific — it reproduces identically with the raw `@ai-sdk/openai` `openai.chat()` pointed at the gateway. `gpt-oss` is not served on the Responses endpoint (`/openai/v1/responses` → 400), so there's no alternate route.

Every other provider serving the same model (OpenRouter, Groq, DeepSeek/vLLM) returns the compliant shape — `content` as a string with reasoning in a separate `reasoning`/`reasoning_content` field — which the AI SDK already parses.

## Fix

Add a `fetch` wrapper on the chat route (`neon-harmony-normalize.ts`) that flattens the harmony array into the OpenAI Chat Completions contract **before** schema validation:
- `message.content` array → concatenated `text` string
- reasoning parts (`summary[].text` / `content[].text` / `text`) → `reasoning_content` (which `@ai-sdk/openai-compatible` surfaces as an AI SDK reasoning part)
- same transform on streaming `delta.content` frames (reasoning-only deltas emit `reasoning_content`; empty text dropped)

The transform only rewrites when `content` is an **array**, so it is a **no-op for every already-compliant model** (Llama, Gemini, Qwen, …) and **self-retires** if the gateway is fixed to return a compliant shape. It composes with a caller-supplied `fetch`.

Result: `gpt-oss-120b`/`gpt-oss-20b` work end-to-end via `generateText` and `streamText`, and their reasoning is now surfaced instead of lost.

## Test plan

- [x] Unit tests for the pure transforms (`neon-harmony-normalize.test.ts`, 8 cases) — string passthrough, array flattening, multi-source reasoning, streaming deltas, no-overwrite of existing reasoning
- [x] `tsc --noEmit` clean
- [x] e2e (live gateway): replaced the skipped gpt-oss placeholder with real `generateText`/`streamText` checks in the capability matrix — both pass
- [x] Verified live: `generateText` → text + reasoning, no throw; `streamText` → text + reasoning-delta, no error flood

The durable fix is still gateway-side (emit `content: string` + `reasoning_content` on `/v1` for gpt-oss); this provider shim unblocks users in the meantime. Refs #308.