### PR TITLE
ci: run the live Neon e2e suites on every pull request

### DIFF
--- a/.github/workflows/e2e-live.yml
+++ b/.github/workflows/e2e-live.yml
@@ -1,0 +1,54 @@
+# Live Neon e2e suites for @neon/config, @neon/config-runtime and @neon/env.
+#
+# Unlike every other workflow here, these tests call the real Neon Management API:
+# they create Postgres projects, mutate branches, and delete everything again. They
+# run against the dedicated throwaway "neon-pkgs Integration Test Org", reached
+# through the NEON_TEST_API_KEY repository secret (an org-scoped key). Never point
+# that secret at an org holding anything worth keeping — the suite sweeps stale
+# `neon-ts-e2e-*` projects on start.
+#
+# Fork and Dependabot pull requests skip the job: GitHub does not expose repository
+# secrets to untrusted pull request code, so the suite could only fail there.
+name: e2e (live Neon)
+
+on:
+    pull_request: ~
+    push:
+        branches:
+            - main
+    workflow_dispatch: ~
+
+permissions:
+    contents: read
+    id-token: write # mint the JFrog OIDC token in ./.github/actions/prepare
+
+concurrency:
+    group: e2e-live-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    e2e:
+        name: Live Neon e2e
+        if: >-
+            github.event_name != 'pull_request' ||
+            (github.event.pull_request.head.repo.full_name == github.repository &&
+            github.actor != 'dependabot[bot]')
+        runs-on:
+            group: neondatabase-protected-runner-group
+            labels: linux-ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - name: Harden the runner (Audit all outbound calls)
+              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+              with:
+                  egress-policy: audit
+
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: ./.github/actions/prepare
+            # One suite at a time: they share a single org, and running them in
+            # parallel multiplies the project churn for no wall-clock gain.
+            - name: Run live e2e suites
+              env:
+                  NEON_API_KEY: ${{ secrets.NEON_TEST_API_KEY }}
+                  NEON_ORG_ID: ${{ vars.NEON_TEST_ORG_ID }}
+              run: pnpm test:e2e:live

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist
 coverage
 .env
 .env.*
