### PR TITLE
chore: release neon@2.38.0 and neonctl@2.38.0

### DIFF
--- a/.changeset/calm-clis-forward.md
+++ b/.changeset/calm-clis-forward.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-Make `neon` the package that carries the Neon CLI implementation, and turn `neonctl` into a lightweight compatibility package that depends on `neon` and runs its CLI entry point. `neonctl` keeps providing both the `neonctl` and `neon` commands, so installing it — including via Homebrew — behaves exactly as before, and now also downloads `neon`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,4 +1,10 @@
-# neonctl
+# neon
+
+## 2.38.0
+
+### Minor Changes
+
+- eda9d82: Make `neon` the package that carries the Neon CLI implementation, and turn `neonctl` into a lightweight compatibility package that depends on `neon` and runs its CLI entry point. `neonctl` keeps providing both the `neonctl` and `neon` commands, so installing it — including via Homebrew — behaves exactly as before, and now also downloads `neon`.
 
 ## 2.37.1
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon",
-  "version": "2.37.1",
+  "version": "2.38.0",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,0 +1,12 @@
+# neonctl
+
+## 2.38.0
+
+### Minor Changes
+
+- eda9d82: Make `neon` the package that carries the Neon CLI implementation, and turn `neonctl` into a lightweight compatibility package that depends on `neon` and runs its CLI entry point. `neonctl` keeps providing both the `neonctl` and `neon` commands, so installing it — including via Homebrew — behaves exactly as before, and now also downloads `neon`.
+
+### Patch Changes
+
+- Updated dependencies [eda9d82]
+  - neon@2.38.0

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.37.1",
+  "version": "2.38.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## What this releases

The CLI rename from [#331](https://github.com/neondatabase/neon-pkgs/pull/331): `packages/cli` is now published as **`neon`**, and `packages/neonctl` is a compatibility package that depends on it and imports `neon/cli`.

| Package | Version | Bump |
| --- | --- | --- |
| `neon` | 2.37.1 → **2.38.0** | minor |
| `neonctl` | 2.37.1 → **2.38.0** | minor |

Both move together because they're a Changesets `fixed` group. Nothing else in the workspace bumped — no package depends on either one via `workspace:*` except the shim itself.

## Contents

`changeset version` output only: the changeset is consumed, two `package.json` versions bump, and two CHANGELOGs gain an entry. One extra line: `packages/cli/CHANGELOG.md`'s `# neonctl` heading becomes `# neon` to match the renamed package (Changesets doesn't rewrite the H1). No source changes.

## Publish order — this one matters

```
package=neon      # first: implementation, binaries, GitHub release
package=neonctl   # second: shim, pinned to neon@2.38.0 exactly
```

`pnpm pack` rewrites the shim's `neon: workspace:*` to an exact `neon: 2.38.0`, so `npm i neonctl@2.38.0` cannot resolve until `neon@2.38.0` is on npm. Verified by packing the shim locally.

## Verification before merging

- Dispatched the release workflow in dry-run mode against the shim branch with the companion workflow PR ([run](https://github.com/databricks/secure-public-registry-releases-eng/actions/runs/30275049541)). It packed `neon@2.37.1` and `neonctl@2.37.1` as independent targets with no alias re-pack, and both the `npm-neon` and `npm-neonctl` OIDC environments resolved and published green.
- Packed the shim locally: 4 files, `"neon": "2.37.1"` exact pin. The repo's `publish-workspace-protocol=true` does not leak `workspace:*` into the tarball.
- Full CI green on the merge commit, including the shim's own tests, which exercise both commands through links named the way npm and Homebrew create them.

## Known gaps

- `neon@2.38.0` drops the `neonctl` bin that `neon@2.37.1` carried. Anyone who ran `npm i -g neon` since 2026-06-15 and invokes `neonctl` needs the `neonctl` package. A breaking change shipped in a minor, with a small blast radius.
- Release assets are now `neon-<platform>`. The workflow also uploads them under the legacy `neonctl-<platform>` names, so the download URLs on neon.com/docs/cli/install keep working; [website#5364](https://github.com/neondatabase/website/pull/5364) updates the docs to the new names and lands after this release.