### PR TITLE
chore: release neonctl@2.36.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.36.0
+
+### Minor Changes
+
+- Add `neon inspect db` diagnostic commands to help investigate database health, sizes, and query statistics.
+
 ## 2.35.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.35.2",
+  "version": "2.36.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
Release PR (version bump + CHANGELOG only) for the Neon CLI.

## Bumped
- `neonctl`: 2.35.2 → 2.36.0 (minor)

### Changes
- Add `neon inspect db` diagnostic commands (#283) to help investigate database health, sizes, and query statistics.

This is the forgotten-changeset backfill for #283, which merged to `main` without a changeset. Publish to npm is a separate manual `neon-pkgs.yml` dispatch after merge.