### PR TITLE
fix(env): restore function-slug autocomplete in parseEnv

### DIFF
--- a/.changeset/lucky-jars-listen.md
+++ b/.changeset/lucky-jars-listen.md
@@ -1,0 +1,14 @@
+---
+"@neon/env": patch
+---
+
+Restore editor autocomplete for `parseEnv`'s function-slug scope. Typing
+`parseEnv(config, "…")` offered no completions, so the declared slugs of
+`preview.functions` had to be recalled by hand (the slugs were already
+type-checked — an undeclared one was always a type error — only the suggestions
+were missing). The cause was overload order: an editor takes string-literal
+completions from the first candidate overload, and the key-array overload was
+declared first, so the expected type of the argument was read as an array, which
+has no literal completions. The slug overload now comes first and the slugs
+autocomplete. A policy that declares no functions at all also reports a readable
+hint instead of the opaque `Type '"x"' is not assignable to type 'never'`.

--- a/packages/env/src/lib/env.completions.test.ts
+++ b/packages/env/src/lib/env.completions.test.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
-import { describe, expect, test } from "vitest";
+import { beforeAll, describe, expect, test } from "vitest";
 
 /**
  * Editor-autocomplete tests for `parseEnv`'s second argument, driven through the same
@@ -115,6 +115,16 @@ const TWO_FUNCTIONS = `{
 }`;
 
 describe("parseEnv autocomplete", () => {
+	// The *first* query is what builds the program behind the language service (`env.ts` plus
+	// `@neon/config`'s source, zod's declarations and the TypeScript lib files); every query
+	// after it reuses that program and is quick. Locally the build takes a few hundred ms, but
+	// on a cold CI runner under coverage instrumentation it ran past Vitest's 5s default and
+	// failed the first test on time rather than on its result. Pay the cost once here, with a
+	// hook timeout sized for the slowest runner, so the assertions below time only themselves.
+	beforeAll(() => {
+		completionsAt(fixture("{}", `parseEnv(config, "${CARET}")`));
+	}, 120_000);
+
 	test("offers the policy's declared function slugs", () => {
 		const entries = completionsAt(
 			fixture(TWO_FUNCTIONS, `parseEnv(config, "${CARET}")`),

--- a/packages/env/src/lib/env.completions.test.ts
+++ b/packages/env/src/lib/env.completions.test.ts
@@ -1,0 +1,148 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, test } from "vitest";
+
+/**
+ * Editor-autocomplete tests for `parseEnv`'s second argument, driven through the same
+ * TypeScript language service an editor uses.
+ *
+ * `env.test-d.ts` proves the *types* are sound (an undeclared function slug is rejected), but
+ * type soundness and autocomplete are separate behaviours: the completion list for a
+ * half-typed string literal comes from the **first candidate overload**, so simply reordering
+ * `parseEnv`'s overloads silently empties it while every type test keeps passing. That
+ * regression already shipped once — a `parseEnv(config, "…")` slug offered no completions
+ * because the `keys` array overload was listed first — hence these assertions.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/** Marks the caret position in a fixture; stripped before the file is handed to the LS. */
+const CARET = "/*|*/";
+
+/** Virtual fixture path. Lives next to `env.ts` so its relative import resolves normally. */
+const FIXTURE = resolve(here, "__completions_fixture.ts");
+
+const tsconfigPath = resolve(here, "../../tsconfig.json");
+const tsconfig = ts.parseJsonConfigFileContent(
+	ts.readConfigFile(tsconfigPath, ts.sys.readFile).config,
+	ts.sys,
+	dirname(tsconfigPath),
+);
+
+/**
+ * Resolve `@neon/config/v1` to the sibling package's TypeScript **source** instead of its
+ * built `dist/`, for the same reason `vitest.config.ts` aliases it: the package `exports`
+ * point at `dist/`, so without this the completions asserted here would come from a
+ * potentially **stale** build of `config` (CI installs but never builds it).
+ */
+const compilerOptions: ts.CompilerOptions = {
+	...tsconfig.options,
+	baseUrl: here,
+	paths: {
+		"@neon/config/v1": [resolve(here, "../../../config/src/v1.ts")],
+	},
+};
+
+let fixtureText = "";
+let fixtureVersion = 0;
+
+const host: ts.LanguageServiceHost = {
+	getScriptFileNames: () => [FIXTURE],
+	getScriptVersion: (fileName) =>
+		fileName === FIXTURE ? String(fixtureVersion) : "1",
+	getScriptSnapshot: (fileName) => {
+		if (fileName === FIXTURE) {
+			return ts.ScriptSnapshot.fromString(fixtureText);
+		}
+		const contents = ts.sys.readFile(fileName);
+		return contents === undefined
+			? undefined
+			: ts.ScriptSnapshot.fromString(contents);
+	},
+	getCurrentDirectory: () => here,
+	getCompilationSettings: () => compilerOptions,
+	getDefaultLibFileName: (options) => ts.getDefaultLibFilePath(options),
+	fileExists: (fileName) =>
+		fileName === FIXTURE ? true : ts.sys.fileExists(fileName),
+	readFile: (fileName, encoding) =>
+		fileName === FIXTURE
+			? fixtureText
+			: ts.sys.readFile(fileName, encoding),
+	readDirectory: ts.sys.readDirectory,
+	directoryExists: ts.sys.directoryExists,
+	getDirectories: ts.sys.getDirectories,
+	realpath: ts.sys.realpath,
+};
+
+const service = ts.createLanguageService(host, ts.createDocumentRegistry());
+
+/**
+ * The completions an editor would offer at the {@link CARET} marker in `source`, sorted so
+ * assertions don't depend on the language service's ordering.
+ */
+function completionsAt(source: string): string[] {
+	const caret = source.indexOf(CARET);
+	if (caret === -1) throw new Error(`fixture has no ${CARET} marker`);
+	fixtureText = source.replace(CARET, "");
+	fixtureVersion += 1;
+	const completions = service.getCompletionsAtPosition(FIXTURE, caret, {
+		includeCompletionsWithInsertText: true,
+	});
+	return (completions?.entries ?? []).map((entry) => entry.name).sort();
+}
+
+/** A policy declaring two functions, plus whichever extra services a case needs. */
+function fixture(configBody: string, call: string): string {
+	return [
+		'import { defineConfig } from "@neon/config/v1";',
+		'import { parseEnv } from "./env.js";',
+		"",
+		`const config = defineConfig(${configBody});`,
+		"",
+		`export const env = ${call};`,
+		"",
+	].join("\n");
+}
+
+const TWO_FUNCTIONS = `{
+	preview: {
+		functions: {
+			hello: { name: "Hello", source: "./hello.ts", env: { resendApiKey: "" } },
+			world: { name: "World", source: "./world.ts" },
+		},
+	},
+}`;
+
+describe("parseEnv autocomplete", () => {
+	test("offers the policy's declared function slugs", () => {
+		const entries = completionsAt(
+			fixture(TWO_FUNCTIONS, `parseEnv(config, "${CARET}")`),
+		);
+		expect(entries).toEqual(["hello", "world"]);
+	});
+
+	test("offers the env-var keys of exactly the policy's namespaces", () => {
+		const entries = completionsAt(
+			fixture(
+				`{ auth: true, ${TWO_FUNCTIONS.slice(1)}`,
+				`parseEnv(config, ["${CARET}"])`,
+			),
+		);
+		// Postgres + auth only: no storage / AI Gateway keys, since the policy enables neither.
+		expect(entries).toEqual([
+			"DATABASE_URL",
+			"DATABASE_URL_UNPOOLED",
+			"NEON_AUTH_BASE_URL",
+			"NEON_AUTH_JWKS_URL",
+		]);
+	});
+
+	test("explains itself when the policy declares no functions", () => {
+		const entries = completionsAt(
+			fixture("{ auth: true }", `parseEnv(config, "${CARET}")`),
+		);
+		expect(entries).toHaveLength(1);
+		expect(entries[0]).toMatch(/declares no .?preview\.functions/);
+	});
+});

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -11,6 +11,7 @@ import type {
 	NeonFunctionEnv,
 	NeonPostgresEnv,
 	NeonStorageEnv,
+	NoFunctionScopeHint,
 } from "./env.js";
 import { type NeonEnv, parseEnv, type SelectableEnvKey } from "./env.js";
 