+!.env.example
 CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,44 @@ pnpm --filter neon-new test
 pnpm --filter vite-plugin-neon-new test
 ```
 
+#### Live Neon e2e tests
+
+`pnpm test:e2e:live` runs the `@neon/config`, `@neon/config-runtime`, and `@neon/env`
+e2e suites against the **real Neon Management API**. They create Postgres projects,
+mutate branches, read connection strings, and delete everything again. They are
+excluded from `pnpm test:ci` (each package's Vitest config excludes `**/*.e2e.test.ts`)
+and only run through their own `test:e2e` script.
+
+Run them against a **dedicated throwaway organization** — never a personal or
+production one. The suite sweeps stale `neon-ts-e2e-*` projects on start, so any
+project matching that prefix in reach of the key is fair game for deletion.
+
+```bash
+cp packages/config/.env.example packages/config/.env   # and the same for config-runtime + env
+# Fill in NEON_API_KEY with an org-scoped key for the throwaway org.
+# Set NEON_ORG_ID too when the key is user-scoped, so the sweep stays inside one org.
+pnpm test:e2e:live
+```
+
+| | |
+| --- | --- |
+| **Workflow** | `.github/workflows/e2e-live.yml` — every PR, every push to `main`, plus `workflow_dispatch` |
+| **Org** | `org-autumn-tree-56376911` ("neon-pkgs Integration Test Org"), Launch plan |
+| **Secrets** | Repository secret `NEON_TEST_API_KEY` → `NEON_API_KEY`; repository variable `NEON_TEST_ORG_ID` → `NEON_ORG_ID` |
+| **Skipped for** | Fork and Dependabot PRs — GitHub does not expose repository secrets to untrusted PR code |
+| **Runner** | Protected runner group. Unlike `neon.com` and `models.dev`, the Neon **API** is reachable from it |
+
+The org needs the **Launch plan or above**: `lifecycle.e2e.test.ts` protects a branch
+through `pushConfig`, and the free plan allows zero protected branches.
+
+Suites run one at a time (`--workspace-concurrency=1`) because they share one org.
+Across concurrent CI runs, safety comes from the sweep ignoring projects younger than
+an hour, so a sibling run's in-flight project is never deleted underneath it.
+
+`@neon/ai-sdk-provider` also has a `test:e2e`, but it targets a live AI Gateway with a
+different pair of credentials (`NEON_AI_GATEWAY_BASE_URL`, `NEON_AI_GATEWAY_TOKEN`) and
+is not part of `test:e2e:live`.
+
 ### Linting & Formatting
 
 ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,11 @@ pnpm test:e2e:live
 The org needs the **Launch plan or above**: `lifecycle.e2e.test.ts` protects a branch
 through `pushConfig`, and the free plan allows zero protected branches.
 
-Suites run one at a time (`--workspace-concurrency=1`) because they share one org.
-Across concurrent CI runs, safety comes from the sweep ignoring projects younger than
-an hour, so a sibling run's in-flight project is never deleted underneath it.
+Suites run one at a time (`--workspace-concurrency=1`) because they share one org, and
+with `--no-bail` so one failure neither hides the other suites' results nor aborts a
+suite that has already started creating projects. Across concurrent CI runs, safety
+comes from the sweep ignoring projects younger than an hour, so a sibling run's
+in-flight project is never deleted underneath it.
 
 `@neon/ai-sdk-provider` also has a `test:e2e`, but it targets a live AI Gateway with a
 different pair of credentials (`NEON_AI_GATEWAY_BASE_URL`, `NEON_AI_GATEWAY_TOKEN`) and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,7 @@ pnpm install          # install all workspaces
 pnpm build            # build every package (tsc + tsdown)
 pnpm test:ci          # run the test suites (Vitest)
 pnpm lint:ci          # lint + format check (Biome)
+pnpm test:e2e:live    # e2e suites against a real Neon org — needs credentials, see below
 ```
 
 Scope a command to a single package with a filter:
@@ -57,6 +58,22 @@ checkout, so everything is current already. Run `test:ci` locally only right aft
 
 See [`AGENTS.md`](./AGENTS.md) for the deeper architecture and per-package notes (especially the
 CLI package, which keeps its own toolchain).
+
+## Live Neon e2e tests
+
+`pnpm test:e2e:live` runs the `@neon/config`, `@neon/config-runtime`, and `@neon/env` e2e suites
+against the real Neon API, creating and deleting real projects. They are excluded from
+`pnpm test:ci`, so you only pay for them when you ask for them.
+
+Copy each package's `.env.example` to `.env` and fill in `NEON_API_KEY` with an **org-scoped key
+for a throwaway organization**. The suite deletes stale `neon-ts-e2e-*` projects on start, so
+never point it at an org holding anything you care about. If your key is user-scoped rather than
+org-scoped, set `NEON_ORG_ID` as well to keep the sweep inside a single org. The org must be on
+the Launch plan or above — one test protects a branch, which the free plan disallows.
+
+In CI these run as the `e2e (live Neon)` workflow on every pull request from this repository.
+Fork and Dependabot PRs skip the job, because GitHub does not expose repository secrets to
+untrusted pull request code; a maintainer runs the suite before merging those.
 
 ## Changing the supported Node floor
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"format": "biome check --error-on-warnings --write",
 		"lint:ci": "biome ci --error-on-warnings",
 		"test:ci": "pnpm --recursive test:ci",
+		"test:e2e:live": "pnpm --workspace-concurrency=1 --filter @neon/config --filter @neon/config-runtime --filter @neon/env test:e2e",
 		"prepare": "husky"
 	},
 	"lint-staged": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"format": "biome check --error-on-warnings --write",
 		"lint:ci": "biome ci --error-on-warnings",
 		"test:ci": "pnpm --recursive test:ci",
-		"test:e2e:live": "pnpm --workspace-concurrency=1 --filter @neon/config --filter @neon/config-runtime --filter @neon/env test:e2e",
+		"test:e2e:live": "pnpm --workspace-concurrency=1 --no-bail --filter @neon/config --filter @neon/config-runtime --filter @neon/env test:e2e",
 		"prepare": "husky"
 	},
 	"lint-staged": {

--- a/packages/config-runtime/.env.example
+++ b/packages/config-runtime/.env.example
@@ -1,5 +1,5 @@
 # Copy to `.env` and fill in real values. `.env` itself is gitignored.
-# Required to run `pnpm --filter @neon/env test:e2e`.
+# Required to run `pnpm --filter @neon/config-runtime test:e2e`.
 #
 # The suite creates and deletes real Neon projects, and sweeps stale
 # `neon-ts-e2e-*` projects on start. Point it at a throwaway org only.

--- a/packages/config-runtime/e2e/helpers.ts
+++ b/packages/config-runtime/e2e/helpers.ts
@@ -4,7 +4,9 @@ import { createNeonClient } from "@neon/sdk";
 import {
 	deleteProject as rawDeleteProject,
 	getProject as rawGetProject,
+	listProjectBranches as rawListProjectBranches,
 	listProjects as rawListProjects,
+	updateProjectBranch as rawUpdateProjectBranch,
 } from "@neon/sdk/raw";
 import { test } from "vitest";
 
@@ -176,8 +178,10 @@ async function deleteProject(projectId: string): Promise<void> {
 		);
 	}
 	// Retry on 423 (locked while a previous mutation is in flight) so cleanup is robust.
+	// A 422 means a branch is still protected; clear the flag once and try again.
 	const maxAttempts = 12;
 	let delay = 500;
+	let unprotected = false;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
 			unwrap(
@@ -192,10 +196,43 @@ async function deleteProject(projectId: string): Promise<void> {
 				err as { response?: { status?: number } } | undefined
 			)?.response?.status;
 			if (status === 404 || status === 410) return;
+			if (status === 422 && !unprotected) {
+				unprotected = true;
+				await unprotectBranches(client, projectId);
+				continue;
+			}
 			if (status !== 423 || attempt === maxAttempts) throw err;
 			await sleep(delay);
 			delay = Math.min(delay * 2, 5_000);
 		}
+	}
+}
+
+/**
+ * Neon refuses to delete a project while any of its branches is protected, and
+ * `lifecycle.e2e.test.ts` leaves the default branch that way on purpose. Without clearing
+ * the flag the project is undeletable — not just by the test that made it, but by
+ * {@link sweepOrphans} too, so it would sit in the org forever.
+ */
+async function unprotectBranches(
+	client: ReturnType<typeof makeRawClient>,
+	projectId: string,
+): Promise<void> {
+	const body = unwrap(
+		await rawListProjectBranches({
+			client,
+			path: { project_id: projectId },
+		}),
+	);
+	for (const branch of body.branches) {
+		if (!branch.protected) continue;
+		unwrap(
+			await rawUpdateProjectBranch({
+				client,
+				path: { project_id: projectId, branch_id: branch.id },
+				body: { branch: { protected: false } },
+			}),
+		);
 	}
 }
 
