### PR TITLE
fix(cli): stop printing NEON_API_KEY in help output

### DIFF
--- a/.changeset/quiet-pandas-listen.md
+++ b/.changeset/quiet-pandas-listen.md
@@ -1,0 +1,22 @@
+---
+"neon": patch
+"neonctl": patch
+---
+
+`neon --help` no longer prints the value of `NEON_API_KEY`.
+
+The global `--api-key` option took its yargs `default` from `process.env.NEON_API_KEY`, and yargs renders an option's default into every help screen it produces. With the variable exported — the normal setup in CI and in any shell that sources a `.env` — the key was printed verbatim on `neon --help` and on every subcommand's `--help`, so it reached CI logs, terminal recordings, and pasted bug reports:
+
+```
+--api-key
+└────────────────>  API key [string] [default: "napi_1a2b3c…"]
+```
+
+Help now names the variable instead of its value:
+
+```
+--api-key
+└────────────────>  API key [string] [default: NEON_API_KEY]
+```
+
+Resolution is unchanged: `--api-key` wins, `NEON_API_KEY` is used when the flag is absent, and stored credentials are used when neither is set. The environment lookup moved out of the option default into a middleware that runs after help has been rendered.

--- a/packages/cli/src/help.test.ts
+++ b/packages/cli/src/help.test.ts
@@ -1,0 +1,121 @@
+import { fork } from "node:child_process";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { join } from "node:path";
+import express from "express";
+import { describe, expect, it } from "vitest";
+
+// A key shaped like a real one, so a regression can't pass by the value looking harmless.
+const API_KEY = "napi_test_help_leak_guard_9f3a1c";
+
+const runCli = async (
+	args: string[],
+	env: Record<string, string> = {},
+): Promise<{ code: number; stdout: string; stderr: string }> => {
+	let stdout = "";
+	let stderr = "";
+	const code = await new Promise<number>((resolve, reject) => {
+		const cp = fork(join(process.cwd(), "./dist/index.js"), args, {
+			stdio: "pipe",
+			env: {
+				PATH: `mocks/bin:${process.env.PATH}`,
+				CI: "true",
+				...env,
+			},
+		});
+		cp.stdout?.on("data", (c) => {
+			stdout += String(c);
+		});
+		cp.stderr?.on("data", (c) => {
+			stderr += String(c);
+		});
+		cp.on("error", reject);
+		cp.on("close", (exitCode) => {
+			resolve(exitCode ?? -1);
+		});
+	});
+	return { code, stdout, stderr };
+};
+
+// yargs prints every option's default into its help output, so resolving NEON_API_KEY in
+// the `--api-key` default printed the user's key on any help screen — including into CI
+// logs and pasted bug reports.
+describe("help output never prints secrets", () => {
+	it("does not print NEON_API_KEY in top-level help", async () => {
+		const { stdout, stderr } = await runCli(["--help"], {
+			NEON_API_KEY: API_KEY,
+		});
+
+		expect(stderr + stdout).not.toContain(API_KEY);
+		// The option itself is still documented, and says where it reads from.
+		expect(stderr).toContain("--api-key");
+		expect(stderr).toContain("NEON_API_KEY");
+	});
+
+	it("does not print NEON_API_KEY in subcommand help", async () => {
+		const { stdout, stderr } = await runCli(
+			["projects", "list", "--help"],
+			{ NEON_API_KEY: API_KEY },
+		);
+
+		expect(stderr + stdout).not.toContain(API_KEY);
+		expect(stderr).toContain("--api-key");
+	});
+
+	it("does not print an explicit --api-key value in help", async () => {
+		const { stdout, stderr } = await runCli([
+			"--api-key",
+			API_KEY,
+			"--help",
+		]);
+
+		expect(stderr + stdout).not.toContain(API_KEY);
+	});
+});
+
+// The key must still authenticate requests when it comes from the environment: moving the
+// lookup out of the yargs default is only correct if this keeps working.
+describe("NEON_API_KEY still authorizes requests", () => {
+	it("sends the environment key as the bearer token", async () => {
+		const authHeaders: (string | undefined)[] = [];
+		const app = express();
+		app.use((req, _res, next) => {
+			authHeaders.push(req.headers.authorization);
+			next();
+		});
+		app.get("/projects/shared", (_req, res) => {
+			res.json({ projects: [] });
+		});
+		app.get("/projects", (_req, res) => {
+			res.json({ projects: [] });
+		});
+		app.use((_req, res) => res.status(404).json({ message: "Not Found" }));
+
+		const server = await new Promise<Server>((resolve) => {
+			const s = app.listen(0, () => {
+				resolve(s);
+			});
+		});
+		const { port } = server.address() as AddressInfo;
+
+		try {
+			const { code } = await runCli(
+				[
+					"--api-host",
+					`http://localhost:${port}`,
+					"--no-analytics",
+					"projects",
+					"list",
+				],
+				{ NEON_API_KEY: API_KEY },
+			);
+
+			expect(code).toBe(0);
+			expect(authHeaders).toContain(`Bearer ${API_KEY}`);
+		} finally {
+			await new Promise<void>((resolve, reject) => {
+				server.close((err) => (err ? reject(err) : resolve()));
+			});
+		}
+	});
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,7 +24,7 @@ import {
 import { showHelp } from "./help.js";
 import { log } from "./log.js";
 import pkg from "./pkg.js";
-import { fillInArgs } from "./utils/middlewares.js";
+import { fillInArgs, resolveApiKeyFromEnv } from "./utils/middlewares.js";
 
 const NO_SUBCOMMANDS_VERBS = [
 	// `api <path>` has a handler but no subcommands (like `status`), so the
@@ -117,7 +117,12 @@ builder = builder
 			describe: "API key",
 			group: "Global options:",
 			type: "string",
-			default: process.env.NEON_API_KEY ?? "",
+			// The default must never be the value of NEON_API_KEY: yargs renders an
+			// option's default into every help screen, so that printed the user's key
+			// verbatim on `neon --help`. `resolveApiKeyFromEnv` reads the env var
+			// instead, and `defaultDescription` names it in help without its value.
+			default: "",
+			defaultDescription: "NEON_API_KEY",
 		},
 		apiClient: {
 			hidden: true,
@@ -146,6 +151,7 @@ builder = builder
 	.middleware((args) => {
 		fillInArgs(args);
 	}, true)
+	.middleware(resolveApiKeyFromEnv, true)
 	.middleware(initAnalyticsClientMiddleware, true)
 	.help(false)
 	.group("help", "Global options:")

--- a/packages/cli/src/utils/middlewares.ts
+++ b/packages/cli/src/utils/middlewares.ts
@@ -1,4 +1,20 @@
 /**
+ * Resolves `--api-key` from `NEON_API_KEY` when the flag is absent, leaving it an
+ * empty string when neither is set.
+ *
+ * This cannot be expressed as the option's yargs `default`, because yargs prints
+ * defaults in help output and would print the key itself.
+ */
+export const resolveApiKeyFromEnv = (args: Record<string, unknown>) => {
+	if (typeof args.apiKey === "string" && args.apiKey !== "") {
+		return;
+	}
+	const fromEnv = process.env.NEON_API_KEY ?? "";
+	args.apiKey = fromEnv;
+	args["api-key"] = fromEnv;
+};
+
+/**
  * This middleware is needed to fill in the args for nested objects,
  * so that required arguments would work
  * otherwise yargs just throws an error


### PR DESCRIPTION
## Problem

With `NEON_API_KEY` exported, every help screen printed the key:

```
$ NEON_API_KEY=napi_fake_secret_abc123 neon --help
...
--api-key
└────────────────>  API key [string] [default: "napi_fake_secret_abc123"]
```

It affects `neon --help`, `neonctl --help`, and every subcommand's `--help`, because
`--api-key` is a global option. The environments where the variable is exported are exactly
the ones where output is captured: CI logs, `set -x` traces, terminal recordings, and the
`--help` output people paste into bug reports. A key printed there is a key that has to be
rotated.

## Diagnosis

`--api-key` read the environment in its yargs `default`:

```ts
"api-key": {
    describe: "API key",
    type: "string",
    default: process.env.NEON_API_KEY ?? "",
},
```

yargs renders an option's `default` into the help text it generates, and `showHelp` in
`packages/cli/src/help.ts` restyles that string without inspecting it. The value therefore
reaches the terminal through the ordinary help path — no error, no debug flag, no verbose
mode required.

The option default is also the wrong place for the lookup on its own terms: it is evaluated
at module load, for every invocation, including the ones that never authenticate.

Nothing else in the CLI leaks a secret this way. `--api-host`, `--oauth-host`, `--client-id`,
and `--spec-url` also read the environment in their defaults, but none of them holds a
credential, and `--password` / `--oauth-client-secret` have no environment defaults at all.
Analytics sends only `output`, never `apiKey`.

## The fix

The environment lookup moved into a middleware, and `defaultDescription` names the variable
in help without its value:

```ts
"api-key": {
    describe: "API key",
    type: "string",
    default: "",
    defaultDescription: "NEON_API_KEY",
},
```

```ts
export const resolveApiKeyFromEnv = (args: Record<string, unknown>) => {
    if (typeof args.apiKey === "string" && args.apiKey !== "") {
        return;
    }
    const fromEnv = process.env.NEON_API_KEY ?? "";
    args.apiKey = fromEnv;
    args["api-key"] = fromEnv;
};
```

It is registered with `applyBeforeValidation: true`, so it runs before `ensureAuth` and
before any command handler — and after the help middleware has already written and exited.

`default: ""` stays because dropping it widens the inferred argv type to
`string | undefined` and breaks `ensureAuth`'s `apiKey: string` contract; the empty string is
the same value the option resolved to before when the variable was unset.

## Interface

Help output, the only user-visible change:

```
# before, with NEON_API_KEY set
--api-key
└────────────────>  API key [string] [default: "napi_fake_secret_abc123"]

# after
--api-key
└────────────────>  API key [string] [default: NEON_API_KEY]
```

Nothing else changes. Precedence is still `--api-key` > `NEON_API_KEY` > stored credentials
in `--config-dir`, an explicit flag still wins over the environment, and the 401 handling that
distinguishes a user-supplied key from a stored token is untouched.

## Verification

Base commit `86764d3` on `main`.

- Reproduced against the built binary before the change and confirmed the fix after:
  `NEON_API_KEY=… node dist/cli.js --help` and `… projects list --help`.
- Reverted the option default temporarily and re-ran the new tests: the two
  environment-variable cases fail, the other two pass. The guard fails for the right reason.
- `pnpm --filter neon lint` (tsc + biome) and the full package suite: 3153 passed, 6 skipped,
  115 files.

New tests in `packages/cli/src/help.test.ts`, spawning the built CLI:

- `NEON_API_KEY` never appears in top-level help, which still documents `--api-key`
- `NEON_API_KEY` never appears in subcommand help (`projects list --help`)
- an explicit `--api-key <value> --help` does not echo the value either
- a command run with only `NEON_API_KEY` set still sends `Authorization: Bearer <key>` and
  exits 0 — the guard that the moved lookup still works

Not verified against the live API: this needs no network, and the live e2e suite passes
`--api-key` as a flag, which this does not change.

## For your attention

- **The CLI reference on neon.com is generated from help output.**
  `scripts/docs-checks/neonctl/refresh.js` in `neondatabase/website` regenerates it from a
  release, so the published reference will change from `[default: ""]` to
  `[default: NEON_API_KEY]` for this option. The generator runs without `NEON_API_KEY` set,
  so no key was ever published there.
- **`bootstrap` still passes the key to a child process as an argument.**
  `packages/cli/src/commands/bootstrap.ts` pushes `--api-key <key>` onto the argv of the
  `neon-init` subprocess, which makes it readable in `ps` output for the life of that process.
  That is a different exposure class from printing to a terminal and is left alone here.