### PR TITLE
feat(neonctl): add snapshots command group

### DIFF
--- a/.changeset/snapshots-commands.md
+++ b/.changeset/snapshots-commands.md
@@ -1,0 +1,5 @@
+---
+"neonctl": minor
+---
+
+Add a `snapshots` command group (alias `snapshot`) for managing Neon snapshots from the CLI: `list`, `get`, `create` (from a branch head, timestamp, or LSN, with optional expiration), `update` (rename / set / clear expiration), `delete`, `restore` (to a new branch or onto an existing branch, with optional immediate `--finalize`), `finalize` (commit a previewed restore), and `schedule get` / `schedule set` for a branch's automatic snapshot (backup) schedule.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -505,6 +505,50 @@ $ neon bootstrap . --template hono
 
 The target directory must be empty unless you pass `--force` (a lone `.git` is ignored, so a freshly `git init`ed folder is fine). Symlinks and executable bits in the template are preserved.
 
+## Snapshots (`snapshots`)
+
+`neon snapshots` (alias `neon snapshot`) manages **snapshots** — point-in-time backups of a branch that you can list, rename, expire, restore into a branch, or schedule automatically. Snapshots are a Beta Neon feature and were previously only available in the Console and REST API; this command group brings them to the CLI.
+
+Every sub-command resolves the project through the standard chain (`--project-id`, then the `.neon` context file, then a single-project auto-detect). Branch-scoped sub-commands (`create`, `schedule`) default to the branch pinned in `.neon`, falling back to the project's default branch, and accept `--branch <id|name>`. The `get`, `update`, `delete`, and `restore` sub-commands take a snapshot **id or name** as their positional argument (an id wins; an ambiguous name errors and asks you to use the id).
+
+```bash
+# Snapshot the head of the current/default branch
+neon snapshots create --name pre-migration
+
+# Snapshot a specific branch at a point in time (RFC 3339 timestamp OR LSN — mutually exclusive)
+neon snapshots create --branch main --timestamp 2025-01-01T00:00:00Z
+neon snapshots create --branch main --lsn 0/1F3C8A0 --expires-at 2025-12-31T23:59:59Z
+
+# List / inspect
+neon snapshots list
+neon snapshots get pre-migration
+
+# Rename or change expiration (omit both to error; --expires-at and --clear-expiration conflict)
+neon snapshots update snap-1234 --name nightly
+neon snapshots update snap-1234 --expires-at 2030-01-01T00:00:00Z
+neon snapshots update snap-1234 --clear-expiration      # keep indefinitely
+
+# Restore a snapshot to a NEW branch
+neon snapshots restore snap-1234 --name recovered
+
+# Restore ONTO an existing branch. Without --finalize the restore is left un-finalized
+# so you can inspect it first, then swap it in:
+neon snapshots restore snap-1234 --target-branch main
+neon snapshots finalize br-restored-1234                # commit the swap
+# …or do it in one step:
+neon snapshots restore snap-1234 --target-branch main --finalize
+
+# Delete
+neon snapshots delete snap-1234
+
+# Automatic snapshot (backup) schedule of a branch
+neon snapshots schedule get --branch main
+neon snapshots schedule set --branch main --frequency daily --hour 3 --retention 604800
+neon snapshots schedule set --branch main --schedule '[{"frequency":"hourly"},{"frequency":"daily","hour":3}]'
+```
+
+All sub-commands honor the [global options](#global-options), including `--output json|yaml|table`.
+
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                                  | Description                        |
@@ -518,6 +562,7 @@ The target directory must be empty unless you pass `--force` (a lone `.git` is i
 | function                                                                   | `deploy`, `list`, `get`, `delete`                                                                            | Manage Neon Functions              |
 | [roles](https://neon.com/docs/reference/cli-roles)                         | `list`, `create`, `delete`                                                                                   | Manage roles                       |
 | [operations](https://neon.com/docs/reference/cli-operations)               | `list`                                                                                                       | Manage operations                  |
+| snapshots                                                                  | `list`, `get`, `create`, `update`, `delete`, `restore`, `finalize`, `schedule get`, `schedule set`           | Manage snapshots                   |
 | [connection-string](https://neon.com/docs/reference/cli-connection-string) |                                                                                                              | Get connection string              |
 | [psql](https://neon.com/docs/reference/cli-psql)                           |                                                                                                              | Connect to a database via psql     |
 | set-context                                                                |                                                                                                              | Deprecated; use `link`             |

--- a/packages/cli/mocks/main/projects/test/branches/br-main-branch-123456/backup_schedule/GET.json
+++ b/packages/cli/mocks/main/projects/test/branches/br-main-branch-123456/backup_schedule/GET.json
@@ -1,0 +1,9 @@
+{
+  "schedule": [
+    {
+      "frequency": "daily",
+      "hour": 3,
+      "retention_seconds": 604800
+    }
+  ]
+}

--- a/packages/cli/mocks/main/projects/test/branches/br-main-branch-123456/backup_schedule/PUT.js
+++ b/packages/cli/mocks/main/projects/test/branches/br-main-branch-123456/backup_schedule/PUT.js
@@ -1,0 +1,11 @@
+import { expect } from 'vitest';
+
+export default function (req, res) {
+  expect(Array.isArray(req.body.schedule)).toBe(true);
+  expect(req.body.schedule.length).toBeGreaterThan(0);
+  for (const item of req.body.schedule) {
+    expect(typeof item.frequency).toBe('string');
+  }
+  // PUT backup_schedule returns an empty body on success.
+  res.status(200).send();
+}

--- a/packages/cli/mocks/main/projects/test/branches/br-main-branch-123456/snapshot/POST.js
+++ b/packages/cli/mocks/main/projects/test/branches/br-main-branch-123456/snapshot/POST.js
@@ -1,0 +1,27 @@
+import { expect } from 'vitest';
+
+export default function (req, res) {
+  // Point-in-time params are mutually exclusive and passed as query params.
+  expect(req.query.lsn && req.query.timestamp).toBeFalsy();
+
+  res.status(200).json({
+    snapshot: {
+      id: 'snap-new-snapshot-123456',
+      name: req.query.name ?? 'snap-new-snapshot-123456',
+      source_branch_id: 'br-main-branch-123456',
+      created_at: '2021-01-01T00:00:00.000Z',
+      ...(req.query.lsn ? { lsn: req.query.lsn } : {}),
+      ...(req.query.timestamp ? { timestamp: req.query.timestamp } : {}),
+      ...(req.query.expires_at ? { expires_at: req.query.expires_at } : {}),
+      manual: true,
+    },
+    operations: [
+      {
+        id: 'op-create-snapshot-1',
+        action: 'create_snapshot',
+        status: 'running',
+        created_at: '2021-01-01T00:00:00.000Z',
+      },
+    ],
+  });
+}

--- a/packages/cli/mocks/main/projects/test/branches/br-restored-branch-123456/finalize_restore/POST.js
+++ b/packages/cli/mocks/main/projects/test/branches/br-restored-branch-123456/finalize_restore/POST.js
@@ -1,0 +1,12 @@
+export default function (_req, res) {
+  res.status(200).json({
+    operations: [
+      {
+        id: 'op-finalize-restore-1',
+        action: 'finalize_restore',
+        status: 'running',
+        created_at: '2021-03-01T00:00:00.000Z',
+      },
+    ],
+  });
+}

--- a/packages/cli/mocks/main/projects/test/snapshots/GET.json
+++ b/packages/cli/mocks/main/projects/test/snapshots/GET.json
@@ -1,0 +1,19 @@
+{
+  "snapshots": [
+    {
+      "id": "snap-first-snapshot-123456",
+      "name": "nightly",
+      "source_branch_id": "br-main-branch-123456",
+      "created_at": "2021-01-01T00:00:00.000Z",
+      "expires_at": "2022-01-01T00:00:00.000Z",
+      "manual": false
+    },
+    {
+      "id": "snap-second-snapshot-123456",
+      "name": "pre-migration",
+      "source_branch_id": "br-main-branch-123456",
+      "created_at": "2021-02-01T00:00:00.000Z",
+      "manual": true
+    }
+  ]
+}

--- a/packages/cli/mocks/main/projects/test/snapshots/snap-first-snapshot-123456/DELETE.js
+++ b/packages/cli/mocks/main/projects/test/snapshots/snap-first-snapshot-123456/DELETE.js
@@ -1,0 +1,12 @@
+export default function (_req, res) {
+  res.status(202).json({
+    operations: [
+      {
+        id: 'op-delete-snapshot-1',
+        action: 'delete_snapshot',
+        status: 'running',
+        created_at: '2021-01-01T00:00:00.000Z',
+      },
+    ],
+  });
+}

--- a/packages/cli/mocks/main/projects/test/snapshots/snap-first-snapshot-123456/PATCH.js
+++ b/packages/cli/mocks/main/projects/test/snapshots/snap-first-snapshot-123456/PATCH.js
@@ -1,0 +1,19 @@
+export default function (req, res) {
+  const update = req.body.snapshot ?? {};
+  res.status(200).json({
+    snapshot: {
+      id: 'snap-first-snapshot-123456',
+      name: update.name ?? 'nightly',
+      source_branch_id: 'br-main-branch-123456',
+      created_at: '2021-01-01T00:00:00.000Z',
+      // `null` clears the expiration; a string sets it; `undefined` leaves it.
+      ...(update.expires_at === null
+        ? {}
+        : {
+            expires_at:
+              update.expires_at ?? '2022-01-01T00:00:00.000Z',
+          }),
+      manual: false,
+    },
+  });
+}

--- a/packages/cli/mocks/main/projects/test/snapshots/snap-first-snapshot-123456/restore/POST.js
+++ b/packages/cli/mocks/main/projects/test/snapshots/snap-first-snapshot-123456/restore/POST.js
@@ -1,0 +1,21 @@
+export default function (req, res) {
+  res.status(200).json({
+    branch: {
+      id: 'br-restored-branch-123456',
+      name: req.body?.name ?? 'restored-from-snap-first-snapshot-123456',
+      source_branch_id: 'br-main-branch-123456',
+      parent_id: req.body?.target_branch_id ?? 'br-main-branch-123456',
+      created_at: '2021-03-01T00:00:00.000Z',
+      current_state: 'ready',
+    },
+    endpoints: [],
+    operations: [
+      {
+        id: 'op-restore-snapshot-1',
+        action: 'restore_snapshot',
+        status: 'running',
+        created_at: '2021-03-01T00:00:00.000Z',
+      },
+    ],
+  });
+}

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -628,6 +628,89 @@ export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) => {
 				}),
 			),
 
+		// ─── Snapshots ───────────────────────────────────────────────────────
+		listSnapshots: (projectId: string) =>
+			call(() =>
+				raw.listSnapshots({
+					client,
+					path: { project_id: projectId },
+				}),
+			),
+		createSnapshot: (
+			projectId: string,
+			branchId: string,
+			query?: NonNullable<raw.CreateSnapshotData["query"]>,
+		) =>
+			call(() =>
+				raw.createSnapshot({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					...(query !== undefined ? { query } : {}),
+				}),
+			),
+		updateSnapshot: (
+			projectId: string,
+			snapshotId: string,
+			data: NonNullable<raw.UpdateSnapshotData["body"]>,
+		) =>
+			call(() =>
+				raw.updateSnapshot({
+					client,
+					path: { project_id: projectId, snapshot_id: snapshotId },
+					body: data,
+				}),
+			),
+		deleteSnapshot: (projectId: string, snapshotId: string) =>
+			call(() =>
+				raw.deleteSnapshot({
+					client,
+					path: { project_id: projectId, snapshot_id: snapshotId },
+				}),
+			),
+		restoreSnapshot: (
+			projectId: string,
+			snapshotId: string,
+			data?: raw.RestoreSnapshotData["body"],
+		) =>
+			call(() =>
+				raw.restoreSnapshot({
+					client,
+					path: { project_id: projectId, snapshot_id: snapshotId },
+					...(data !== undefined ? { body: data } : {}),
+				}),
+			),
+		finalizeRestoreBranch: (
+			projectId: string,
+			branchId: string,
+			data?: raw.FinalizeRestoreBranchData["body"],
+		) =>
+			call(() =>
+				raw.finalizeRestoreBranch({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					...(data !== undefined ? { body: data } : {}),
+				}),
+			),
+		getSnapshotSchedule: (projectId: string, branchId: string) =>
+			call(() =>
+				raw.getSnapshotSchedule({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+				}),
+			),
+		setSnapshotSchedule: (
+			projectId: string,
+			branchId: string,
+			data: NonNullable<raw.SetSnapshotScheduleData["body"]>,
+		) =>
+			call(() =>
+				raw.setSnapshotSchedule({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					body: data,
+				}),
+			),
+
 		// ─── Databases ───────────────────────────────────────────────────────
 		listProjectBranchDatabases: (projectId: string, branchId: string) =>
 			call(() =>

--- a/packages/cli/src/commands/__snapshots__/snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/snapshots.test.ts.snap
@@ -1,0 +1,225 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`snapshots > create at a timestamp 1`] = `
+"id: snap-new-snapshot-123456
+name: snap-new-snapshot-123456
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+timestamp: 2021-01-01T00:00:00Z
+manual: true
+"
+`;
+
+exports[`snapshots > create at an lsn with expiration 1`] = `
+"id: snap-new-snapshot-123456
+name: snap-new-snapshot-123456
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+lsn: 0/1F3C8A0
+expires_at: 2025-12-31T23:59:59.000Z
+manual: true
+"
+`;
+
+exports[`snapshots > create from default branch 1`] = `
+"id: snap-new-snapshot-123456
+name: snap-new-snapshot-123456
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+manual: true
+"
+`;
+
+exports[`snapshots > create rejects an invalid lsn 1`] = `""`;
+
+exports[`snapshots > create rejects both timestamp and lsn 1`] = `""`;
+
+exports[`snapshots > create with name 1`] = `
+"id: snap-new-snapshot-123456
+name: pre-migration
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+manual: true
+"
+`;
+
+exports[`snapshots > delete by id 1`] = `
+"id: snap-first-snapshot-123456
+name: nightly
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+expires_at: 2022-01-01T00:00:00.000Z
+manual: false
+"
+`;
+
+exports[`snapshots > delete by name 1`] = `
+"id: snap-first-snapshot-123456
+name: nightly
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+expires_at: 2022-01-01T00:00:00.000Z
+manual: false
+"
+`;
+
+exports[`snapshots > finalize a restored branch 1`] = `
+"- id: op-finalize-restore-1
+  action: finalize_restore
+  status: running
+  created_at: 2021-03-01T00:00:00.000Z
+"
+`;
+
+exports[`snapshots > get by id 1`] = `
+"id: snap-first-snapshot-123456
+name: nightly
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+expires_at: 2022-01-01T00:00:00.000Z
+manual: false
+"
+`;
+
+exports[`snapshots > get by name 1`] = `
+"id: snap-second-snapshot-123456
+name: pre-migration
+source_branch_id: br-main-branch-123456
+created_at: 2021-02-01T00:00:00.000Z
+manual: true
+"
+`;
+
+exports[`snapshots > get not found errors 1`] = `""`;
+
+exports[`snapshots > list/table output 1`] = `
+"snapshots
+┌─────────────────────────────┬───────────────┬───────────────────────┬──────────────────────────┬──────────────────────────┐
+│ Id                          │ Name          │ Source Branch Id      │ Created At               │ Expires At               │
+├─────────────────────────────┼───────────────┼───────────────────────┼──────────────────────────┼──────────────────────────┤
+│ snap-first-snapshot-123456  │ nightly       │ br-main-branch-123456 │ 2021-01-01T00:00:00.000Z │ 2022-01-01T00:00:00.000Z │
+├─────────────────────────────┼───────────────┼───────────────────────┼──────────────────────────┼──────────────────────────┤
+│ snap-second-snapshot-123456 │ pre-migration │ br-main-branch-123456 │ 2021-02-01T00:00:00.000Z │ never                    │
+└─────────────────────────────┴───────────────┴───────────────────────┴──────────────────────────┴──────────────────────────┘
+"
+`;
+
+exports[`snapshots > list/yaml 1`] = `
+"- id: snap-first-snapshot-123456
+  name: nightly
+  source_branch_id: br-main-branch-123456
+  created_at: 2021-01-01T00:00:00.000Z
+  expires_at: 2022-01-01T00:00:00.000Z
+  manual: false
+- id: snap-second-snapshot-123456
+  name: pre-migration
+  source_branch_id: br-main-branch-123456
+  created_at: 2021-02-01T00:00:00.000Z
+  manual: true
+"
+`;
+
+exports[`snapshots > restore onto a target branch and finalize 1`] = `
+"restored_branch:
+  id: br-restored-branch-123456
+  name: restored-from-snap-first-snapshot-123456
+  source_branch_id: br-main-branch-123456
+  parent_id: br-main-branch-123456
+  created_at: 2021-03-01T00:00:00.000Z
+  current_state: ready
+operations:
+  - id: op-restore-snapshot-1
+    action: restore_snapshot
+    status: running
+    created_at: 2021-03-01T00:00:00.000Z
+"
+`;
+
+exports[`snapshots > restore to a new branch 1`] = `
+"restored_branch:
+  id: br-restored-branch-123456
+  name: recovered
+  source_branch_id: br-main-branch-123456
+  parent_id: br-main-branch-123456
+  created_at: 2021-03-01T00:00:00.000Z
+  current_state: ready
+operations:
+  - id: op-restore-snapshot-1
+    action: restore_snapshot
+    status: running
+    created_at: 2021-03-01T00:00:00.000Z
+"
+`;
+
+exports[`snapshots > schedule get 1`] = `
+"- frequency: daily
+  hour: 3
+  retention_seconds: 604800
+"
+`;
+
+exports[`snapshots > schedule set from flags 1`] = `
+"- frequency: daily
+  hour: 3
+  retention_seconds: 604800
+"
+`;
+
+exports[`snapshots > schedule set from json 1`] = `
+"- frequency: hourly
+- frequency: daily
+  hour: 3
+"
+`;
+
+exports[`snapshots > schedule set rejects invalid json 1`] = `""`;
+
+exports[`snapshots > schedule set with nothing errors 1`] = `""`;
+
+exports[`snapshots > snapshot alias works 1`] = `
+"- id: snap-first-snapshot-123456
+  name: nightly
+  source_branch_id: br-main-branch-123456
+  created_at: 2021-01-01T00:00:00.000Z
+  expires_at: 2022-01-01T00:00:00.000Z
+  manual: false
+- id: snap-second-snapshot-123456
+  name: pre-migration
+  source_branch_id: br-main-branch-123456
+  created_at: 2021-02-01T00:00:00.000Z
+  manual: true
+"
+`;
+
+exports[`snapshots > update clear expiration 1`] = `
+"id: snap-first-snapshot-123456
+name: nightly
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+manual: false
+"
+`;
+
+exports[`snapshots > update expiration 1`] = `
+"id: snap-first-snapshot-123456
+name: nightly
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+expires_at: 2030-01-01T00:00:00.000Z
+manual: false
+"
+`;
+
+exports[`snapshots > update name 1`] = `
+"id: snap-first-snapshot-123456
+name: renamed
+source_branch_id: br-main-branch-123456
+created_at: 2021-01-01T00:00:00.000Z
+expires_at: 2022-01-01T00:00:00.000Z
+manual: false
+"
+`;
+
+exports[`snapshots > update rejects expires-at with clear-expiration 1`] = `""`;
+
+exports[`snapshots > update with nothing to change errors 1`] = `""`;

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -23,6 +23,7 @@ import * as projects from "./projects.js";
 import * as psql from "./psql.js";
 import * as roles from "./roles.js";
 import * as setContext from "./set_context.js";
+import * as snapshots from "./snapshots.js";
 import * as status from "./status.js";
 import * as users from "./user.js";
 import * as vpcEndpoints from "./vpc_endpoints.js";
@@ -40,6 +41,7 @@ export default [
 	databases,
 	roles,
 	operations,
+	snapshots,
 	cs,
 	psql,
 	setContext,

--- a/packages/cli/src/commands/snapshots.test.ts
+++ b/packages/cli/src/commands/snapshots.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect } from "vitest";
+
+import { test } from "../test_utils/fixtures";
+
+describe("snapshots", () => {
+	/* list */
+
+	test("list/yaml", async ({ testCliCommand }) => {
+		await testCliCommand(["snapshots", "list", "--project-id", "test"]);
+	});
+
+	test("list/table output", async ({ testCliCommand }) => {
+		await testCliCommand(["snapshots", "list", "--project-id", "test"], {
+			outputTable: true,
+		});
+	});
+
+	test("snapshot alias works", async ({ testCliCommand }) => {
+		await testCliCommand(["snapshot", "list", "--project-id", "test"]);
+	});
+
+	/* get */
+
+	test("get by id", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"get",
+			"snap-first-snapshot-123456",
+			"--project-id",
+			"test",
+		]);
+	});
+
+	test("get by name", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"get",
+			"pre-migration",
+			"--project-id",
+			"test",
+		]);
+	});
+
+	test("get not found errors", async ({ testCliCommand }) => {
+		await testCliCommand(
+			["snapshots", "get", "does-not-exist", "--project-id", "test"],
+			{
+				code: 1,
+				stderr: expect.stringContaining(
+					'Snapshot "does-not-exist" not found',
+				),
+			},
+		);
+	});
+
+	/* create */
+
+	test("create from default branch", async ({ testCliCommand }) => {
+		await testCliCommand(["snapshots", "create", "--project-id", "test"]);
+	});
+
+	test("create with name", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"create",
+			"--project-id",
+			"test",
+			"--branch",
+			"main",
+			"--name",
+			"pre-migration",
+		]);
+	});
+
+	test("create at a timestamp", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"create",
+			"--project-id",
+			"test",
+			"--branch",
+			"main",
+			"--timestamp",
+			"2021-01-01T00:00:00Z",
+		]);
+	});
+
+	test("create at an lsn with expiration", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"create",
+			"--project-id",
+			"test",
+			"--branch",
+			"main",
+			"--lsn",
+			"0/1F3C8A0",
+			"--expires-at",
+			"2025-12-31T23:59:59Z",
+		]);
+	});
+
+	test("create rejects both timestamp and lsn", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"create",
+				"--project-id",
+				"test",
+				"--timestamp",
+				"2021-01-01T00:00:00Z",
+				"--lsn",
+				"0/1F3C8A0",
+			],
+			{ code: 1 },
+		);
+	});
+
+	test("create rejects an invalid lsn", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"create",
+				"--project-id",
+				"test",
+				"--lsn",
+				"not-an-lsn",
+			],
+			{
+				code: 1,
+				stderr: expect.stringContaining("Invalid --lsn value"),
+			},
+		);
+	});
+
+	/* update */
+
+	test("update name", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"update",
+			"snap-first-snapshot-123456",
+			"--project-id",
+			"test",
+			"--name",
+			"renamed",
+		]);
+	});
+
+	test("update expiration", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"update",
+			"snap-first-snapshot-123456",
+			"--project-id",
+			"test",
+			"--expires-at",
+			"2030-01-01T00:00:00Z",
+		]);
+	});
+
+	test("update clear expiration", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"update",
+			"snap-first-snapshot-123456",
+			"--project-id",
+			"test",
+			"--clear-expiration",
+		]);
+	});
+
+	test("update with nothing to change errors", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"update",
+				"snap-first-snapshot-123456",
+				"--project-id",
+				"test",
+			],
+			{
+				code: 1,
+				stderr: expect.stringContaining("Nothing to update"),
+			},
+		);
+	});
+
+	test("update rejects expires-at with clear-expiration", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"update",
+				"snap-first-snapshot-123456",
+				"--project-id",
+				"test",
+				"--expires-at",
+				"2030-01-01T00:00:00Z",
+				"--clear-expiration",
+			],
+			{ code: 1 },
+		);
+	});
+
+	/* delete */
+
+	test("delete by id", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"delete",
+			"snap-first-snapshot-123456",
+			"--project-id",
+			"test",
+		]);
+	});
+
+	test("delete by name", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"delete",
+			"nightly",
+			"--project-id",
+			"test",
+		]);
+	});
+
+	/* restore */
+
+	test("restore to a new branch", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"restore",
+			"snap-first-snapshot-123456",
+			"--project-id",
+			"test",
+			"--name",
+			"recovered",
+		]);
+	});
+
+	test("restore onto a target branch and finalize", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand([
+			"snapshots",
+			"restore",
+			"snap-first-snapshot-123456",
+			"--project-id",
+			"test",
+			"--target-branch",
+			"main",
+			"--finalize",
+		]);
+	});
+
+	/* finalize */
+
+	test("finalize a restored branch", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"finalize",
+			"br-restored-branch-123456",
+			"--project-id",
+			"test",
+		]);
+	});
+
+	/* schedule */
+
+	test("schedule get", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"schedule",
+			"get",
+			"--project-id",
+			"test",
+			"--branch",
+			"main",
+		]);
+	});
+
+	test("schedule set from flags", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"schedule",
+			"set",
+			"--project-id",
+			"test",
+			"--branch",
+			"main",
+			"--frequency",
+			"daily",
+			"--hour",
+			"3",
+			"--retention",
+			"604800",
+		]);
+	});
+
+	test("schedule set from json", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"snapshots",
+			"schedule",
+			"set",
+			"--project-id",
+			"test",
+			"--branch",
+			"main",
+			"--schedule",
+			'[{"frequency":"hourly"},{"frequency":"daily","hour":3}]',
+		]);
+	});
+
+	test("schedule set with nothing errors", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"schedule",
+				"set",
+				"--project-id",
+				"test",
+				"--branch",
+				"main",
+			],
+			{
+				code: 1,
+				stderr: expect.stringContaining("Provide --frequency"),
+			},
+		);
+	});
+
+	test("schedule set rejects invalid json", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"schedule",
+				"set",
+				"--project-id",
+				"test",
+				"--branch",
+				"main",
+				"--schedule",
+				"{not json}",
+			],
+			{
+				code: 1,
+				stderr: expect.stringContaining("valid JSON"),
+			},
+		);
+	});
+});

