### PR TITLE
feat(ai-sdk-provider): support AI SDK 7 without dropping v6

### DIFF
--- a/.changeset/bright-bats-adapt.md
+++ b/.changeset/bright-bats-adapt.md
@@ -1,0 +1,5 @@
+---
+"@neon/ai-sdk-provider": patch
+---
+
+Support both AI SDK 6 and AI SDK 7, with compatibility coverage for every model currently enabled by the Neon AI Gateway.

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -1,6 +1,6 @@
 # @neon/ai-sdk-provider
 
-Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://neon.com) AI Gateway. Requires **AI SDK v6** (`ai@^6`).
+Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://neon.com) AI Gateway. Supports **AI SDK v6 and v7** (`ai@^6` or `ai@^7`).
 
 The Neon AI Gateway is **branch-scoped**: each Neon project branch gets its own gateway host, and a platform token authorizes requests for that branch. This provider routes each model to the best gateway endpoint (Anthropic → native Messages, OpenAI → native Responses incl. **Codex**, everything else → unified OpenAI-compatible MLflow endpoint), so a single `neon('claude-...')` call reaches the whole catalog.
 
@@ -9,10 +9,10 @@ Model ids use the canonical Neon (unprefixed) form — `claude-sonnet-4-6`, `gpt
 ## Install
 
 ```bash
-npm install @neon/ai-sdk-provider ai@^6
+npm install @neon/ai-sdk-provider ai
 ```
 
-> **Requirements:** Node.js >= 20.19.
+> **Requirements:** Node.js >= 20.19 with AI SDK 6. AI SDK 7 itself requires Node.js >= 22.
 
 ## Configuration
 
@@ -100,4 +100,4 @@ cp .env.example .env   # fill NEON_AI_GATEWAY_BASE_URL + NEON_AI_GATEWAY_TOKEN f
 pnpm test:e2e
 ```
 
-The matrix covers one models.dev `neon` model per family (Anthropic, OpenAI, Codex, Gemini, Meta) across `generateText`, `streamText`, `generateObject`, tool calling, and `neon.tools.imageGeneration`. Skipped when gateway env vars are absent.
+The matrix covers one models.dev `neon` model per family (Anthropic, OpenAI, Codex, Gemini, Meta) across `generateText`, `streamText`, `generateObject`, tool calling, and `neon.tools.imageGeneration`. It also fetches the live `/v1/models` catalog and calls every currently enabled model with both AI SDK 6 and AI SDK 7. Tests are skipped when gateway env vars are absent.

--- a/packages/ai-sdk-provider/e2e/helpers.ts
+++ b/packages/ai-sdk-provider/e2e/helpers.ts
@@ -2,6 +2,8 @@
  * Representative models from the models.dev `neon` provider — one per gateway route
  * family. See `NEON_MODELS_DEV_IDS` / `NEON_EXTRA_MODEL_IDS` in neon-chat-options.ts.
  */
