### PR TITLE
chore: build workspace deps before a package's tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,13 @@ pnpm --filter @neon/env build
 pnpm --filter @neon/env test:ci
 ```
 
+Workspace packages import each other through their build output (`dist`), not their source, so
+a package's tests see a dependency's **last build** — not the source you just edited. `pnpm test`
+therefore builds the package and its workspace dependencies first (`pnpm --filter <pkg>... build`),
+which is what makes a single-package test run trustworthy after an edit anywhere in the graph.
+`test:ci` skips that: on CI, `pnpm install` runs each package's `prepare` (a build) on a fresh
+checkout, so everything is current already. Run `test:ci` locally only right after a build.
+
 See [`AGENTS.md`](./AGENTS.md) for the deeper architecture and per-package notes (especially the
 CLI package, which keeps its own toolchain).
 

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -56,7 +56,6 @@
 		"vitest": "catalog:",
 		"zod": "^4.4.3"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "pnpm typecheck && biome check src",
     "lint:fix": "pnpm typecheck && biome check src --write",
-    "test": "pnpm build && vitest run",
+		"test": "pnpm --filter neonctl... build && vitest run",
     "test:ci": "pnpm build && vitest run",
     "test:conformance": "vitest run --config tests/psql-conformance/vitest.config.ts"
   },

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -43,7 +43,7 @@
 	"scripts": {
 		"build": "tsc --noEmit && tsdown",
 		"prepare": "npm run build",
-		"test": "vitest --passWithNoTests",
+		"test": "pnpm --filter @neon/config-runtime... build && vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"test:e2e": "vitest run --config vitest.e2e.config.ts",
 		"tsc": "tsc"
@@ -62,7 +62,6 @@
 		"esbuild": "^0.28.1",
 		"fflate": "^0.8.3"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -42,7 +42,7 @@
 	"scripts": {
 		"build": "tsc --noEmit && tsdown",
 		"prepare": "npm run build",
-		"test": "vitest --passWithNoTests",
+		"test": "pnpm --filter @neon/config... build && vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"test:types": "vitest run --typecheck.enabled --typecheck.only",
 		"test:e2e": "vitest run --config vitest.e2e.config.ts",
@@ -61,7 +61,6 @@
 		"jiti": "^2.7.0",
 		"zod": "^4.4.3"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -40,7 +40,7 @@
 	"scripts": {
 		"build": "tsc --noEmit && tsdown",
 		"prepare": "npm run build",
-		"test": "vitest --passWithNoTests",
+		"test": "pnpm --filter @neon/env... build && vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"test:types": "vitest run --typecheck.enabled --typecheck.only",
 		"test:e2e": "vitest run --config vitest.e2e.config.ts",
@@ -61,7 +61,6 @@
 		"zod": "^4.4.3",
 		"yargs": "^18.0.0"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -49,7 +49,6 @@
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/get-db/package.json
+++ b/packages/get-db/package.json
@@ -45,7 +45,7 @@
 	],
 	"scripts": {
 		"build": "tsc --noEmit && tsdown",
-		"test": "vitest --passWithNoTests",
+		"test": "pnpm --filter get-db... build && vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"tsc": "tsc"
 	},
@@ -56,7 +56,6 @@
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -65,7 +65,6 @@
 		"yargs": "^18.0.0",
 		"yoctocolors": "^2.1.2"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/neon-new/package.json
+++ b/packages/neon-new/package.json
@@ -61,7 +61,6 @@
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/neondb/package.json
+++ b/packages/neondb/package.json
@@ -45,7 +45,7 @@
 	],
 	"scripts": {
 		"build": "tsc --noEmit && tsdown",
-		"test": "vitest --passWithNoTests",
+		"test": "pnpm --filter neondb... build && vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"tsc": "tsc"
 	},
@@ -56,7 +56,6 @@
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -65,7 +65,6 @@
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},
-	"packageManager": "pnpm@10.4.0",
 	"engines": {
 		"node": ">=20.19.0"
 	},

--- a/packages/vite-plugin-db/package.json
+++ b/packages/vite-plugin-db/package.json
@@ -20,7 +20,7 @@
 	],
 	"scripts": {
 		"build": "tsc --noEmit && tsdown",
-		"test": "vitest --passWithNoTests",
+		"test": "pnpm --filter vite-plugin-db... build && vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"tsc": "tsc"
 	},

--- a/packages/vite-plugin-neon-new/package.json
+++ b/packages/vite-plugin-neon-new/package.json
@@ -19,7 +19,7 @@
 	],
 	"scripts": {
 		"build": "tsc --noEmit && tsdown",
-		"test": "vitest --passWithNoTests",
+		"test": "pnpm --filter vite-plugin-neon-new... build && vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",
 		"tsc": "tsc",
 		"dry:run": "pnpm build && node dist/cli.js --yes",


### PR DESCRIPTION
Follow-up to a trap I hit while working on #338: I edited `@neon/config-runtime`, ran the CLI tests, and they **passed against the previous build** of that package. The change under test simply wasn't in what ran. Nothing failed, nothing warned — the run just wasn't testing what I'd written.

## Why it happens

Workspace packages import each other through their build output (`dist`), not their source. So a package's tests always see its dependencies' *last build*, and nothing in a test run refreshes it.

CI never hits this: `pnpm install` runs each package's `prepare` (a build) on a fresh checkout, so `dist` is always current there. Locally `prepare` runs at install time only, so `dist` goes stale the moment you edit a dependency's source — and stays stale until you happen to build.

That asymmetry is the worst part: the failure is silent, local-only, and looks like a passing test run.

## The fix

`pnpm test` in a package that depends on other workspace packages now builds itself and its dependencies first:

```json
"test": "pnpm --filter neonctl... build && vitest run"
```

`<pkg>...` (package + dependencies, topologically ordered) is the same idiom the CI workflows already use — `pnpm --filter neonctl... build` in `psql-conformance.yml`, `pnpm --filter ${{ matrix.name }}... build` in `dist-typecheck.yml`. Applied to the eight packages with workspace dependencies: `neonctl`, `@neon/config`, `@neon/config-runtime`, `@neon/env`, `get-db`, `neondb`, `vite-plugin-db`, `vite-plugin-neon-new`.

**`test:ci` is deliberately unchanged.** On CI, install already builds everything, and adding per-package dep builds to a recursive run would rebuild shared packages once per dependent — `@neon/sdk` four times over. CONTRIBUTING now says so, so nobody "fixes" the inconsistency later without knowing why.

## Removing the stale `packageManager` pins

Ten packages still pin `"packageManager": "pnpm@10.4.0"`, left over from before they moved into this monorepo. The root pins `pnpm@10.30.3` (as does `mise.toml`), so they also just disagree.

They aren't harmless. Corepack honors the *nearest* pin, so any pnpm invocation with one of those packages as its working directory — exactly what a nested build inside a test script is, and equally `cd packages/config && pnpm test` — tries to download pnpm 10.4.0 from the public npm registry. On a machine or runner without public npm egress that's a hard failure:

```
! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-10.4.0.tgz
Error: Error when performing the request to https://registry.npmjs.org/...
```

Note the protected CI runners have no public-npm egress either (see `.github/actions/prepare`), so this was a latent trap there too — it just never fired because no CI job runs pnpm from inside a package directory.

Dropping the per-package pins leaves the root `packageManager` and `mise.toml` as the single source of truth, which is what `pnpm/action-setup` reads in CI anyway.

## Verification

The staleness trap, reproduced and closed. With the create-time-settings line temporarily deleted from `config-runtime`'s source and **no manual build**:

```
$ pnpm --filter neonctl test src/commands/config.test.ts
FAIL  src/commands/config.test.ts > … > creates the branch with the policy's settings on the create call
Tests  1 failed | 22 passed (23)
```

Before this change that run passed against the old `dist`. Restoring the line returns it to 23 passed.

- [x] `pnpm --filter @neon/config-runtime test` builds `@neon/sdk` → `@neon/config` → `@neon/config-runtime` in topological order, then runs 59 tests.
- [x] `cd packages/config && pnpm test:ci` now works (225 tests); it previously died in corepack.
- [x] Full `pnpm build` clean, and `pnpm test:ci` across the workspace matches `main` — only the 3 `psql` testcontainers files fail locally, for want of a Docker runtime.