### PR TITLE
chore: release neon-init@0.20.4, neon@2.38.5, neonctl@2.38.5

### DIFF
--- a/.changeset/olive-donkeys-repeat.md
+++ b/.changeset/olive-donkeys-repeat.md
@@ -1,5 +1,0 @@
----
-"neon-init": patch
----
-
-`neon-init --version` now prints the installed version instead of `unknown`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neon
 
+## 2.38.5
+
+### Patch Changes
+
+- Updated dependencies [fac9ab2]
+  - neon-init@0.20.4
+
 ## 2.38.4
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon",
-  "version": "2.38.4",
+  "version": "2.38.5",
   "description": "CLI tool for Neon Serverless Postgres",
   "keywords": [
     "neon",
@@ -64,7 +64,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.20.3",
+    "neon-init": "0.20.4",
     "open": "^10.2.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/packages/init/CHANGELOG.md
+++ b/packages/init/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon-init
 
+## 0.20.4
+
+### Patch Changes
+
+- fac9ab2: `neon-init --version` now prints the installed version instead of `unknown`.
+
 ## 0.20.3
 
 ### Patch Changes

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-init",
-	"version": "0.20.3",
+	"version": "0.20.4",
 	"description": "Initialize Neon projects",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 2.38.5
+
+### Patch Changes
+
+- neon@2.38.5
+
 ## 2.38.4
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.38.4",
+  "version": "2.38.5",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.20.3
-        version: 0.20.3
+        specifier: 0.20.4
+        version: 0.20.4
       open:
         specifier: ^10.2.0
         version: 10.2.0
@@ -3322,8 +3322,8 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
-  neon-init@0.20.3:
-    resolution: {integrity: sha512-LYdL9tGwLm81O48fphN0YyXQq4U2wBqJ/tO3I0UJNjWw7h6AhZSWuOukM0IrcA+q5wovPU/LoSoCdhV9Rf4vWQ==}
+  neon-init@0.20.4:
+    resolution: {integrity: sha512-oqmAT8pqmjohKCrtBxWyDuQROj8lYIde/jEhz/Ya5MuRdZrdVWzJk8lLNIS2Si3bRSsVJykX1EaKIkR2PeUu6w==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -7080,7 +7080,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  neon-init@0.20.3:
+  neon-init@0.20.4:
     dependencies:
       '@clack/core': 0.4.2
       '@clack/prompts': 0.10.1


### PR DESCRIPTION
`changeset version` output for the `neon-init --version` fix (#351), whose changeset had been queued through three releases. No source changes.

## Bumped

| Package | Old | New | Why |
|---|---|---|---|
| `neon-init` | 0.20.3 | 0.20.4 | The queued changeset |
| `neon` | 2.38.4 | 2.38.5 | Dependent cascade — the CLI pins `neon-init` |
| `neonctl` | 2.38.4 | 2.38.5 | Fixed group with `neon` |

## This PR is green, and the last one of its kind was not

`packages/cli` pins `neon-init` to a published version rather than `workspace:*`, so `changeset version` rewrites the pin without touching `pnpm-lock.yaml`. Every job then fails in under a minute on `pnpm install --frozen-lockfile`, which is what happened to #348: it merged with all eleven checks red, and #349 followed to repair `main`.

`pnpm install --lockfile-only` cannot fix that at bump time, because the version it needs to resolve is not on npm yet. So `neon-init@0.20.4` was published first, from a throwaway ref (`chore/tmp-publish-neon-init`) carrying these same bumps with the CLI pin held at `0.20.3` so its lockfile stayed consistent. That ref published only `neon-init` and is never merged; it is deleted once this lands.

With `neon-init@0.20.4` on npm, the lockfile resolves, and the sync is the second commit here rather than a follow-up PR. The whole diff is five lines:

```
neon-init:
-  specifier: 0.20.3
-  version: 0.20.3
+  specifier: 0.20.4
+  version: 0.20.4
```

## Publish backlog after this merges

`neon-init@0.20.4` is already live. Remaining dispatches, CLI last:

| Package | npm | main |
|---|---|---|
| `neon` | 2.38.4 | 2.38.5 |
| `neonctl` | 2.38.4 | 2.38.5 |

## For your attention

The ordering above is a workaround for the pin, not a fix. Moving `packages/cli` to `neon-init: workspace:*` like every other internal dependency removes the catch-22 permanently — `AGENTS.md` already records it as the planned fix. It is a source change, so it is not in this release PR.