### PR TITLE
feat(neonctl): add project configuration flags

### DIFF
--- a/.changeset/neonctl-project-config-flags.md
+++ b/.changeset/neonctl-project-config-flags.md
@@ -1,0 +1,5 @@
+---
+"neonctl": minor
+---
+
+Add project PostgreSQL-version selection, protected branch creation, and confirmed logical-replication enablement.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -58,6 +58,40 @@ neon projects list --api-key <neon_api_key>
 
 For information about obtaining an Neon API key, see [Authentication](https://api-docs.neon.tech/reference/authentication), in the _Neon API Reference_.
 
+## Project and branch creation
+
+Choose the PostgreSQL version when creating a project:
+
+```bash
+neon projects create --name my-project --pg-version 18
+```
+
+Supported versions are `14` through `19`; version `19` is available only in
+regions where it has been enabled.
+
+Create a protected branch when it should not be modified or deleted by routine
+automation:
+
+```bash
+neon branches create --project-id <project-id> --name production --protected
+```
+
+### Enable logical replication
+
+Enable logical replication for every endpoint in an existing project:
+
+```bash
+neon projects update <project-id> --enable-logical-replication
+```
+
+The CLI asks for confirmation because enabling logical replication suspends
+active endpoints and cannot be undone. For non-interactive automation, pass
+`--yes` explicitly:
+
+```bash
+neon projects update <project-id> --enable-logical-replication --yes
+```
+
 ## Connect with psql
 
 ### The `psql` command

--- a/packages/cli/mocks/main/projects/POST.js
+++ b/packages/cli/mocks/main/projects/POST.js
@@ -23,6 +23,13 @@ export default function (req, res) {
         },
       },
     });