+import { expect } from "vitest";
+
 export const MATRIX_MODELS = {
 	/** Native Anthropic Messages API */
 	anthropic: "claude-haiku-4-5",

--- a/packages/ai-sdk-provider/e2e/sdk-version-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/sdk-version-matrix.e2e.test.ts
@@ -1,0 +1,131 @@
+import { generateText as generateTextV6 } from "ai";
+import { generateText as generateTextV7 } from "ai-v7";
+import { beforeAll, describe, expect, it } from "vitest";
+import { neon } from "../src/index.js";
+import { assertGatewayEnv, hasGatewayEnv } from "./helpers.js";
+
+const PROMPT = "Reply with exactly the single word pong.";
+const CONCURRENCY = 4;
+
+interface SdkRunner {
+	version: string;
+	generate(modelId: string): Promise<string>;
+}
+
+const SDK_RUNNERS = [
+	{
+		version: "6",
+		async generate(modelId) {
+			const result = await generateTextV6({
+				model: neon(modelId),
+				prompt: PROMPT,
+				maxOutputTokens: 2048,
+			});
+			return result.text;
+		},
+	},
+	{
+		version: "7",
+		async generate(modelId) {
+			const result = await generateTextV7({
+				model: neon(modelId),
+				prompt: PROMPT,
+				maxOutputTokens: 2048,
+			});
+			return result.text;
+		},
+	},
+] satisfies SdkRunner[];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+async function fetchCurrentModelIds(): Promise<string[]> {
+	assertGatewayEnv();
+	const baseURL = process.env.NEON_AI_GATEWAY_BASE_URL;
+	const token = process.env.NEON_AI_GATEWAY_TOKEN;
+	if (baseURL === undefined || token === undefined) {
+		throw new Error("Gateway environment was not initialized");
+	}
+
+	const response = await fetch(`${baseURL.replace(/\/$/, "")}/v1/models`, {
+		headers: {
+			Authorization: `Bearer ${token}`,
+			Accept: "application/json",
+		},
+	});
+	if (!response.ok) {
+		throw new Error(
+			`Failed to list current gateway models: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	const payload: unknown = await response.json();
+	if (!isRecord(payload) || !Array.isArray(payload.data)) {
+		throw new Error("Unexpected /v1/models response: missing data array");
+	}
+
+	const ids = payload.data.flatMap((model) =>
+		isRecord(model) && typeof model.id === "string" ? [model.id] : [],
+	);
+	if (ids.length === 0) {
+		throw new Error(
+			"The gateway /v1/models endpoint returned no model ids",
+		);
+	}
+	return [...new Set(ids)].sort();
+}
+
+async function verifyAllModels(
+	modelIds: string[],
+	runner: SdkRunner,
+): Promise<string[]> {
+	const failures: string[] = [];
+
+	for (let index = 0; index < modelIds.length; index += CONCURRENCY) {
+		const batch = modelIds.slice(index, index + CONCURRENCY);
+		const results = await Promise.all(
+			batch.map(async (modelId) => {
+				try {
+					const text = await runner.generate(modelId);
+					if (text.trim().length === 0) {
+						return `${modelId}: generated an empty response`;
+					}
+					return null;
+				} catch (error) {
+					const message =
+						error instanceof Error ? error.message : String(error);
+					return `${modelId}: ${message}`;
+				}
+			}),
+		);
+
+		for (const result of results) {
+			if (result !== null) failures.push(result);
+		}
+	}
+
+	return failures;
+}
+
+describe.skipIf(!hasGatewayEnv())(
+	"e2e — every currently enabled model on AI SDK 6 and 7",
+	() => {
+		let modelIds: string[] = [];
+
+		beforeAll(async () => {
+			modelIds = await fetchCurrentModelIds();
+		});
+
+		for (const runner of SDK_RUNNERS) {
+			it(`generates text with every /v1/models entry using AI SDK ${runner.version}`, async () => {
+				const failures = await verifyAllModels(modelIds, runner);
+				expect(
+					failures,
+					`AI SDK ${runner.version} failures:\n${failures.join("\n")}`,
+				).toEqual([]);
+			}, 600_000);
+		}
+	},
+);

--- a/packages/ai-sdk-provider/e2e/sdk-version-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/sdk-version-matrix.e2e.test.ts
@@ -1,5 +1,8 @@
 import { generateText as generateTextV6 } from "ai";
-import { generateText as generateTextV7 } from "ai-v7";
+import {
+	generateText as generateTextV7,
+	streamText as streamTextV7,
+} from "ai-v7";
 import { beforeAll, describe, expect, it } from "vitest";
 import { neon } from "../src/index.js";
 import { assertGatewayEnv, hasGatewayEnv } from "./helpers.js";
@@ -127,5 +130,37 @@ describe.skipIf(!hasGatewayEnv())(
 				).toEqual([]);
 			}, 600_000);
 		}
+
+		it("uses the Neon image-generation tool with AI SDK 7", async () => {
+			const result = streamTextV7({
+				model: neon("gpt-5-mini"),
+				prompt: "Generate a simple red circle on a white background.",
+				tools: {
+					image_generation: neon.tools.imageGeneration({
+						outputFormat: "jpeg",
+						quality: "low",
+						outputCompression: 30,
+						size: "1024x1024",
+					}),
+				},
+				maxOutputTokens: 2048,
+			});
+
+			let gotImage = false;
+			for await (const part of result.fullStream) {
+				if (
+					part.type === "tool-result" &&
+					part.toolName === "image_generation" &&
+					typeof part.output === "object" &&
+					part.output !== null &&
+					"result" in part.output &&
+					typeof part.output.result === "string" &&
+					part.output.result.length > 1000
+				) {
+					gotImage = true;
+				}
+			}
+			expect(gotImage).toBe(true);
+		}, 120_000);
 	},
 );

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -48,7 +48,8 @@
 	"devDependencies": {
 		"@types/node": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
-		"ai": "6.0.132",
+		"ai": "6.0.228",
+		"ai-v7": "npm:ai@7.0.0-beta.187",
 		"console-fail-test": "catalog:",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
@@ -70,7 +71,7 @@
 		"@ai-sdk/provider-utils": "^4.0.27"
 	},
 	"peerDependencies": {
-		"ai": "^6.0.0",
+		"ai": "^6.0.0 || ^7.0.0-0",
 		"zod": "^3.25.76 || ^4.1.8"
 	}
 }

--- a/packages/ai-sdk-provider/src/lib/neon-openai-tools.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-openai-tools.ts
@@ -1,0 +1,56 @@
+import { openai as openaiProvider } from "@ai-sdk/openai";
+import { z } from "zod/v4";
+
+export type NeonImageGenerationArgs = {
+	background?: "auto" | "opaque" | "transparent";
+	inputFidelity?: "low" | "high";
+	inputImageMask?: {
+		fileId?: string;
+		imageUrl?: string;
+	};
+	model?: string;
+	moderation?: "auto";
+	outputCompression?: number;
+	outputFormat?: "png" | "jpeg" | "webp";
+	partialImages?: number;
+	quality?: "auto" | "low" | "medium" | "high";
+	size?: "auto" | "1024x1024" | "1024x1536" | "1536x1024";
+};
+
+const imageGenerationInputSchema = z.object({});
+const imageGenerationOutputSchema = z.object({ result: z.string() });
+
+/**
+ * OpenAI image generation tool with a schema shape shared by AI SDK 6 and 7.
+ *
+ * AI SDK 6's official factory wraps schemas in its version-specific `Schema`
+ * type. AI SDK 7 can execute the resulting object, but rejects that type at
+ * compile time. Raw Zod 4 schemas implement the shared Standard Schema
+ * interface accepted by both SDK versions.
+ */
+export function imageGeneration(args: NeonImageGenerationArgs = {}) {
+	const type: "provider" = "provider";
+	const id: "openai.image_generation" = "openai.image_generation";
+	const isProviderExecuted: true = true;
+
+	return {
+		type,
+		id,
+		args: { ...args },
+		inputSchema: imageGenerationInputSchema,
+		outputSchema: imageGenerationOutputSchema,
+		isProviderExecuted,
+	};
+}
+
+export type NeonOpenAITools = Omit<
+	typeof openaiProvider.tools,
+	"imageGeneration"
+> & {
+	imageGeneration: typeof imageGeneration;
+};
+
+export const neonOpenAITools: NeonOpenAITools = {
+	...openaiProvider.tools,
+	imageGeneration,
+};

--- a/packages/ai-sdk-provider/src/lib/provider.ts
+++ b/packages/ai-sdk-provider/src/lib/provider.ts
@@ -10,7 +10,6 @@
  * `NEON_AI_GATEWAY_TOKEN` emitted by `neonctl env pull` / `neon dev`, or pass
  * `baseURL` / `apiKey` explicitly.
  */
-import { openai as openaiProvider } from "@ai-sdk/openai";
 import type { ProviderErrorStructure } from "@ai-sdk/openai-compatible";
 import {
 	type LanguageModelV3,
@@ -31,6 +30,7 @@ import { NeonChatLanguageModel } from "./neon-chat-language-model.js";
 import type { NeonChatModelId } from "./neon-chat-options.js";
 import { wrapFetchWithHarmonyNormalization } from "./neon-harmony-normalize.js";
 import { getNeonModelRoute } from "./neon-model-capabilities.js";
+import { neonOpenAITools } from "./neon-openai-tools.js";
 import { NeonResponsesLanguageModel } from "./neon-responses-language-model.js";
 import { VERSION } from "./version.js";
 
@@ -119,7 +119,7 @@ export interface NeonProvider extends ProviderV3 {
 	chat(modelId: NeonChatModelId): LanguageModelV3;
 
 	/** OpenAI Responses tools (e.g. `imageGeneration`) for OpenAI-routed models. */
-	tools: typeof openaiProvider.tools;
+	tools: typeof neonOpenAITools;
 
 	/** @deprecated Use `embeddingModel` instead. */
 	textEmbeddingModel(modelId: string): never;
@@ -206,7 +206,7 @@ export function createNeon(options: NeonProviderSettings = {}): NeonProvider {
 	provider.specificationVersion = "v3" as const;
 	provider.languageModel = createLanguageModel;
 	provider.chat = createLanguageModel;
-	provider.tools = openaiProvider.tools;
+	provider.tools = neonOpenAITools;
 
 	provider.embeddingModel = (modelId: string) => {
 		throw new NoSuchModelError({ modelId, modelType: "embeddingModel" });

--- a/packages/ai-sdk-provider/src/lib/sdk-compatibility.test.ts
+++ b/packages/ai-sdk-provider/src/lib/sdk-compatibility.test.ts
@@ -1,0 +1,117 @@
+import { generateText as generateTextV6, streamText as streamTextV6 } from "ai";
+import {
+	generateText as generateTextV7,
+	streamText as streamTextV7,
+} from "ai-v7";
+import { describe, expect, it } from "vitest";
+import { createNeon } from "./provider.js";
+
+const responseBody = {
+	id: "chatcmpl-neon-sdk-compatibility",
+	object: "chat.completion",
+	created: 0,
+	model: "gpt-oss-20b",
+	choices: [
+		{
+			index: 0,
+			message: { role: "assistant", content: "pong" },
+			finish_reason: "stop",
+		},
+	],
+	usage: {
+		prompt_tokens: 1,
+		completion_tokens: 1,
+		total_tokens: 2,
+	},
+};
+
+function createTestProvider() {
+	return createNeon({
+		baseURL: "https://example.com",
+		apiKey: "test-token",
+		fetch: async () =>
+			new Response(JSON.stringify(responseBody), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			}),
+	});
+}
+
+function createStreamingTestProvider() {
+	const chunks = [
+		{
+			id: "chatcmpl-neon-sdk-compatibility",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: "gpt-oss-20b",
+			choices: [
+				{
+					index: 0,
+					delta: { role: "assistant", content: "pong" },
+					finish_reason: null,
+				},
+			],
+		},
+		{
+			id: "chatcmpl-neon-sdk-compatibility",
+			object: "chat.completion.chunk",
+			created: 0,
+			model: "gpt-oss-20b",
+			choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+			usage: {
+				prompt_tokens: 1,
+				completion_tokens: 1,
+				total_tokens: 2,
+			},
+		},
+	];
+	const body = `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`;
+
+	return createNeon({
+		baseURL: "https://example.com",
+		apiKey: "test-token",
+		fetch: async () =>
+			new Response(body, {
+				status: 200,
+				headers: { "content-type": "text/event-stream" },
+			}),
+	});
+}
+
+describe("AI SDK compatibility", () => {
+	it("generates text with AI SDK 6", async () => {
+		const result = await generateTextV6({
+			model: createTestProvider()("gpt-oss-20b"),
+			prompt: "Reply with pong.",
+		});
+
+		expect(result.text).toBe("pong");
+	});
+
+	it("generates text with AI SDK 7", async () => {
+		const result = await generateTextV7({
+			model: createTestProvider()("gpt-oss-20b"),
+			prompt: "Reply with pong.",
+		});
+
+		expect(result.text).toBe("pong");
+	});
+
+	it("streams text with AI SDK 6", async () => {
+		const result = streamTextV6({
+			model: createStreamingTestProvider()("gpt-oss-20b"),
+			prompt: "Reply with pong.",
+		});
+
+		await expect(result.text).resolves.toBe("pong");
+	});
+
+	it("streams text with AI SDK 7", async () => {
+		const result = streamTextV7({
+			model: createStreamingTestProvider()("gpt-oss-20b"),
+			prompt: "Reply with pong.",
+		});
+
+		await expect(result.text).resolves.toBe("pong");
+	});
+});

--- a/packages/ai-sdk-provider/tsconfig.json
+++ b/packages/ai-sdk-provider/tsconfig.json
@@ -1,4 +1,10 @@
 {
 	"extends": "../../tsconfig.base.json",
-	"include": ["src", "vitest.config.ts", "tsdown.config.ts"]
+	"include": [
+		"src",
+		"e2e/sdk-version-matrix.e2e.test.ts",
+		"vitest.config.ts",
+		"vitest.e2e.config.ts",
+		"tsdown.config.ts"
+	]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,11 @@ importers:
         specifier: 'catalog:'
         version: 3.0.9(vitest@3.0.9(@types/debug@4.1.13)(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.22.3)(yaml@2.9.0))
       ai:
-        specifier: 6.0.132
-        version: 6.0.132(zod@4.4.3)
+        specifier: 6.0.228
+        version: 6.0.228(zod@4.4.3)
+      ai-v7:
+        specifier: npm:ai@7.0.0-beta.187
+        version: ai@7.0.0-beta.187(zod@4.4.3)
       console-fail-test:
         specifier: 'catalog:'
         version: 0.5.0
@@ -630,9 +633,15 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.76':
-    resolution: {integrity: sha512-tQWC8ty42Mcs2p7EENNwvVkX5z1nBTQCE7qOfDPv1ifSCmsSc1zGIdnZfwAXr3eTA132DwJfXAcp1QgpGKQw0w==}
+  '@ai-sdk/gateway@3.0.151':
+    resolution: {integrity: sha512-gsKEm1LleR/xm1FiJjnNxf1ZUKZryj20STsKJB7TdMcaiRqQgeHrdYWv/DNSA8ZBkRahHC+wEYHaI0VR9/EOwQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/gateway@4.0.0-beta.114':
+    resolution: {integrity: sha512-boKygbaK78FxxupfhhjD8P7yT/Xo3O2H/xpUo9XgKojOEx/LisAX2qGN1L9uaEV8gpjrwIzXeysbhDeM8L5vNQ==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -648,15 +657,21 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.20':
-    resolution: {integrity: sha512-gpUIj9uDhIGbuo9afKEgQ074BWmhvK4THJAAeBjRnroTy2yQYo6rbtGD7pQDMZM8ouXPYmT/SCdkWVJ0KcpX8A==}
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@4.0.27':
-    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+  '@ai-sdk/provider-utils@4.0.39':
+    resolution: {integrity: sha512-XPR6o7561RYUkfYlLYouWsvm6Gv2tYIQy5pttGRkvML98u138ClPThn5yiQg5rMQutTtZLB+GUC8qFFCzDKQQQ==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.0-beta.50':
+    resolution: {integrity: sha512-B0sw1hDWbU4Prrjql5d/mcCLVWPnhIVvLwoSQV0JbHf9Jqm4c660HqsDN/C7316foa4Z8JlaO5IDVm3o9BPs5Q==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -664,9 +679,13 @@ packages:
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@3.0.8':
-    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+  '@ai-sdk/provider@3.0.14':
+    resolution: {integrity: sha512-5X1k57JBJ4H7H1QjX7CnJYAB1I19r/trVZTMcSms7/kLNZ8RaU4Nt2agcwZzv82Hfx6Q7/TOLU7agAKeFfc8cA==}
     engines: {node: '>=18'}
+
+  '@ai-sdk/provider@4.0.0-beta.20':
+    resolution: {integrity: sha512-xW/ASShhkKWL+D/ynwJehJgelQIxebhx4UO3fFLmkcDAK+h30mBfgeXIHlduJ3IZCh5iH9xFTF4PcMuQqUcb+g==}
+    engines: {node: '>=22'}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -894,11 +913,11 @@ packages:
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
 
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+  '@emnapi/core@1.11.2':
+    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
 
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -1356,8 +1375,8 @@ packages:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
 
-  '@oxc-project/types@0.139.0':
-    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+  '@oxc-project/types@0.140.0':
+    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1393,97 +1412,97 @@ packages:
   '@quansync/fs@0.1.4':
     resolution: {integrity: sha512-vy/41FCdnIalPTQCb2Wl0ic1caMdzGus4ktDp+gpZesQNydXcx8nhh8qB3qMPbGkictOTaXgXEUUfQEm8DQYoA==}
 
-  '@rolldown/binding-android-arm64@1.1.5':
-    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+  '@rolldown/binding-android-arm64@1.2.0':
+    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+  '@rolldown/binding-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+  '@rolldown/binding-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
-    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+  '@rolldown/binding-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
-    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
+    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
+    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+  '@rolldown/binding-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+  '@rolldown/binding-openharmony-arm64@1.2.0':
+    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+  '@rolldown/binding-wasm32-wasi@1.2.0':
+    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1769,8 +1788,8 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
-  '@vercel/oidc@3.1.0':
-    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
   '@vitest/coverage-v8@3.0.9':
@@ -1814,6 +1833,9 @@ packages:
   '@vitest/utils@3.0.9':
     resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   '@yao-pkg/pkg-fetch@3.5.30':
     resolution: {integrity: sha512-OrXQlsR3vE/IvwXSk8R5ETYbcxAFtUPmLkeepbG+ArN82TvlIwcUJ65tEWxLG3Tl89VRbmOupuhkXfmuaO05+Q==}
     hasBin: true
@@ -1853,9 +1875,15 @@ packages:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
 
-  ai@6.0.132:
-    resolution: {integrity: sha512-B+r6j2q8dOou0MZl5imavEWwPxM+DCvc0p3Af7IdjvB+sMqav7/bYNI5KsGkpqTzs2vp0ZAZWL5w87/udbJYCA==}
+  ai@6.0.228:
+    resolution: {integrity: sha512-3TXPF+meV/B0ObVWqLZDfTo0UjT9eKQX+QO5B8n7TSyLxnU3U9FHKxRp7U9mGuTVh7fdo2OtU0J8uGFR4EStsg==}
     engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.0-beta.187:
+    resolution: {integrity: sha512-j4dH+Vy+6MLaSqsbX/g5QzbiAoFldkpso63bZ0IIU9v9wcuck8LZozYIbADFiNnA7M8eh3s66Ri05QoHijD0/A==}
+    engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
@@ -3682,8 +3710,8 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.1.5:
-    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+  rolldown@1.2.0:
+    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -4361,11 +4389,18 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.76(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.151(zod@4.4.3)':
     dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.20(zod@4.4.3)
-      '@vercel/oidc': 3.1.0
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.39(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/gateway@4.0.0-beta.114(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.20
+      '@ai-sdk/provider-utils': 5.0.0-beta.50(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
   '@ai-sdk/openai-compatible@2.0.48(zod@4.4.3)':
@@ -4380,13 +4415,6 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/provider-utils@4.0.20(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 3.0.8
-      '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
   '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -4394,11 +4422,30 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.39(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.14
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.0-beta.50(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0-beta.20
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@3.0.8':
+  '@ai-sdk/provider@3.0.14':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@4.0.0-beta.20':
     dependencies:
       json-schema: 0.4.0
 
@@ -4718,13 +4765,13 @@ snapshots:
   '@csstools/css-tokenizer@3.0.4':
     optional: true
 
-  '@emnapi/core@1.11.1':
+  '@emnapi/core@1.11.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.2
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.11.1':
+  '@emnapi/runtime@1.11.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5045,10 +5092,10 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.3
     optional: true
 
@@ -5071,7 +5118,7 @@ snapshots:
 
   '@opentelemetry/api@1.9.0': {}
 
-  '@oxc-project/types@0.139.0': {}
+  '@oxc-project/types@0.140.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5100,53 +5147,53 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
-  '@rolldown/binding-android-arm64@1.1.5':
+  '@rolldown/binding-android-arm64@1.2.0':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
+  '@rolldown/binding-darwin-arm64@1.2.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.5':
+  '@rolldown/binding-darwin-x64@1.2.0':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
+  '@rolldown/binding-freebsd-x64@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+  '@rolldown/binding-linux-arm64-gnu@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
+  '@rolldown/binding-linux-arm64-musl@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+  '@rolldown/binding-linux-s390x-gnu@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
+  '@rolldown/binding-linux-x64-gnu@1.2.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.5':
+  '@rolldown/binding-linux-x64-musl@1.2.0':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.5':
+  '@rolldown/binding-openharmony-arm64@1.2.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.5':
+  '@rolldown/binding-wasm32-wasi@1.2.0':
     dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@emnapi/core': 1.11.2
+      '@emnapi/runtime': 1.11.2
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+  '@rolldown/binding-win32-arm64-msvc@1.2.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
+  '@rolldown/binding-win32-x64-msvc@1.2.0':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -5413,7 +5460,7 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vercel/oidc@3.1.0': {}
+  '@vercel/oidc@3.2.0': {}
 
   '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/debug@4.1.13)(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
@@ -5476,6 +5523,8 @@ snapshots:
       '@vitest/pretty-format': 3.0.9
       loupe: 3.2.1
       tinyrainbow: 2.0.0
+
+  '@workflow/serde@4.1.0': {}
 
   '@yao-pkg/pkg-fetch@3.5.30':
     dependencies:
@@ -5552,12 +5601,19 @@ snapshots:
   agent-base@7.1.3:
     optional: true
 
-  ai@6.0.132(zod@4.4.3):
+  ai@6.0.228(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.76(zod@4.4.3)
-      '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.20(zod@4.4.3)
+      '@ai-sdk/gateway': 3.0.151(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.14
+      '@ai-sdk/provider-utils': 4.0.39(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
+
+  ai@7.0.0-beta.187(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.0-beta.114(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0-beta.20
+      '@ai-sdk/provider-utils': 5.0.0-beta.50(zod@4.4.3)
       zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.20.0):
@@ -7396,7 +7452,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.6(rolldown@1.1.5)(typescript@5.9.3):
+  rolldown-plugin-dts@0.15.6(rolldown@1.2.0)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -7406,33 +7462,33 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.1
       get-tsconfig: 4.10.1
-      rolldown: 1.1.5
+      rolldown: 1.2.0
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver
       - supports-color
 
-  rolldown@1.1.5:
+  rolldown@1.2.0:
     dependencies:
-      '@oxc-project/types': 0.139.0
+      '@oxc-project/types': 0.140.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.5
-      '@rolldown/binding-darwin-arm64': 1.1.5
-      '@rolldown/binding-darwin-x64': 1.1.5
-      '@rolldown/binding-freebsd-x64': 1.1.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
-      '@rolldown/binding-linux-arm64-gnu': 1.1.5
-      '@rolldown/binding-linux-arm64-musl': 1.1.5
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
-      '@rolldown/binding-linux-s390x-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-musl': 1.1.5
-      '@rolldown/binding-openharmony-arm64': 1.1.5
-      '@rolldown/binding-wasm32-wasi': 1.1.5
-      '@rolldown/binding-win32-arm64-msvc': 1.1.5
-      '@rolldown/binding-win32-x64-msvc': 1.1.5
+      '@rolldown/binding-android-arm64': 1.2.0
+      '@rolldown/binding-darwin-arm64': 1.2.0
+      '@rolldown/binding-darwin-x64': 1.2.0
+      '@rolldown/binding-freebsd-x64': 1.2.0
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
+      '@rolldown/binding-linux-arm64-gnu': 1.2.0
+      '@rolldown/binding-linux-arm64-musl': 1.2.0
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
+      '@rolldown/binding-linux-s390x-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-gnu': 1.2.0
+      '@rolldown/binding-linux-x64-musl': 1.2.0
+      '@rolldown/binding-openharmony-arm64': 1.2.0
+      '@rolldown/binding-wasm32-wasi': 1.2.0
+      '@rolldown/binding-win32-arm64-msvc': 1.2.0
+      '@rolldown/binding-win32-x64-msvc': 1.2.0
 
   rollup@3.29.4:
     optionalDependencies:
@@ -7901,8 +7957,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.1.5
-      rolldown-plugin-dts: 0.15.6(rolldown@1.1.5)(typescript@5.9.3)
+      rolldown: 1.2.0
+      rolldown-plugin-dts: 0.15.6(rolldown@1.2.0)(typescript@5.9.3)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15


### PR DESCRIPTION
## Summary
- widen the `ai` peer range to AI SDK 6 and 7 while retaining the v3 provider contract that AI SDK 7 adapts to v4, preserving AI SDK 6 compatibility
- expose `neon.tools.imageGeneration()` with shared Standard Schema types so it typechecks and runs with both SDK majors
- validate non-streaming and streaming generation with AI SDK 6.0.228 and 7.0.0-beta.187, including packed-package consumer installs
- add a live `/v1/models` matrix that exercises every model currently exposed by the branch gateway under both SDK versions
- document dual-version support and add a patch changeset

## Test plan
- [x] `pnpm --filter @neon/ai-sdk-provider test:ci` (22 passed, 2 drift checks skipped)
- [x] `pnpm --filter @neon/ai-sdk-provider build`
- [x] `pnpm lint:ci`
- [x] install the packed tarball in independent AI SDK 6 and 7 consumers; `generateText` and `streamText` passed in both
- [x] run every live `/v1/models` entry with AI SDK 6 and 7: both produced the same result, 21/27 passed
- [x] run live `neon.tools.imageGeneration()` streaming with both AI SDK 6 and 7; both returned JPEG output
- [x] run the broader live capability matrix: OpenAI, Codex, Meta, image generation, and gpt-oss generation/streaming passed

## Live gateway findings
The branch's temporary `/v1/models` response currently lists 27 models. Both SDK versions succeeded on the same 21 and failed on the same 6, so there was no v6/v7 behavioral divergence:

- `gemini-2-5-flash` and `gemini-2-5-pro`: gateway returns 400 because the backing Databricks endpoints are deprecated
- `gemini-3-pro`: gateway returns 404 because the backing model is unavailable or inaccessible
- `gpt-5-1-codex-max`, `gpt-5-1-codex-mini`, and `gpt-5-2-codex`: `/v1/models` advertises them, but their native Responses routes return 404

Anthropic is absent from the temporary `/v1/models` list as expected. The representative Anthropic capability checks therefore return 404; those failures are gateway availability rather than SDK-version incompatibility.