### PR TITLE
chore: release neon@2.38.1, neonctl@2.38.1, neon-init@0.20.3

### DIFF
--- a/.changeset/calm-plums-smile.md
+++ b/.changeset/calm-plums-smile.md
@@ -1,5 +1,0 @@
----
-"neon-init": patch
----
-
-Stop installing the Neon editor extension during default setup while keeping it available as an option during customized setup.

--- a/.changeset/tidy-keys-listen.md
+++ b/.changeset/tidy-keys-listen.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-Stop deleting stored credentials when a 401 comes from an API key. A rejected `--api-key` or `NEON_API_KEY` no longer signs you out of the account saved in your config directory, and reports the rejection instead of retrying. When the stored OAuth token is what was rejected, it is still cleared — but now from the directory named by `--config-dir` rather than always the default one.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neon
 
+## 2.38.1
+
+### Patch Changes
+
+- 2532f9e: Stop deleting stored credentials when a 401 comes from an API key. A rejected `--api-key` or `NEON_API_KEY` no longer signs you out of the account saved in your config directory, and reports the rejection instead of retrying. When the stored OAuth token is what was rejected, it is still cleared — but now from the directory named by `--config-dir` rather than always the default one.
+- Updated dependencies [54ab231]
+  - neon-init@0.20.3
+
 ## 2.38.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",
@@ -64,7 +64,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.20.2",
+    "neon-init": "0.20.3",
     "open": "^10.2.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon-init
 
+## 0.20.3
+
+### Patch Changes
+
+- 54ab231: Stop installing the Neon editor extension during default setup while keeping it available as an option during customized setup.
+
 ## 0.20.2
 
 ### Patch Changes

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.20.2",
+	"version": "0.20.3",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 2.38.1
+
+### Patch Changes
+
+- Updated dependencies [2532f9e]
+  - neon@2.38.1
+
 ## 2.38.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.38.0",
+  "version": "2.38.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## What this releases

| Package | Version | Source |
| --- | --- | --- |
| `neon` | 2.38.0 → **2.38.1** | [#347](https://github.com/neondatabase/neon-pkgs/pull/347) — 401 no longer deletes credentials it didn't authenticate with |
| `neonctl` | 2.38.0 → **2.38.1** | Fixed group with `neon` |
| `neon-init` | 0.20.2 → **0.20.3** | [#328](https://github.com/neondatabase/neon-pkgs/pull/328) — editor extension is opt-in |

`changeset version` output only — two changesets consumed, three version bumps, three CHANGELOG entries. No source changes.

## ⚠️ CI is red on purpose — this is the `neon-init` lockfile trap

Every job fails with `ERR_PNPM_OUTDATED_LOCKFILE`:

```
specifiers in the lockfile don't match specifiers in package.json:
  - neon-init (lockfile: 0.20.2, manifest: 0.20.3)
```

This is the documented catch-22 in `AGENTS.md` § "Publish order — the `neon-init` lockfile trap", not a regression. `packages/cli` pins `neon-init` to a *published* version rather than `workspace:*`, so `changeset version` rewrote that pin to `0.20.3` but can't touch `pnpm-lock.yaml`. The lockfile can't be fixed here either, because `0.20.3` isn't on npm yet — and it can't be published while the frozen install is broken.

I reproduced it locally to confirm it's exactly this and nothing else.

## Release plan

Following `AGENTS.md` step by step, adjusted for the `neon`/`neonctl` split from #331:

1. Merge this PR (red CI is expected and unavoidable at this point).
2. Publish `neon-init@0.20.3` from a **throwaway branch** off `main` with the CLI's pin reverted to `0.20.2`, so `package.json` matches the still-old lockfile. Only `neon-init` publishes from that ref; the branch is deleted, never merged.
3. Open a `chore: sync lockfile for neon-init@0.20.3` PR against `main`. Its CI passes, because `0.20.3` now resolves.
4. Publish `neon@2.38.1`, then `neonctl@2.38.1`. Order matters permanently: the shim pins `neon` exactly, so `npm i neonctl` can't resolve until `neon` is up.

## Note for a follow-up

`AGENTS.md` line 441 still describes the last publish step as "`neonctl` (which also ships `neon`, the standalone binaries, and the GitHub release)". That was true before #331 and isn't now — `neon` is the package that ships the binaries and the GitHub release, and `neonctl` is a separate publish after it. The in-repo release skill was updated by #331; this one paragraph in `AGENTS.md` was missed. Not fixing it here to keep this PR bump-only.