### PR TITLE
chore: release neonctl@2.37.0 + @neon/sdk@1.3.0 (+ dependent patch bumps)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,27 @@
 # neonctl
 
+## 2.37.0
+
+### Minor Changes
+
+- Fix snapshot expiration updates and schedule frequency options
+
+  - SDK: regenerate from the latest API spec so `SnapshotUpdateRequest` supports
+    updating (`expires_at`) and clearing (`null`) a snapshot's expiration, and the
+    backup schedule `frequency` documents only the supported `daily`/`weekly`/`monthly`
+    values.
+  - CLI: `neon snapshots update --expires-at`/`--clear-expiration` now work, and
+    `snapshots schedule set --frequency` only offers `daily`, `weekly`, and `monthly`
+    (dropping `hourly`/`yearly`, which the API rejects).
+
+### Patch Changes
+
+- Updated dependencies
+  - @neon/sdk@1.3.0
+  - @neon/config@0.9.6
+  - @neon/config-runtime@0.9.7
+  - @neon/env@0.11.6
+
 ## 2.36.0
 
 ### Minor Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -578,7 +578,7 @@ neon snapshots delete snap-1234
 # Automatic snapshot (backup) schedule of a branch
 neon snapshots schedule get --branch main
 neon snapshots schedule set --branch main --frequency daily --hour 3 --retention 604800
-neon snapshots schedule set --branch main --schedule '[{"frequency":"hourly"},{"frequency":"daily","hour":3}]'
+neon snapshots schedule set --branch main --schedule '[{"frequency":"weekly","day":1,"hour":2},{"frequency":"daily","hour":3}]'
 ```
 
 All sub-commands honor the [global options](#global-options), including `--output json|yaml|table`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.36.0",
+  "version": "2.37.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/cli/src/commands/__snapshots__/snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/snapshots.test.ts.snap
@@ -166,7 +166,9 @@ exports[`snapshots > schedule set from flags 1`] = `
 `;
 
 exports[`snapshots > schedule set from json 1`] = `
-"- frequency: hourly
+"- frequency: weekly
+  hour: 2
+  day: 1
 - frequency: daily
   hour: 3
 "

--- a/packages/cli/src/commands/snapshots.test.ts
+++ b/packages/cli/src/commands/snapshots.test.ts
@@ -311,7 +311,7 @@ describe("snapshots", () => {
 			"--branch",
 			"main",
 			"--schedule",
-			'[{"frequency":"hourly"},{"frequency":"daily","hour":3}]',
+			'[{"frequency":"weekly","day":1,"hour":2},{"frequency":"daily","hour":3}]',
 		]);
 	});
 

--- a/packages/cli/src/commands/snapshots.ts
+++ b/packages/cli/src/commands/snapshots.ts
@@ -34,13 +34,7 @@ const OPERATION_FIELDS: readonly (keyof Operation)[] = [
 	"status",
 ];
 
-const SNAPSHOT_FREQUENCIES = [
-	"hourly",
-	"daily",
-	"weekly",
-	"monthly",
-	"yearly",
-] as const;
+const SNAPSHOT_FREQUENCIES = ["daily", "weekly", "monthly"] as const;
 
 export const command = "snapshots";
 export const describe = "Manage snapshots";
@@ -273,7 +267,7 @@ export const builder = (argv: yargs.Argv) =>
 										"A daily 03:00 snapshot kept for 7 days",
 									],
 									[
-										'$0 snapshots schedule set --branch main --schedule \'[{"frequency":"hourly"},{"frequency":"daily","hour":3}]\'',
+										'$0 snapshots schedule set --branch main --schedule \'[{"frequency":"weekly","day":1,"hour":2},{"frequency":"daily","hour":3}]\'',
 										"A multi-entry schedule via JSON",
 									],
 								]),