--- a/packages/cli/src/commands/snapshots.ts
+++ b/packages/cli/src/commands/snapshots.ts
@@ -1,0 +1,652 @@
+import type { BackupScheduleItem, Operation, Snapshot } from "@neon/sdk";
+import type yargs from "yargs";
+import { retryOnLock } from "../api.js";
+import { log } from "../log.js";
+import type { ProjectScopeProps } from "../types.js";
+import {
+	branchIdResolve,
+	fillSingleProject,
+	resolveBranchRef,
+} from "../utils/enrichers.js";
+import { looksLikeLSN, looksLikeTimestamp } from "../utils/formats.js";
+import { writer } from "../writer.js";
+import { BRANCH_FIELDS } from "./branches.js";
+
+export const SNAPSHOT_FIELDS: readonly (keyof Snapshot)[] = [
+	"id",
+	"name",
+	"source_branch_id",
+	"created_at",
+	"expires_at",
+];
+
+const SCHEDULE_FIELDS: readonly (keyof BackupScheduleItem)[] = [
+	"frequency",
+	"hour",
+	"day",
+	"month",
+	"retention_seconds",
+];
+
+const OPERATION_FIELDS: readonly (keyof Operation)[] = [
+	"id",
+	"action",
+	"status",
+];
+
+const SNAPSHOT_FREQUENCIES = [
+	"hourly",
+	"daily",
+	"weekly",
+	"monthly",
+	"yearly",
+] as const;
+
+export const command = "snapshots";
+export const describe = "Manage snapshots";
+export const aliases = ["snapshot"];
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 snapshots <sub-command> [options]")
+		.options({
+			"project-id": {
+				describe: "Project ID",
+				type: "string",
+			},
+		})
+		.middleware(fillSingleProject as any)
+		.command(
+			"list",
+			"List snapshots in the project",
+			(yargs) => yargs,
+			(args) => list(args as any),
+		)
+		.command(
+			"get <id>",
+			"Get a snapshot by id or name",
+			(yargs) => yargs,
+			(args) => get(args as any),
+		)
+		.command(
+			"create",
+			"Create a snapshot from a branch",
+			(yargs) =>
+				yargs
+					.options({
+						branch: {
+							alias: "b",
+							describe:
+								"Branch id or name to snapshot. Defaults to the branch in your context, or the project's default branch.",
+							type: "string",
+						},
+						name: {
+							describe: "A name for the snapshot",
+							type: "string",
+						},
+						timestamp: {
+							describe:
+								"Take the snapshot at this point in time (RFC 3339, e.g. 2025-01-01T00:00:00Z). Must fall within the branch's restore window. Mutually exclusive with --lsn.",
+							type: "string",
+						},
+						lsn: {
+							describe:
+								"Take the snapshot at this LSN (e.g. 0/1F3C8A0). Must fall within the branch's restore window. Mutually exclusive with --timestamp.",
+							type: "string",
+						},
+						"expires-at": {
+							describe:
+								"When the snapshot is automatically deleted (RFC 3339, e.g. 2025-12-31T23:59:59Z). Omit to keep it indefinitely.",
+							type: "string",
+						},
+					})
+					.conflicts("timestamp", "lsn")
+					.example([
+						[
+							"$0 snapshots create",
+							"Snapshot the head of the context/default branch",
+						],
+						[
+							"$0 snapshots create --branch main --name pre-migration",
+							"Snapshot the head of main with a name",
+						],
+						[
+							"$0 snapshots create --branch main --timestamp 2025-01-01T00:00:00Z",
+							"Snapshot main at a point in time",
+						],
+						[
+							"$0 snapshots create --branch main --lsn 0/1F3C8A0 --expires-at 2025-12-31T23:59:59Z",
+							"Snapshot main at an LSN, auto-deleting at the given time",
+						],
+					]),
+			(args) => create(args as any),
+		)
+		.command(
+			"update <id>",
+			"Update a snapshot's name or expiration",
+			(yargs) =>
+				yargs
+					.options({
+						name: {
+							describe: "Rename the snapshot",
+							type: "string",
+						},
+						"expires-at": {
+							describe:
+								"Set when the snapshot expires (RFC 3339). Mutually exclusive with --clear-expiration.",
+							type: "string",
+						},
+						"clear-expiration": {
+							describe:
+								"Clear the expiration so the snapshot is kept indefinitely.",
+							type: "boolean",
+						},
+					})
+					.conflicts("expires-at", "clear-expiration"),
+			(args) => update(args as any),
+		)
+		.command(
+			"delete <id>",
+			"Delete a snapshot by id or name",
+			(yargs) => yargs,
+			(args) => deleteSnapshot(args as any),
+		)
+		.command(
+			"restore <id>",
+			"Restore a snapshot into a branch",
+			(yargs) =>
+				yargs
+					.options({
+						name: {
+							describe:
+								"Name for the newly restored branch. Auto-generated when omitted.",
+							type: "string",
+						},
+						"target-branch": {
+							describe:
+								"Branch id or name to restore the snapshot onto. Defaults to the snapshot's source branch. Recommended when you intend to finalize (replace an existing branch).",
+							type: "string",
+						},
+						finalize: {
+							describe:
+								"Finalize the restore immediately: move computes onto the restored branch and swap it in for the target. Without this, the restore is left un-finalized so you can inspect it first, then run `snapshots finalize <branch>`.",
+							type: "boolean",
+							default: false,
+						},
+					})
+					.example([
+						[
+							"$0 snapshots restore snap-1234 --name recovered",
+							"Restore a snapshot to a new branch named 'recovered'",
+						],
+						[
+							"$0 snapshots restore snap-1234 --target-branch main --finalize",
+							"Restore onto main and swap it in immediately",
+						],
+						[
+							"$0 snapshots restore snap-1234 --target-branch main",
+							"Restore onto main un-finalized to preview, then run `snapshots finalize`",
+						],
+					]),
+			(args) => restore(args as any),
+		)
+		.command(
+			"finalize <branch>",
+			"Finalize a previewed snapshot restore (swap the restored branch in)",
+			(yargs) =>
+				yargs.options({
+					name: {
+						describe:
+							"Name to give the replaced (old) branch. Auto-generated when omitted.",
+						type: "string",
+					},
+				}),
+			(args) => finalize(args as any),
+		)
+		.command(
+			"schedule",
+			"Manage the automatic snapshot (backup) schedule of a branch",
+			(yargs) =>
+				yargs
+					.usage("$0 snapshots schedule <sub-command> [options]")
+					.command(
+						"get",
+						"Get a branch's automatic snapshot schedule",
+						(yargs) =>
+							yargs.options({
+								branch: {
+									alias: "b",
+									describe:
+										"Branch id or name. Defaults to the branch in your context, or the project's default branch.",
+									type: "string",
+								},
+							}),
+						(args) => scheduleGet(args as any),
+					)
+					.command(
+						"set",
+						"Set a branch's automatic snapshot schedule",
+						(yargs) =>
+							yargs
+								.options({
+									branch: {
+										alias: "b",
+										describe:
+											"Branch id or name. Defaults to the branch in your context, or the project's default branch.",
+										type: "string",
+									},
+									frequency: {
+										describe:
+											"How often to take snapshots. Builds a single-entry schedule together with --hour/--day/--month/--retention.",
+										choices: SNAPSHOT_FREQUENCIES,
+										type: "string",
+									},
+									hour: {
+										describe:
+											"Hour of the day (0-23) to take the snapshot (used with --frequency).",
+										type: "number",
+									},
+									day: {
+										describe:
+											"Day of the week/month (1-31) to take the snapshot (used with --frequency).",
+										type: "number",
+									},
+									month: {
+										describe:
+											"Month of the year (1-12) to take the snapshot (used with --frequency).",
+										type: "number",
+									},
+									retention: {
+										describe:
+											"How long to keep each snapshot, in seconds (min 3600). Omit to keep indefinitely.",
+										type: "number",
+									},
+									schedule: {
+										describe:
+											'Full schedule as JSON, for multi-entry schedules, e.g. \'[{"frequency":"daily","hour":3,"retention_seconds":604800}]\'. Overrides the single-entry flags.',
+										type: "string",
+									},
+								})
+								.example([
+									[
+										"$0 snapshots schedule set --branch main --frequency daily --hour 3 --retention 604800",
+										"A daily 03:00 snapshot kept for 7 days",
+									],
+									[
+										'$0 snapshots schedule set --branch main --schedule \'[{"frequency":"hourly"},{"frequency":"daily","hour":3}]\'',
+										"A multi-entry schedule via JSON",
+									],
+								]),
+						(args) => scheduleSet(args as any),
+					)
+					.demandCommand(1, "Specify `get` or `set`."),
+			() => {},
+		)
+		.demandCommand(1, "Specify a snapshots sub-command.");
+
+export const handler = (args: yargs.Argv) => {
+	return args;
+};
+
+/** Narrow an unknown parsed JSON value to a plain object without type casting. */
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Normalize a user-supplied date to an ISO 8601 string, or throw a friendly error. */
+const toIso = (value: string, flag: string): string => {
+	const ms = Date.parse(value);
+	if (Number.isNaN(ms)) {
+		throw new Error(
+			`Invalid ${flag} value: "${value}". Use an RFC 3339 timestamp, e.g. 2025-12-31T23:59:59Z.`,
+		);
+	}
+	return new Date(ms).toISOString();
+};
+
+/**
+ * Resolve a snapshot from an id **or** a name. Snapshot names are not guaranteed
+ * unique, so an id match wins; a name that resolves to more than one snapshot is a
+ * hard error asking the user to disambiguate by id.
+ */
+const resolveSnapshot = async (
+	props: ProjectScopeProps & { id: string },
+): Promise<Snapshot> => {
+	const {
+		data: { snapshots },
+	} = await props.apiClient.listSnapshots(props.projectId);
+
+	const byId = snapshots.find((s: Snapshot) => s.id === props.id);
+	if (byId) {
+		return byId;
+	}
+
+	const byName = snapshots.filter((s: Snapshot) => s.name === props.id);
+	if (byName.length === 1) {
+		return byName[0];
+	}
+	if (byName.length > 1) {
+		throw new Error(
+			`Multiple snapshots are named "${props.id}". Re-run with the snapshot id:\n${byName
+				.map((s: Snapshot) => `  ${s.id}`)
+				.join("\n")}`,
+		);
+	}
+
+	throw new Error(
+		`Snapshot "${props.id}" not found.\nAvailable snapshots: ${
+			snapshots.map((s: Snapshot) => `${s.name} (${s.id})`).join(", ") ||
+			"none"
+		}`,
+	);
+};
+
+const list = async (props: ProjectScopeProps) => {
+	const {
+		data: { snapshots },
+	} = await props.apiClient.listSnapshots(props.projectId);
+	writer(props).end(snapshots, {
+		fields: SNAPSHOT_FIELDS,
+		title: "snapshots",
+		emptyMessage:
+			"No snapshots found. Create one with:\n> neon snapshots create --help",
+		renderColumns: {
+			expires_at: (s) => s.expires_at || "never",
+		},
+	});
+};
+
+const get = async (props: ProjectScopeProps & { id: string }) => {
+	const snapshot = await resolveSnapshot(props);
+	writer(props).end(snapshot, {
+		fields: SNAPSHOT_FIELDS,
+		renderColumns: {
+			expires_at: (s) => s.expires_at || "never",
+		},
+	});
+};
+
+const create = async (
+	props: ProjectScopeProps & {
+		branch?: string;
+		name?: string;
+		timestamp?: string;
+		lsn?: string;
+		expiresAt?: string;
+	},
+) => {
+	if (props.lsn !== undefined && !looksLikeLSN(props.lsn)) {
+		throw new Error(
+			`Invalid --lsn value: "${props.lsn}". Expected an LSN like 0/1F3C8A0.`,
+		);
+	}
+	if (props.timestamp !== undefined && !looksLikeTimestamp(props.timestamp)) {
+		throw new Error(
+			`Invalid --timestamp value: "${props.timestamp}". Use an RFC 3339 timestamp, e.g. 2025-01-01T00:00:00Z.`,
+		);
+	}
+
+	const { branchId } = await resolveBranchRef({
+		...props,
+		branch: props.branch,
+	} as any);
+
+	const { data } = await retryOnLock(() =>
+		props.apiClient.createSnapshot(props.projectId, branchId, {
+			name: props.name,
+			timestamp: props.timestamp,
+			lsn: props.lsn,
+			expires_at: props.expiresAt
+				? toIso(props.expiresAt, "--expires-at")
+				: undefined,
+		}),
+	);
+
+	writer(props).end(data.snapshot, {
+		fields: SNAPSHOT_FIELDS,
+		title: "snapshot",
+		renderColumns: {
+			expires_at: (s) => s.expires_at || "never",
+		},
+	});
+};
+
+const update = async (
+	props: ProjectScopeProps & {
+		id: string;
+		name?: string;
+		expiresAt?: string;
+		clearExpiration?: boolean;
+	},
+) => {
+	if (
+		props.name === undefined &&
+		props.expiresAt === undefined &&
+		!props.clearExpiration
+	) {
+		throw new Error(
+			"Nothing to update. Pass --name, --expires-at, or --clear-expiration.",
+		);
+	}
+
+	const snapshot = await resolveSnapshot(props);
+
+	// `undefined` fields are dropped by JSON serialization, so an omitted
+	// `expires_at` leaves the expiration unchanged while an explicit `null`
+	// clears it.
+	const expiresAt = props.clearExpiration
+		? null
+		: props.expiresAt !== undefined
+			? toIso(props.expiresAt, "--expires-at")
+			: undefined;
+
+	const { data } = await retryOnLock(() =>
+		props.apiClient.updateSnapshot(props.projectId, snapshot.id, {
+			snapshot: {
+				name: props.name,
+				expires_at: expiresAt,
+			},
+		}),
+	);
+
+	writer(props).end(data.snapshot, {
+		fields: SNAPSHOT_FIELDS,
+		renderColumns: {
+			expires_at: (s) => s.expires_at || "never",
+		},
+	});
+};
+
+const deleteSnapshot = async (props: ProjectScopeProps & { id: string }) => {
+	const snapshot = await resolveSnapshot(props);
+	await retryOnLock(() =>
+		props.apiClient.deleteSnapshot(props.projectId, snapshot.id),
+	);
+	// The delete endpoint returns the tracking operations (202), not the snapshot
+	// body, so echo the snapshot we just deleted for confirmation.
+	writer(props).end(snapshot, {
+		fields: SNAPSHOT_FIELDS,
+		renderColumns: {
+			expires_at: (s) => s.expires_at || "never",
+		},
+	});
+};
+
+const restore = async (
+	props: ProjectScopeProps & {
+		id: string;
+		name?: string;
+		targetBranch?: string;
+		finalize: boolean;
+	},
+) => {
+	const snapshot = await resolveSnapshot(props);
+
+	const targetBranchId = props.targetBranch
+		? await branchIdResolve({
+				branch: props.targetBranch,
+				projectId: props.projectId,
+				apiClient: props.apiClient,
+			})
+		: undefined;
+
+	const { data } = await retryOnLock(() =>
+		props.apiClient.restoreSnapshot(props.projectId, snapshot.id, {
+			name: props.name,
+			target_branch_id: targetBranchId,
+			finalize_restore: props.finalize,
+		}),
+	);
+
+	const out = writer(props).write(data.branch, {
+		fields: BRANCH_FIELDS,
+		title: "restored branch",
+	});
+	if (data.operations?.length) {
+		out.write(data.operations, {
+			fields: OPERATION_FIELDS,
+			title: "operations",
+		});
+	}
+	out.end();
+
+	if (!props.finalize) {
+		log.info(
+			`Restore left un-finalized. Inspect branch ${data.branch.id}, then run:\n  neon snapshots finalize ${data.branch.id} --project-id ${props.projectId}`,
+		);
+	}
+};
+
+const finalize = async (
+	props: ProjectScopeProps & { branch: string; name?: string },
+) => {
+	const branchId = await branchIdResolve({
+		branch: props.branch,
+		projectId: props.projectId,
+		apiClient: props.apiClient,
+	});
+
+	const { data } = await retryOnLock(() =>
+		props.apiClient.finalizeRestoreBranch(
+			props.projectId,
+			branchId,
+			props.name ? { name: props.name } : undefined,
+		),
+	);
+
+	writer(props).end(data.operations ?? [], {
+		fields: OPERATION_FIELDS,
+		title: "operations",
+		emptyMessage: `Finalized restore for branch ${branchId}.`,
+	});
+};
+
+const scheduleGet = async (props: ProjectScopeProps & { branch?: string }) => {
+	const { branchId } = await resolveBranchRef({
+		...props,
+		branch: props.branch,
+	} as any);
+	const { data } = await props.apiClient.getSnapshotSchedule(
+		props.projectId,
+		branchId,
+	);
+	writer(props).end(data.schedule, {
+		fields: SCHEDULE_FIELDS,
+		title: "schedule",
+		emptyMessage: "No automatic snapshot schedule is configured.",
+	});
+};
+
+/**
+ * Validate an untrusted parsed value as a {@link BackupScheduleItem}[] without any
+ * type casting, throwing a clear error for the first invalid field it finds.
+ */
+const parseScheduleJson = (raw: string): BackupScheduleItem[] => {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		throw new Error("--schedule must be valid JSON.");
+	}
+	if (!Array.isArray(parsed)) {
+		throw new Error(
+			'--schedule must be a JSON array of schedule entries, e.g. \'[{"frequency":"daily","hour":3}]\'.',
+		);
+	}
+
+	return parsed.map((entry, index) => {
+		if (!isRecord(entry)) {
+			throw new Error(`--schedule entry ${index} must be an object.`);
+		}
+		const record = entry;
+		const frequency = record.frequency;
+		if (typeof frequency !== "string") {
+			throw new Error(
+				`--schedule entry ${index} is missing a string "frequency".`,
+			);
+		}
+		const item: BackupScheduleItem = { frequency };
+		for (const key of [
+			"hour",
+			"day",
+			"month",
+			"retention_seconds",
+		] as const) {
+			const value = record[key];
+			if (value === undefined) {
+				continue;
+			}
+			if (typeof value !== "number") {
+				throw new Error(
+					`--schedule entry ${index} field "${key}" must be a number.`,
+				);
+			}
+			item[key] = value;
+		}
+		return item;
+	});
+};
+
+const scheduleSet = async (
+	props: ProjectScopeProps & {
+		branch?: string;
+		frequency?: string;
+		hour?: number;
+		day?: number;
+		month?: number;
+		retention?: number;
+		schedule?: string;
+	},
+) => {
+	const { branchId } = await resolveBranchRef({
+		...props,
+		branch: props.branch,
+	} as any);
+
+	let schedule: BackupScheduleItem[];
+	if (props.schedule) {
+		schedule = parseScheduleJson(props.schedule);
+	} else if (props.frequency) {
+		const item: BackupScheduleItem = { frequency: props.frequency };
+		if (props.hour !== undefined) item.hour = props.hour;
+		if (props.day !== undefined) item.day = props.day;
+		if (props.month !== undefined) item.month = props.month;
+		if (props.retention !== undefined)
+			item.retention_seconds = props.retention;
+		schedule = [item];
+	} else {
+		throw new Error(
+			"Provide --frequency (optionally with --hour/--day/--month/--retention) or --schedule <json>.",
+		);
+	}
+
+	await retryOnLock(() =>
+		props.apiClient.setSnapshotSchedule(props.projectId, branchId, {
+			schedule,
+		}),
+	);
+
+	writer(props).end(schedule, {
+		fields: SCHEDULE_FIELDS,
+		title: "schedule",
+	});
+};