+  } else if (req.body.project?.name === 'test_project_with_pg_version') {
+    expect(req.body).toMatchObject({
+      project: {
+        name: 'test_project_with_pg_version',
+        pg_version: 18,
+      },
+    });
   } else {
     expect(req.body).toMatchObject({
       project: {

--- a/packages/cli/mocks/main/projects/test/PATCH.js
+++ b/packages/cli/mocks/main/projects/test/PATCH.js
@@ -1,3 +1,5 @@
+import { expect } from 'vitest';
+
 const defaultSettings = {
   allowed_ips: {
     ips: ['192.168.1.1'],
@@ -7,6 +9,9 @@ const defaultSettings = {
 
 export default function (req, res) {
   const project = req.body.project ?? {};
+  if (project.settings?.enable_logical_replication !== undefined) {
+    expect(project.settings.enable_logical_replication).toBe(true);
+  }
   res.send({
     project: {
       id: 'test',

--- a/packages/cli/mocks/main/projects/test/branches/POST.js
+++ b/packages/cli/mocks/main/projects/test/branches/POST.js
@@ -98,6 +98,20 @@ export default function (req, res) {
         suspend_timeout: req.body.endpoints[0].suspend_timeout_seconds,
       },
     });
+  } else if (req.body.branch?.name === 'protected_branch') {
+    expect(req.body).toMatchObject({
+      branch: {
+        name: 'protected_branch',
+        protected: true,
+      },
+    });
+    res.send({
+      branch: {
+        id: 'br-new-branch-123456',
+        name: 'protected_branch',
+        created_at: '2021-01-01T00:00:00.000Z',
+      },
+    });
   } else {
     expect(req.body).toMatchObject({
       branch: {

--- a/packages/cli/src/commands/__snapshots__/branches.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/branches.test.ts.snap
@@ -77,6 +77,13 @@ connection_uris:
 "
 `;
 
+exports[`branches > create protected branch 1`] = `
+"id: br-new-branch-123456
+name: protected_branch
+created_at: 2021-01-01T00:00:00.000Z
+"
+`;
+
 exports[`branches > create schema-only branch 1`] = `
 "branch:
   id: br-new-branch-123456

--- a/packages/cli/src/commands/__snapshots__/projects.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/projects.test.ts.snap
@@ -60,6 +60,16 @@ connection_uris:
 "
 `;
 
+exports[`projects > create with PostgreSQL version 1`] = `
+"project:
+  id: new-project-123456
+  name: test_project
+  created_at: 2021-01-01T00:00:00.000Z
+connection_uris:
+  - connection_uri: postgres://localhost:5432/test_project
+"
+`;
+
 exports[`projects > create with database and role 1`] = `
 "project:
   id: new-project-123456
@@ -176,6 +186,19 @@ created_at: 2019-01-01T00:00:00.000Z
 "
 `;
 
+exports[`projects > update enables logical replication with confirmation bypass 1`] = `
+"id: test
+name: test_project
+created_at: 2019-01-01T00:00:00Z
+settings:
+  allowed_ips:
+    ips:
+      - 192.168.1.1
+    protected_branches_only: false
+  enable_logical_replication: true
+"
+`;
+
 exports[`projects > update hipaa flag 1`] = `
 "id: test
 name: test_project
@@ -224,3 +247,7 @@ settings:
     protected_branches_only: false
 "
 `;
+
+exports[`projects > update rejects disabling logical replication 1`] = `""`;
+
+exports[`projects > update requires confirmation to enable logical replication 1`] = `""`;

--- a/packages/cli/src/commands/branches.test.ts
+++ b/packages/cli/src/commands/branches.test.ts
@@ -115,6 +115,18 @@ describe("branches", () => {
 		]);
 	});
 
+	test("create protected branch", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"branches",
+			"create",
+			"--project-id",
+			"test",
+			"--name",
+			"protected_branch",
+			"--protected",
+		]);
+	});
+
 	test("create with parent by name", async ({ testCliCommand }) => {
 		await testCliCommand([
 			"branches",

--- a/packages/cli/src/commands/branches.ts
+++ b/packages/cli/src/commands/branches.ts
@@ -130,6 +130,11 @@ export const builder = (argv: yargs.Argv) =>
 						type: "string",
 						requiresArg: true,
 					},
+					protected: {
+						describe:
+							branchCreateRequest["branch.protected"].description,
+						type: "boolean",
+					},
 				}),
 			(args) => create(args as any),
 		)
@@ -360,6 +365,7 @@ const create = async (
 		annotation?: string;
 		schemaOnly: boolean;
 		"expires-at"?: string;
+		protected?: boolean;
 		"--"?: string[];
 	},
 ) => {
@@ -419,6 +425,9 @@ const create = async (
 								props["expires-at"],
 							).toISOString(),
 						}
+					: {}),
+				...(props.protected !== undefined
+					? { protected: props.protected }
 					: {}),
 			},
 			endpoints: props.compute

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -56,6 +56,17 @@ describe("projects", () => {
 		]);
 	});
 
+	test("create with PostgreSQL version", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"projects",
+			"create",
+			"--name",
+			"test_project_with_pg_version",
+			"--pg-version",
+			"18",
+		]);
+	});
+
 	test("create and connect with psql", async ({ testCliCommand }) => {
 		await testCliCommand([
 			"projects",
@@ -149,6 +160,47 @@ describe("projects", () => {
 
 	test("update hipaa flag", async ({ testCliCommand }) => {
 		await testCliCommand(["projects", "update", "test", "--hipaa"]);
+	});
+
+	test("update enables logical replication with confirmation bypass", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand([
+			"projects",
+			"update",
+			"test",
+			"--enable-logical-replication",
+			"--yes",
+		]);
+	});
+
+	test("update requires confirmation to enable logical replication", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["projects", "update", "test", "--enable-logical-replication"],
+			{
+				code: 1,
+				stderr: "ERROR: Enabling logical replication requires confirmation. Re-run interactively or pass --yes.",
+			},
+		);
+	});
+
+	test("update rejects disabling logical replication", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"projects",
+				"update",
+				"test",
+				"--enable-logical-replication=false",
+			],
+			{
+				code: 1,
+				stderr: "ERROR: Logical replication cannot be disabled once it has been enabled.",
+			},
+		);
 	});
 
 	test("update project with default fixed size CU", async ({

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -129,6 +129,12 @@ export const builder = (argv: yargs.Argv) => {
 								.description,
 						type: "string",
 					},
+					"pg-version": {
+						describe:
+							"Major PostgreSQL version (14–19). Version 19 is available only in regions where it has been enabled.",
+						type: "number",
+						choices: [14, 15, 16, 17, 18, 19],
+					},
 					"set-context": {
 						type: "boolean",
 						describe: "Set the current context to the new project",
@@ -180,6 +186,17 @@ export const builder = (argv: yargs.Argv) => {
 						describe:
 							projectUpdateRequest["project.name"].description,
 						type: "string",
+					},
+					"enable-logical-replication": {
+						describe:
+							"Enable logical replication for all project endpoints. This suspends active endpoints and cannot be disabled.",
+						type: "boolean",
+					},
+					yes: {
+						type: "boolean",
+						default: false,
+						describe:
+							"Skip the confirmation prompt when enabling logical replication.",
 					},
 				}),
 			async (args) => {
@@ -288,6 +305,7 @@ const create = async (
 		orgId?: string;
 		database?: string;
 		role?: string;
+		pgVersion?: number;
 		psql: boolean;
 		fallback: boolean;
 		setContext: boolean;
@@ -330,6 +348,9 @@ const create = async (
 	}
 	if (props.role) {
 		project.branch.role_name = props.role;
+	}
+	if (props.pgVersion !== undefined) {
+		project.pg_version = props.pgVersion;
 	}
 	if (props.cu) {
 		project.default_endpoint_settings = props.cu
@@ -378,9 +399,40 @@ const update = async (
 			blockVpcConnections?: boolean;
 			blockPublicConnections?: boolean;
 			hipaa?: boolean;
+			enableLogicalReplication?: boolean;
+			yes: boolean;
 		},
 ) => {
 	const project: ProjectUpdateRequest["project"] = {};
+	if (props.enableLogicalReplication !== undefined) {
+		if (!props.enableLogicalReplication) {
+			throw new Error(
+				"Logical replication cannot be disabled once it has been enabled.",
+			);
+		}
+		if (!props.yes) {
+			if (isCi() || !process.stdin.isTTY) {
+				throw new Error(
+					"Enabling logical replication requires confirmation. Re-run interactively or pass --yes.",
+				);
+			}
+			const { proceed } = await prompts({
+				onState: onPromptState,
+				type: "confirm",
+				name: "proceed",
+				message:
+					"Enable logical replication? This suspends active endpoints and cannot be undone.",
+				initial: false,
+			});
+			if (!proceed) {
+				log.info("Logical replication was not enabled.");
+				return;
+			}
+		}
+		project.settings = {
+			enable_logical_replication: true,
+		};
+	}
 	if (props.hipaa !== undefined) {
 		if (!project.settings) {
 			project.settings = {};


### PR DESCRIPTION
## Summary
- add PostgreSQL version selection when creating projects
- add protected branch creation and confirmed logical-replication enablement
- document the new flags and cover request bodies with command tests

## Test plan
- [x] `pnpm lint` in `packages/cli`
- [x] `pnpm vitest run src/commands/projects.test.ts src/commands/branches.test.ts`
- [x] Live smoke: project creation with PostgreSQL 18 and logical replication update