### PR TITLE
fix(neon-init): report the real version instead of "unknown"

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,0 +1,5 @@
+---
+"neon-init": patch
+---
+
+`neon-init --version` now prints the installed version instead of `unknown`.

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -51,6 +51,7 @@
 		"@vitest/coverage-v8": "catalog:",
 		"console-fail-test": "catalog:",
 		"tsdown": "catalog:",
+		"tsx": "4.22.3",
 		"typescript": "catalog:",
 		"vitest": "catalog:"
 	},

--- a/packages/init/src/cli.ts
+++ b/packages/init/src/cli.ts
@@ -13,6 +13,7 @@ import { handleNeonAuthPhase } from "./lib/phases/neon-auth.js";
 import { handleSetupPhase } from "./lib/phases/setup.js";
 import { handleSkillsPhase } from "./lib/phases/skills.js";
 import { handleStatusPhase } from "./lib/phases/status.js";
+import pkg from "./pkg.js";
 import { orchestrate } from "./v2.js";
 
 // ---------------------------------------------------------------------------
@@ -695,6 +696,9 @@ const cli = yargs(hideBin(process.argv))
 	)
 
 	.help()
+	// Without this yargs guesses the version, and in an ESM bin it guesses
+	// wrong — `neon-init --version` printed "unknown".
+	.version(pkg.version)
 	.strict();
 
 // Parse and execute

--- a/packages/init/src/cli.version.test.ts
+++ b/packages/init/src/cli.version.test.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+import pkg from "./pkg.js";
+
+const declaredVersion = (
+	JSON.parse(
+		readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+	) as { version: string }
+).version;
+
+describe("--version", () => {
+	// `pkg.ts` walks up to the nearest package.json so one module works both from
+	// `src/` and from the bundled `dist/`. A walk that resolved somewhere else —
+	// a parent workspace manifest, say — would report a wrong version rather than
+	// throw, so pin what it resolves to.
+	test("pkg resolves this package's own manifest", () => {
+		expect(pkg.name).toBe("neon-init");
+		expect(pkg.version).toBe(declaredVersion);
+	});
+
+	// The regression this guards: with no `.version()` call, yargs guesses, and in
+	// an ESM bin the guess fails — `neon-init --version` printed "unknown". Run the
+	// real CLI end to end rather than asserting on the builder.
+	test("the CLI reports that version", () => {
+		const result = spawnSync(
+			fileURLToPath(new URL("../node_modules/.bin/tsx", import.meta.url)),
+			[fileURLToPath(new URL("./cli.ts", import.meta.url)), "--version"],
+			{ encoding: "utf8" },
+		);
+		expect(result.status, result.stderr).toBe(0);
+		expect(result.stdout.trim()).toBe(declaredVersion);
+	});
+});

--- a/packages/init/src/pkg.ts
+++ b/packages/init/src/pkg.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Load this package's package.json for version metadata by walking up from this
+ * module to the nearest one. That resolves to the same file whether the code is
+ * running bundled from `dist/` or straight from `src/` under tsx or Vitest, so
+ * `pkg.version` is correct everywhere without a test-only shim.
+ *
+ * `package.json` is in the package's published `files`, so this also resolves
+ * for an installed copy.
+ */
+const loadPkg = (): { name: string; version: string } => {
+	let dir = dirname(fileURLToPath(import.meta.url));
+	for (;;) {
+		try {
+			return JSON.parse(
+				readFileSync(join(dir, "package.json"), "utf-8"),
+			) as {
+				name: string;
+				version: string;
+			};
+		} catch {
+			const parent = dirname(dir);
+			if (parent === dir) {
+				throw new Error(
+					"Could not locate package.json for version detection.",
+				);
+			}
+			dir = parent;
+		}
+	}
+};
+
+export default loadPkg();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -448,6 +448,9 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.9.3)
+      tsx:
+        specifier: 4.22.3
+        version: 4.22.3
       typescript:
         specifier: 'catalog:'
         version: 5.9.3


### PR DESCRIPTION
## Problem

```console
$ npx neon-init@0.20.3 --version
unknown
```

`src/cli.ts` builds its yargs instance with `.help()` and `.strict()` but never calls `.version()`. Without it, yargs falls back to guessing the version by locating a `package.json` itself — a guess that doesn't work for this ESM bin, so it yields `unknown`.

Pre-existing, not from a recent release: `0.20.2` behaves identically. I checked it while smoke-testing the 2.38.1 release.

The guess is at least *consistently* wrong rather than dangerously wrong — I verified it doesn't pick up an unrelated `package.json` from the working directory. Running it in a directory whose manifest says `99.99.99` still prints `unknown`, not `99.99.99`.

## Solution

Resolve the version from the package's own manifest and hand it to yargs.

`src/pkg.ts` is the same walk-up loader `packages/cli` already uses: it starts at the module's own directory and climbs to the nearest `package.json`. That resolves to the same file whether the code runs from `src/` (Vitest, tsx) or from the built `dist/`, so no test-only shim is needed. `package.json` is already in the package's published `files`, so it resolves for an installed copy too.

```ts
.help()
// Without this yargs guesses the version, and in an ESM bin it guesses
// wrong — `neon-init --version` printed "unknown".
.version(pkg.version)
.strict();
```

## Verification

Two tests in `src/cli.version.test.ts`. The second is the real one: it spawns the actual CLI and asserts on its output, rather than asserting against the yargs builder.

Confirmed it fails without the fix, with exactly the reported symptom:

```
× --version > the CLI reports that version
  → expected 'unknown' to be '0.20.3'
```

Also exercised the built artifact, since `pkg.ts` has to resolve from the bundle as well as from source:

```console
$ pnpm build && node dist/cli.js --version
0.20.3
$ cd /tmp/some-other-project && node …/dist/cli.js --version   # manifest here says 99.99.99
0.20.3
```

`neon-init` suite green (125 tests), `tsc` clean, root `biome ci --error-on-warnings` clean.

## Notes for review

- **New devDependency**: `tsx` (pinned `4.22.3`, matching `packages/cli`) so the test can run the CLI from source. `neon-init`'s `test:ci` doesn't build first, and `tsx` was only reachable here as an undeclared hoisted binary, which isn't something to depend on. Lockfile updated; no proxy hosts in the diff.
- **No public API change.** `tsdown` runs with `bundle: false`, so every source file already emits a matching `dist` file — `dist/pkg.js` is consistent with `dist/v2.js` and friends. The `exports` map is explicit (`.` and `./bootstrap`), so the new module isn't reachable by consumers.
- The version-resolution helper is now duplicated between `packages/cli` and `packages/init`. Left as a copy rather than extracting a shared internal package, which would be a bigger change than this fix warrants — worth doing if a third package needs it.