### PR TITLE
feat(sdk): refresh OpenAPI spec + narrow backup-schedule frequency ergonomically (@neon/sdk@1.3.0, neonctl@2.36.1)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # neonctl
 
+## 2.36.1
+
+### Patch Changes
+
+- `neon snapshots schedule set` now only accepts the backup frequencies the API supports (`daily`, `weekly`, `monthly`).
+
+  - The `--frequency` flag drops `hourly` / `yearly` from its choices.
+  - The `--schedule <json>` path now validates each entry's `frequency` and errors on an unsupported value (e.g. `hourly`) instead of forwarding it to the API, closing the gap where invalid frequencies bypassed the flag-level check.
+  - Regenerated `--pg-version` help text from the spec (documents the Postgres 19 rollout).
+
+- Updated dependencies
+  - @neon/sdk@1.3.0
+  - @neon/config@0.9.6
+  - @neon/config-runtime@0.9.7
+  - @neon/env@0.11.6
+
 ## 2.36.0
 
 ### Minor Changes

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -578,7 +578,7 @@ neon snapshots delete snap-1234
 # Automatic snapshot (backup) schedule of a branch
 neon snapshots schedule get --branch main
 neon snapshots schedule set --branch main --frequency daily --hour 3 --retention 604800
-neon snapshots schedule set --branch main --schedule '[{"frequency":"hourly"},{"frequency":"daily","hour":3}]'
+neon snapshots schedule set --branch main --schedule '[{"frequency":"weekly","day":1,"hour":2},{"frequency":"daily","hour":3}]'
 ```
 
 All sub-commands honor the [global options](#global-options), including `--output json|yaml|table`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.36.0",
+  "version": "2.36.1",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/cli/src/commands/__snapshots__/snapshots.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/snapshots.test.ts.snap
@@ -166,11 +166,15 @@ exports[`snapshots > schedule set from flags 1`] = `
 `;
 
 exports[`snapshots > schedule set from json 1`] = `