@@ -116,6 +117,125 @@ describe("parseEnv existing overloads still type", () => {
 		const env = parseEnv(config, "hello");
 		expectTypeOf(env.function).toEqualTypeOf<{ resendApiKey: string }>();
 		expectTypeOf(env.function.resendApiKey).toEqualTypeOf<string>();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Function-slug scope. The slug is the one `parseEnv` argument whose accepted values come
+// from the *policy* rather than a fixed list, so these pin both halves of that contract:
+// only declared slugs type-check, and the chosen slug alone decides the `function` namespace.
+// The matching editor-autocomplete behaviour is covered by `env.completions.test.ts`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseEnv function slug scope (types)", () => {
+	const twoFunctions = defineConfig({
+		preview: {
+			functions: {
+				hello: {
+					name: "Hello",
+					source: "./hello.ts",
+					env: { resendApiKey: "" },
+				},
+				world: {
+					name: "World",
+					source: "./world.ts",
+					env: { otherKey: "" },
+				},
+			},
+		},
+	});
+
+	test("FunctionSlugOf is exactly the declared slugs", () => {
+		expectTypeOf<FunctionSlugOf<typeof twoFunctions>>().toEqualTypeOf<
+			"hello" | "world"
+		>();
+	});
+
+	test("the function namespace carries only the selected function's env keys", () => {
+		// A widened slug (the whole union instead of the one passed) would leak `otherKey`
+		// in here, which is why the two fixtures declare *different* env keys.
+		expectTypeOf(parseEnv(twoFunctions, "hello").function).toEqualTypeOf<{
+			resendApiKey: string;
+		}>();
+		expectTypeOf(parseEnv(twoFunctions, "world").function).toEqualTypeOf<{
+			otherKey: string;
+		}>();
+	});
+
+	test("accepts a slug held in a narrowed variable", () => {
+		// Callers don't always inline the literal; a `const` binding keeps its literal type
+		// and must resolve to that one function's env keys.
+		const slug = "world";
+		expectTypeOf(parseEnv(twoFunctions, slug).function).toEqualTypeOf<{
+			otherKey: string;
+		}>();
+	});
+
+	test("rejects a slug the policy does not declare", () => {
+		// @ts-expect-error "nope" is not a declared function slug
+		parseEnv(twoFunctions, "nope");
+	});
+
+	test("rejects a value only known to be a string", () => {
+		// Guards the constraint itself: if `FunctionSlugOf` ever widened to `string`, every
+		// assertion above would still pass while any slug became acceptable.
+		const widened: string = "hello";
+		// @ts-expect-error a plain string could name a function the policy never declared
+		parseEnv(twoFunctions, widened);
+	});
+
+	test("a key array still selects the filtered overload, not the slug one", () => {
+		// The slug overload is deliberately declared *first* (see the overload-order test
+		// below), so this pins that it doesn't shadow the array overload for a policy that
+		// declares functions — the case where both overloads are live at once.
+		expectTypeOf(parseEnv(twoFunctions, ["DATABASE_URL"])).toEqualTypeOf<{
+			postgres: { databaseUrl: string };
+		}>();
+	});
+
+	test("a policy with no functions has no slug to pass", () => {
+		const noFunctions = defineConfig({ auth: true });
+		expectTypeOf<
+			FunctionSlugOf<typeof noFunctions>
+		>().toEqualTypeOf<never>();
+		// The expected type collapses to the readable hint instead of a bare `never`.
+		// @ts-expect-error no functions are declared, so no scope is accepted
+		parseEnv(noFunctions, "hello");
+	});
+
+	test("an untyped policy exposes no slugs", () => {
+		// A bare `Config` carries no literal function info, so it must not optimistically
+		// accept arbitrary slugs.
+		expectTypeOf<FunctionSlugOf<Config>>().toEqualTypeOf<never>();
+	});
+
+	test("the no-functions hint stays a literal, not a bare string", () => {
+		// Load-bearing: the hint *is* the expected type of `scope` for a policy without
+		// functions, so widening it to `string` would silently accept any slug there.
+		expectTypeOf<NoFunctionScopeHint>().not.toEqualTypeOf<string>();
+		expectTypeOf<NoFunctionScopeHint>().toExtend<string>();
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Overload order.
+//
+// `parseEnv`'s overloads must keep the function-slug signature ahead of the key-array one:
+// the editor takes string-literal completions from the *first* candidate overload, so with
+// the array overload first, typing `parseEnv(config, "…")` offers no slugs at all. That is
+// invisible to every assertion above — the types stay sound either way — which is exactly why
+// it regressed once. `env.completions.test.ts` catches it through the real language service;
+// this locks the same invariant in the type system, so `tsc` fails on a reorder too.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("parseEnv overload order (types)", () => {
+	test("the key-array overload is declared last", () => {
+		// `Parameters<>` of an overloaded function resolves to its **last** signature, which
+		// makes the declaration order observable: if the slug overload were moved after the
+		// array one, this would resolve to the slug/hint parameter instead.
+		expectTypeOf<Parameters<typeof parseEnv>[1]>().toEqualTypeOf<
+			readonly SelectableEnvKey<Config>[]
+		>();
 	});
 });
 

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -284,6 +284,32 @@ export type FunctionSlugOf<C extends Config> = Extract<
 	string
 >;
 
+/**
+ * Human-readable hint surfaced as the **expected type** of `parseEnv`'s `scope` argument when
+ * the policy declares no functions at all. Without it the argument's expected type is the bare
+ * `never` {@link FunctionSlugOf} yields, and TypeScript reports the opaque `Type '"x"' is not
+ * assignable to type 'never'`; the literal turns that into a sentence naming the fix (and the
+ * editor offers it as the single completion, so the empty completion list is explained rather
+ * than just empty). Mirrors `NeonAuthRequiredHint` in `@neon/config`.
+ */
+// Exported (type-only) for the type tests in `env.test-d.ts`; intentionally not re-exported
+// from `index.ts`, so it stays an internal implementation detail.
+export type NoFunctionScopeHint =
+	"this policy declares no `preview.functions`, so there is no function scope to read. Declare the function in `neon.ts` first, or omit the scope to read the branch env";
+
+/**
+ * The expected type of `parseEnv`'s function-slug `scope` argument: the caller's inferred slug
+ * `S` normally, and the {@link NoFunctionScopeHint} message when the policy declares no
+ * functions. Keeping `S` (rather than `FunctionSlugOf<C>`) in the enabled branch is what makes
+ * the returned `function` namespace exact — it stays the one function's env keys instead of
+ * widening to every declared function's.
+ */
+type FunctionScopeField<C extends Config, S extends string> = [
+	FunctionSlugOf<C>,
+] extends [never]
+	? NoFunctionScopeHint
+	: S;
+
 /** The declared env-var keys of one function `S`, as a string union. */
 type FunctionEnvKeysOf<
 	C extends Config,
@@ -1037,7 +1063,8 @@ function isServiceEnabledInput(
  *   full `{ postgres, auth?, dataApi?, … }` the policy enables.
  * - a **function slug** (a key of `config.preview.functions`) — *function* scope: you are
  *   running inside that function. Returns the same branch secrets **plus** a typed
- *   `function` namespace with the function's declared env-var keys.
+ *   `function` namespace with the function's declared env-var keys. The slug autocompletes
+ *   from the policy ({@link FunctionSlugOf}) and an undeclared one is a type error.
  * - an **array of OS-level env-var keys** (e.g. `["DATABASE_URL", "NEON_AUTH_BASE_URL"]`) —
  *   *filtered* mode: only those vars are required and returned, as a narrowed namespaced
  *   shape. The keys autocomplete from the policy ({@link SelectableEnvKey}), so you can only
@@ -1066,14 +1093,25 @@ function isServiceEnabledInput(
  * ```
  */
 export function parseEnv<const C extends Config>(config: C): NeonEnv<C>;
+// Overload order is load-bearing for **editor autocomplete**, not for type checking: when the
+// argument is a half-typed string literal the call resolves against no signature, and the
+// editor takes its string-literal completions from the first candidate overload. With the
+// `keys` overload listed first, the expected type of `parseEnv(config, "…")` is read as
+// `readonly K[]` — an array has no literal completions, so typing a function slug offered
+// nothing. Keep the slug overload ahead of the array one: `env.completions.test.ts` asserts the
+// completions through the language service, and `env.test-d.ts` locks the order itself (the
+// last overload is observable as `Parameters<typeof parseEnv>`), so `tsc` fails on a reorder.
+export function parseEnv<
+	const C extends Config,
+	const S extends FunctionSlugOf<C>,
+>(
+	config: C,
+	scope: FunctionScopeField<C, S>,
+): NeonEnv<C> & NeonFunctionEnv<C, S>;
 export function parseEnv<
 	const C extends Config,
 	const K extends SelectableEnvKey<C>,
 >(config: C, keys: readonly K[]): FilteredNeonEnv<K>;
-export function parseEnv<
-	const C extends Config,
-	const S extends FunctionSlugOf<C>,
->(config: C, scope: S): NeonEnv<C> & NeonFunctionEnv<C, S>;
 export function parseEnv(
 	config: Config,
 	scopeOrKeys?: string | readonly string[],


### PR DESCRIPTION
## Summary

`parseEnv(config, "…")` offered no editor completions for the function slugs declared in `preview.functions`, so they had to be recalled by hand. The slugs were already sound at the type level — an undeclared slug has always been a type error — only the suggestions were missing.

The cause is **overload order**. When the argument is a half-typed string literal the call matches no signature yet, and the editor takes its string-literal completions from the *first* candidate overload. The key-array overload was declared first, so the expected type of `parseEnv(config, "…")` was read as `readonly K[]`; an array type has no literal completions, hence the empty list. The array mode autocompleted fine precisely because its overload came first. Moving the slug overload ahead of it fixes the slug case and leaves the array case unchanged.

Verified through the actual TypeScript language service, not by inspection: before the change the slug position returned **0** completions while the array position returned all 4 env keys; after it, the slug position returns `hello` / `world` and the array position still returns its 4 keys.

Two smaller changes ride along:

- **Readable hint for a policy with no functions.** The `scope` argument's expected type was the bare `never` that `FunctionSlugOf` yields, so a mistake read as `Type '"x"' is not assignable to type 'never'`. It now collapses to a `NoFunctionScopeHint` sentence, mirroring the existing `NeonAuthRequiredHint` in `@neon/config` — the editor offers that sentence as the single completion, so an empty list is explained rather than just empty. Confirmed this does **not** widen the result: with two functions declaring different env keys, `parseEnv(config, "hello").function` is still exactly `{ resendApiKey: string }`.
- **Regression guards** (below), because overload order is invisible to ordinary type assertions — which is why it regressed silently in the first place.

## Test plan

- [x] `env.completions.test.ts` (new) drives the real language service and asserts the offered completions for all three cases. It resolves `@neon/config/v1` to the sibling package's **source** for the same stale-`dist` reason `vitest.config.ts` already documents.
- [x] A type test pins the order itself: `Parameters<>` of an overloaded function resolves to its **last** signature, so asserting the last overload is the key-array one makes a reorder fail `tsc`, not just the language-service test.
- [x] Nine new type tests in `env.test-d.ts`: exact slug union, per-slug precision, a slug in a `const` binding, undeclared-slug rejection, rejection of a value only known to be `string` (guards the constraint itself), a key array still selecting the filtered overload for a policy that *does* declare functions, `FunctionSlugOf<Config>` being `never`, and the hint staying a string literal rather than a bare `string`.
- [x] **Mutation-tested** each invariant rather than trusting the assertions pass: overloads reordered → 1 failure (the order lock); `FunctionSlugOf` widened to `string` → 5 failures; `NoFunctionScopeHint` widened to `string` → 2 failures.
- [x] Confirmed the guards actually run in CI: the `Build` job's `pnpm build` recurses into `@neon/env`, whose build starts with `tsc --noEmit` over a tsconfig that includes `src`, so `env.test-d.ts` is type-checked there (both `expectTypeOf` mismatches and unsatisfied `@ts-expect-error` comments fail it); the `Test` job's `pnpm test:ci` picks up the completions test.
- [x] Verified the overload order survives into the published `dist/lib/env.d.ts`, which is what consumers' editors actually read, and that the new test file is excluded from `dist`.
- [x] `parseEnv` is the only overloaded exported function in the repo, so this trap isn't lurking elsewhere.
- [x] 31 type tests, 106 runtime tests, `tsc --noEmit`, and biome all pass.

Changeset: patch for `@neon/env`.