### PR TITLE
chore: sync lockfile for neon-init@0.20.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.20.2
-        version: 0.20.2
+        specifier: 0.20.3
+        version: 0.20.3
       open:
         specifier: ^10.2.0
         version: 10.2.0
@@ -3319,8 +3319,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.20.2:
-    resolution: {integrity: sha512-iaY/+UjVxejVpgXhLoaqOi6OBR3zZanEfCrtyc00QaOafE0BAj9qx7GBDo+XQ/VnJjQkxz5faV250CvFUQKBtg==}
+  neon-init@0.20.3:
+    resolution: {integrity: sha512-LYdL9tGwLm81O48fphN0YyXQq4U2wBqJ/tO3I0UJNjWw7h6AhZSWuOukM0IrcA+q5wovPU/LoSoCdhV9Rf4vWQ==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -7077,7 +7077,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.20.2:
+  neon-init@0.20.3:
     dependencies:
       '@clack/core': 0.4.2
       '@clack/prompts': 0.10.1


### PR DESCRIPTION
## Why

The [2.38.1 release](https://github.com/neondatabase/neon-pkgs/pull/348) bumped `neon-init` to 0.20.3 and `changeset version` rewrote `packages/cli`'s registry pin to match, but it can't update `pnpm-lock.yaml`. `main` has been failing `pnpm install --frozen-lockfile` since that merge:

```
specifiers in the lockfile don't match specifiers in package.json:
  - neon-init (lockfile: 0.20.2, manifest: 0.20.3)
```

`neon-init@0.20.3` is now on npm, so `pnpm install --lockfile-only` resolves it and the lockfile can be brought in line. This unblocks CI on `main` and the remaining `neon` / `neonctl` publishes.

This is the routine third step of `AGENTS.md` § "Publish order — the `neon-init` lockfile trap".

## Contents

Lockfile only — the `neon-init` specifier, its resolution integrity hash, and its snapshot key. Five lines each way, no other dependency moved.

## Verification

- `pnpm install --frozen-lockfile` succeeds again locally.
- No `npm-proxy.cloud.databricks.com` URLs anywhere in the lockfile, so nothing here can break CI for anyone else.