### PR TITLE
fix(cli): scope 401 credential deletion to the credentials that failed

### DIFF
--- a/.changeset/tidy-keys-listen.md
+++ b/.changeset/tidy-keys-listen.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+Stop deleting stored credentials when a 401 comes from an API key. A rejected `--api-key` or `NEON_API_KEY` no longer signs you out of the account saved in your config directory, and reports the rejection instead of retrying. When the stored OAuth token is what was rejected, it is still cleared — but now from the directory named by `--config-dir` rather than always the default one.

--- a/packages/cli/src/auth_context.ts
+++ b/packages/cli/src/auth_context.ts
@@ -1,0 +1,36 @@
+/**
+ * How the current invocation authenticated, recorded by `ensureAuth` so the
+ * top-level 401 handler can react to the credential that actually failed.
+ *
+ * - `api-key`: an explicit `--api-key` flag or `NEON_API_KEY`.
+ * - `stored-credentials`: the OAuth token set the CLI keeps in the config dir.
+ */
+export type AuthSource = "api-key" | "stored-credentials";
+
+export type AuthContext = {
+	source: AuthSource;
+	configDir: string;
+};
+
+let current: AuthContext | null = null;
+
+export const setAuthContext = (context: AuthContext): void => {
+	current = context;
+};
+
+export const getAuthContext = (): AuthContext | null => current;
+
+/**
+ * The config directory whose credentials a 401 should clear, or `null` to leave
+ * stored credentials alone.
+ *
+ * An API key passed on the command line never touches the stored OAuth token,
+ * so a 401 on that key says nothing about whether the stored credentials are
+ * still good — clearing them would sign the user out of an account the failed
+ * request never used. The directory comes from the context rather than the
+ * default so that `--config-dir` isolates the deletion too.
+ */
+export const credentialsToClearOn401 = (
+	context: AuthContext | null,
+): string | null =>
+	context?.source === "stored-credentials" ? context.configDir : null;

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -7,6 +7,7 @@ import type { NeonApiClient } from "../api.js";
 
 import { getApiClient } from "../api.js";
 import { auth, refreshToken } from "../auth.js";
+import { setAuthContext } from "../auth_context.js";
 import { CREDENTIALS_FILE } from "../config.js";
 import { isConfigInit, isCurrentBranchProbe } from "../context.js";
 import { isCi } from "../env.js";
