### PR TITLE
chore: release @neon/config-runtime@0.9.6 + neonctl@2.35.1

### DIFF
--- a/.changeset/pull-config-buckets-env.md
+++ b/.changeset/pull-config-buckets-env.md
@@ -1,6 +1,0 @@
----
-"@neon/config-runtime": patch
-"neonctl": patch
----
-
-Pull a branch's object-storage vars without a `neon.ts`. `pullConfig` now mirrors the branch's buckets into the resolvable config, so `neon dev` / `neon env pull` inject the S3-compatible `AWS_*` credentials for a branch that has a bucket even when there is no local `neon.ts` policy — matching how Neon Auth / the Data API already resolve from live branch state. Functions and the AI Gateway remain excluded (neither has branch-level state that can be faithfully read back).

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 2.35.1
+
+### Patch Changes
+
+- a89d6ca: Pull a branch's object-storage vars without a `neon.ts`. `pullConfig` now mirrors the branch's buckets into the resolvable config, so `neon dev` / `neon env pull` inject the S3-compatible `AWS_*` credentials for a branch that has a bucket even when there is no local `neon.ts` policy — matching how Neon Auth / the Data API already resolve from live branch state. Functions and the AI Gateway remain excluded (neither has branch-level state that can be faithfully read back).
+- Updated dependencies [a89d6ca]
+  - @neon/config-runtime@0.9.6
+
 ## 2.35.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.35.0",
+  "version": "2.35.1",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 0.9.6
+
+### Patch Changes
+
+- a89d6ca: Pull a branch's object-storage vars without a `neon.ts`. `pullConfig` now mirrors the branch's buckets into the resolvable config, so `neon dev` / `neon env pull` inject the S3-compatible `AWS_*` credentials for a branch that has a bucket even when there is no local `neon.ts` policy — matching how Neon Auth / the Data API already resolve from live branch state. Functions and the AI Gateway remain excluded (neither has branch-level state that can be faithfully read back).
+
 ## 0.9.5
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "0.9.5",
+	"version": "0.9.6",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Release PR (version bump only) for the merged fix in #320 — pull a branch's object-storage `AWS_*` env vars without a `neon.ts`.

## Bumps (patch)
- `@neon/config-runtime` 0.9.5 → **0.9.6** (the fix)
- `neonctl` 2.35.0 → **2.35.1** (dependent + user-facing surface)

Diff is `changeset version` output only: consumes the changeset, rewrites `package.json` + `CHANGELOG.md`. No source changes.

After merge: dispatch `neon-pkgs.yml` in the releases repo once per package, then verify with `npm view`.