### PR DESCRIPTION
## Summary

Adds a first-class **`neon snapshots`** command group (alias `neon snapshot`) to the Neon CLI. Snapshots — point-in-time backups of a branch — were previously only reachable through the Console and the REST API; this brings the full snapshot lifecycle to `neonctl`.

The implementation wires the `Snapshot` / `backup_schedule` / `finalize_restore` endpoints (all from the vendored `@neon/sdk` OpenAPI spec, tagged `Snapshot`) through the existing fetch-based `api.ts` façade, follows the conventions of `branches` / `projects` (project resolution chain, `--branch <id|name>` scoping, `writer` output, `retryOnLock`, RFC 3339 handling), adds emocks fixtures + a 27-case test suite, and documents everything in the CLI README. **Verified end to end against the live Neon API** (create/list/get/update/delete/restore/finalize all succeed; `schedule set` correctly surfaces the API's Beta gating).

## Command reference

Global: every sub-command resolves the project via `--project-id` → `.neon` context → single-project auto-detect, and honors the global `--output json|yaml|table`. Snapshot-targeting sub-commands take a snapshot **id or name** as the positional (id wins; an ambiguous name errors and asks for the id). Branch-scoped sub-commands default to the `.neon` branch, then the project's default branch, and accept `--branch, -b <id|name>`.

### `neon snapshots list`
List every snapshot in the project.
- Args: none (project-scoped). Options: `--project-id`, `--output`.
- Edge cases: empty project prints a friendly "No snapshots found" hint.

### `neon snapshots get <id|name>`
Show one snapshot. Convenience over `list` (the API has no get-one endpoint) — resolves by id or name.
- Edge cases: not-found lists the available snapshots; a name shared by multiple snapshots errors and asks for the id.

### `neon snapshots create`
Create a snapshot from a branch (`POST /projects/{id}/branches/{branch}/snapshot`).
- Options: `--branch, -b <id|name>` (default: context/default branch), `--name`, `--timestamp <RFC3339>`, `--lsn <lsn>`, `--expires-at <RFC3339>`, `--project-id`.
- `--timestamp` and `--lsn` are **mutually exclusive** (enforced by `conflicts` + validated: bad LSN / bad timestamp give friendly errors before any API call). `--expires-at` is normalized to ISO 8601. Point-in-time values must fall within the branch's restore window (API-enforced).

### `neon snapshots update <id|name>`
Rename a snapshot and/or change its expiration (`PATCH /projects/{id}/snapshots/{sid}`).
- Options: `--name`, `--expires-at <RFC3339>`, `--clear-expiration`.
- Edge cases: `--expires-at` and `--clear-expiration` **conflict**; passing none of `--name/--expires-at/--clear-expiration` errors ("Nothing to update"). Omitting expiration leaves it unchanged; `--clear-expiration` sends `null` (keep indefinitely); `--expires-at` sets an absolute time.

### `neon snapshots delete <id|name>`
Delete a snapshot (`DELETE /projects/{id}/snapshots/{sid}`, returns tracking operations). Echoes the deleted snapshot for confirmation.

### `neon snapshots restore <id|name>`
Restore a snapshot into a branch (`POST /projects/{id}/snapshots/{sid}/restore`).
- Options: `--name` (name for the new branch), `--target-branch <id|name>` (branch to restore onto; resolved to an id; defaults to the snapshot's source branch), `--finalize`.
- Without `--finalize` the restore is left **un-finalized** so you can inspect it first; the command prints the exact `snapshots finalize …` follow-up. With `--finalize` (or the two-step `finalize` below) computes move onto the restored branch and it's swapped in. Prints the restored branch + operations.

### `neon snapshots finalize <branch-id|name>`
Finalize a previously previewed restore (`POST /projects/{id}/branches/{branch}/finalize_restore`) — swaps the restored branch in for the original. Optional `--name` renames the replaced (old) branch. Prints the resulting operations.

### `neon snapshots schedule get`
Show a branch's automatic snapshot (backup) schedule (`GET …/backup_schedule`). Options: `--branch`, `--project-id`.

### `neon snapshots schedule set`
Set a branch's automatic snapshot schedule (`PUT …/backup_schedule`).
- Single-entry via flags: `--frequency <hourly|daily|weekly|monthly|yearly>` plus optional `--hour`, `--day`, `--month`, `--retention <seconds>`.
- Multi-entry via `--schedule '<json>'` (a JSON array of `{frequency, hour?, day?, month?, retention_seconds?}`), which overrides the single-entry flags.
- Edge cases: neither `--frequency` nor `--schedule` errors with guidance; malformed JSON and non-array / non-numeric fields give precise per-entry errors (validated with a type guard, no casts). Note: automatic backup schedules are a gated Beta feature; the CLI surfaces the API's "not enabled for this project" message verbatim.

## Implementation notes

- `packages/cli/src/api.ts`: 8 new façade methods (`listSnapshots`, `createSnapshot`, `updateSnapshot`, `deleteSnapshot`, `restoreSnapshot`, `finalizeRestoreBranch`, `getSnapshotSchedule`, `setSnapshotSchedule`) over `@neon/sdk/raw`.
- `packages/cli/src/commands/snapshots.ts`: the command group, registered in `commands/index.ts` (next to `operations`).
- No type casting: snapshot resolution and JSON schedule parsing use narrowing + a type guard.

## Test plan

- [x] `pnpm --filter neonctl lint` (tsc --noEmit + biome) — clean
- [x] `pnpm --filter neonctl build`
- [x] Unit/integration: `snapshots.test.ts` — **27 cases pass** (list/get/create/update/delete/restore/finalize/schedule + all error/conflict paths) via the emocks server; `branches` + `help` suites still green
- [x] **Live e2e against the real Neon API** (throwaway smoke-org project, deleted after): create → list → get-by-name → update (set + clear expiration) → restore (un-finalized) → finalize → delete → empty list; `schedule get` returns `[]`; `schedule set` correctly returns the Beta-gating error; invalid `--lsn` returns the friendly pre-flight error with exit code 1