@@ -198,6 +199,10 @@ export const ensureAuth = async (
 	if (props.apiKey || props._[0] === "auth") {
 		if (props.apiKey) {
 			log.debug("Using an API key to authorize requests");
+			setAuthContext({
+				source: "api-key",
+				configDir: props.configDir,
+			});
 		}
 		props.apiClient = getApiClient({
 			apiKey: props.apiKey,
@@ -225,6 +230,10 @@ export const ensureAuth = async (
 			if (result) {
 				props.apiKey = result.apiKey;
 				props.apiClient = result.apiClient;
+				setAuthContext({
+					source: "stored-credentials",
+					configDir: props.configDir,
+				});
 				return;
 			}
 		} catch (err) {
@@ -274,6 +283,10 @@ export const ensureAuth = async (
 	props.apiClient = getApiClient({
 		apiKey,
 		apiHost: props.apiHost,
+	});
+	setAuthContext({
+		source: "stored-credentials",
+		configDir: props.configDir,
 	});
 };
 

--- a/packages/cli/src/commands/error_handling.test.ts
+++ b/packages/cli/src/commands/error_handling.test.ts
@@ -1,6 +1,14 @@
 import { fork } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import express from "express";
 import { describe, expect, it } from "vitest";
@@ -103,6 +111,149 @@ describe("top-level error handling", () => {
 					}
 				});
 			});
+		}
+	});
+});
+
+// A 401 makes the CLI clear the OAuth token it stored, so that the next run logs in again.
+// Which credentials it may clear, and from where, depends entirely on how the failing
+// request was authorized — these guard both halves of that.
+describe("401 credential handling", () => {
+	// Serves 401 to everything and hands the test a real port.
+	const unauthorizedServer = async (): Promise<{
+		port: number;
+		close: () => Promise<void>;
+	}> => {
+		const app = express();
+		app.use((_req, res) =>
+			res.status(401).json({ message: "Unauthorized" }),
+		);
+		const server = await new Promise<Server>((resolve) => {
+			const s = app.listen(0, () => {
+				resolve(s);
+			});
+		});
+		return {
+			port: (server.address() as AddressInfo).port,
+			close: () =>
+				new Promise<void>((resolve, reject) => {
+					server.close((err) => (err ? reject(err) : resolve()));
+				}),
+		};
+	};
+
+	// Runs the built CLI with both the config dir and the *default* config dir pointed at
+	// throwaway directories, so a misdirected delete can't reach the real ~/.config/neonctl.
+	const runCli = async (
+		args: string[],
+		env: Record<string, string>,
+	): Promise<{ code: number; output: string }> => {
+		let output = "";
+		const code = await new Promise<number>((resolve, reject) => {
+			const cp = fork(join(process.cwd(), "./dist/index.js"), args, {
+				stdio: "pipe",
+				env: {
+					PATH: `mocks/bin:${process.env.PATH}`,
+					CI: "true",
+					...env,
+				},
+			});
+			cp.stdout?.on("data", (c) => {
+				output += String(c);
+			});
+			cp.stderr?.on("data", (c) => {
+				output += String(c);
+			});
+			cp.on("error", reject);
+			cp.on("close", (exitCode) => {
+				resolve(exitCode ?? -1);
+			});
+		});
+		return { code, output };
+	};
+
+	const writeCredentials = (configDir: string): string => {
+		mkdirSync(configDir, { recursive: true });
+		const path = join(configDir, "credentials.json");
+		writeFileSync(
+			path,
+			JSON.stringify({
+				access_token: "stored-access-token",
+				refresh_token: "stored-refresh-token",
+				// Comfortably unexpired, so the CLI uses it as-is instead of refreshing.
+				expires_at: Date.now() + 60 * 60 * 1000,
+				user_id: "test-user",
+			}),
+		);
+		return path;
+	};
+
+	// An explicit --api-key never consults the stored token, so its rejection says nothing
+	// about whether that token is still valid. Clearing it would sign the user out of an
+	// account the failed request never touched.
+	it("leaves stored credentials alone when the rejected key came from --api-key", async () => {
+		const server = await unauthorizedServer();
+		const home = mkdtempSync(join(tmpdir(), "neon-401-apikey-"));
+		const configDir = join(home, "neonctl");
+		const credentials = writeCredentials(configDir);
+
+		try {
+			const { code, output } = await runCli(
+				[
+					"--api-host",
+					`http://localhost:${server.port}`,
+					"--config-dir",
+					configDir,
+					"--api-key",
+					"rejected-key",
+					"--no-analytics",
+					"projects",
+					"list",
+				],
+				{ XDG_CONFIG_HOME: home },
+			);
+
+			expect(existsSync(credentials)).toBe(true);
+			expect(code).toBe(1);
+			// The homebrew-core formula asserts on this exact phrase; keep it in the message.
+			expect(output).toContain("Authentication failed");
+		} finally {
+			await server.close();
+			rmSync(home, { recursive: true, force: true });
+		}
+	});
+
+	// The complement: when the stored token itself is what got rejected, it must be cleared —
+	// and from the --config-dir actually in use, not from the default location.
+	it("clears the stored credentials in --config-dir when they are what was rejected", async () => {
+		const server = await unauthorizedServer();
+		const home = mkdtempSync(join(tmpdir(), "neon-401-stored-"));
+		// Deliberately not $XDG_CONFIG_HOME/neonctl: if the handler falls back to the default
+		// directory instead of honoring --config-dir, this file survives and the test fails.
+		const configDir = join(home, "explicit-config-dir");
+		const credentials = writeCredentials(configDir);
+		const defaultCredentials = writeCredentials(join(home, "neonctl"));
+
+		try {
+			const { code } = await runCli(
+				[
+					"--api-host",
+					`http://localhost:${server.port}`,
+					"--config-dir",
+					configDir,
+					"--no-analytics",
+					"projects",
+					"list",
+				],
+				{ XDG_CONFIG_HOME: home },
+			);
+
+			expect(existsSync(credentials)).toBe(false);
+			expect(existsSync(defaultCredentials)).toBe(true);
+			expect(code).toBe(1);
+		} finally {
+			await server.close();
+			rmSync(home, { recursive: true, force: true });
 		}
 	});
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./analytics.js";
 import { isNeonApiError, messageFromBody, type NeonApiClient } from "./api.js";
 import { defaultClientID } from "./auth.js";
+import { credentialsToClearOn401, getAuthContext } from "./auth_context.js";
 import { deleteCredentials, ensureAuth } from "./commands/auth.js";
 import commands from "./commands/index.js";
 import { defaultDir, ensureConfigDir } from "./config.js";
@@ -210,9 +211,19 @@ async function handleError(msg: string, err: unknown): Promise<boolean> {
 			return false;
 		} else if (err.status === 401) {
 			sendError(err, "AUTH_FAILED");
+			const configDir = credentialsToClearOn401(getAuthContext());
+			// The request was authorized with a key the user supplied, so there
+			// is nothing of ours to clear and nothing to retry — the same key
+			// would just be rejected again.
+			if (configDir === null) {
+				log.error(
+					"Authentication failed: the Neon API rejected the API key. Check --api-key or NEON_API_KEY.",
+				);
+				return false;
+			}
 			log.info("Authentication failed, deleting credentials...");
 			try {
-				deleteCredentials(defaultDir);
+				deleteCredentials(configDir);
 				return true; // Allow retry for auth failures
 			} catch (deleteErr) {
 				log.debug(


### PR DESCRIPTION
## Problem

A 401 from the Neon API makes the CLI delete the OAuth token it stored, so the next run logs in again. Sensible for an expired token — but the handler never asked *which* credential failed, or *where* the config directory is.

```206:217:packages/cli/src/index.ts
		} else if (err.status === 401) {
			sendError(err, "AUTH_FAILED");
			log.info("Authentication failed, deleting credentials...");
			try {
				deleteCredentials(defaultDir);
				return true; // Allow retry for auth failures
```

Two defects fall out of those two lines.

**An `--api-key` rejection signs you out.** `ensureAuth` returns early when `--api-key` or `NEON_API_KEY` is set — the stored OAuth token is never read. So a 401 on that key says nothing about whether the stored token is valid, and deleting it logs the user out of an account the failed request never touched. Running one command against someone else's project with a bad key ends your own session.

**`--config-dir` doesn't protect anything.** `--config-dir` is a real option that defaults to `defaultDir`, but the handler hardcodes `deleteCredentials(defaultDir)`. Isolating your config to a scratch directory still deletes `~/.config/neonctl/credentials.json`.

Both are easy to hit. homebrew-core's formula test runs `neonctl --api-key DOES-NOT-EXIST projects create` with no `--config-dir`, so `brew test neonctl` on a developer machine logs them out. That is how I found this.

There is a third, smaller symptom: an api-key 401 returns `true` to allow a retry, so the CLI re-runs and fails again with the same key, printing the message twice.

## Solution

`ensureAuth` already knows which path it took, so record it. A new `src/auth_context.ts` holds the resolved source and config directory, and a pure function decides what a 401 may clear:

```ts
export const credentialsToClearOn401 = (
	context: AuthContext | null,
): string | null =>
	context?.source === "stored-credentials" ? context.configDir : null;
```

The handler clears the stored token only when that token is what was rejected, and from the recorded directory. An api-key rejection reports the failure and stops.

## Behavior change

| Scenario | Before | After |
| --- | --- | --- |
| 401 with `--api-key` / `NEON_API_KEY` | Stored credentials deleted, command retried | Credentials untouched, one clear error, exit 1 |
| 401 with stored OAuth token | Deleted from `defaultDir` | Deleted from the resolved `--config-dir` |
| 401 with stored token, no `--config-dir` | Deleted from `defaultDir` | Unchanged |

New message on the api-key path:

```
ERROR: Authentication failed: the Neon API rejected the API key. Check --api-key or NEON_API_KEY.
```

It deliberately keeps the phrase **"Authentication failed"**, because the homebrew-core formula asserts on that exact string and on exit code 1. Both still hold — verified by replaying the assertion.

## Verification

Two end-to-end tests in `error_handling.test.ts`, following the existing pattern there: a real express server returning 401, the real built CLI forked against it, a real credentials file on disk. No mocks. Both point `XDG_CONFIG_HOME` at a temp directory so a misdirected delete can't reach the real config.

The second test writes credentials in *both* the explicit `--config-dir` and the default location, and asserts the explicit one is gone and the default one survives — which is precisely the `defaultDir` bug.

Confirmed they fail without the fix, for the right reasons:

```
× leaves stored credentials alone when the rejected key came from --api-key
  → expect(existsSync(credentials)).toBe(true)   // got false: deleted
× clears the stored credentials in --config-dir when they are what was rejected
  → expect(existsSync(credentials)).toBe(false)  // got true: wrong directory
```

Also run against the real production API, which is the original repro:

```
$ node dist/index.js --config-dir "$T/neonctl" --api-key DOES-NOT-EXIST projects create
ERROR: Authentication failed: the Neon API rejected the API key. Check --api-key or NEON_API_KEY.
$ echo $?
1
$ ls "$T/neonctl"
credentials.json      # survives
```

Full suite green: 3147 passed, 6 skipped. `tsc --noEmit` and root `biome ci` clean.

## Not covered

I did not add a test for the freshly-completed-OAuth path (`authFlow` → 401), which would need to drive the interactive browser flow. It records `stored-credentials` like the other OAuth path, so a 401 there still clears the token as before.