--- a/packages/cli/src/parameters.gen.ts
+++ b/packages/cli/src/parameters.gen.ts
@@ -124,7 +124,7 @@ export const projectCreateRequest = {
   },
   'project.pg_version': {
               type: "number",
-              description: "The major Postgres version number. Currently supported versions are `14`, `15`, `16`, `17`, and `18`.",
+              description: "The major Postgres version number. Generally available versions are `14`, `15`, `16`, `17`, and `18`. `19` is being rolled out and is only accepted in regions where it has been enabled; requesting it in a region where it is not yet available returns an error.",
               demandOption: false,
   },
   'project.store_passwords': {

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 0.9.7
+
+### Patch Changes
+
+- @neon/config@0.9.6
+
 ## 0.9.6
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "0.9.6",
+	"version": "0.9.7",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 0.9.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @neon/sdk@1.3.0
+
 ## 0.9.5
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "0.9.5",
+	"version": "0.9.6",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 0.11.6
+
+### Patch Changes
+
+- @neon/config@0.9.6
+
 ## 0.11.5
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "0.11.5",
+	"version": "0.11.6",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @neon/sdk
 
+## 1.3.0
+
+### Minor Changes
+
+- Fix snapshot expiration updates and schedule frequency options
+
+  - SDK: regenerate from the latest API spec so `SnapshotUpdateRequest` supports
+    updating (`expires_at`) and clearing (`null`) a snapshot's expiration, and the
+    backup schedule `frequency` documents only the supported `daily`/`weekly`/`monthly`
+    values.
+  - CLI: `neon snapshots update --expires-at`/`--clear-expiration` now work, and
+    `snapshots schedule set --frequency` only offers `daily`, `weekly`, and `monthly`
+    (dropping `hourly`/`yearly`, which the API rejects).
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/sdk/spec/neon-openapi.json
+++ b/packages/sdk/spec/neon-openapi.json
@@ -8163,7 +8163,7 @@
             },
             "put": {
                 "summary": "Update backup schedule",
-                "description": "Updates the backup schedule for the specified branch.\nThe schedule defines how often automatic snapshots are created (e.g., `hourly`, `daily`).\n\n**Note**: This endpoint is currently in Beta.\n",
+                "description": "Updates the backup schedule for the specified branch.\nThe schedule defines how often automatic snapshots are created (e.g., `daily`, `weekly`).\n\n**Note**: This endpoint is currently in Beta.\n",
                 "tags": [
                     "Snapshot"
                 ],
@@ -10085,7 +10085,8 @@
                     "swap_binding_id",
                     "finalize_migration",
                     "mark_migration_prepared",
-                    "update_catalog"
+                    "update_catalog",
+                    "epc_sync"
                 ]
             },
             "OperationStatus": {
@@ -15150,7 +15151,7 @@
                 "properties": {
                     "frequency": {
                         "type": "string",
-                        "description": "How often to take snapshots. Must be one of the following values:\n  - `hourly`\n  - `daily`\n  - `weekly`\n  - `monthly`\n  - `yearly`\n"
+                        "description": "How often to take snapshots. Must be one of the following values:\n  - `daily`\n  - `weekly`\n  - `monthly`\n"
                     },
                     "hour": {
                         "type": "integer",

--- a/packages/sdk/src/client/sdk.gen.ts
+++ b/packages/sdk/src/client/sdk.gen.ts
@@ -4045,7 +4045,7 @@ export const getSnapshotSchedule = <ThrowOnError extends boolean = false>(option
  * Update backup schedule
  *
  * Updates the backup schedule for the specified branch.
- * The schedule defines how often automatic snapshots are created (e.g., `hourly`, `daily`).
+ * The schedule defines how often automatic snapshots are created (e.g., `daily`, `weekly`).
  *
  * **Note**: This endpoint is currently in Beta.
  *

--- a/packages/sdk/src/client/types.gen.ts
+++ b/packages/sdk/src/client/types.gen.ts
@@ -363,7 +363,7 @@ export type OperationsResponse = {
 /**
  * The action performed by the operation
  */
-export type OperationAction = 'create_compute' | 'create_timeline' | 'start_compute' | 'suspend_compute' | 'apply_config' | 'check_availability' | 'delete_timeline' | 'create_branch' | 'import_data' | 'tenant_ignore' | 'tenant_attach' | 'tenant_detach' | 'tenant_detach_safekeepers' | 'tenant_attach_safekeepers' | 'tenant_reattach' | 'replace_safekeeper' | 'disable_maintenance' | 'apply_storage_config' | 'prepare_secondary_pageserver' | 'switch_pageserver' | 'detach_parent_branch' | 'timeline_archive' | 'timeline_unarchive' | 'start_reserved_compute' | 'sync_dbs_and_roles_from_compute' | 'apply_schema_from_branch' | 'timeline_mark_invisible' | 'timeline_update_protected_config' | 'prewarm_replica' | 'promote_replica' | 'set_storage_non_dirty' | 'swap_binding_id' | 'finalize_migration' | 'mark_migration_prepared' | 'update_catalog';
+export type OperationAction = 'create_compute' | 'create_timeline' | 'start_compute' | 'suspend_compute' | 'apply_config' | 'check_availability' | 'delete_timeline' | 'create_branch' | 'import_data' | 'tenant_ignore' | 'tenant_attach' | 'tenant_detach' | 'tenant_detach_safekeepers' | 'tenant_attach_safekeepers' | 'tenant_reattach' | 'replace_safekeeper' | 'disable_maintenance' | 'apply_storage_config' | 'prepare_secondary_pageserver' | 'switch_pageserver' | 'detach_parent_branch' | 'timeline_archive' | 'timeline_unarchive' | 'start_reserved_compute' | 'sync_dbs_and_roles_from_compute' | 'apply_schema_from_branch' | 'timeline_mark_invisible' | 'timeline_update_protected_config' | 'prewarm_replica' | 'promote_replica' | 'set_storage_non_dirty' | 'swap_binding_id' | 'finalize_migration' | 'mark_migration_prepared' | 'update_catalog' | 'epc_sync';
 
 /**
  * The status of the operation
@@ -3177,11 +3177,9 @@ export type SnapshotUpdateRequest = {
 export type BackupScheduleItem = {
     /**
      * How often to take snapshots. Must be one of the following values:
-     * - `hourly`
      * - `daily`
      * - `weekly`
      * - `monthly`
-     * - `yearly`
      *
      */
     frequency: string;


### PR DESCRIPTION
## Summary
Fixes the `neon snapshots` feature against the latest API spec (regenerates `@neon/sdk`, then `changeset version` cascades patch bumps to `workspace:*` dependents):
- **SDK**: `SnapshotUpdateRequest` supports setting/clearing `expires_at`; schedule `frequency` limited to `daily`/`weekly`/`monthly`.
- **CLI**: `snapshots update --expires-at`/`--clear-expiration` work; `schedule set --frequency` offers only `daily`/`weekly`/`monthly`.

## Bumped packages
| Package | Old → New | Why |
|---|---|---|
| `@neon/sdk` | 1.2.0 → **1.3.0** | minor — snapshot `expires_at` + frequency spec fix |
| `neonctl` | 2.36.0 → **2.37.0** | minor — snapshots CLI fixes; depends on `@neon/sdk` |
| `@neon/config` | 0.9.5 → 0.9.6 | patch — depends on `@neon/sdk` |
| `@neon/config-runtime` | 0.9.6 → 0.9.7 | patch — depends on `@neon/config` |
| `@neon/env` | 0.11.5 → 0.11.6 | patch — depends on `@neon/config` |

`neon-init` is **not** bumped, so the CLI publish lockfile dance is not needed.

## Test plan
- [x] `pnpm lint:ci`, SDK 17/17, CLI snapshots 27/27
- [x] Live-verified: create/update/clear expiration + README schedule examples
