### PR TITLE
chore: release @neon/env@0.11.5 + neonctl@2.35.2

### DIFF
--- a/.changeset/neondb-default-autopick.md
+++ b/.changeset/neondb-default-autopick.md
@@ -1,6 +1,0 @@
----
-"@neon/env": patch
-"neonctl": patch
----
-
-Auto-pick Neon's default `neondb` database when a branch has more than one. Previously `fetchEnv` threw as soon as a branch had multiple databases, so `neonctl link` / `neonctl env pull` failed on a branch that had `neondb` alongside another database. It now uses `neondb` when present (or the sole database otherwise); a branch with several databases and no `neondb` still throws so the choice is never made randomly — rename one to `neondb` or keep a single database (or pass `databaseName` when calling `fetchEnv` directly).

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 2.35.2
+
+### Patch Changes
+
+- d031275: Auto-pick Neon's default `neondb` database when a branch has more than one. Previously `fetchEnv` threw as soon as a branch had multiple databases, so `neonctl link` / `neonctl env pull` failed on a branch that had `neondb` alongside another database. It now uses `neondb` when present (or the sole database otherwise); a branch with several databases and no `neondb` still throws so the choice is never made randomly — rename one to `neondb` or keep a single database (or pass `databaseName` when calling `fetchEnv` directly).
+- Updated dependencies [d031275]
+  - @neon/env@0.11.5
+
 ## 2.35.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.35.1",
+  "version": "2.35.2",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 0.11.5
+
+### Patch Changes
+
+- d031275: Auto-pick Neon's default `neondb` database when a branch has more than one. Previously `fetchEnv` threw as soon as a branch had multiple databases, so `neonctl link` / `neonctl env pull` failed on a branch that had `neondb` alongside another database. It now uses `neondb` when present (or the sole database otherwise); a branch with several databases and no `neondb` still throws so the choice is never made randomly — rename one to `neondb` or keep a single database (or pass `databaseName` when calling `fetchEnv` directly).
+
 ## 0.11.4
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "0.11.4",
+	"version": "0.11.5",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Summary
- release `@neon/env` 0.11.5 with default `neondb` auto-selection for multi-database branches
- release `neonctl` 2.35.2 against `@neon/env` 0.11.5

## Test plan
- [x] `pnpm lint:ci`