### PR TITLE
chore: release neonctl@2.35.0

### DIFF
--- a/.changeset/fix-windows-context-root.md
+++ b/.changeset/fix-windows-context-root.md
@@ -1,5 +1,0 @@
----
-"neonctl": patch
----
-
-Prevent the CLI from hanging while looking up `.neon` context files at Windows drive and UNC roots.

--- a/.changeset/neonctl-project-config-flags.md
+++ b/.changeset/neonctl-project-config-flags.md
@@ -1,5 +1,0 @@
----
-"neonctl": minor
----
-
-Add project PostgreSQL-version selection, protected branch creation, and confirmed logical-replication enablement.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neonctl
 
+## 2.35.0
+
+### Minor Changes
+
+- f62419c: Add project PostgreSQL-version selection, protected branch creation, and confirmed logical-replication enablement.
+
+### Patch Changes
+
+- c7c8156: Prevent the CLI from hanging while looking up `.neon` context files at Windows drive and UNC roots.
+
 ## 2.34.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.34.1",
+  "version": "2.35.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Summary
- bump `neonctl` from 2.34.1 to 2.35.0
- include project configuration flags from #317
- include the Windows context-root fix from #318

## Validation
- [x] `pnpm lint:ci`