### PR TITLE
feat(sdk): refresh Neon OpenAPI spec (Postgres 19 + safekeeper actions)

### DIFF
--- a/.changeset/sdk-spec-refresh-pg19-safekeeper-actions.md
+++ b/.changeset/sdk-spec-refresh-pg19-safekeeper-actions.md
@@ -1,0 +1,10 @@
+---
+"@neon/sdk": minor
+---
+
+Refresh the vendored Neon OpenAPI spec and regenerated client to track the live API.
+
+- `PgVersion` now allows major version `19` (max bumped `18` → `19`). Postgres 19 is being rolled out and is only accepted in regions where it has been enabled; requesting it elsewhere returns an error. The type description is updated to reflect GA vs. rollout versions.
+- `OperationAction` gains two new values, `tenant_detach_safekeepers` and `tenant_attach_safekeepers`.
+
+No wrapped operations were added or removed (163 operations, coverage unchanged), so the ergonomic `createNeonClient` surface is unaffected — this is a pure type/spec refresh.

--- a/packages/sdk/spec/neon-openapi.json
+++ b/packages/sdk/spec/neon-openapi.json
@@ -10063,6 +10063,8 @@
                     "tenant_ignore",
                     "tenant_attach",
                     "tenant_detach",
+                    "tenant_detach_safekeepers",
+                    "tenant_attach_safekeepers",
                     "tenant_reattach",
                     "replace_safekeeper",
                     "disable_maintenance",
@@ -13559,10 +13561,10 @@
                 }
             },
             "PgVersion": {
-                "description": "The major Postgres version number. Currently supported versions are `14`, `15`, `16`, `17`, and `18`.",
+                "description": "The major Postgres version number. Generally available versions are `14`, `15`, `16`, `17`, and `18`. `19` is being rolled out and is only accepted in regions where it has been enabled; requesting it in a region where it is not yet available returns an error.",
                 "type": "integer",
                 "minimum": 14,
-                "maximum": 18,
+                "maximum": 19,
                 "default": 17
             },
             "ProjectOwnerData": {

--- a/packages/sdk/src/client/types.gen.ts
+++ b/packages/sdk/src/client/types.gen.ts
@@ -363,7 +363,7 @@ export type OperationsResponse = {
 /**
  * The action performed by the operation
  */
-export type OperationAction = 'create_compute' | 'create_timeline' | 'start_compute' | 'suspend_compute' | 'apply_config' | 'check_availability' | 'delete_timeline' | 'create_branch' | 'import_data' | 'tenant_ignore' | 'tenant_attach' | 'tenant_detach' | 'tenant_reattach' | 'replace_safekeeper' | 'disable_maintenance' | 'apply_storage_config' | 'prepare_secondary_pageserver' | 'switch_pageserver' | 'detach_parent_branch' | 'timeline_archive' | 'timeline_unarchive' | 'start_reserved_compute' | 'sync_dbs_and_roles_from_compute' | 'apply_schema_from_branch' | 'timeline_mark_invisible' | 'timeline_update_protected_config' | 'prewarm_replica' | 'promote_replica' | 'set_storage_non_dirty' | 'swap_binding_id' | 'finalize_migration' | 'mark_migration_prepared' | 'update_catalog';
+export type OperationAction = 'create_compute' | 'create_timeline' | 'start_compute' | 'suspend_compute' | 'apply_config' | 'check_availability' | 'delete_timeline' | 'create_branch' | 'import_data' | 'tenant_ignore' | 'tenant_attach' | 'tenant_detach' | 'tenant_detach_safekeepers' | 'tenant_attach_safekeepers' | 'tenant_reattach' | 'replace_safekeeper' | 'disable_maintenance' | 'apply_storage_config' | 'prepare_secondary_pageserver' | 'switch_pageserver' | 'detach_parent_branch' | 'timeline_archive' | 'timeline_unarchive' | 'start_reserved_compute' | 'sync_dbs_and_roles_from_compute' | 'apply_schema_from_branch' | 'timeline_mark_invisible' | 'timeline_update_protected_config' | 'prewarm_replica' | 'promote_replica' | 'set_storage_non_dirty' | 'swap_binding_id' | 'finalize_migration' | 'mark_migration_prepared' | 'update_catalog';
 
 /**
  * The status of the operation
@@ -2482,7 +2482,7 @@ export type PgbouncerSettingsData = {
 };
 
 /**
- * The major Postgres version number. Currently supported versions are `14`, `15`, `16`, `17`, and `18`.
+ * The major Postgres version number. Generally available versions are `14`, `15`, `16`, `17`, and `18`. `19` is being rolled out and is only accepted in regions where it has been enabled; requesting it in a region where it is not yet available returns an error.
  */
 export type PgVersion = number;
 


### PR DESCRIPTION
## Why

The daily [`SDK Spec Drift`](https://github.com/neondatabase/neon-pkgs/actions/workflows/sdk-spec-refresh.yml) workflow went red — the [scheduled run](https://github.com/neondatabase/neon-pkgs/actions/runs/29570371346) failed on the **"Fail when spec or generated client drifted"** step, meaning the vendored OpenAPI spec / generated `@neon/sdk` client had drifted from the live release spec (https://neon.com/api_spec/release/v2.json). The workflow intentionally does not open a PR (the org IP allow list blocks the hosted runner from pushing), so the refresh has to be done by hand — this is that PR.

## What

Regenerated from a clean `main` via the documented recipe (`spec:pull` → `generate` → `build`). The drift is small and is a **pure type/spec refresh**:

- **`PgVersion`**: `maximum` bumped `18` → `19` (Postgres 19 rollout) and the description updated to distinguish GA versions (`14`–`18`) from `19`, which is only accepted in regions where it has been enabled.
- **`OperationAction`**: two new enum values — `tenant_detach_safekeepers` and `tenant_attach_safekeepers`.

No wrapped operations were added or removed (**163 operations**, unchanged): `src/client/raw.gen.ts` and `src/neon/coverage.ts` are untouched, so the ergonomic `createNeonClient` surface is unaffected and `coverage.ts` needed no reconciliation.

## Files changed

- `packages/sdk/spec/neon-openapi.json` — refreshed vendored spec
- `packages/sdk/src/client/types.gen.ts` — regenerated types
- `.changeset/sdk-spec-refresh-pg19-safekeeper-actions.md` — `@neon/sdk` minor

## Verification

- `pnpm --filter @neon/sdk build` ✅ (`tsc --noEmit` + `tsdown`)
- `pnpm --filter @neon/sdk test:ci` ✅ — 17 passed incl. `coverage.test.ts`

This should turn the `SDK Spec Drift` check green again.