### PR TITLE
fix(init): make editor extension opt-in

### DIFF
--- a/.changeset/calm-plums-smile.md
+++ b/.changeset/calm-plums-smile.md
@@ -1,0 +1,5 @@
+---
+"neon-init": patch
+---
+
+Stop installing the Neon editor extension during default setup while keeping it available as an option during customized setup.

--- a/packages/init/src/interactive.ts
+++ b/packages/init/src/interactive.ts
@@ -501,14 +501,14 @@ async function interactiveInitInner(
 				log.step(dim("Neon editor extension already installed ✓"));
 			}
 		}
-		let doInstallExtension =
+		const canInstallExtension =
 			vscodeEditors.length > 0 && !extensionAlreadyInstalled;
+		let doInstallExtension = false;
 
 		// Build hint showing only what needs installing
 		const hintParts: string[] = [];
 		if (needsMcp) hintParts.push("MCP server (global)");
 		if (needsSkills) hintParts.push("agent skills (project)");
-		if (doInstallExtension) hintParts.push("editor extension");
 
 		// Installation preferences
 		let mcpScope: "global" | "project" | "none" = "global";
@@ -528,7 +528,9 @@ async function interactiveInitInner(
 					{
 						value: "customize",
 						label: "Customize installation",
-						hint: "choose scopes and options",
+						hint: canInstallExtension
+							? "choose scopes and optional editor extension"
+							: "choose scopes and options",
 					},
 					{
 						value: "change_editor",
@@ -620,7 +622,7 @@ async function interactiveInitInner(
 				skillsScope = skillsScopeResult as "global" | "project";
 			}
 
-			if (doInstallExtension) {
+			if (canInstallExtension) {
 				const extResult = await confirm({
 					message: `Install the Neon extension for ${vscodeEditors.join(", ")}?`,
 				});

--- a/packages/init/src/lib/phases/setup.test.ts
+++ b/packages/init/src/lib/phases/setup.test.ts
@@ -140,10 +140,27 @@ describe("setup phase", () => {
 
 			const modePref = prefs.find((p) => p.id === "mode");
 			expect(modePref?.phase).toBe("after_checks");
+			const defaultsOption = modePref?.options.find(
+				(option) =>
+					typeof option !== "string" && option.value === "defaults",
+			);
+			expect(
+				typeof defaultsOption === "string"
+					? defaultsOption
+					: defaultsOption?.label,
+			).not.toContain("extension");
 
 			const mcpScopePref = prefs.find((p) => p.id === "mcpScope");
 			expect(mcpScopePref?.phase).toBe("after_checks");
 			expect(mcpScopePref?.condition).toEqual({
+				preferenceId: "mode",
+				equals: "customize",
+			});
+
+			const extensionPref = prefs.find(
+				(p) => p.id === "installExtension",
+			);
+			expect(extensionPref?.condition).toEqual({
 				preferenceId: "mode",
 				equals: "customize",
 			});
@@ -175,10 +192,6 @@ describe("setup phase", () => {
 	});
 
 	test("defaults mode executes installation and chains to getting-started", async () => {
-		// claude agent doesn't map to a VS Code editor, so extension install is skipped
-		// Use "vscode" agent to test full install with extension
-		mockFindEditorCommand.mockResolvedValue("/usr/bin/code");
-
 		const result = await handleSetupPhase({
 			agent: "vscode",
 			mcpConfigured: false,
@@ -199,7 +212,7 @@ describe("setup phase", () => {
 		expect(resultIds).toContain("neonctl");
 		expect(resultIds).toContain("install_mcp");
 		expect(resultIds).toContain("install_skills");
-		expect(resultIds).toContain("install_extension");
+		expect(resultIds).not.toContain("install_extension");
 		expect(results.every((r) => r.status === "success")).toBe(true);
 
 		// nextAction should chain to the getting-started CLI command
@@ -207,8 +220,8 @@ describe("setup phase", () => {
 		const args = (result.nextAction as { args: string[] }).args;
 		expect(args[0]).toBe("getting-started");
 
-		// Should have called execa for MCP and extension (neonctl mocked, skills via ensureSkillsUpToDate)
-		expect(mockExeca).toHaveBeenCalledTimes(2);
+		// Should have called execa for MCP only (neonctl mocked, skills via ensureSkillsUpToDate)
+		expect(mockExeca).toHaveBeenCalledTimes(1);
 		expect(mockEnsureSkills).toHaveBeenCalled();
 
 		// MCP call should use -g for global scope
@@ -216,11 +229,6 @@ describe("setup phase", () => {
 		expect(mcpCall[0]).toBe("npx");
 		expect(mcpCall[1]).toContain("-g");
 		expect(mcpCall[1]).toContain("add-mcp");
-
-		// Extension call should use resolved path
-		const extCall = mockExeca.mock.calls[1];
-		expect(extCall[0]).toBe("/usr/bin/code");
-		expect(extCall[1]).toContain("--install-extension");
 	});
 
 	test("defaults mode skips MCP when already configured", async () => {
@@ -289,7 +297,7 @@ describe("setup phase", () => {
 		}
 	});
 
-	test("cursor agent installs extension via direct --install-extension", async () => {
+	test("defaults mode does not install the Cursor extension", async () => {
 		mockFindEditorCommand.mockResolvedValue(
 			"/Applications/Cursor.app/Contents/Resources/app/bin/cursor",
 		);
@@ -311,12 +319,10 @@ describe("setup phase", () => {
 			manualAction?: boolean;
 		}[];
 		const extResult = results.find((r) => r.id === "install_extension");
-		expect(extResult?.status).toBe("success");
-		expect(extResult?.manualAction).toBeUndefined();
-		expect(extResult?.description).toContain("Installed Neon extension");
+		expect(extResult).toBeUndefined();
 	});
 
-	test("falls back to manual when both direct install and VSIX fail", async () => {
+	test("custom install falls back to manual when extension installation fails", async () => {
 		mockFindEditorCommand.mockResolvedValue("/usr/bin/cursor");
 		// Make direct install fail
 		mockExeca.mockImplementation((_cmd: string, args: string[]) => {
@@ -333,7 +339,8 @@ describe("setup phase", () => {
 			framework: "none",
 			orm: "none",
 			isVscodeIde: true,
-			mode: "defaults",
+			mode: "customize",
+			installExtension: true,
 		});
 
 		const results = result.results as {

--- a/packages/init/src/lib/phases/setup.ts
+++ b/packages/init/src/lib/phases/setup.ts
@@ -102,13 +102,11 @@ export async function handleSetupPhase(
 		options.mode !== "custom"
 	) {
 		const merged = await mergeCliInspection(options);
-		const shouldInstallExt =
-			merged.installExtension ?? isVscodeBasedIde(merged);
 		return executeBatchedInstallation({
 			...merged,
 			mcpScope: merged.mcpScope ?? "global",
 			skillsScope: merged.skillsScope ?? "project",
-			installExtension: shouldInstallExt,
+			installExtension: false,
 		});
 	}
 
@@ -306,8 +304,8 @@ async function buildBulkInspection(
 								{
 									value: "defaults",
 									label: hasApp
-										? "Use defaults (Neon CLI, MCP: global, skills: project-level, extension if applicable — already-configured components will be skipped)"
-										: "Use defaults (Neon CLI, MCP: global, extension if applicable — skills included in template)",
+										? "Use defaults (Neon CLI, MCP: global, skills: project-level — already-configured components will be skipped)"
+										: "Use defaults (Neon CLI, MCP: global — skills included in template)",
 								},
 								{
 									value: "customize",
@@ -470,7 +468,6 @@ function _buildModeQuestion(options: SetupPhaseOptions): PhaseResponse {
 	const defaultsParts: string[] = ["Neon CLI"];
 	if (!options.mcpConfigured) defaultsParts.push("MCP global");
 	defaultsParts.push("skills in project");
-	if (options.isVscodeIde) defaultsParts.push("install extension");
 	const defaultsLabel =
 		defaultsParts.length > 0
 			? `Use defaults (${defaultsParts.join(", ")})`


### PR DESCRIPTION
## Summary
- stop installing the VS Code/Cursor extension during default `neon-init` setup
- keep the editor extension available as an opt-in during customized setup
- add regression coverage and a patch changeset

## Test plan
- [x] `pnpm --filter neon-init test:ci`
- [x] `pnpm --filter neon-init build`
- [x] `pnpm exec biome check --error-on-warnings packages/init/src/lib/phases/setup.ts packages/init/src/lib/phases/setup.test.ts packages/init/src/interactive.ts`