### PR TITLE
fix(cli, env): report credential secrets reused from .env, not re-fetched

### DIFF
--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -25,7 +25,7 @@ import type {
 	NeonProjectSnapshot,
 	NeonRoleSnapshot,
 } from "@neon/config";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { autoPullEnvAfterPin, type EnvPullProps, pull } from "./env.js";
 
@@ -200,6 +200,16 @@ class FakeNeonApi implements NeonApi {
 	}
 }
 
+/**
+ * A branch with object storage enabled (one bucket), so env-pull's tier-2 path (`pullConfig`
+ * -> `fetchEnv`) resolves the branch credential and emits the `AWS_*` storage vars.
+ */
+class StorageNeonApi extends FakeNeonApi {
+	override async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+		return [{ name: "assets", accessLevel: "private" }];
+	}
+}
+
 /** Stand-in for the neonctl Api client; only branch resolution is exercised. */
 const fakeApiClient = {
 	listProjectBranches: async () => ({
@@ -355,6 +365,72 @@ describe("env pull", () => {
 		await pull(baseProps(new FakeNeonApi(), cwd));
 
 		expect(existsSync(join(cwd, ".gitignore"))).toBe(false);
+	});
+
+	it("reports storage credentials reused from an existing .env rather than fetched", async () => {
+		// Mirrors the real confusion: the user copied a .env.example (or set AWS_* by hand) with
+		// storage credentials already in place, then ran `pull`. The credential secrets are
+		// echoed back verbatim (never fetched/verified), so they must be reported as reused —
+		// not lumped into the "Pulled N variables" list as if refreshed from Neon.
+		writeFileSync(
+			join(cwd, ".env"),
+			[
+				"AWS_ACCESS_KEY_ID=nak_live_frombyhand",
+				"AWS_SECRET_ACCESS_KEY=secretsetbyhand",
+				"",
+			].join("\n"),
+		);
+
+		const lines: string[] = [];
+		const stderr = vi
+			.spyOn(process.stderr, "write")
+			.mockImplementation((chunk: string | Uint8Array) => {
+				lines.push(String(chunk));
+				return true;
+			});
+		let result: Awaited<ReturnType<typeof pull>>;
+		try {
+			result = await pull(baseProps(new StorageNeonApi(), cwd));
+		} finally {
+			stderr.mockRestore();
+		}
+		const logged = lines.join("");
+
+		expect(result.status).toBe("written");
+		if (result.status === "written") {
+			// The reused secrets stay in `written` (they were written to the file)…
+			expect(result.written).toContain("AWS_ACCESS_KEY_ID");
+			expect(result.written).toContain("AWS_SECRET_ACCESS_KEY");
+			// …and their by-hand values are preserved untouched (never validated/refetched).
+			const content = readFileSync(join(cwd, ".env"), "utf8");
+			expect(content).toContain("AWS_ACCESS_KEY_ID=nak_live_frombyhand");
+			expect(content).toContain("AWS_SECRET_ACCESS_KEY=secretsetbyhand");
+			// The freshly-fetched non-secret storage vars are still written.
+			expect(content).toMatch(/^AWS_ENDPOINT_URL_S3=/m);
+			expect(content).toMatch(/^AWS_REGION=/m);
+		}
+
+		// The rendered message must split reused-from-disk secrets out of the "Pulled" line.
+		const reusedLine = logged.split("\n").find((l) => l.includes("Reused"));
+		expect(reusedLine).toBeDefined();
+		expect(reusedLine).toContain("AWS_ACCESS_KEY_ID");
+		expect(reusedLine).toContain("AWS_SECRET_ACCESS_KEY");
+		expect(reusedLine).toContain("not fetched/verified");
+		// The reused secrets must NOT appear on the "Pulled" line.
+		const pulledLine = logged.split("\n").find((l) => l.includes("Pulled"));
+		expect(pulledLine).toBeDefined();
+		expect(pulledLine).not.toContain("AWS_ACCESS_KEY_ID");
+		expect(pulledLine).toContain("AWS_ENDPOINT_URL_S3");
+	});
+
+	it("mints storage credentials when none are on disk (not reused)", async () => {
+		const result = await pull(baseProps(new StorageNeonApi(), cwd));
+
+		expect(result.status).toBe("written");
+		const content = readFileSync(join(cwd, ".env.local"), "utf8");
+		// A fresh credential was minted, so its access keys land in the file.
+		expect(content).toContain("AWS_ACCESS_KEY_ID=cred-fake-0000");
+		expect(content).toMatch(/^AWS_SECRET_ACCESS_KEY=/m);
 	});
 });
 

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -131,6 +131,10 @@ export const pull = async (
 	// Reuse `neon dev`'s tiered resolver (neon.ts policy -> plan gate -> fetchEnv, else
 	// pullConfig -> fetchEnv). Unlike dev, an unresolved context or failure is surfaced —
 	// `env pull` is an explicit action, so it should error rather than write nothing.
+	// Credential secrets already on disk are reused as-is, not fetched (see `onCredential`).
+	// Track which so we can report them separately — a user who set them by hand (e.g. from a
+	// .env.example) shouldn't think `pull` refreshed them.
+	let reusedKeys: string[] = [];
 	const vars = await resolveNeonEnvVars({
 		cwd,
 		projectId: props.projectId,
@@ -139,6 +143,9 @@ export const pull = async (
 		...(props.apiKey ? { apiKey: props.apiKey } : {}),
 		...(props.apiHost ? { apiHost: props.apiHost } : {}),
 		...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+		onCredential: ({ source, keys }) => {
+			if (source === "reused") reusedKeys = keys;
+		},
 	});
 
 	const neonVars = pickNeonVars(vars);
@@ -156,13 +163,30 @@ export const pull = async (
 	const { written, removed } = mergeEnvFile(targetPath, neonVars, {
 		managedKeys: NEON_OWNED_ENV_KEYS,
 	});
-	log.info(
-		"Pulled %d Neon variable%s into %s: %s",
-		written.length,
-		written.length === 1 ? "" : "s",
-		targetPath,
-		written.join(", "),
-	);
+
+	// Split the written keys into those fetched from Neon and those reused as-is from disk.
+	const reused = written.filter((key) => reusedKeys.includes(key));
+	const fetched = written.filter((key) => !reused.includes(key));
+
+	if (fetched.length > 0) {
+		log.info(
+			"Pulled %d Neon variable%s into %s: %s",
+			fetched.length,
+			fetched.length === 1 ? "" : "s",
+			targetPath,
+			fetched.join(", "),
+		);
+	}
+	if (reused.length > 0) {
+		// No source named: a reused secret may come from process.env, not the file — so
+		// "as-is" rather than "from <targetPath>".
+		log.info(
+			"Reused %d existing value%s as-is (not fetched/verified from Neon): %s",
+			reused.length,
+			reused.length === 1 ? "" : "s",
+			reused.join(", "),
+		);
+	}
 	if (removed.length > 0) {
 		log.info(
 			"Removed %d stale Neon variable%s not enabled on this branch: %s",

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -20,6 +20,11 @@ export type DevEnvContext = {
 	 * `s3_secret_access_key` — are **reused** rather than re-minted on every run.
 	 */
 	env?: NodeJS.ProcessEnv;
+	/** Forwarded to {@link fetchEnv}'s `onCredential`; see there. Lets `env pull` report reused secrets. */
+	onCredential?: (info: {
+		source: "reused" | "minted";
+		keys: string[];
+	}) => void;
 };
 
 /** The API-targeting options every runtime call forwards from the context. */
@@ -242,6 +247,7 @@ const fetchAndProject = async (
 		branch: ctx.branchId as string,
 		...apiOptions(ctx),
 		...(ctx.env ? { env: ctx.env } : {}),
+		...(ctx.onCredential ? { onCredential: ctx.onCredential } : {}),
 	});
 	return toEntries(env);
 };

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -774,6 +774,39 @@ describe("branch storage + AI Gateway (Preview)", () => {
 		);
 	});
 
+	test("onCredential reports minted vs reused with the credential's env keys", async () => {
+		const { api, projectId } = seededFake();
+		const config = defineConfig({ preview: { buckets: { uploads: {} } } });
+		const calls: { source: "reused" | "minted"; keys: string[] }[] = [];
+
+		const first = await fetchEnv(config, {
+			api,
+			projectId,
+			branchId: "br-main",
+			onCredential: (info) => calls.push(info),
+		});
+		// Fresh branch: the credential is minted, reported under the AWS storage keys.
+		expect(calls).toEqual([
+			{
+				source: "minted",
+				keys: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+			},
+		]);
+
+		await fetchEnv(config, {
+			api,
+			projectId,
+			branchId: "br-main",
+			env: { ...process.env, ...toEntries(first) },
+			onCredential: (info) => calls.push(info),
+		});
+		// Second pull with the secrets on disk: reused verbatim, not minted again.
+		expect(calls[1]).toEqual({
+			source: "reused",
+			keys: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+		});
+	});
+
 	test("re-mints when a newly-enabled feature's secret is absent", async () => {
 		const { api, projectId } = seededFake();
 		// Persist a storage-only credential, then ask for a policy that also needs the AI Gateway

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -465,6 +465,18 @@ export interface FetchEnvOptions {
 	 * creation. Defaults to `process.env`; callers may layer values from `.env.local`.
 	 */
 	env?: NodeJS.ProcessEnv;
+	/**
+	 * Called when the branch credential (object storage / AI Gateway) is resolved, reporting
+	 * whether its secrets were `"reused"` (already in `env`, echoed back — no API call, no
+	 * validation) or freshly `"minted"`, plus the env-var `keys` they surface under (storage
+	 * keys and/or the gateway token, per what the policy enables). Lets `neon env pull` report
+	 * reused secrets without re-deriving which keys are credential-backed. Only fires when the
+	 * policy enables storage or the AI Gateway.
+	 */
+	onCredential?: (info: {
+		source: "reused" | "minted";
+		keys: string[];
+	}) => void;
 }
 
 /**
@@ -641,6 +653,20 @@ export async function fetchEnv<const C extends Config>(
 			needStorage: wantsStorage,
 			needApiToken: wantsAiGateway,
 		});
+		// Report the exact env keys the credential secrets land under, so callers don't have to
+		// re-derive "which keys are credential-backed" (and drift when that set changes here).
+		options.onCredential?.({
+			source: secrets.source,
+			keys: [
+				...(wantsStorage
+					? [
+							NEON_ENV_VAR_KEYS.storage.accessKeyId,
+							NEON_ENV_VAR_KEYS.storage.secretAccessKey,
+						]
+					: []),
+				...(wantsAiGateway ? [NEON_ENV_VAR_KEYS.aiGateway.apiKey] : []),
+			],
+		});
 		if (wantsStorage) {
 			const storage = await api.getProjectBranchStorage(
 				projectId,
@@ -720,6 +746,13 @@ async function resolveCredentialSecrets(args: {
 	accessKeyId: string;
 	secretAccessKey: string;
 	apiToken: string;
+	/**
+	 * Where the returned secrets came from: `"reused"` when every needed secret was already
+	 * present in the env source and echoed back verbatim (no API call, no validation),
+	 * `"minted"` when a fresh `user` credential was created. Surfaced so callers can report
+	 * that reused secrets were passed through untouched rather than fetched.
+	 */
+	source: "reused" | "minted";
 }> {
 	const sKeys = NEON_ENV_VAR_KEYS.storage;
 	const aKeys = NEON_ENV_VAR_KEYS.aiGateway;
@@ -732,6 +765,7 @@ async function resolveCredentialSecrets(args: {
 			accessKeyId: args.env[sKeys.accessKeyId] ?? "",
 			secretAccessKey: args.env[sKeys.secretAccessKey] ?? "",
 			apiToken: args.env[aKeys.apiKey] ?? "",
+			source: "reused",
 		};
 	}
 	const minted = await args.api.createCredential(
@@ -750,6 +784,7 @@ async function resolveCredentialSecrets(args: {
 		accessKeyId: minted.tokenId,
 		secretAccessKey: minted.s3SecretAccessKey,
 		apiToken: minted.apiToken,
+		source: "minted",
 	};
 }
 


### PR DESCRIPTION
## Problem
`neon env pull` listed storage / AI-gateway secrets (`AWS_ACCESS_KEY_ID`,
`AWS_SECRET_ACCESS_KEY`, `NEON_AI_GATEWAY_TOKEN`) under the same "Pulled N
variables" line as freshly-fetched vars. But those one-time secrets, when
already present, are reused from the existing `.env` — never re-fetched — so
the output looked like they'd been refreshed.

This bit most when copying a `.env.example` and running `pull`: the placeholder
secrets were reported as "Pulled" yet silently kept their example values,
leaving no signal that they weren't updated from Neon.

## Change
`fetchEnv` now reports how the branch credential was resolved via a new
`onCredential({ source, keys })` option. `env pull` uses it to split the output:

```
Pulled 5 Neon variables into .env: NEON_BRANCH, DATABASE_URL, ...
Reused 2 existing values as-is (not fetched/verified from Neon): AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
```

Reporting only — no change to what's minted, reused, or written.

## Test
Added coverage for the `onCredential` signal (`@neon/env`) and the pull output
split (CLI). Verified against a real gateway+storage branch.

This pull request and its description were written by Isaac.