@@ -257,12 +294,23 @@ export const e2eTest = test.extend<{
 				// Surface, but don't fail on cleanup errors — the orphan sweep on the next
 				// run will mop up anything we miss.
 				console.error(
-					`[e2e cleanup] failed to delete ${projectId}: ${(err as Error).message}`,
+					`[e2e cleanup] failed to delete ${projectId}: ${describeError(err)}`,
 				);
 			}
 		}
 	},
 });
+
+/**
+ * {@link unwrap} throws a bare `{ response: { status } }`, not an `Error`, so reading
+ * `.message` off it reports `undefined` and hides why cleanup failed.
+ */
+function describeError(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	const status = (err as { response?: { status?: number } } | undefined)
+		?.response?.status;
+	return status ? `HTTP ${status}` : String(err);
+}
 
 /**
  * Some Neon operations are eventually consistent (notably branch creation finishing

--- a/packages/config-runtime/e2e/helpers.ts
+++ b/packages/config-runtime/e2e/helpers.ts
@@ -16,10 +16,32 @@ import { test } from "vitest";
 const PROJECT_PREFIX = "neon-ts-e2e-";
 
 /**
+ * Projects younger than this are assumed to belong to a run that is still in flight. CI
+ * runs several suites against one shared org, so {@link sweepOrphans} must never delete a
+ * sibling run's project out from under it. Comfortably longer than a full suite.
+ */
+const ORPHAN_MIN_AGE_MS = 60 * 60 * 1000;
+
+/**
  * Default Neon region used by every e2e test that creates a project. Override per-test
  * by passing `region` to `defineConfig`.
  */
 export const DEFAULT_REGION = "aws-us-east-2";
