### PR TITLE
chore: release @neon/ai-sdk-provider@0.7.1

### DIFF
--- a/.changeset/gpt-oss-harmony-normalize.md
+++ b/.changeset/gpt-oss-harmony-normalize.md
@@ -1,5 +1,0 @@
----
-"@neon/ai-sdk-provider": patch
----
-
-Support `gpt-oss-*` models on the unified endpoint. The Neon AI Gateway returns gpt-oss responses in a non-OpenAI-compliant "harmony" shape (`message.content` as an array of reasoning/text parts instead of a string), which caused `generateText`/`streamText` to fail with `AI_APICallError: Invalid JSON response`. The provider now normalizes this to the OpenAI Chat Completions contract (string `content` + `reasoning_content`) before validation, so gpt-oss works end-to-end and its reasoning is surfaced. The transform is a no-op for every already-compliant model.

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/ai-sdk-provider
 
+## 0.7.1
+
+### Patch Changes
+
+- 7463e28: Support `gpt-oss-*` models on the unified endpoint. The Neon AI Gateway returns gpt-oss responses in a non-OpenAI-compliant "harmony" shape (`message.content` as an array of reasoning/text parts instead of a string), which caused `generateText`/`streamText` to fail with `AI_APICallError: Invalid JSON response`. The provider now normalizes this to the OpenAI Chat Completions contract (string `content` + `reasoning_content`) before validation, so gpt-oss works end-to-end and its reasoning is surfaced. The transform is a no-op for every already-compliant model.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/ai-sdk-provider",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Release bump for the gpt-oss harmony normalization fix (#310).

## Bumped
- `@neon/ai-sdk-provider`: 0.7.0 → **0.7.1** (patch)

## Changelog
Support `gpt-oss-*` models on the unified endpoint — normalize the gateway's non-compliant harmony content-array shape to the OpenAI Chat Completions contract (string `content` + `reasoning_content`) so `generateText`/`streamText` work and reasoning is surfaced. Transparent pass-through for compliant responses.

The pending `neonctl` telemetry changeset is intentionally left in `.changeset/` for the next CLI release.

Publish to npm is a manual `neon-pkgs.yml` dispatch after merge.