### PR TITLE
chore: release neonctl@2.37.1

### DIFF
--- a/.changeset/cli-post-signin-logomark.md
+++ b/.changeset/cli-post-signin-logomark.md
@@ -1,5 +1,0 @@
----
-"neonctl": patch
----
-
-Update the post-sign-in page to the current official Neon logomark, with brand light/dark fills that follow the system color scheme.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.37.1
+
+### Patch Changes
+
+- 30d42c9: Update the post-sign-in page to the current official Neon logomark, with brand light/dark fills that follow the system color scheme.
+
 ## 2.37.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.37.0",
+  "version": "2.37.1",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",


### PR DESCRIPTION
Version bump + CHANGELOG only (`changeset version` output), no source changes.

| Package | Version |
|---|---|
| `neonctl` | 2.37.0 → 2.37.1 |

Ships #342 — the post-sign-in page now uses the current official Neon logomark with brand light/dark fills.