-"- frequency: hourly
+"- frequency: weekly
+  hour: 2
+  day: 1
 - frequency: daily
   hour: 3
 "
 `;
+
+exports[`snapshots > schedule set from json rejects an unsupported frequency 1`] = `""`;
 
 exports[`snapshots > schedule set rejects invalid json 1`] = `""`;
 

--- a/packages/cli/src/commands/snapshots.test.ts
+++ b/packages/cli/src/commands/snapshots.test.ts
@@ -311,8 +311,30 @@ describe("snapshots", () => {
 			"--branch",
 			"main",
 			"--schedule",
-			'[{"frequency":"hourly"},{"frequency":"daily","hour":3}]',
+			'[{"frequency":"weekly","day":1,"hour":2},{"frequency":"daily","hour":3}]',
 		]);
+	});
+
+	test("schedule set from json rejects an unsupported frequency", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"schedule",
+				"set",
+				"--project-id",
+				"test",
+				"--branch",
+				"main",
+				"--schedule",
+				'[{"frequency":"hourly"}]',
+			],
+			{
+				code: 1,
+				stderr: expect.stringContaining('unsupported "frequency"'),
+			},
+		);
 	});
 
 	test("schedule set with nothing errors", async ({ testCliCommand }) => {

--- a/packages/cli/src/commands/snapshots.ts
+++ b/packages/cli/src/commands/snapshots.ts
@@ -40,9 +40,9 @@ const OPERATION_FIELDS: readonly (keyof Operation)[] = [
 ];
 
 // The values the Neon API accepts for a backup-schedule entry's `frequency`
-// (per the OpenAPI `BackupScheduleItem` description). `satisfies` keeps this
-// list in lockstep with the SDK's `SnapshotFrequency` union — if the spec adds
-// or drops a value, this stops compiling until both are updated together.
+// (per the OpenAPI `BackupScheduleItem` description). `satisfies` fails the
+// build if a value listed here leaves the SDK's `SnapshotFrequency` union, so
+// the CLI can never offer a frequency the API rejects.
 const SNAPSHOT_FREQUENCIES = [
 	"daily",
 	"weekly",

--- a/packages/cli/src/commands/snapshots.ts
+++ b/packages/cli/src/commands/snapshots.ts
@@ -1,4 +1,9 @@
-import type { BackupScheduleItem, Operation, Snapshot } from "@neon/sdk";
+import type {
+	BackupScheduleItem,
+	Operation,
+	Snapshot,
+	SnapshotFrequency,
+} from "@neon/sdk";
 import type yargs from "yargs";
 import { retryOnLock } from "../api.js";
 import { log } from "../log.js";
@@ -34,13 +39,19 @@ const OPERATION_FIELDS: readonly (keyof Operation)[] = [
 	"status",
 ];
 
+// The values the Neon API accepts for a backup-schedule entry's `frequency`
+// (per the OpenAPI `BackupScheduleItem` description). `satisfies` keeps this
+// list in lockstep with the SDK's `SnapshotFrequency` union — if the spec adds
+// or drops a value, this stops compiling until both are updated together.
 const SNAPSHOT_FREQUENCIES = [
-	"hourly",
 	"daily",
 	"weekly",
 	"monthly",
-	"yearly",
-] as const;
+] as const satisfies readonly SnapshotFrequency[];
+
+/** Narrow an arbitrary string to a supported {@link SnapshotFrequency}. */
+const isSnapshotFrequency = (value: string): value is SnapshotFrequency =>
+	SNAPSHOT_FREQUENCIES.some((frequency) => frequency === value);
 
 export const command = "snapshots";
 export const describe = "Manage snapshots";
@@ -273,7 +284,7 @@ export const builder = (argv: yargs.Argv) =>
 										"A daily 03:00 snapshot kept for 7 days",
 									],
 									[
-										'$0 snapshots schedule set --branch main --schedule \'[{"frequency":"hourly"},{"frequency":"daily","hour":3}]\'',
+										'$0 snapshots schedule set --branch main --schedule \'[{"frequency":"weekly","day":1,"hour":2},{"frequency":"daily","hour":3}]\'',
 										"A multi-entry schedule via JSON",
 									],
 								]),
@@ -582,6 +593,11 @@ const parseScheduleJson = (raw: string): BackupScheduleItem[] => {
 		if (typeof frequency !== "string") {
 			throw new Error(
 				`--schedule entry ${index} is missing a string "frequency".`,
+			);
+		}
+		if (!isSnapshotFrequency(frequency)) {
+			throw new Error(
+				`--schedule entry ${index} has an unsupported "frequency": "${frequency}". Use one of: ${SNAPSHOT_FREQUENCIES.join(", ")}.`,
 			);
 		}
 		const item: BackupScheduleItem = { frequency };

--- a/packages/cli/src/parameters.gen.ts
+++ b/packages/cli/src/parameters.gen.ts
@@ -124,7 +124,7 @@ export const projectCreateRequest = {
   },
   'project.pg_version': {
               type: "number",
-              description: "The major Postgres version number. Currently supported versions are `14`, `15`, `16`, `17`, and `18`.",
+              description: "The major Postgres version number. Generally available versions are `14`, `15`, `16`, `17`, and `18`. `19` is being rolled out and is only accepted in regions where it has been enabled; requesting it in a region where it is not yet available returns an error.",
               demandOption: false,
   },
   'project.store_passwords': {

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 0.9.7
+
+### Patch Changes
+
+- @neon/config@0.9.6
+
 ## 0.9.6
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "0.9.6",
+	"version": "0.9.7",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 0.9.6
+
+### Patch Changes
+
+- Updated dependencies
+  - @neon/sdk@1.3.0
+
 ## 0.9.5
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "0.9.5",
+	"version": "0.9.6",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 0.11.6
+
+### Patch Changes
+
+- @neon/config@0.9.6
+
 ## 0.11.5
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "0.11.5",
+	"version": "0.11.6",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   - **Regenerated from the latest spec:** `OperationAction` gains `epc_sync` (additive), and the backup-schedule update endpoint + `BackupScheduleItem.frequency` descriptions now document only `daily` / `weekly` / `monthly` (dropping `hourly` / `yearly`). The generated `frequency` stays `string` — the spec documents the allowed values in prose, not as an `enum` — so the type-level narrowing lives in the ergonomic layer.
   - **Ergonomic layer:** `snapshots.setSchedule` now takes a `SetScheduleInput` whose entries' `frequency` is narrowed to the new `SnapshotFrequency` union (`"daily" | "weekly" | "monthly"`), so unsupported values are rejected at compile time instead of by the API. `getSchedule` still returns the server-controlled `BackupSchedule` unchanged (received data stays wide).
-  - **New exported types:** `SnapshotFrequency`, `ScheduleItem`, `SetScheduleInput`, plus the previously-unexported `UpdateSnapshotInput`.
+  - **New exported types:** `SnapshotFrequency`, `BackupScheduleItemInput`, `SetScheduleInput`, plus the previously-unexported `UpdateSnapshotInput`.
 
   Snapshot expiration (`expiresAt` / clearing with `null`) already shipped in 1.1.0 and is unchanged here.
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @neon/sdk
 
+## 1.3.0
+
+### Minor Changes
+
+- Refresh the vendored Neon OpenAPI spec and regenerated client, and narrow the backup-schedule `frequency` in the ergonomic layer.
+
+  - **Regenerated from the latest spec:** `OperationAction` gains `epc_sync` (additive), and the backup-schedule update endpoint + `BackupScheduleItem.frequency` descriptions now document only `daily` / `weekly` / `monthly` (dropping `hourly` / `yearly`). The generated `frequency` stays `string` — the spec documents the allowed values in prose, not as an `enum` — so the type-level narrowing lives in the ergonomic layer.
+  - **Ergonomic layer:** `snapshots.setSchedule` now takes a `SetScheduleInput` whose entries' `frequency` is narrowed to the new `SnapshotFrequency` union (`"daily" | "weekly" | "monthly"`), so unsupported values are rejected at compile time instead of by the API. `getSchedule` still returns the server-controlled `BackupSchedule` unchanged (received data stays wide).
+  - **New exported types:** `SnapshotFrequency`, `ScheduleItem`, `SetScheduleInput`, plus the previously-unexported `UpdateSnapshotInput`.
+
+  Snapshot expiration (`expiresAt` / clearing with `null`) already shipped in 1.1.0 and is unchanged here.
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -322,7 +322,7 @@ Branch-scoped AI Gateway endpoint metadata (beta).
 | `delete(projectId, snapshotId)` | **→void** | |
 | `restore(projectId, snapshotId, input?)` | `Branch` | see below |
 | `getSchedule(projectId, branchId)` | `BackupSchedule` | |
-| `setSchedule(projectId, branchId, schedule)` | **→void** | |
+| `setSchedule(projectId, branchId, schedule)` | **→void** | `schedule.schedule[].frequency` is narrowed to `SnapshotFrequency` (`"daily" \| "weekly" \| "monthly"`) |
 
 ```ts
 // Snapshot a branch at a point in time (or an `lsn`), with a name + TTL

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -321,7 +321,7 @@ Branch-scoped AI Gateway endpoint metadata (beta).
 | `update(projectId, snapshotId, input)` | `Snapshot` | `input`: `{ name?, expiresAt? }` — pass `expiresAt: null` to clear the expiration |
 | `delete(projectId, snapshotId)` | **→void** | |
 | `restore(projectId, snapshotId, input?)` | `Branch` | see below |