+
+/**
+ * Pins every create and list to one organization. Redundant for an org-scoped API key,
+ * which can't see anything else anyway, but essential for a user-scoped key: without it
+ * {@link sweepOrphans} would range over every org the user belongs to.
+ */
+function configuredOrgId(): string | undefined {
+	const value = process.env.NEON_ORG_ID?.trim();
+	return value ? value : undefined;
+}
+
+function orgQuery(): { org_id?: string } {
+	const org = configuredOrgId();
+	return org ? { org_id: org } : {};
+}
 
 /** Generate a project name guaranteed not to collide with anything else in the org. */
 export function uniqueProjectName(suffix?: string): string {
@@ -33,7 +55,7 @@ function requireApiKey(): string {
 	const key = process.env.NEON_API_KEY;
 	if (!key || key.trim() === "") {
 		throw new Error(
-			"NEON_API_KEY is not set. Create packages/config/.env (see .env.example) before running test:e2e.",
+			"NEON_API_KEY is not set. Create packages/config-runtime/.env (see .env.example) before running test:e2e.",
 		);
 	}
 	return key;
@@ -53,9 +75,11 @@ export async function bootstrapProject(
 	api: NeonApi,
 	args: { name: string; region: string },
 ): Promise<string> {
+	const org = configuredOrgId();
 	const created = await api.createProject({
 		name: args.name,
 		regionId: args.region,
+		...(org ? { orgId: org } : {}),
 	});
 	return created.id;
 }
@@ -98,7 +122,12 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
 	if (cachedScope) return cachedScope;
 	const client = makeRawClient();
 	try {
-		unwrap(await rawListProjects({ client, query: { limit: 1 } }));
+		unwrap(
+			await rawListProjects({
+				client,
+				query: { limit: 1, ...orgQuery() },
+			}),
+		);
 		cachedScope = { kind: "org-or-user", canCreate: true };
 		return cachedScope;
 	} catch (err) {
@@ -110,7 +139,7 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
 	if (!fixedProjectId || fixedProjectId.trim() === "") {
 		throw new Error(
 			"API key cannot list projects (looks project-scoped) and NEON_PROJECT_ID is not set. " +
-				"Set NEON_PROJECT_ID in packages/config/.env to target a fixed project for the bounded e2e subset.",
+				"Set NEON_PROJECT_ID in packages/config-runtime/.env to target a fixed project for the bounded e2e subset.",
 		);
 	}
 	cachedScope = {
@@ -171,27 +200,33 @@ async function deleteProject(projectId: string): Promise<void> {
 }
 
 /**
- * List every project whose name starts with {@link PROJECT_PREFIX} and delete them.
- * Called once at suite start to mop up orphans from a previous failed run.
+ * List every project whose name starts with {@link PROJECT_PREFIX} and is older than
+ * {@link ORPHAN_MIN_AGE_MS}, then delete them. Called once at suite start to mop up
+ * orphans from a previous failed run without touching a concurrent run's projects.
  */
 export async function sweepOrphans(): Promise<{ swept: string[] }> {
 	const scope = await detectApiKeyScope();
 	if (scope.kind === "project") return { swept: [] };
 	const client = makeRawClient();
 	const swept: string[] = [];
+	const cutoff = Date.now() - ORPHAN_MIN_AGE_MS;
 	let cursor: string | undefined;
 	while (true) {
 		const body = unwrap(
 			await rawListProjects({
 				client,
-				query: { limit: 100, ...(cursor ? { cursor } : {}) },
+				query: {
+					limit: 100,
+					...orgQuery(),
+					...(cursor ? { cursor } : {}),
+				},
 			}),
 		);
 		for (const project of body.projects) {
-			if (project.name.startsWith(PROJECT_PREFIX)) {
-				await deleteProject(project.id);
-				swept.push(project.id);
-			}
+			if (!project.name.startsWith(PROJECT_PREFIX)) continue;
+			if (Date.parse(project.created_at) > cutoff) continue;
+			await deleteProject(project.id);
+			swept.push(project.id);
 		}
 		const next = (body as { pagination?: { next?: string } }).pagination
 			?.next;

--- a/packages/config/.env.example
+++ b/packages/config/.env.example
@@ -1,5 +1,9 @@
 # Copy to `.env` and fill in real values. `.env` itself is gitignored.
 # Required to run `pnpm --filter @neon/config test:e2e`.
+#
+# The suite creates and deletes real Neon projects, and sweeps stale
+# `neon-ts-e2e-*` projects on start. Point it at a throwaway org only.
 NEON_API_KEY=
 # Optional. When set, e2e tests scope project creation/listing to this org.
+# Set it whenever the key is user-scoped, so the sweep can't reach other orgs.
 NEON_ORG_ID=

--- a/packages/config/e2e/helpers.ts
+++ b/packages/config/e2e/helpers.ts
@@ -17,10 +17,32 @@ import { createRealNeonApi } from "../src/lib/neon-api-real.js";
 const PROJECT_PREFIX = "neon-ts-e2e-";
 
 /**
+ * Projects younger than this are assumed to belong to a run that is still in flight. CI
+ * runs several suites against one shared org, so {@link sweepOrphans} must never delete a
+ * sibling run's project out from under it. Comfortably longer than a full suite.
+ */
+const ORPHAN_MIN_AGE_MS = 60 * 60 * 1000;
+
+/**
  * Default Neon region used by every e2e test that creates a project. Override per-test
  * by passing `region` to `defineConfig`.
  */
 export const DEFAULT_REGION = "aws-us-east-2";
+
+/**
+ * Pins every create and list to one organization. Redundant for an org-scoped API key,
+ * which can't see anything else anyway, but essential for a user-scoped key: without it
+ * {@link sweepOrphans} would range over every org the user belongs to.
+ */
+function configuredOrgId(): string | undefined {
+	const value = process.env.NEON_ORG_ID?.trim();
+	return value ? value : undefined;
+}
+
+function orgQuery(): { org_id?: string } {
+	const org = configuredOrgId();
+	return org ? { org_id: org } : {};
+}
 
 /** Generate a project name guaranteed not to collide with anything else in the org. */
 export function uniqueProjectName(suffix?: string): string {
@@ -54,9 +76,11 @@ export async function bootstrapProject(
 	api: NeonApi,
 	args: { name: string; region: string },
 ): Promise<string> {
+	const org = configuredOrgId();
 	const created = await api.createProject({
 		name: args.name,
 		regionId: args.region,
+		...(org ? { orgId: org } : {}),
 	});
 	return created.id;
 }
@@ -99,7 +123,12 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
 	if (cachedScope) return cachedScope;
 	const client = makeRawClient();
 	try {
-		unwrap(await rawListProjects({ client, query: { limit: 1 } }));
+		unwrap(
+			await rawListProjects({
+				client,
+				query: { limit: 1, ...orgQuery() },
+			}),
+		);
 		cachedScope = { kind: "org-or-user", canCreate: true };
 		return cachedScope;
 	} catch (err) {
@@ -172,27 +201,33 @@ async function deleteProject(projectId: string): Promise<void> {
 }
 
 /**
- * List every project whose name starts with {@link PROJECT_PREFIX} and delete them.
- * Called once at suite start to mop up orphans from a previous failed run.
+ * List every project whose name starts with {@link PROJECT_PREFIX} and is older than
+ * {@link ORPHAN_MIN_AGE_MS}, then delete them. Called once at suite start to mop up
+ * orphans from a previous failed run without touching a concurrent run's projects.
  */
 export async function sweepOrphans(): Promise<{ swept: string[] }> {
 	const scope = await detectApiKeyScope();
 	if (scope.kind === "project") return { swept: [] };
 	const client = makeRawClient();
 	const swept: string[] = [];
+	const cutoff = Date.now() - ORPHAN_MIN_AGE_MS;
 	let cursor: string | undefined;
 	while (true) {
 		const body = unwrap(
 			await rawListProjects({
 				client,
-				query: { limit: 100, ...(cursor ? { cursor } : {}) },
+				query: {
+					limit: 100,
+					...orgQuery(),
+					...(cursor ? { cursor } : {}),
+				},
 			}),
 		);
 		for (const project of body.projects) {
-			if (project.name.startsWith(PROJECT_PREFIX)) {
-				await deleteProject(project.id);
-				swept.push(project.id);
-			}
+			if (!project.name.startsWith(PROJECT_PREFIX)) continue;
+			if (Date.parse(project.created_at) > cutoff) continue;
+			await deleteProject(project.id);
+			swept.push(project.id);
 		}
 		const next = (body as { pagination?: { next?: string } }).pagination
 			?.next;

--- a/packages/config/e2e/helpers.ts
+++ b/packages/config/e2e/helpers.ts
@@ -3,7 +3,9 @@ import { createNeonClient } from "@neon/sdk";
 import {
 	deleteProject as rawDeleteProject,
 	getProject as rawGetProject,
+	listProjectBranches as rawListProjectBranches,
 	listProjects as rawListProjects,
+	updateProjectBranch as rawUpdateProjectBranch,
 } from "@neon/sdk/raw";
 import { test } from "vitest";
 import type { NeonApi } from "../src/lib/neon-api.js";
@@ -177,8 +179,10 @@ async function deleteProject(projectId: string): Promise<void> {
 		);
 	}
 	// Retry on 423 (locked while a previous mutation is in flight) so cleanup is robust.
+	// A 422 means a branch is still protected; clear the flag once and try again.
 	const maxAttempts = 12;
 	let delay = 500;
+	let unprotected = false;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
 			unwrap(
@@ -193,10 +197,43 @@ async function deleteProject(projectId: string): Promise<void> {
 				err as { response?: { status?: number } } | undefined
 			)?.response?.status;
 			if (status === 404 || status === 410) return;
+			if (status === 422 && !unprotected) {
+				unprotected = true;
+				await unprotectBranches(client, projectId);
+				continue;
+			}
 			if (status !== 423 || attempt === maxAttempts) throw err;
 			await sleep(delay);
 			delay = Math.min(delay * 2, 5_000);
 		}
+	}
+}
+
+/**
+ * Neon refuses to delete a project while any of its branches is protected, and
+ * `@neon/config-runtime`'s lifecycle test leaves the default branch that way on purpose.
+ * Without clearing the flag the project is undeletable — not just by the test that made
+ * it, but by {@link sweepOrphans} too, so it would sit in the org forever.
+ */
+async function unprotectBranches(
+	client: ReturnType<typeof makeRawClient>,
+	projectId: string,
+): Promise<void> {
+	const body = unwrap(
+		await rawListProjectBranches({
+			client,
+			path: { project_id: projectId },
+		}),
+	);
+	for (const branch of body.branches) {
+		if (!branch.protected) continue;
+		unwrap(
+			await rawUpdateProjectBranch({
+				client,
+				path: { project_id: projectId, branch_id: branch.id },
+				body: { branch: { protected: false } },
+			}),
+		);
 	}
 }
 
@@ -258,12 +295,23 @@ export const e2eTest = test.extend<{
 				// Surface, but don't fail on cleanup errors — the orphan sweep on the next
 				// run will mop up anything we miss.
 				console.error(
-					`[e2e cleanup] failed to delete ${projectId}: ${(err as Error).message}`,
+					`[e2e cleanup] failed to delete ${projectId}: ${describeError(err)}`,
 				);
 			}
 		}
 	},
 });
+
+/**
+ * {@link unwrap} throws a bare `{ response: { status } }`, not an `Error`, so reading
+ * `.message` off it reports `undefined` and hides why cleanup failed.
+ */
+function describeError(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	const status = (err as { response?: { status?: number } } | undefined)
+		?.response?.status;
+	return status ? `HTTP ${status}` : String(err);
+}
 
 /**
  * Some Neon operations are eventually consistent (notably branch creation finishing

--- a/packages/env/e2e/helpers.ts
+++ b/packages/env/e2e/helpers.ts
@@ -16,9 +16,31 @@ import { test } from "vitest";
 const PROJECT_PREFIX = "neon-ts-e2e-";
 
 /**
+ * Projects younger than this are assumed to belong to a run that is still in flight. CI
+ * runs several suites against one shared org, so {@link sweepOrphans} must never delete a
+ * sibling run's project out from under it. Comfortably longer than a full suite.
+ */
+const ORPHAN_MIN_AGE_MS = 60 * 60 * 1000;
+
+/**
  * Default Neon region used by every e2e test that creates a project.
  */
 export const DEFAULT_REGION = "aws-us-east-2";
+
+/**
+ * Pins every create and list to one organization. Redundant for an org-scoped API key,
+ * which can't see anything else anyway, but essential for a user-scoped key: without it
+ * {@link sweepOrphans} would range over every org the user belongs to.
+ */
+function configuredOrgId(): string | undefined {
+	const value = process.env.NEON_ORG_ID?.trim();
+	return value ? value : undefined;
+}
+
+function orgQuery(): { org_id?: string } {
+	const org = configuredOrgId();
+	return org ? { org_id: org } : {};
+}
 
 /** Generate a project name guaranteed not to collide with anything else in the org. */
 export function uniqueProjectName(suffix?: string): string {
@@ -50,9 +72,11 @@ export async function bootstrapProject(
 	api: NeonApi,
 	args: { name: string; region: string },
 ): Promise<string> {
+	const org = configuredOrgId();
 	const created = await api.createProject({
 		name: args.name,
 		regionId: args.region,
+		...(org ? { orgId: org } : {}),
 	});
 	return created.id;
 }
@@ -91,7 +115,12 @@ export async function detectApiKeyScope(): Promise<ApiKeyScope> {
 	if (cachedScope) return cachedScope;
 	const client = makeRawClient();
 	try {
-		unwrap(await rawListProjects({ client, query: { limit: 1 } }));
+		unwrap(
+			await rawListProjects({
+				client,
+				query: { limit: 1, ...orgQuery() },
+			}),
+		);
 		cachedScope = { kind: "org-or-user", canCreate: true };
 		return cachedScope;
 	} catch (err) {
@@ -163,26 +192,32 @@ async function deleteProject(projectId: string): Promise<void> {
 }
 
 /**
- * List every project whose name starts with {@link PROJECT_PREFIX} and delete them.
+ * List every project whose name starts with {@link PROJECT_PREFIX} and is older than
+ * {@link ORPHAN_MIN_AGE_MS}, then delete them. Leaves a concurrent run's projects alone.
  */
 export async function sweepOrphans(): Promise<{ swept: string[] }> {
 	const scope = await detectApiKeyScope();
 	if (scope.kind === "project") return { swept: [] };
 	const client = makeRawClient();
 	const swept: string[] = [];
+	const cutoff = Date.now() - ORPHAN_MIN_AGE_MS;
 	let cursor: string | undefined;
 	while (true) {
 		const body = unwrap(
 			await rawListProjects({
 				client,
-				query: { limit: 100, ...(cursor ? { cursor } : {}) },
+				query: {
+					limit: 100,
+					...orgQuery(),
+					...(cursor ? { cursor } : {}),
+				},
 			}),
 		);
 		for (const project of body.projects) {
-			if (project.name.startsWith(PROJECT_PREFIX)) {
-				await deleteProject(project.id);
-				swept.push(project.id);
-			}
+			if (!project.name.startsWith(PROJECT_PREFIX)) continue;
+			if (Date.parse(project.created_at) > cutoff) continue;
+			await deleteProject(project.id);
+			swept.push(project.id);
 		}
 		const next = (body as { pagination?: { next?: string } }).pagination
 			?.next;

--- a/packages/env/e2e/helpers.ts
+++ b/packages/env/e2e/helpers.ts
@@ -4,7 +4,9 @@ import { createNeonClient } from "@neon/sdk";
 import {
 	deleteProject as rawDeleteProject,
 	getProject as rawGetProject,
+	listProjectBranches as rawListProjectBranches,
 	listProjects as rawListProjects,
+	updateProjectBranch as rawUpdateProjectBranch,
 } from "@neon/sdk/raw";
 import { test } from "vitest";
 
@@ -168,8 +170,11 @@ async function deleteProject(projectId: string): Promise<void> {
 			`Refusing to delete project ${projectId} ("${project.project.name}"): does not match the e2e prefix.`,
 		);
 	}
+	// Retry on 423 (locked while a previous mutation is in flight) so cleanup is robust.
+	// A 422 means a branch is still protected; clear the flag once and try again.
 	const maxAttempts = 12;
 	let delay = 500;
+	let unprotected = false;
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
 			unwrap(
@@ -184,10 +189,43 @@ async function deleteProject(projectId: string): Promise<void> {
 				err as { response?: { status?: number } } | undefined
 			)?.response?.status;
 			if (status === 404 || status === 410) return;
+			if (status === 422 && !unprotected) {
+				unprotected = true;
+				await unprotectBranches(client, projectId);
+				continue;
+			}
 			if (status !== 423 || attempt === maxAttempts) throw err;
 			await sleep(delay);
 			delay = Math.min(delay * 2, 5_000);
 		}
+	}
+}
+
+/**
+ * Neon refuses to delete a project while any of its branches is protected, and
+ * `@neon/config-runtime`'s lifecycle test leaves the default branch that way on purpose.
+ * Without clearing the flag the project is undeletable — not just by the test that made
+ * it, but by {@link sweepOrphans} too, so it would sit in the org forever.
+ */
+async function unprotectBranches(
+	client: ReturnType<typeof makeRawClient>,
+	projectId: string,
+): Promise<void> {
+	const body = unwrap(
+		await rawListProjectBranches({
+			client,
+			path: { project_id: projectId },
+		}),
+	);
+	for (const branch of body.branches) {
+		if (!branch.protected) continue;
+		unwrap(
+			await rawUpdateProjectBranch({
+				client,
+				path: { project_id: projectId, branch_id: branch.id },
+				body: { branch: { protected: false } },
+			}),
+		);
 	}
 }
 
@@ -245,12 +283,23 @@ export const e2eTest = test.extend<{
 				await deleteProject(projectId);
 			} catch (err) {
 				console.error(
-					`[e2e cleanup] failed to delete ${projectId}: ${(err as Error).message}`,
+					`[e2e cleanup] failed to delete ${projectId}: ${describeError(err)}`,
 				);
 			}
 		}
 	},
 });
+
+/**
+ * {@link unwrap} throws a bare `{ response: { status } }`, not an `Error`, so reading
+ * `.message` off it reports `undefined` and hides why cleanup failed.
+ */
+function describeError(err: unknown): string {
+	if (err instanceof Error) return err.message;
+	const status = (err as { response?: { status?: number } } | undefined)
+		?.response?.status;
+	return status ? `HTTP ${status}` : String(err);
+}
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));


