### PR TITLE
chore: release @neon/sdk@1.4.0

### DIFF
--- a/.changeset/lucky-pandas-explain.md
+++ b/.changeset/lucky-pandas-explain.md
@@ -1,8 +1,0 @@
----
-"@neon/sdk": minor
----
-
-Make errors diagnosable in production builds.
-
-- Error class names are now string literals rather than derived from the constructor, so they survive bundling. Previously every error surfaced as `s` or `r` in a minified consumer, which broke log reading and error-tracker grouping.
-- `NeonNetworkError` gains a `reason` field carrying the most specific transport reason available (an `errno` code such as `ECONNRESET`, otherwise the innermost non-empty message), and interpolates it into `message`. A DNS failure, a reset connection, and a timeout no longer share one indistinguishable string.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neon
 
+## 2.38.3
+
+### Patch Changes
+
+- Updated dependencies [630f102]
+  - @neon/sdk@1.4.0
+  - @neon/config@0.10.1
+  - @neon/config-runtime@0.10.1
+  - @neon/env@0.12.1
+
 ## 2.38.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon",
-  "version": "2.38.2",
+  "version": "2.38.3",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 0.10.1
+
+### Patch Changes
+
+- @neon/config@0.10.1
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 0.10.1
+
+### Patch Changes
+
+- Updated dependencies [630f102]
+  - @neon/sdk@1.4.0
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 0.12.1
+
+### Patch Changes
+
+- @neon/config@0.10.1
+
 ## 0.12.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "0.12.0",
+	"version": "0.12.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.38.3
+
+### Patch Changes
+
+- neon@2.38.3
+
 ## 2.38.2
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.38.2",
+  "version": "2.38.3",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @neon/sdk
 
+## 1.4.0
+
+### Minor Changes
+
+- 630f102: Make errors diagnosable in production builds.
+
+  - Error class names are now string literals rather than derived from the constructor, so they survive bundling. Previously every error surfaced as `s` or `r` in a minified consumer, which broke log reading and error-tracker grouping.
+  - `NeonNetworkError` gains a `reason` field carrying the most specific transport reason available (an `errno` code such as `ECONNRESET`, otherwise the innermost non-empty message), and interpolates it into `message`. A DNS failure, a reset connection, and a timeout no longer share one indistinguishable string.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Version bump + CHANGELOGs only. No source changes.

Releases [#355](https://github.com/neondatabase/neon-pkgs/pull/355), which makes SDK errors diagnosable in bundled builds: error class names are string literals so they survive minification, and `NeonNetworkError` carries a `reason` field naming the transport fault instead of collapsing every one onto the same sentence.

| Package | From | To | Why |
| --- | --- | --- | --- |
| `@neon/sdk` | 1.3.0 | 1.4.0 | the change |
| `neon` | 2.38.2 | 2.38.3 | dependent cascade |
| `neonctl` | 2.38.2 | 2.38.3 | dependent cascade |
| `@neon/config` | 0.10.0 | 0.10.1 | dependent cascade |
| `@neon/config-runtime` | 0.10.0 | 0.10.1 | dependent cascade |
| `@neon/env` | 0.12.0 | 0.12.1 | dependent cascade |

`pnpm-lock.yaml` is unchanged, as internal deps are `workspace:*`.

### Held back deliberately

`.changeset/olive-donkeys-repeat.md` (`neon-init` patch, the `--version` fix from #351) is **not** consumed here and stays pending. `packages/cli` pins `neon-init` to a published version rather than `workspace:*`, so bumping it rewrites that pin without updating the lockfile, and every publish dispatch then fails `--frozen-lockfile` until the throwaway-ref publish and lockfile-sync PR are done. That is unrelated to this release and would have blocked it. `neon-init` stays at 0.20.3 and its changeset is still queued for whoever cuts it next.