-| `getSchedule(projectId, branchId)` | `BackupSchedule` | |
+| `getSchedule(projectId, branchId)` | `BackupSchedule` | `frequency` stays a wide `string`: a branch can still hold a schedule created when the API accepted other values |
 | `setSchedule(projectId, branchId, schedule)` | **→void** | `schedule.schedule[].frequency` is narrowed to `SnapshotFrequency` (`"daily" \| "weekly" \| "monthly"`) |
 
 ```ts

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/sdk/spec/neon-openapi.json
+++ b/packages/sdk/spec/neon-openapi.json
@@ -8163,7 +8163,7 @@
             },
             "put": {
                 "summary": "Update backup schedule",
-                "description": "Updates the backup schedule for the specified branch.\nThe schedule defines how often automatic snapshots are created (e.g., `hourly`, `daily`).\n\n**Note**: This endpoint is currently in Beta.\n",
+                "description": "Updates the backup schedule for the specified branch.\nThe schedule defines how often automatic snapshots are created (e.g., `daily`, `weekly`).\n\n**Note**: This endpoint is currently in Beta.\n",
                 "tags": [
                     "Snapshot"
                 ],
@@ -10085,7 +10085,8 @@
                     "swap_binding_id",
                     "finalize_migration",
                     "mark_migration_prepared",
-                    "update_catalog"
+                    "update_catalog",
+                    "epc_sync"
                 ]
             },
             "OperationStatus": {
@@ -15150,7 +15151,7 @@
                 "properties": {
                     "frequency": {
                         "type": "string",
-                        "description": "How often to take snapshots. Must be one of the following values:\n  - `hourly`\n  - `daily`\n  - `weekly`\n  - `monthly`\n  - `yearly`\n"
+                        "description": "How often to take snapshots. Must be one of the following values:\n  - `daily`\n  - `weekly`\n  - `monthly`\n"
                     },
                     "hour": {
                         "type": "integer",

--- a/packages/sdk/src/client/sdk.gen.ts
+++ b/packages/sdk/src/client/sdk.gen.ts
@@ -4045,7 +4045,7 @@ export const getSnapshotSchedule = <ThrowOnError extends boolean = false>(option
  * Update backup schedule
  *
  * Updates the backup schedule for the specified branch.
- * The schedule defines how often automatic snapshots are created (e.g., `hourly`, `daily`).
+ * The schedule defines how often automatic snapshots are created (e.g., `daily`, `weekly`).
  *
  * **Note**: This endpoint is currently in Beta.
  *

--- a/packages/sdk/src/client/types.gen.ts
+++ b/packages/sdk/src/client/types.gen.ts
@@ -363,7 +363,7 @@ export type OperationsResponse = {
 /**
  * The action performed by the operation
  */
-export type OperationAction = 'create_compute' | 'create_timeline' | 'start_compute' | 'suspend_compute' | 'apply_config' | 'check_availability' | 'delete_timeline' | 'create_branch' | 'import_data' | 'tenant_ignore' | 'tenant_attach' | 'tenant_detach' | 'tenant_detach_safekeepers' | 'tenant_attach_safekeepers' | 'tenant_reattach' | 'replace_safekeeper' | 'disable_maintenance' | 'apply_storage_config' | 'prepare_secondary_pageserver' | 'switch_pageserver' | 'detach_parent_branch' | 'timeline_archive' | 'timeline_unarchive' | 'start_reserved_compute' | 'sync_dbs_and_roles_from_compute' | 'apply_schema_from_branch' | 'timeline_mark_invisible' | 'timeline_update_protected_config' | 'prewarm_replica' | 'promote_replica' | 'set_storage_non_dirty' | 'swap_binding_id' | 'finalize_migration' | 'mark_migration_prepared' | 'update_catalog';
+export type OperationAction = 'create_compute' | 'create_timeline' | 'start_compute' | 'suspend_compute' | 'apply_config' | 'check_availability' | 'delete_timeline' | 'create_branch' | 'import_data' | 'tenant_ignore' | 'tenant_attach' | 'tenant_detach' | 'tenant_detach_safekeepers' | 'tenant_attach_safekeepers' | 'tenant_reattach' | 'replace_safekeeper' | 'disable_maintenance' | 'apply_storage_config' | 'prepare_secondary_pageserver' | 'switch_pageserver' | 'detach_parent_branch' | 'timeline_archive' | 'timeline_unarchive' | 'start_reserved_compute' | 'sync_dbs_and_roles_from_compute' | 'apply_schema_from_branch' | 'timeline_mark_invisible' | 'timeline_update_protected_config' | 'prewarm_replica' | 'promote_replica' | 'set_storage_non_dirty' | 'swap_binding_id' | 'finalize_migration' | 'mark_migration_prepared' | 'update_catalog' | 'epc_sync';
 
 /**
  * The status of the operation
@@ -3177,11 +3177,9 @@ export type SnapshotUpdateRequest = {
 export type BackupScheduleItem = {
     /**
      * How often to take snapshots. Must be one of the following values:
-     * - `hourly`
      * - `daily`
      * - `weekly`
      * - `monthly`
-     * - `yearly`
      *
      */
     frequency: string;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -46,10 +46,10 @@ export type {
 	TransferProjectsInput,
 } from "./neon/resources/projects.js";
 export type {
+	BackupScheduleItemInput,
 	CreateSnapshotInput,
 	RestorePreview,
 	RestoreSnapshotInput,
-	ScheduleItem,
 	SetScheduleInput,
 	SnapshotFrequency,
 	UpdateSnapshotInput,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -49,6 +49,10 @@ export type {
 	CreateSnapshotInput,
 	RestorePreview,
 	RestoreSnapshotInput,
+	ScheduleItem,
+	SetScheduleInput,
+	SnapshotFrequency,
+	UpdateSnapshotInput,
 } from "./neon/resources/snapshots.js";
 export type { NeonResult, Outcome } from "./neon/result.js";
 export type { WaitForOptions } from "./neon/wait.js";

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -116,6 +116,17 @@ it("agent-platform helpers (default org, default branch, transfer, finalize) are
 			},
 		}),
 	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+
+	// setSchedule narrows `frequency` to the API-accepted values.
+	expectTypeOf(
+		neon.snapshots.setSchedule("p", "br", {
+			schedule: [{ frequency: "daily", hour: 3 }],
+		}),
+	).resolves.toEqualTypeOf<NeonResult<void>>();
+	neon.snapshots.setSchedule("p", "br", {
+		// @ts-expect-error — "hourly" is not an accepted SnapshotFrequency
+		schedule: [{ frequency: "hourly" }],
+	});
 });
 
 it("phase-1 namespaces (auth, permissions, recover, branch endpoints) are typed", () => {

--- a/packages/sdk/src/neon/resources/snapshots.test.ts
+++ b/packages/sdk/src/neon/resources/snapshots.test.ts
@@ -57,3 +57,24 @@ describe("snapshots.update maps the ergonomic input to the API body", () => {
 		expect(calls[0]?.body).toEqual({ snapshot: { name: "renamed" } });
 	});
 });
+
+describe("snapshots.setSchedule forwards the schedule body verbatim", () => {
+	it("sends the narrowed schedule as the request body", async () => {
+		const { neon, calls } = neonCapturing();
+		await neon.snapshots.setSchedule("p-1", "br-1", {
+			schedule: [
+				{ frequency: "weekly", day: 1, hour: 2 },
+				{ frequency: "daily", hour: 3, retention_seconds: 604800 },
+			],
+		});
+		expect(calls[0]?.url).toContain(
+			"/projects/p-1/branches/br-1/backup_schedule",
+		);
+		expect(calls[0]?.body).toEqual({
+			schedule: [
+				{ frequency: "weekly", day: 1, hour: 2 },
+				{ frequency: "daily", hour: 3, retention_seconds: 604800 },
+			],
+		});
+	});
+});

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -11,6 +11,7 @@ import {
 } from "../../client/sdk.gen.js";
 import type {
 	BackupSchedule,
+	BackupScheduleItem,
 	Branch,
 	Snapshot,
 } from "../../client/types.gen.js";
@@ -68,6 +69,30 @@ export interface RestoreSnapshotInput {
 	preview?: RestorePreview;
 	/** Keep the preview branch when `preview` returns `false` (default: delete it). */
 	keepOnAbort?: boolean;
+}
+
+/**
+ * How often the automatic snapshot (backup) schedule takes a snapshot. These are
+ * the values the Neon API accepts, per the OpenAPI spec's `BackupScheduleItem`
+ * description. The generated `BackupScheduleItem.frequency` is a broad `string`
+ * (the spec documents the allowed values in prose rather than an `enum`), so this
+ * union narrows what {@link Snapshots.setSchedule} sends.
+ */
+export type SnapshotFrequency = "daily" | "weekly" | "monthly";
+
+/**
+ * A single entry in an automatic snapshot (backup) schedule. Identical to the
+ * generated {@link BackupScheduleItem} except `frequency` is narrowed to
+ * {@link SnapshotFrequency} — the values the API actually accepts.
+ */
+export type ScheduleItem = Omit<BackupScheduleItem, "frequency"> & {
+	frequency: SnapshotFrequency;
+};
+
+/** Input for {@link Snapshots.setSchedule}. */
+export interface SetScheduleInput {
+	/** The ordered list of schedule entries to apply to the branch. */
+	schedule: ScheduleItem[];
 }
 
 /** Snapshot resource. */
@@ -331,18 +356,18 @@ export class Snapshots<DThrow extends boolean> {
 	setSchedule(
 		projectId: string,
 		branchId: string,
-		schedule: BackupSchedule,
+		schedule: SetScheduleInput,
 	): Promise<Outcome<void, DThrow>>;
 	setSchedule<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
-		schedule: BackupSchedule,
+		schedule: SetScheduleInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	setSchedule(
 		projectId: string,
 		branchId: string,
-		schedule: BackupSchedule,
+		schedule: SetScheduleInput,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(
@@ -351,7 +376,9 @@ export class Snapshots<DThrow extends boolean> {
 				setSnapshotSchedule({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					body: schedule,
+					// `SetScheduleInput` narrows `frequency` to the accepted values;
+					// it is otherwise structurally the generated `BackupSchedule`.
+					body: schedule satisfies BackupSchedule,
 					throwOnError: false,
 				}),
 			() => undefined,

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -81,18 +81,18 @@ export interface RestoreSnapshotInput {
 export type SnapshotFrequency = "daily" | "weekly" | "monthly";
 
 /**
- * A single entry in an automatic snapshot (backup) schedule. Identical to the
- * generated {@link BackupScheduleItem} except `frequency` is narrowed to
+ * A single entry to write to an automatic snapshot (backup) schedule. Identical
+ * to the generated {@link BackupScheduleItem} except `frequency` is narrowed to
  * {@link SnapshotFrequency} — the values the API actually accepts.
  */
-export type ScheduleItem = Omit<BackupScheduleItem, "frequency"> & {
+export type BackupScheduleItemInput = Omit<BackupScheduleItem, "frequency"> & {
 	frequency: SnapshotFrequency;
 };
 
 /** Input for {@link Snapshots.setSchedule}. */
 export interface SetScheduleInput {
 	/** The ordered list of schedule entries to apply to the branch. */
-	schedule: ScheduleItem[];
+	schedule: BackupScheduleItemInput[];
 }
 
 /** Snapshot resource. */
@@ -352,7 +352,17 @@ export class Snapshots<DThrow extends boolean> {
 		);
 	}
 
-	/** @apiCall PUT /projects/{project_id}/branches/{branch_id}/backup_schedule */
+	/**
+	 * Replace a branch's automatic snapshot schedule.
+	 *
+	 * `frequency` is narrowed to {@link SnapshotFrequency}, so a value the API
+	 * rejects fails to compile. {@link Snapshots.getSchedule} deliberately keeps
+	 * the wider generated type, because a branch can still hold a schedule
+	 * created when the API accepted other frequencies; feeding one straight back
+	 * here is a type error rather than a runtime rejection.
+	 *
+	 * @apiCall PUT /projects/{project_id}/branches/{branch_id}/backup_schedule
+	 */
 	setSchedule(
 		projectId: string,
 		branchId: string,
@@ -376,9 +386,7 @@ export class Snapshots<DThrow extends boolean> {
 				setSnapshotSchedule({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					// `SetScheduleInput` narrows `frequency` to the accepted values;
-					// it is otherwise structurally the generated `BackupSchedule`.
-					body: schedule satisfies BackupSchedule,
+					body: schedule,
 					throwOnError: false,
 				}),
 			() => undefined,


### PR DESCRIPTION
## Summary

Alternative to #329. Same underlying spec refresh, but the ergonomic layer is actually updated, the CLI JSON path is hardened, and the CHANGELOGs are generated by `changeset version` from real changesets (no hand-written narrative). Intended as a drop-in replacement so #329 can be closed.

The **only** things the live spec (`neon.com/api_spec/release/v2.json`) changed vs `main` are:

1. `OperationAction` gains `epc_sync` (additive enum value).
2. Backup-schedule update endpoint description: `hourly, daily` → `daily, weekly`.
3. `BackupScheduleItem.frequency` description: drops `hourly`/`yearly`, leaving `daily`/`weekly`/`monthly`. The field stays `type: string` (the spec uses prose, not an `enum`).

`packages/sdk/spec/neon-openapi.json` is byte-identical to the live spec; `raw.gen.ts` is unchanged (no operation added/removed, coverage guard untouched at 163 wrapped ops).

## What this does that #329 does not

- **Narrows frequency in the ergonomic layer (real type safety).** New `SnapshotFrequency = "daily" | "weekly" | "monthly"`. `snapshots.setSchedule` now takes `SetScheduleInput` whose entries' `frequency` is narrowed, so `{ frequency: "hourly" }` fails at compile time instead of at the API. `getSchedule` keeps returning the server-controlled `BackupSchedule` unchanged (received data stays wide). Also exports the previously-omitted `UpdateSnapshotInput`.
- **Fixes the CLI `--schedule <json>` gap.** #329 only narrowed the `--frequency` flag; the JSON path still forwarded any string. Here `parseScheduleJson` validates each entry against the supported set and errors on unsupported values. `SNAPSHOT_FREQUENCIES` is `satisfies readonly SnapshotFrequency[]`, so if a value ever leaves the SDK union the CLI stops compiling rather than offering a frequency the API rejects.
- **Honest changelog.** #329 claims 1.3.0 makes `SnapshotUpdateRequest` support `expires_at` and that the CLI expiration flags "now work" — that surface already shipped in `@neon/sdk@1.1.0` / `neonctl@2.34.0` and is untouched. This PR's changeset states the real delta and explicitly notes expiration is unchanged.
- **Accurate bumps.** `@neon/sdk` **minor** (1.3.0 — additive enum + new ergonomic types). `neonctl` **patch** (2.36.1 — it's a fix: dropping invalid options + validating JSON, plus stale PG19 help-text catch-up), not a minor. `@neon/config` / `@neon/config-runtime` / `@neon/env` cascade-patch as `workspace:*` dependents. No `neon-init` bump ⇒ no lockfile dance.
- Documents the `epc_sync` enum addition and PG19 help-text refresh instead of shipping them silently.

## Test plan

- [x] `pnpm --filter @neon/sdk spec:pull && generate` — spec matches live; generated diff limited to the 3 changes above
- [x] `@neon/sdk` build, 18 unit tests (incl. new `setSchedule` body test), 14 type tests (incl. `@ts-expect-error` on `frequency: "hourly"`)
- [x] `neonctl` full suite: 3131 passed / 6 skipped (added a negative test for unsupported JSON frequency; updated the multi-entry snapshot)
- [x] `pnpm lint:ci` (Biome) and `pnpm --filter neonctl typecheck` clean
- [x] Coverage guard unchanged (no operation drift); `raw.gen.ts` untouched

## Not included (deliberately, not grounded in the spec diff)

- No removal of `--month` (the API still documents the `month` field on `BackupScheduleItem`).
- No `retentionSeconds` camelCase remap for schedule entries — `BackupScheduleItemInput` keeps the generated snake-case fields and narrows only `frequency`, to avoid inventing shape the spec doesn't define.

## Self-review follow-ups (second pass)

- Renamed `ScheduleItem` → `BackupScheduleItemInput`: the SDK re-exports generated types flat, so a bare `ScheduleItem` next to the generated `BackupScheduleItem` gave no hint which to use.
- Dropped a redundant `satisfies BackupSchedule` on the `setSchedule` body — the generated `SetSnapshotScheduleData` already types `body`, and `satisfies` appears nowhere else in the SDK.
- Documented why `getSchedule` stays wide while `setSchedule` narrows: a branch can still hold a schedule created when other frequencies were accepted, so a read-modify-write round trip surfaces as a type error instead of a runtime rejection.
- Corrected a CLI comment that claimed `satisfies` also catches values *added* to the union (it only catches removals).
