### PR TITLE
fix(neonctl): pull object-storage env vars without a neon.ts

### DIFF
--- a/.changeset/pull-config-buckets-env.md
+++ b/.changeset/pull-config-buckets-env.md
@@ -1,0 +1,6 @@
+---
+"@neon/config-runtime": patch
+"neonctl": patch
+---
+
+Pull a branch's object-storage vars without a `neon.ts`. `pullConfig` now mirrors the branch's buckets into the resolvable config, so `neon dev` / `neon env pull` inject the S3-compatible `AWS_*` credentials for a branch that has a bucket even when there is no local `neon.ts` policy — matching how Neon Auth / the Data API already resolve from live branch state. Functions and the AI Gateway remain excluded (neither has branch-level state that can be faithfully read back).

--- a/packages/cli/src/dev/env.test.ts
+++ b/packages/cli/src/dev/env.test.ts
@@ -43,6 +43,11 @@ type FakeOverrides = {
 	 * is correct this is never called, since functions carry no branch env.
 	 */
 	listBranchFunctions?: NeonApi["listBranchFunctions"];
+	/**
+	 * Override `listBranchBuckets` (e.g. to simulate a branch that has an object-storage
+	 * bucket). Defaults to returning `[]`.
+	 */
+	listBranchBuckets?: NeonApi["listBranchBuckets"];
 };
 
 /**
@@ -183,7 +188,13 @@ class FakeNeonApi implements NeonApi {
 		throw new Error("not implemented");
 	}
 
-	async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+	async listBranchBuckets(
+		projectId: string,
+		branchId: string,
+	): Promise<NeonBucketSnapshot[]> {
+		if (this.overrides.listBranchBuckets) {
+			return this.overrides.listBranchBuckets(projectId, branchId);
+		}
 		return [];
 	}
 
@@ -329,6 +340,39 @@ describe("resolveDevEnv", () => {
 		expect(result.vars.NEON_AUTH_JWKS_URL).toBe(
 			"https://auth.fake.neon.tech/.well-known/jwks.json",
 		);
+	});
+
+	it("tier 2 with a bucket present: surfaces the AWS_* object-storage vars too", async () => {
+		// The feature-gap fix: a branch that has an object-storage bucket but no local
+		// neon.ts. pullConfig now mirrors the bucket into `config.preview.buckets`, so
+		// `fetchEnv`'s `wantsStorage` fires — it mints a branch credential and injects the
+		// S3-compatible AWS_* vars, exactly what a deployed function would receive. No
+		// policy required.
+		const api = new FakeNeonApi({
+			listBranchBuckets: async () => [
+				{ name: "assets", accessLevel: "private" },
+			],
+		});
+
+		const result = await resolveDevEnv({
+			cwd,
+			projectId: PROJECT_ID,
+			branchId: BRANCH_ID,
+			api,
+		});
+
+		// The storage gateway authenticates against the full token id, so accessKeyId is the
+		// minted credential's `tokenId` (not the short id).
+		expect(result.vars.AWS_ACCESS_KEY_ID).toBe("cred-fake-0000");
+		expect(result.vars.AWS_SECRET_ACCESS_KEY).toBeDefined();
+		expect(result.vars.AWS_ENDPOINT_URL_S3).toBe(
+			"https://fake.storage.neon.tech",
+		);
+		expect(result.vars.AWS_REGION).toBe("us-east-1");
+		// The AI Gateway has no branch-level enabled state to read back, so pullConfig never
+		// declares it — its vars must not leak into the no-policy pull.
+		expect(result.vars.NEON_AI_GATEWAY_TOKEN).toBeUndefined();
+		expect(result.vars.NEON_AI_GATEWAY_BASE_URL).toBeUndefined();
 	});
 
 	it("tier 1: a neon.ts policy enabling auth -> DATABASE_URL and NEON_AUTH_BASE_URL", async () => {

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -62,8 +62,9 @@ export class MissingBranchContextError extends Error {
  *      the branch is missing, we stop with a {@link DevEnvMismatchError} pointing at
  *      `neonctl deploy`. Otherwise `fetchEnv` evaluates the policy.
  *   2. no `neon.ts`, but a project + branch are known -> `pullConfig` reads the
- *      branch's live state (incl. Auth / Data API enablement) into a config, then
- *      `fetchEnv` resolves what is actually enabled.
+ *      branch's live state (Auth / Data API enablement plus any object-storage
+ *      buckets) into a config, then `fetchEnv` resolves what is actually enabled —
+ *      so a branch with a bucket gets its `AWS_*` storage vars pulled with no policy.
  *   3. otherwise -> throw {@link MissingBranchContextError}.
  *
  * Unlike {@link resolveDevEnv}, this never swallows errors — callers decide how to
@@ -101,8 +102,11 @@ export const resolveNeonEnvVars = async (
 			branchId: ctx.branchId,
 			...apiOptions(ctx),
 		});
-		// `pulled.config` is already a `Config` (static auth/dataApi toggles + a branch
-		// tuning closure), so it feeds straight into fetchEnv — no wrapping needed.
+		// `pulled.config` is already a `Config` (static auth/dataApi toggles, any
+		// object-storage `preview.buckets`, and a branch tuning closure), so it feeds
+		// straight into fetchEnv — no wrapping needed. pullConfig excludes functions and
+		// the AI Gateway (neither can be faithfully read back), so fetchEnv never probes
+		// the functions API here and only mints a storage credential when a bucket exists.
 		return await fetchAndProject(pulled.config, ctx);
 	}
 

--- a/packages/config-runtime/src/lib/pull-config.test.ts
+++ b/packages/config-runtime/src/lib/pull-config.test.ts
@@ -212,6 +212,83 @@ describe("pullConfig", () => {
 		expect(pulled.config.dataApi).toBe(true);
 	});
 
+	test("includes the branch's buckets in config so the no-policy env path resolves storage", async () => {
+		// Regression for the feature gap: a branch with a bucket but no local neon.ts must
+		// still get its object-storage vars pulled. `pullConfig` mirrors the bucket into
+		// `config.preview.buckets` (buckets round-trip: name + access), which is what makes
+		// `fetchEnv`'s `wantsStorage` fire in the no-policy tier (`neon dev` / `neon env pull`).
+		const api = new FakeNeonApi();
+		const projectId = "proj-buckets";
+		api.seedProject({
+			project: {
+				id: projectId,
+				name: "buckets",
+				regionId: "aws-us-east-2",
+				pgVersion: 17,
+			},
+			branches: [
+				{ branch: { id: "br-main", name: "main", isDefault: true } },
+			],
+		});
+		api.seedBucket(projectId, "br-main", {
+			name: "assets",
+			accessLevel: "private",
+		});
+
+		const pulled = await pullConfig({
+			api,
+			projectId,
+			branchId: "br-main",
+		});
+
+		// The bucket rides on the resolvable `config` (not just the display-only `preview`),
+		// with its access level preserved …
+		expect(pulled.config.preview?.buckets).toEqual({
+			assets: { access: "private" },
+		});
+		// … and it is what a downstream `resolveConfig` reads as "storage wanted".
+		const resolved = resolveConfig(pulled.config, {
+			name: "main",
+			exists: true,
+		});
+		expect(resolved.preview?.buckets.map((b) => b.name)).toEqual([
+			"assets",
+		]);
+		// The AI Gateway has no branch-level enabled state to read back, so it is never
+		// smuggled into the pulled config (only buckets are).
+		expect(pulled.config.preview?.aiGateway).toBeUndefined();
+		// It also stays in the display-only preview view for `config status` / inspect.
+		expect(pulled.preview?.buckets).toEqual([
+			{ name: "assets", access: "private" },
+		]);
+	});
+
+	test("omits preview from config when the branch has no buckets", async () => {
+		const api = new FakeNeonApi();
+		const projectId = "proj-no-buckets";
+		api.seedProject({
+			project: {
+				id: projectId,
+				name: "no-buckets",
+				regionId: "aws-us-east-1",
+				pgVersion: 17,
+			},
+			branches: [
+				{ branch: { id: "br-main", name: "main", isDefault: true } },
+			],
+		});
+
+		const pulled = await pullConfig({
+			api,
+			projectId,
+			branchId: "br-main",
+		});
+
+		// No buckets → no `preview` on the resolvable config, so `fetchEnv` never mints a
+		// storage credential or probes the storage endpoint.
+		expect(pulled.config.preview).toBeUndefined();
+	});
+
 	test("reports issued credential metadata (secret-free) under preview", async () => {
 		const api = new FakeNeonApi();
 		const projectId = "proj-creds";

--- a/packages/config-runtime/src/lib/pull-config.ts
+++ b/packages/config-runtime/src/lib/pull-config.ts
@@ -65,9 +65,16 @@ export interface PulledBranchConfig {
 	};
 	/**
 	 * The branch's live state expressed as a {@link Config}: static `auth` / `dataApi`
-	 * toggles plus a `branch` closure carrying the branch's lifecycle/compute tuning.
-	 * Preview functions/buckets are reported separately in {@link PulledBranchConfig.preview}
-	 * because functions cannot round-trip (the remote has no `source` path).
+	 * toggles, any object-storage `preview.buckets`, plus a `branch` closure carrying the
+	 * branch's lifecycle/compute tuning. Buckets are included here (not just in
+	 * {@link PulledBranchConfig.preview}) because they round-trip cleanly — name + access
+	 * level is all a {@link Config} needs — so the no-policy env path (`neon dev` /
+	 * `neon env pull`) can resolve the branch's storage credentials without a local
+	 * `neon.ts`. Preview **functions** are reported only in
+	 * {@link PulledBranchConfig.preview}: they cannot round-trip (the remote has no local
+	 * `source` path). The AI Gateway is omitted from both — it has no branch-level "enabled"
+	 * state to read back (it is always available, credential-gated), so `pullConfig` cannot
+	 * tell whether a policy would enable it.
 	 */
 	config: Config;
 	/**
@@ -206,9 +213,22 @@ export function buildPulledBranchConfig(
 		const compute = endpointToComputeSettings(endpoint, project);
 		if (compute) tuning.postgres = { computeSettings: compute };
 	}
+	// Buckets round-trip cleanly (name + access level), so they belong in the config the
+	// env path resolves from — this is what lets `neon dev` / `neon env pull` inject the
+	// branch's object-storage credentials (AWS_*) with no local neon.ts. Functions are
+	// deliberately NOT emitted here (they can't round-trip: the remote has no `source`
+	// path) and neither is the AI Gateway (no branch-level enabled state to detect, only a
+	// credential) — both would otherwise turn a read-back into a bogus policy declaration.
+	const bucketDefs: Record<string, { access: BucketAccessLevel }> = {};
+	for (const b of previewState?.buckets ?? []) {
+		bucketDefs[b.name] = { access: b.accessLevel };
+	}
 	const config: Config = {
 		...(previewState?.authEnabled ? { auth: true } : {}),
 		...(previewState?.dataApiEnabled ? { dataApi: true } : {}),
+		...(Object.keys(bucketDefs).length > 0
+			? { preview: { buckets: bucketDefs } }
+			: {}),
 		...(Object.keys(tuning).length > 0 ? { branch: () => tuning } : {}),
 	};
 	const result: PulledBranchConfig = {


### PR DESCRIPTION
## Summary

Closes a feature gap found while smoke-testing `neon link` + `neon env pull`: a Neon project with a **bucket** but **no `neon.ts`** did not get its object-storage credentials pulled, even though Postgres, Neon Auth, and the Data API all resolve automatically from live branch state.

Root cause: in the no-policy env tier, `pullConfig` reverse-engineers the branch into a `Config` for `fetchEnv`, but it only emitted `auth` / `dataApi` toggles — buckets were reported in the display-only `preview` field, never in the resolvable `config`. So `fetchEnv`'s `wantsStorage` (`desired.preview?.buckets.length > 0`) never fired without a local `neon.ts`.

Fix: `buildPulledBranchConfig` now mirrors the branch's buckets into `config.preview.buckets` (buckets round-trip cleanly — name + access level). `neon dev` / `neon env pull` then mint the branch credential and inject the S3-compatible `AWS_*` vars for any branch that has a bucket, no policy required.

Deliberately unchanged:
- **Functions** — still `preview`-only; they can't round-trip (the remote has no local `source` path), and probing them must never sink env injection.
- **AI Gateway** — still excluded from the pulled config. It has no branch-level "enabled" state to read back (always available, credential-gated), so `pullConfig` genuinely cannot tell whether a policy would want it. (A `neon.ts` declaring `preview.aiGateway` remains the way to pull it.)

Behavior parity: with a `neon.ts` declaring the bucket, storage vars were already pulled — this makes the **no-`neon.ts`** path match, which is the branch-first workflow (`neon link` → `neon env pull`).

## Changes

- `@neon/config-runtime`: `buildPulledBranchConfig` emits `preview.buckets` when the branch has buckets; docstring updated.
- `neonctl` (`packages/cli`): updated tier-2 resolver comments; the fix flows through `resolveNeonEnvVars` unchanged otherwise.
- Changeset: patch bump for both.

## Test plan

- [x] `@neon/config-runtime` unit tests — added coverage that a branch with a bucket yields `config.preview.buckets` (access preserved), still surfaces it in the display-only `preview`, and omits `preview` entirely when there are no buckets; AI Gateway never smuggled in. Full suite: 51 passed.
- [x] `neonctl` `dev/env` tests — added a tier-2 test asserting a branch with a bucket (no `neon.ts`) injects `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_ENDPOINT_URL_S3` / `AWS_REGION` and no AI Gateway vars. `dev/env`, `commands/config`, `commands/env`, `config_format` suites: all passed.
- [x] `tsc --noEmit` clean for both packages.
- [x] Manually verified end-to-end before the fix (live smoke test in the smoke org): without `neon.ts`, only `DATABASE_URL[_UNPOOLED]` + `NEON_AUTH_*` were pulled; with a bucket-declaring `neon.ts`, the `AWS_*` vars appeared. This PR makes the no-`neon.ts` path pull them too.