### PR TITLE
fix(neonctl): stop context walk at filesystem roots

### DIFF
--- a/.changeset/fix-windows-context-root.md
+++ b/.changeset/fix-windows-context-root.md
@@ -1,0 +1,5 @@
+---
+"neonctl": patch
+---
+
+Prevent the CLI from hanging while looking up `.neon` context files at Windows drive and UNC roots.

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -6,7 +6,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, win32 } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 
 import {
@@ -14,6 +14,7 @@ import {
 	currentContextFile,
 	ensureGitignored,
 	isCurrentBranchProbe,
+	walkContextFile,
 } from "./context.js";
 
 describe("isCurrentBranchProbe", () => {
@@ -69,6 +70,104 @@ describe("isCurrentBranchProbe", () => {
 		expect(
 			isCurrentBranchProbe({ _: ["config"], currentBranch: true }),
 		).toBe(false);
+	});
+});
+
+const createBoundedWindowsResolver = () => {
+	let terminalParentResolutions = 0;
+
+	return {
+		resolvePath: (...paths: string[]) => {
+			const resolved = win32.resolve(...paths);
+			const currentDir = paths[0];
+			if (
+				currentDir !== undefined &&
+				paths.at(-1) === ".." &&
+				resolved === currentDir
+			) {
+				terminalParentResolutions += 1;
+				if (terminalParentResolutions > 1) {
+					throw new Error(
+						"Context walk did not stop at the filesystem root.",
+					);
+				}
+			}
+			return resolved;
+		},
+		terminalParentResolutions: () => terminalParentResolutions,
+	};
+};
+
+describe("walkContextFile with Windows path semantics", () => {
+	const root = win32.normalize("/");
+	const home = "C:\\Users\\test-user";
+
+	test("terminates after reaching a drive root from a nested directory", () => {
+		const cwd = "C:\\workspace\\nested";
+		const { resolvePath, terminalParentResolutions } =
+			createBoundedWindowsResolver();
+
+		expect(walkContextFile(cwd, root, home, resolvePath, () => false)).toBe(
+			win32.resolve(cwd, ".neon"),
+		);
+		expect(terminalParentResolutions()).toBe(1);
+	});
+
+	test("terminates when invoked directly at a drive root", () => {
+		const cwd = "D:\\";
+		const { resolvePath, terminalParentResolutions } =
+			createBoundedWindowsResolver();
+
+		expect(walkContextFile(cwd, root, home, resolvePath, () => false)).toBe(
+			win32.resolve(cwd, ".neon"),
+		);
+		expect(terminalParentResolutions()).toBe(1);
+	});
+
+	test("terminates after reaching a UNC share root", () => {
+		const cwd = "\\\\server\\share\\workspace\\nested";
+		const { resolvePath, terminalParentResolutions } =
+			createBoundedWindowsResolver();
+
+		expect(walkContextFile(cwd, root, home, resolvePath, () => false)).toBe(
+			win32.resolve(cwd, ".neon"),
+		);
+		expect(terminalParentResolutions()).toBe(1);
+	});
+
+	test("uses a context file found before the root", () => {
+		const cwd = "C:\\workspace\\nested";
+		const contextFile = "C:\\workspace\\.neon";
+		const { resolvePath, terminalParentResolutions } =
+			createBoundedWindowsResolver();
+
+		expect(
+			walkContextFile(
+				cwd,
+				root,
+				home,
+				resolvePath,
+				(file) => file === contextFile,
+			),
+		).toBe(contextFile);
+		expect(terminalParentResolutions()).toBe(0);
+	});
+
+	test("does not inspect a context file in the home directory", () => {
+		const cwd = "C:\\Users\\test-user\\workspace";
+		const inspectedFiles: string[] = [];
+		const { resolvePath, terminalParentResolutions } =
+			createBoundedWindowsResolver();
+
+		walkContextFile(cwd, root, home, resolvePath, (file) => {
+			inspectedFiles.push(file);
+			return false;
+		});
+
+		expect(inspectedFiles).toEqual([
+			"C:\\Users\\test-user\\workspace\\.neon",
+		]);
+		expect(terminalParentResolutions()).toBe(0);
 	});
 });
 

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -63,7 +63,48 @@ export const isConfigInit = (args: { _: (string | number)[] }): boolean =>
 const CONTEXT_FILE = ".neon";
 const GITIGNORE_FILE = ".gitignore";
 
-const wrapWithContextFile = (dir: string) => resolve(dir, CONTEXT_FILE);
+type ResolvePath = (...paths: string[]) => string;
+type CanAccessFile = (file: string) => boolean;
+
+const canAccessFile = (file: string): boolean => {
+	try {
+		accessSync(file);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+/**
+ * Walk upward to find an existing `.neon` file.
+ *
+ * The walk keeps the established home and POSIX-root boundaries, then also
+ * stops when resolving a parent makes no progress. That second guard handles
+ * Windows drive and UNC-share roots, whose paths do not equal `normalize("/")`.
+ */
+export const walkContextFile = (
+	cwd: string,
+	root: string,
+	home: string,
+	resolvePath: ResolvePath,
+	canAccess: CanAccessFile,
+): string => {
+	let currentDir = cwd;
+	while (currentDir !== root && currentDir !== home) {
+		const contextFile = resolvePath(currentDir, CONTEXT_FILE);
+		if (canAccess(contextFile)) {
+			return contextFile;
+		}
+
+		const parentDir = resolvePath(currentDir, "..");
+		if (parentDir === currentDir) {
+			break;
+		}
+		currentDir = parentDir;
+	}
+
+	return resolvePath(cwd, CONTEXT_FILE);
+};
 
 /**
  * Resolve the default `.neon` path for the current working directory.
@@ -83,22 +124,8 @@ const wrapWithContextFile = (dir: string) => resolve(dir, CONTEXT_FILE);
  * `cwd` is overridable so tests can exercise the walk-up without mutating
  * `process.cwd()` (which would race with other tests running in parallel).
  */
-export const currentContextFile = (cwd: string = process.cwd()) => {
-	let currentDir = cwd;
-	const root = normalize("/");
-	const home = homedir();
-	while (currentDir !== root && currentDir !== home) {
-		try {
-			accessSync(resolve(currentDir, CONTEXT_FILE));
-			return wrapWithContextFile(currentDir);
-		} catch {
-			// ignore
-		}
-		currentDir = resolve(currentDir, "..");
-	}
-
-	return wrapWithContextFile(cwd);
-};
+export const currentContextFile = (cwd: string = process.cwd()) =>
+	walkContextFile(cwd, normalize("/"), homedir(), resolve, canAccessFile);
 
 export const readContextFile = (file: string): Context => {
 	try {


### PR DESCRIPTION
## Summary
- stop `.neon` context discovery when a parent path no longer advances
- preserve existing home and POSIX-root lookup boundaries
- add drive-root, UNC-root, ancestor-context, and home-boundary regression coverage using `node:path.win32`

Closes #289.

Co-authored-by @agustin-caceres.

## Test plan
- [x] `pnpm lint` in `packages/cli`
- [x] `pnpm vitest run src/context.test.ts`