### PR DESCRIPTION
## The problem

`@neon/config`, `@neon/config-runtime` and `@neon/env` each ship an e2e suite that talks to the **real Neon Management API** — creating projects, mutating branches, resolving connection strings. Nothing ran them. They existed only as per-package `test:e2e` scripts that a maintainer had to remember to run against credentials they had to assemble themselves, so in practice a regression in the real-API adapters could reach `main` unnoticed. Every other suite in CI is either pure or Docker-local.

## The solution

A new `e2e (live Neon)` workflow runs all three suites against a dedicated throwaway organization, plus three harness fixes that running them in CI turned up.

### 1. The workflow

`.github/workflows/e2e-live.yml` — every pull request, every push to `main`, and `workflow_dispatch`. It reuses the existing `./.github/actions/prepare` composite (JFrog OIDC, pnpm, `--frozen-lockfile`) and runs one new root script.

The Neon API is reachable from the protected runner group, so unlike `catalog-drift.yml` and `sdk-spec-refresh.yml` this does **not** need `ubuntu-latest`.

### 2. Cleanup couldn't delete a project whose branch a test had protected

Neon rejects a project delete with **HTTP 422** while any branch is protected, and `lifecycle.e2e.test.ts` protects the default branch on purpose. Cleanup gave up there, and since `sweepOrphans()` goes through the same `deleteProject`, *nothing could ever reclaim those projects* — they would have accumulated in the org indefinitely. Now a 422 clears the flag and retries:

