### PR TITLE
fix(cli): use current Neon brand logomark on post-sign-in page

### DIFF
--- a/.changeset/cli-post-signin-logomark.md
+++ b/.changeset/cli-post-signin-logomark.md
@@ -1,0 +1,5 @@
+---
+"neonctl": patch
+---
+
+Update the post-sign-in page to the current official Neon logomark, with brand light/dark fills that follow the system color scheme.

--- a/packages/cli/src/callback.html
+++ b/packages/cli/src/callback.html
@@ -31,17 +31,26 @@
         height: 100px;
         margin: 0 auto;
       }
-      svg {
-        overflow: visible;
+      .logo svg path {
+        fill: #37c38f;
+      }
+      @media (prefers-color-scheme: dark) {
+        .logo svg path {
+          fill: #34d59a;
+        }
       }
     </style>
   </head>
   <body>
     <div class="logo">
-      <svg viewBox="0 0 58 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <svg
+        viewBox="0 0 64 64"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+      >
         <path
-          d="M58 0.0162365V58L35.3688 38.5587V58H0V0L58 0.0162365ZM7.10962 50.9603H28.2591V23.1112L50.8907 42.937V7.05391L7.10962 7.04147V50.9603Z"
-          fill="#34D59A"
+          d="M63 0.0177909V63.5526L38.4178 42.2501V63.5526H0V0L63 0.0177909ZM7.72251 55.8389H30.6953V25.3238L55.2779 47.0476V7.72922L7.72251 7.71559V55.8389Z"
         />
       </svg>
     </div>


### PR DESCRIPTION
Re-lands #341 from a branch on this repo so CI can run. The fork PR could not go green: every job fails in `.github/actions/prepare` at `jfrog/setup-jfrog-cli` with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` — GitHub does not issue OIDC tokens to workflows triggered from forks, so the JFrog/npm registry setup never completes. Original commit is cherry-picked with authorship preserved (@davidgomes).

## Problem

The post-sign-in page shown after `neonctl auth` still rendered the old Neon logomark path, and hardcoded a single fill that did not follow the brand's light/dark values.

## Solution

- Replace the SVG path with the current official logomark from neon.com/brand (verified byte-for-byte against `brand/neon/neon-logomark-*.svg`).
- Move the fill into CSS: `#37c38f` by default, `#34d59a` under `prefers-color-scheme: dark`.
- Mark the decorative SVG `aria-hidden="true"`.

## Changes vs #341

- Added the missing changeset (`neonctl`: patch) so the fix actually ships.
- Dropped the `packages/cli/.pr-preview/*.png` screenshot commit — those were PR-presentation artifacts and don't belong in the published package. Screenshots remain visible on #341.

## User-facing surface

No API change. Only the HTML served on the OAuth callback page after `neonctl auth`.

## Verification

- Rendered `packages/cli/src/callback.html` in light and dark mode.
- Diffed the SVG path against the official brand asset.
- CI on this branch (fork PR could not be verified at all).