### PR TITLE
chore: release @neon/ai-sdk-provider@0.7.2

### DIFF
--- a/.changeset/bright-bats-adapt.md
+++ b/.changeset/bright-bats-adapt.md
@@ -1,5 +1,0 @@
----
-"@neon/ai-sdk-provider": patch
----
-
-Support both AI SDK 6 and AI SDK 7, with compatibility coverage for every model currently enabled by the Neon AI Gateway.

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/ai-sdk-provider
 
+## 0.7.2
+
+### Patch Changes
+
+- ec97d62: Support both AI SDK 6 and AI SDK 7, with compatibility coverage for every model currently enabled by the Neon AI Gateway.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/ai-sdk-provider",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Summary
- bump `@neon/ai-sdk-provider` from 0.7.1 to 0.7.2
- consume the AI SDK 6/7 compatibility changeset
- update the package changelog

## Verification
- `pnpm lint:ci`
- local version: 0.7.2
- npm version before publish: 0.7.1