```ts
if (status === 422 && !unprotected) {
    unprotected = true;
    await unprotectBranches(client, projectId);
    continue;
}
```

The one signal that would have surfaced this printed `undefined`, because the cleanup log read `.message` off the bare `{ response: { status } }` that `unwrap()` throws. It now reports the status.

### 3. `sweepOrphans()` no longer deletes a concurrent run's projects

The suites mop up leftovers from previous failed runs by deleting every project named `neon-ts-e2e-*`. Fine for a single developer running one suite; with three suites and several PRs sharing one org it would have deleted a sibling run's project mid-test. The sweep now skips anything created within the last hour, comfortably longer than a full run.

### 4. `NEON_ORG_ID` is now actually read

Every `.env.example` documented it as *"Optional. When set, e2e tests scope project creation/listing to this org"* — but no helper read it. Project creation and listing now honour it. This matters for the sweep: with a **user**-scoped key and no org pin, the sweep ranges over every org the user belongs to.

## User-facing API

One new root script:

```jsonc
"test:e2e:live": "pnpm --workspace-concurrency=1 --no-bail --filter @neon/config --filter @neon/config-runtime --filter @neon/env test:e2e"
```

```bash
cp packages/config/.env.example packages/config/.env   # and config-runtime + env
# NEON_API_KEY = org-scoped key for a throwaway org
# NEON_ORG_ID  = optional; set it when the key is user-scoped
pnpm test:e2e:live
```

