### PR TITLE
chore: release neonctl@2.34.0

### DIFF
--- a/.changeset/clear-telemetry-context.md
+++ b/.changeset/clear-telemetry-context.md
@@ -1,5 +1,0 @@
----
-"neonctl": patch
----
-
-Include the CLI version and CI context in error analytics events so failures can be investigated and prioritized accurately.

--- a/.changeset/snapshots-commands.md
+++ b/.changeset/snapshots-commands.md
@@ -1,5 +1,0 @@
----
-"neonctl": minor
----
-
-Add a `snapshots` command group (alias `snapshot`) for managing Neon snapshots from the CLI: `list`, `get`, `create` (from a branch head, timestamp, or LSN, with optional expiration), `update` (rename / set / clear expiration), `delete`, `restore` (to a new branch or onto an existing branch, with optional immediate `--finalize`), `finalize` (commit a previewed restore), and `schedule get` / `schedule set` for a branch's automatic snapshot (backup) schedule.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neonctl
 
+## 2.34.0
+
+### Minor Changes
+
+- 21db0be: Add a `snapshots` command group (alias `snapshot`) for managing Neon snapshots from the CLI: `list`, `get`, `create` (from a branch head, timestamp, or LSN, with optional expiration), `update` (rename / set / clear expiration), `delete`, `restore` (to a new branch or onto an existing branch, with optional immediate `--finalize`), `finalize` (commit a previewed restore), and `schedule get` / `schedule set` for a branch's automatic snapshot (backup) schedule.
+
+### Patch Changes
+
+- 2fa3793: Include the CLI version and CI context in error analytics events so failures can be investigated and prioritized accurately.
+
 ## 2.33.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.33.2",
+  "version": "2.34.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
Release bump for the CLI.

## Bumped
- `neonctl`: 2.33.2 → **2.34.0** (minor)

## Changelog
- **Minor** (#311): add a `snapshots` command group (alias `snapshot`) — `list`, `get`, `create`, `update`, `delete`, `restore`, `finalize`, and `schedule get`/`schedule set`.
- **Patch** (#306): include CLI version + CI context in error analytics events.

Publish (npm + `neon` alias + standalone binaries + GitHub release) is a manual `neon-pkgs.yml` dispatch after merge.