Suites run **one at a time** because they share one org, and with **`--no-bail`** so a failure in one neither hides the others' results nor aborts a suite that has already begun creating projects. The command still exits non-zero when any suite fails.

Environment contract, unchanged in name, now fully honoured:

| Variable | Required | Meaning |
| --- | --- | --- |
| `NEON_API_KEY` | yes | Org-scoped key for a throwaway org |
| `NEON_ORG_ID` | no | Pins create + list + sweep to one org |
| `NEON_PROJECT_ID` | only for project-scoped keys | Targets a fixed project; create-paths skip |

CI wiring:

| | |
| --- | --- |
| Secret | `NEON_TEST_API_KEY` → `NEON_API_KEY` |
| Variable | `NEON_TEST_ORG_ID` → `NEON_ORG_ID` (`org-autumn-tree-56376911`) |
| Org | "neon-pkgs Integration Test Org" — throwaway, holds nothing, on the Launch plan |
| Skipped for | Fork and Dependabot PRs; GitHub does not expose repository secrets to untrusted PR code |

Both the secret and the variable are already set on this repository.

## Verification

Green locally and in CI on this PR — **5/5 tests pass across all three suites**:

- `@neon/config` — 2/2
- `@neon/config-runtime` — 2/2, including the branch-protection lifecycle
- `@neon/env` — 1/1
- The CI run authenticated through the secret, created and deleted real projects in the pinned org, and **left it empty** — verified against the API after the run, including the previously-undeletable protected-branch project
- Every other check on the PR passes; `pnpm lint:ci` clean; `tsc --noEmit` clean for all three packages (their `tsconfig.json` includes `e2e`)

**The test org must stay on the Launch plan or above.** `lifecycle.e2e.test.ts` protects a branch through `pushConfig`, and the free plan allows zero protected branches — on free it fails with `BRANCHES_PROTECTED_LIMIT_EXCEEDED`.

## Known gaps

- **Three near-identical copies of `e2e/helpers.ts`** (config, config-runtime, env) — this PR patches all three identically rather than deduplicating them, which would mean a shared test-only workspace package. Every fix here had to be made three times, so it's worth doing separately.
- **`@neon/ai-sdk-provider`'s `test:e2e` is not included.** It targets a live AI Gateway with a different credential pair (`NEON_AI_GATEWAY_BASE_URL`, `NEON_AI_GATEWAY_TOKEN`), so it needs its own secrets and its own decision about whether it should gate PRs.
- **`@neon/sdk` has a `test:e2e` script but no `vitest.e2e.config.ts` and no `e2e/`** — it fails if invoked. Left alone; it predates this PR.
- **This becomes a per-PR check that depends on a third-party service.** If Neon API flakiness turns out to be disruptive, the fallback is to move it to `push`-only plus a schedule.