### PR TITLE
Stop suggesting the removed `neonctl` command

### DIFF
--- a/.changeset/neon-in-user-facing-strings.md
+++ b/.changeset/neon-in-user-facing-strings.md
@@ -1,0 +1,7 @@
+---
+"neon": patch
+"@neon/env": patch
+"@neon/config": patch
+---
+
+Emit `neon` instead of the removed `neonctl` binary name in help text, error hints, and `--agent` command templates, so suggested commands are runnable. When invoked via the `neonctl` compat package the commands still read `neonctl`.

--- a/packages/cli/src/commands/__snapshots__/link.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/link.test.ts.snap
@@ -13,7 +13,7 @@ exports[`link > --agent mode > with full project details creates project and emi
     "id": "new-project-789012",
     "name": "test_project"
   },
-  "message": "Created project new-project-789012 (\\"test_project\\") in aws-us-east-2 and linked <TMP>/agent_linked_create/.neon on branch test_branch. Skipped env pull (--no-env-pull); run \`neonctl env pull\` later, or inject env at runtime with \`neon-env run -- <your dev command>\`."
+  "message": "Created project new-project-789012 (\\"test_project\\") in aws-us-east-2 and linked <TMP>/agent_linked_create/.neon on branch test_branch. Skipped env pull (--no-env-pull); run \`neon env pull\` later, or inject env at runtime with \`neon-env run -- <your dev command>\`."
 }
 "
 `;
@@ -44,7 +44,7 @@ exports[`link > --agent mode > with no flags emits needs_org JSON 1`] = `
       "name": "Organization 3"
     }
   ],
-  "next_command_template": "neonctl link --agent --org-id <org_id>"
+  "next_command_template": "neon link --agent --org-id <org_id>"
 }
 "
 `;
@@ -69,9 +69,9 @@ exports[`link > --agent mode > with only --org-id emits needs_project JSON 1`] =
   ],
   "create_option": {
     "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
-    "next_command_template": "neonctl link --agent --org-id org-2 --project-name <name> --region-id <region_id>"
+    "next_command_template": "neon link --agent --org-id org-2 --project-name <name> --region-id <region_id>"
   },
-  "next_command_template": "neonctl link --agent --org-id org-2 --project-id <project_id>"
+  "next_command_template": "neon link --agent --org-id org-2 --project-id <project_id>"
 }
 "
 `;
@@ -87,7 +87,7 @@ exports[`link > --agent mode > with only --project-id infers the org and emits l
   "project": {
     "id": "proj-in-org"
   },
-  "message": "Linked <TMP>/agent_linked_infer/.neon to project proj-in-org (org org-7). No branch pinned — run \`neonctl checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars."
+  "message": "Linked <TMP>/agent_linked_infer/.neon to project proj-in-org (org org-7). No branch pinned — run \`neon checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars."
 }
 "
 `;
@@ -110,7 +110,7 @@ exports[`link > --agent mode > with org+project emits linked JSON (no branch) an
   "project": {
     "id": "test"
   },
-  "message": "Linked <TMP>/agent_linked_existing/.neon to project test (org org-2). No branch pinned — run \`neonctl checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars."
+  "message": "Linked <TMP>/agent_linked_existing/.neon to project test (org org-2). No branch pinned — run \`neon checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars."
 }
 "
 `;
@@ -148,7 +148,7 @@ exports[`link > --agent mode > with org+projectName but no region emits needs_pr
       "default": false
     }
   ],
-  "next_command_template": "neonctl link --agent --org-id org-2 --project-name demo --region-id <region_id>"
+  "next_command_template": "neon link --agent --org-id org-2 --project-name demo --region-id <region_id>"
 }
 "
 `;
@@ -196,7 +196,7 @@ exports[`link > gitignore scaffolding > appends .neon to an existing .gitignore 
   orgId:     org-2
   projectId: test
 
-No branch pinned. Run \`neonctl checkout <branch>\` to pin a branch and pull its env vars.
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
 
 "
 `;
@@ -206,7 +206,7 @@ exports[`link > gitignore scaffolding > appends .neon to an existing .gitignore 
   orgId:     org-2
   projectId: test
 
-No branch pinned. Run \`neonctl checkout <branch>\` to pin a branch and pull its env vars.
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
 
 "
 `;
@@ -216,7 +216,7 @@ exports[`link > gitignore scaffolding > creates a .gitignore listing .neon next 
   orgId:     org-2
   projectId: test
 
-No branch pinned. Run \`neonctl checkout <branch>\` to pin a branch and pull its env vars.
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
 
 "
 `;
@@ -273,7 +273,7 @@ exports[`link > non-interactive flag mode > link --params JSON behaves like flag
   orgId:     org-2
   projectId: test
 
-No branch pinned. Run \`neonctl checkout <branch>\` to pin a branch and pull its env vars.
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
 
 "
 `;
@@ -290,7 +290,7 @@ exports[`link > non-interactive flag mode > link --project-id alone infers the o
   orgId:     org-7
   projectId: proj-in-org
 
-No branch pinned. Run \`neonctl checkout <branch>\` to pin a branch and pull its env vars.
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
 
 "
 `;
@@ -325,7 +325,7 @@ exports[`link > non-interactive flag mode > link to existing project writes org+
   orgId:     org-2
   projectId: test
 
-No branch pinned. Run \`neonctl checkout <branch>\` to pin a branch and pull its env vars.
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
 
 "
 `;
@@ -367,9 +367,9 @@ exports[`link > org-scoped API key behavior > agent mode auto-detects org from e
   ],
   "create_option": {
     "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
-    "next_command_template": "neonctl link --agent --org-id org-detected-99887766 --project-name <name> --region-id <region_id>"
+    "next_command_template": "neon link --agent --org-id org-detected-99887766 --project-name <name> --region-id <region_id>"
   },
-  "next_command_template": "neonctl link --agent --org-id org-detected-99887766 --project-id <project_id>"
+  "next_command_template": "neon link --agent --org-id org-detected-99887766 --project-id <project_id>"
 }
 "
 `;
@@ -415,7 +415,7 @@ exports[`link > org-scoped API key behavior > agent mode falls back to static re
       "default": false
     }
   ],
-  "next_command_template": "neonctl link --agent --org-id org-detected-99887766 --project-name whatever --region-id <region_id>"
+  "next_command_template": "neon link --agent --org-id org-detected-99887766 --project-name whatever --region-id <region_id>"
 }
 "
 `;
@@ -425,7 +425,7 @@ exports[`link > org-scoped API key behavior > agent mode with no orgs available 
   "status": "needs_org",
   "instruction": "This Neon API key is organization-scoped, so the CLI cannot list the user's organizations and no existing project was found to auto-detect the org ID. Ask the user for their Neon organization ID (visible in the Neon Console under the org's Settings page, formatted like \`org-bitter-breeze-12345678\`) and re-run the next_command_template with that --org-id.",
   "options": [],
-  "next_command_template": "neonctl link --agent --org-id <org_id>"
+  "next_command_template": "neon link --agent --org-id <org_id>"
 }
 "
 `;
@@ -435,7 +435,7 @@ exports[`link > overwrites an existing .neon when re-linking non-interactively 1
   orgId:     org-2
   projectId: test
 
-No branch pinned. Run \`neonctl checkout <branch>\` to pin a branch and pull its env vars.
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
 
 "
 `;

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -18,6 +18,7 @@ import { credentialInputs } from "../_shared/auth_selection.js";
 import { isCi } from "../env.js";
 import { log } from "../log.js";
 import type { CommonProps } from "../types.js";
+import { getCliName } from "../utils/cli_name.js";
 import {
 	detectPackageManager,
 	installedPackageManagers,
@@ -142,8 +143,7 @@ export const builder = (argv: yargs.Argv) =>
 				default: true,
 			},
 			link: {
-				describe:
-					"Run `neon link` in the scaffolded directory after installing. In interactive mode this is offered as a prompt; use --no-link to skip without being asked.",
+				describe: `Run \`${getCliName()} link\` in the scaffolded directory after installing. In interactive mode this is offered as a prompt; use --no-link to skip without being asked.`,
 				type: "boolean",
 				default: true,
 			},
@@ -292,7 +292,7 @@ const resolveTargetDir = async (
 		}
 		if (!interactive) {
 			throw new Error(
-				'No target directory given. Pass one, e.g. `neon bootstrap my-app` (or "." for the current directory).',
+				`No target directory given. Pass one, e.g. \`${getCliName()} bootstrap my-app\` (or "." for the current directory).`,
 			);
 		}
 		const { value } = await prompts({
@@ -392,13 +392,13 @@ const runPostScaffoldSteps = async (
 	if (props.link) {
 		if (!installed && hasNeonConfig(targetDir)) {
 			log.info(
-				"Skipping the Neon link step: `neon link` reads this project's neon.ts " +
+				`Skipping the Neon link step: \`${getCliName()} link\` reads this project's neon.ts ` +
 					`to pull env vars, which needs its dependencies. Run \`${pm} install\`, ` +
-					"then `neon link`.",
+					`then \`${getCliName()} link\`.`,
 			);
 		} else if (
 			await confirm(
-				"Link this project to a Neon project now? (runs neon link)",
+				`Link this project to a Neon project now? (runs ${getCliName()} link)`,
 			)
 		) {
 			await runNeonLink(props, targetDir);
@@ -564,7 +564,7 @@ const printNextSteps = (
 		log.info("  %s install", pm);
 	}
 	if (opts.suggestLink) {
-		log.info("  neon link");
+		log.info(`  ${getCliName()} link`);
 	}
 	log.info("  See the README to run it.");
 	log.info("");
@@ -601,7 +601,7 @@ const runAgent = async (props: BootstrapProps): Promise<void> => {
 				description: template.description,
 				...(template.services ? { services: template.services } : {}),
 			})),
-			next_command_template: `neon bootstrap --agent ${
+			next_command_template: `${getCliName()} bootstrap --agent ${
 				props.directory ? shellArg(props.directory) : "<directory>"
 			} --template <template_id>`,
 		});
@@ -622,7 +622,7 @@ const runAgent = async (props: BootstrapProps): Promise<void> => {
 			status: "needs_directory",
 			instruction:
 				'Ask the user which directory to scaffold into (use "." for the current directory), then re-run the next_command_template with it.',
-			next_command_template: `neon bootstrap --agent <directory> --template ${shellArg(
+			next_command_template: `${getCliName()} bootstrap --agent <directory> --template ${shellArg(
 				template.id,
 			)}`,
 		});
@@ -660,7 +660,7 @@ const runAgent = async (props: BootstrapProps): Promise<void> => {
 				action: "link_neon_project",
 				instruction:
 					"Ask the user whether to link the project to a Neon project now. This runs the link state machine — follow its JSON output for the next step.",
-				command: `${runIn}neon link --agent`,
+				command: `${runIn}${getCliName()} link --agent`,
 			},
 		],
 		message: `Scaffolded "${template.title}" (${filesWritten} files) into ${dir}. Offer the next_steps to the user: install dependencies, initialize git, then link a Neon project.`,

--- a/packages/cli/src/commands/checkout.test.ts
+++ b/packages/cli/src/commands/checkout.test.ts
@@ -214,7 +214,7 @@ describe("checkout", () => {
 		await testCliCommand(["checkout", "main", "--context-file", ctx], {
 			mockDir: "checkout_no_project",
 			code: 1,
-			stderr: "ERROR: Could not determine which Neon project to check out a branch from. Provide one via the --project-id flag or a .neon file (created by `neonctl link` / `neonctl set-context`).",
+			stderr: "ERROR: Could not determine which Neon project to check out a branch from. Provide one via the --project-id flag or a .neon file (created by `neon link` / `neon set-context`).",
 		});
 		removeFile(ctx);
 	});
@@ -279,7 +279,7 @@ describe("checkout", () => {
 			["checkout", "--project-id", "test", "--context-file", ctx],
 			{
 				code: 1,
-				stderr: "ERROR: No branch specified. Pass a branch name or id (e.g. `neonctl checkout main`), or run interactively to pick one from a list.",
+				stderr: "ERROR: No branch specified. Pass a branch name or id (e.g. `neon checkout main`), or run interactively to pick one from a list.",
 			},
 		);
 		removeFile(ctx);

--- a/packages/cli/src/commands/checkout.ts
+++ b/packages/cli/src/commands/checkout.ts
@@ -12,6 +12,7 @@ import {
 	createBranch,
 	pickBranchInteractively,
 } from "../utils/branch_picker.js";
+import { getCliName } from "../utils/cli_name.js";
 import { fillSingleProject } from "../utils/enrichers.js";
 import { looksLikeBranchId } from "../utils/formats.js";
 import {
@@ -151,8 +152,8 @@ export const handler = async (props: CheckoutProps) => {
 		throw new Error(
 			[
 				`Branch ${branchName} (${branchId}) was created and checked out, but applying neon.ts to it failed: ${failure}`,
-				"The branch is usable but does not match the policy, and `neonctl checkout` never reconciles a branch that already exists.",
-				`Fix the cause above, then run \`neonctl deploy --update-existing\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`neonctl branches delete ${branchName}\` then \`neonctl checkout ${branchName}\`.`,
+				`The branch is usable but does not match the policy, and \`${getCliName()} checkout\` never reconciles a branch that already exists.`,
+				`Fix the cause above, then run \`${getCliName()} deploy --update-existing\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`${getCliName()} branches delete ${branchName}\` then \`${getCliName()} checkout ${branchName}\`.`,
 			].join("\n"),
 		);
 	}
@@ -217,7 +218,7 @@ const resolveBranchId = async (
 		const picked = await pickBranchInteractively(branches, {
 			message: "Which branch would you like to check out?",
 			nonInteractiveMessage:
-				"No branch specified. Pass a branch name or id (e.g. `neonctl checkout main`), " +
+				`No branch specified. Pass a branch name or id (e.g. \`${getCliName()} checkout main\`), ` +
 				"or run interactively to pick one from a list.",
 		});
 		if (picked.kind === "existing") {
@@ -387,7 +388,7 @@ const resolveProjectId = async (props: CheckoutProps): Promise<string> => {
 	const missingProjectMessage =
 		"Could not determine which Neon project to check out a branch from. " +
 		"Provide one via the --project-id flag " +
-		"or a .neon file (created by `neonctl link` / `neonctl set-context`).";
+		`or a .neon file (created by \`${getCliName()} link\` / \`${getCliName()} set-context\`).`;
 
 	if (isCi() || !process.stdout.isTTY) {
 		throw new Error(missingProjectMessage);
@@ -398,8 +399,7 @@ const resolveProjectId = async (props: CheckoutProps): Promise<string> => {
 	const { runLink } = await prompts({
 		type: "confirm",
 		name: "runLink",
-		message:
-			"Run `neonctl link` in the current folder to pick a project now?",
+		message: `Run \`${getCliName()} link\` in the current folder to pick a project now?`,
 		initial: true,
 	});
 
@@ -420,7 +420,7 @@ const resolveProjectId = async (props: CheckoutProps): Promise<string> => {
 	const linked = readContextFile(props.contextFile);
 	if (!linked.projectId) {
 		throw new Error(
-			"Linking did not produce a project id. Re-run `neonctl checkout` once the directory is linked.",
+			`Linking did not produce a project id. Re-run \`${getCliName()} checkout\` once the directory is linked.`,
 		);
 	}
 	// Carry the freshly-linked org id forward so the merge below keeps it.

--- a/packages/cli/src/commands/config.current_branch.test.ts
+++ b/packages/cli/src/commands/config.current_branch.test.ts
@@ -66,9 +66,7 @@ describe("config status --current-branch (offline, end to end)", () => {
 				// grep-style: "no branch pinned" is a non-zero "no result", so a shell
 				// prompt can guard on it directly. Empty stdout; hint on stderr.
 				code: 1,
-				stderr: expect.stringContaining(
-					"Run `neonctl checkout <branch>`",
-				),
+				stderr: expect.stringContaining("Run `neon checkout <branch>`"),
 			},
 		);
 	});

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -484,7 +484,7 @@ describe("config commands", () => {
 			// stdout stays empty; the hint goes to stderr only.
 			expect(stdoutChunks.join("")).toBe("");
 			expect(stderrChunks.join("")).toContain(
-				"Run `neonctl checkout <branch>`",
+				"Run `neon checkout <branch>`",
 			);
 			// Non-zero exit (grep-style) so a shell prompt can guard on it directly.
 			expect(process.exitCode).toBe(1);

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -42,6 +42,7 @@ import {
 	warnAiGateway,
 } from "../utils/ai_gateway_notice.js";
 import { announceTargetBranch } from "../utils/branch_notice.js";
+import { getCliName } from "../utils/cli_name.js";
 import {
 	renderAppliedChanges,
 	renderBranchSettingConflicts,
@@ -573,7 +574,7 @@ export const status = async (props: ConfigProps): Promise<void> => {
 			// No branch pinned: hint on stderr and exit non-zero (grep-style) so a prompt's
 			// `when` hides the segment cleanly instead of rendering a bare icon.
 			log.info(
-				"No branch pinned. Run `neonctl checkout <branch>` to pin a branch and pull its env vars.",
+				`No branch pinned. Run \`${getCliName()} checkout <branch>\` to pin a branch and pull its env vars.`,
 			);
 			process.exitCode = 1;
 		}

--- a/packages/cli/src/commands/data_api.ts
+++ b/packages/cli/src/commands/data_api.ts
@@ -7,6 +7,7 @@ import type yargs from "yargs";
 import { isNeonApiError, retryOnLock } from "../api.js";
 import { log } from "../log.js";
 import type { BranchScopeProps } from "../types.js";
+import { getCliName } from "../utils/cli_name.js";
 import {
 	branchIdFromProps,
 	fillSingleProject,
@@ -307,7 +308,7 @@ const update = async (
 		} catch (err: unknown) {
 			if (isNeonApiError(err) && err.status === 404) {
 				throw new Error(
-					`Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
+					`Data API is not provisioned for ${database} on branch ${branchId}. Run \`${getCliName()} data-api create\` first.`,
 				);
 			}
 			throw err;
@@ -335,7 +336,7 @@ const update = async (
 	} catch (err: unknown) {
 		if (isNeonApiError(err) && err.status === 404) {
 			throw new Error(
-				`Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
+				`Data API is not provisioned for ${database} on branch ${branchId}. Run \`${getCliName()} data-api create\` first.`,
 			);
 		}
 		throw err;
@@ -363,7 +364,7 @@ const refreshSchema = async (props: DataApiProps): Promise<void> => {
 	} catch (err: unknown) {
 		if (isNeonApiError(err) && err.status === 404) {
 			throw new Error(
-				`Data API is not provisioned for ${database} on branch ${branchId}. Run \`neonctl data-api create\` first.`,
+				`Data API is not provisioned for ${database} on branch ${branchId}. Run \`${getCliName()} data-api create\` first.`,
 			);
 		}
 		throw err;

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -11,6 +11,7 @@ import { log } from "../log.js";
 import type { BranchScopeProps } from "../types.js";
 import { warnAiGateway } from "../utils/ai_gateway_notice.js";
 import { announceTargetBranch } from "../utils/branch_notice.js";
+import { getCliName } from "../utils/cli_name.js";
 import { fillSingleProject, resolveBranchRef } from "../utils/enrichers.js";
 
 export type EnvPullProps = BranchScopeProps & {
@@ -31,7 +32,7 @@ export const describe = "Manage a branch's Neon env variables locally";
  * eagerly: an explicit `neonctl env pull`, or runtime injection via `neon-env run`.
  */
 export const ENV_PULL_SKIPPED_HINT =
-	"Skipped env pull (--no-env-pull). Run `neonctl env pull` to write this branch’s env vars " +
+	`Skipped env pull (--no-env-pull). Run \`${getCliName()} env pull\` to write this branch’s env vars ` +
 	"(DATABASE_URL, …) into a local .env, or inject them at runtime with `neon-env run -- <your dev command>`.";
 export const builder = (argv: yargs.Argv) =>
 	argv
@@ -261,7 +262,7 @@ export const autoPullEnvAfterPin = async (
 		const message = err instanceof Error ? err.message : String(err);
 		log.warning(
 			"Branch pinned, but pulling its Neon env vars failed: %s\n" +
-				"Run `neonctl env pull` once resolved (e.g. `neonctl deploy` if a declared service " +
+				`Run \`${getCliName()} env pull\` once resolved (e.g. \`${getCliName()} deploy\` if a declared service ` +
 				"is missing), or inject them at runtime with `neon-env run -- <your dev command>`.",
 			message,
 		);
@@ -289,11 +290,11 @@ export const renderAgentPullNote = (result: AutoPullResult): string => {
 			return " No Neon env vars to pull for this branch yet.";
 		case "skipped":
 			return (
-				" Skipped env pull (--no-env-pull); run `neonctl env pull` later, " +
+				` Skipped env pull (--no-env-pull); run \`${getCliName()} env pull\` later, ` +
 				"or inject env at runtime with `neon-env run -- <your dev command>`."
 			);
 		case "failed":
-			return ` Could not pull env vars (${result.message}); run \`neonctl env pull\` once resolved.`;
+			return ` Could not pull env vars (${result.message}); run \`${getCliName()} env pull\` once resolved.`;
 	}
 };
 

--- a/packages/cli/src/commands/functions.test.ts
+++ b/packages/cli/src/commands/functions.test.ts
@@ -38,7 +38,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function nowaitfunc. " +
-					"INFO: Check status with: neonctl function get nowaitfunc " +
+					"INFO: Check status with: neon function get nowaitfunc " +
 					"--project-id test-project-123456 --branch br-main-branch-123456",
 			},
 		);
@@ -393,7 +393,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function stuckstart. " +
-					"INFO: Check status with: neonctl function get stuckstart " +
+					"INFO: Check status with: neon function get stuckstart " +
 					"--project-id test-project-123456 --branch br-main-branch-123456 " +
 					"ERROR: Timed out waiting for the deployment of stuckstart to start. " +
 					"It may still be in progress.",
@@ -426,7 +426,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function stuckbuild. " +
-					"INFO: Check status with: neonctl function get stuckbuild " +
+					"INFO: Check status with: neon function get stuckbuild " +
 					"--project-id test-project-123456 --branch br-main-branch-123456 " +
 					"ERROR: Timed out waiting for function deployment stuckbuild/1 to finish. " +
 					"It may still be building.",
@@ -462,7 +462,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function envfunc. " +
-					"INFO: Check status with: neonctl function get envfunc " +
+					"INFO: Check status with: neon function get envfunc " +
 					"--project-id test-project-123456 --branch br-main-branch-123456",
 			},
 		);
@@ -617,7 +617,7 @@ describe("functions", () => {
 				code: 1,
 				stderr:
 					"ERROR: Provide at least one option to deploy, e.g. --src or --env. " +
-					"See: neonctl function deploy --help.",
+					"See: neon function deploy --help.",
 			},
 		);
 	});
@@ -651,7 +651,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function tsoverjs. " +
-					"INFO: Check status with: neonctl function get tsoverjs " +
+					"INFO: Check status with: neon function get tsoverjs " +
 					"--project-id test-project-123456 --branch br-main-branch-123456",
 			},
 		);
@@ -684,7 +684,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function mjsoverjs. " +
-					"INFO: Check status with: neonctl function get mjsoverjs " +
+					"INFO: Check status with: neon function get mjsoverjs " +
 					"--project-id test-project-123456 --branch br-main-branch-123456",
 			},
 		);
@@ -717,7 +717,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function jsonly. " +
-					"INFO: Check status with: neonctl function get jsonly " +
+					"INFO: Check status with: neon function get jsonly " +
 					"--project-id test-project-123456 --branch br-main-branch-123456",
 			},
 		);
@@ -753,7 +753,7 @@ describe("functions", () => {
 				},
 				stderr:
 					"INFO: Function deployment triggered for function srcfile. " +
-					"INFO: Check status with: neonctl function get srcfile " +
+					"INFO: Check status with: neon function get srcfile " +
 					"--project-id test-project-123456 --branch br-main-branch-123456",
 			},
 		);

--- a/packages/cli/src/commands/functions.ts
+++ b/packages/cli/src/commands/functions.ts
@@ -13,6 +13,7 @@ import {
 } from "../functions_api.js";
 import { log } from "../log.js";
 import type { BranchScopeProps } from "../types.js";
+import { getCliName } from "../utils/cli_name.js";
 import { branchIdFromProps, fillSingleProject } from "../utils/enrichers.js";
 import { bundleEntry } from "../utils/esbuild.js";
 import { zipBundle } from "../utils/zip.js";
@@ -220,7 +221,7 @@ const parseEnv = (entries: string[] | undefined): string | undefined => {
 };
 
 const statusHint = (slug: string, projectId: string, branchId: string) =>
-	`Check status with: neonctl function get ${slug} --project-id ${projectId} --branch ${branchId}`;
+	`Check status with: ${getCliName()} function get ${slug} --project-id ${projectId} --branch ${branchId}`;
 
 // Emit the resolved deployment together with the function's invocation_url, so the
 // deploy output shows where the function is reachable (not just the deployment id).
@@ -262,7 +263,7 @@ const deploy = async (props: DeployProps) => {
 	if (!hasOption) {
 		throw new Error(
 			"Provide at least one option to deploy, e.g. --src or --env. " +
-				"See: neonctl function deploy --help.",
+				`See: ${getCliName()} function deploy --help.`,
 		);
 	}
 

--- a/packages/cli/src/commands/help.test.ts
+++ b/packages/cli/src/commands/help.test.ts
@@ -5,7 +5,7 @@ import { test } from "../test_utils/fixtures";
 describe("help", () => {
 	test("without args", async ({ testCliCommand }) => {
 		await testCliCommand([], {
-			stderr: expect.stringContaining(`neonctl <command> [options]`),
+			stderr: expect.stringContaining(`neon <command> [options]`),
 		});
 	});
 });

--- a/packages/cli/src/commands/ip_allow.test.ts
+++ b/packages/cli/src/commands/ip_allow.test.ts
@@ -16,7 +16,7 @@ describe("ip-allow", () => {
 		await testCliCommand(["ip-allow", "add", "--projectId", "test"], {
 			code: 1,
 			stderr: `ERROR: Enter individual IP addresses, define ranges with a dash, or use CIDR notation for more flexibility.
-         Example: neonctl ip-allow add 192.168.1.1, 192.168.1.20-192.168.1.50, 192.168.1.0/24 --project-id <id>`,
+         Example: neon ip-allow add 192.168.1.1, 192.168.1.20-192.168.1.50, 192.168.1.0/24 --project-id <id>`,
 		});
 	});
 
@@ -35,7 +35,7 @@ describe("ip-allow", () => {
 	test("Remove IP allow - Error", async ({ testCliCommand }) => {
 		await testCliCommand(["ip-allow", "remove", "--project-id", "test"], {
 			code: 1,
-			stderr: `ERROR: Remove individual IP addresses and ranges. Example: neonctl ip-allow remove 192.168.1.1 --project-id <id>`,
+			stderr: `ERROR: Remove individual IP addresses and ranges. Example: neon ip-allow remove 192.168.1.1 --project-id <id>`,
 		});
 	});
 

--- a/packages/cli/src/commands/ip_allow.ts
+++ b/packages/cli/src/commands/ip_allow.ts
@@ -3,6 +3,7 @@ import type yargs from "yargs";
 import { log } from "../log.js";
 import { projectUpdateRequest } from "../parameters.gen.js";
 import type { CommonProps, ProjectScopeProps } from "../types";
+import { getCliName } from "../utils/cli_name.js";
 import { fillSingleProject } from "../utils/enrichers.js";
 import { writer } from "../writer.js";
 
@@ -108,7 +109,7 @@ const add = async (
 ) => {
 	if (props.ips.length <= 0) {
 		throw new Error(`Enter individual IP addresses, define ranges with a dash, or use CIDR notation for more flexibility.
-       Example: neonctl ip-allow add 192.168.1.1, 192.168.1.20-192.168.1.50, 192.168.1.0/24 --project-id <id>`);
+       Example: ${getCliName()} ip-allow add 192.168.1.1, 192.168.1.20-192.168.1.50, 192.168.1.0/24 --project-id <id>`);
 	}
 
 	const project: ProjectUpdateRequest["project"] = {};
@@ -140,7 +141,7 @@ const add = async (
 const remove = async (props: ProjectScopeProps & { ips: string[] }) => {
 	if (props.ips.length <= 0) {
 		throw new Error(
-			`Remove individual IP addresses and ranges. Example: neonctl ip-allow remove 192.168.1.1 --project-id <id>`,
+			`Remove individual IP addresses and ranges. Example: ${getCliName()} ip-allow remove 192.168.1.1 --project-id <id>`,
 		);
 	}
 

--- a/packages/cli/src/commands/link.test.ts
+++ b/packages/cli/src/commands/link.test.ts
@@ -321,7 +321,7 @@ describe("link", () => {
 				],
 				{
 					code: 1,
-					stderr: "ERROR: Conflicting inputs: --branch pins a branch of an existing project, but --project-name creates a new one. Create the project first, then `neonctl checkout <branch>`.",
+					stderr: "ERROR: Conflicting inputs: --branch pins a branch of an existing project, but --project-name creates a new one. Create the project first, then `neon checkout <branch>`.",
 				},
 			);
 		});
@@ -640,7 +640,7 @@ describe("link", () => {
 			]);
 			expect(result.code).toBe(1);
 			expect(result.stderr).toContain("CI environment detected");
-			expect(result.stderr).toContain("neonctl link --agent");
+			expect(result.stderr).toContain("neon link --agent");
 		});
 	});
 

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -24,6 +24,7 @@ import {
 	createBranch,
 	pickBranchInteractively,
 } from "../utils/branch_picker.js";
+import { getCliName } from "../utils/cli_name.js";
 import { hasNeonConfigFile, initCmd } from "./config.js";
 import { autoPullEnvAfterPin, renderAgentPullNote } from "./env.js";
 import { REGIONS } from "./projects.js";
@@ -122,7 +123,7 @@ export const builder = (argv: yargs.Argv) =>
 				describe:
 					"Branch name or ID to pin in the context (resolved to its ID before writing). " +
 					"Without it, link only resolves the org and project — pin a branch with " +
-					"`neonctl checkout <branch>` (link never guesses a default).",
+					`\`${getCliName()} checkout <branch>\` (link never guesses a default).`,
 				type: "string",
 			},
 			params: {
@@ -170,7 +171,7 @@ export const builder = (argv: yargs.Argv) =>
 		.example([
 			[
 				"$0 link --project-id polished-snowflake-12345678",
-				"Link an existing project (org is inferred); pin a branch later with 'neonctl checkout'",
+				`Link an existing project (org is inferred); pin a branch later with '${getCliName()} checkout'`,
 			],
 			[
 				"$0 link --org-id org-… --project-name my-app --region-id aws-us-east-2",
@@ -221,9 +222,9 @@ export const handler = async (props: LinkProps) => {
 				"Missing inputs and CI environment detected (no TTY for prompts).",
 				"",
 				"Use one of:",
-				"  neonctl link --agent                                                    (JSON state machine for agents)",
-				"  neonctl link --project-id <project>                                     (link to an existing project; org is inferred)",
-				"  neonctl link --org-id <org> --project-name <name> --region-id <region>  (create a new project and link)",
+				`  ${getCliName()} link --agent                                                    (JSON state machine for agents)`,
+				`  ${getCliName()} link --project-id <project>                                     (link to an existing project; org is inferred)`,
+				`  ${getCliName()} link --org-id <org> --project-name <name> --region-id <region>  (create a new project and link)`,
 			].join("\n"),
 		);
 		process.exit(1);
@@ -288,7 +289,7 @@ const validateInputs = (inputs: Inputs): void => {
 	}
 	if (inputs.projectName && inputs.branch) {
 		throw new Error(
-			"Conflicting inputs: --branch pins a branch of an existing project, but --project-name creates a new one. Create the project first, then `neonctl checkout <branch>`.",
+			`Conflicting inputs: --branch pins a branch of an existing project, but --project-name creates a new one. Create the project first, then \`${getCliName()} checkout <branch>\`.`,
 		);
 	}
 };
@@ -482,7 +483,7 @@ const resolveBranchRef = async (
 					.join(", ")
 			: "(none)";
 	throw new LinkInputError(
-		`Branch '${branchRef}' not found in project '${projectId}'. Available branches: ${available}. Pin one with \`neonctl checkout <branch>\`.`,
+		`Branch '${branchRef}' not found in project '${projectId}'. Available branches: ${available}. Pin one with \`${getCliName()} checkout <branch>\`.`,
 		"NOT_FOUND",
 	);
 };
@@ -960,7 +961,7 @@ const runAgent = async (props: LinkProps, inputs: Inputs) => {
 			context_file: props.contextFile,
 			context: { orgId, projectId },
 			project: { id: projectId },
-			message: `Linked ${props.contextFile} to project ${projectId}${orgSuffix}. No branch pinned — run \`neonctl checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars.`,
+			message: `Linked ${props.contextFile} to project ${projectId}${orgSuffix}. No branch pinned — run \`${getCliName()} checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars.`,
 		});
 		return;
 	}
@@ -982,7 +983,7 @@ const runAgent = async (props: LinkProps, inputs: Inputs) => {
 				name: region.name,
 				default: region.default,
 			})),
-			next_command_template: `neonctl link --agent --org-id ${shellArg(orgId)} --project-name ${shellArg(projectName)} --region-id <region_id>`,
+			next_command_template: `${getCliName()} link --agent --org-id ${shellArg(orgId)} --project-name ${shellArg(projectName)} --region-id <region_id>`,
 		});
 		return;
 	}
@@ -1030,7 +1031,7 @@ const runAgent = async (props: LinkProps, inputs: Inputs) => {
 	// the instruction rather than silently dropped.
 	const projects = await listAllProjects(props, orgId);
 	const branchNote = branch
-		? ` A branch was requested (--branch ${branch}) but a branch can only be pinned once a project is chosen — re-run with --project-id first, then \`neonctl checkout ${branch}\`.`
+		? ` A branch was requested (--branch ${branch}) but a branch can only be pinned once a project is chosen — re-run with --project-id first, then \`${getCliName()} checkout ${branch}\`.`
 		: "";
 	emitAgent({
 		status: "needs_project",
@@ -1047,9 +1048,9 @@ const runAgent = async (props: LinkProps, inputs: Inputs) => {
 		create_option: {
 			instruction:
 				"To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
-			next_command_template: `neonctl link --agent --org-id ${shellArg(orgId)} --project-name <name> --region-id <region_id>`,
+			next_command_template: `${getCliName()} link --agent --org-id ${shellArg(orgId)} --project-name <name> --region-id <region_id>`,
 		},
-		next_command_template: `neonctl link --agent --org-id ${shellArg(orgId)} --project-id <project_id>`,
+		next_command_template: `${getCliName()} link --agent --org-id ${shellArg(orgId)} --project-id <project_id>`,
 	});
 };
 
@@ -1143,7 +1144,7 @@ const buildNeedsOrgResponse = (
 			instruction:
 				"This Neon API key is organization-scoped, so the CLI cannot list the user's organizations and no existing project was found to auto-detect the org ID. Ask the user for their Neon organization ID (visible in the Neon Console under the org's Settings page, formatted like `org-bitter-breeze-12345678`) and re-run the next_command_template with that --org-id.",
 			options: [],
-			next_command_template: "neonctl link --agent --org-id <org_id>",
+			next_command_template: `${getCliName()} link --agent --org-id <org_id>`,
 		};
 	}
 	const orgs = resolution.orgs;
@@ -1154,7 +1155,7 @@ const buildNeedsOrgResponse = (
 				? "The user does not belong to any organizations. Ask them to create one in the Neon Console (https://console.neon.tech/) before linking."
 				: `Ask the user which of these ${orgs.length} organization${orgs.length === 1 ? "" : "s"} they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.`,
 		options: orgs.map((org) => ({ id: org.id, name: org.name })),
-		next_command_template: "neonctl link --agent --org-id <org_id>",
+		next_command_template: `${getCliName()} link --agent --org-id <org_id>`,
 	};
 };
 
@@ -1245,7 +1246,7 @@ const resolveInteractiveBranch = async (
 		message: "Which branch would you like to link?",
 		nonInteractiveMessage:
 			"No branch could be selected without an interactive terminal. " +
-			"Re-run `neonctl link` interactively, or `neonctl checkout <branch>` to pin one.",
+			`Re-run \`${getCliName()} link\` interactively, or \`${getCliName()} checkout <branch>\` to pin one.`,
 	});
 	if (picked.kind === "existing") {
 		const existing = branches.find((b: Branch) => b.id === picked.branchId);
@@ -1365,7 +1366,7 @@ const printSummary = (_props: LinkProps, summary: HumanSummary): void => {
 	} else if (summary.projectId && !summary.branch && !summary.orgOnly) {
 		lines.push("");
 		lines.push(
-			"No branch pinned. Run `neonctl checkout <branch>` to pin a branch and pull its env vars.",
+			`No branch pinned. Run \`${getCliName()} checkout <branch>\` to pin a branch and pull its env vars.`,
 		);
 	}
 	lines.push("");

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -15,6 +15,7 @@ import {
 	projectUpdateRequest,
 } from "../parameters.gen.js";
 import type { CommonProps, IdOrNameProps } from "../types.js";
+import { getCliName } from "../utils/cli_name.js";
 import { getComputeUnits } from "../utils/compute_units.js";
 import { psql } from "../utils/psql.js";
 import { writer } from "../writer.js";
@@ -541,11 +542,11 @@ The organization ID has been saved in ${props.contextFile}
 
 If you'd like to change the default organization later, use
 
-    neonctl link --org-id <org_id>
+    ${getCliName()} link --org-id <org_id>
 
 Or to clear the context file and forget the default organization
 
-    neonctl link --clear
+    ${getCliName()} link --clear
 
 `);
 	}

--- a/packages/cli/src/commands/set_context.test.ts
+++ b/packages/cli/src/commands/set_context.test.ts
@@ -220,7 +220,7 @@ describe("set_context", () => {
 				],
 				{
 					stderr: expect.stringContaining(
-						"`neonctl set-context` is deprecated",
+						"`neon set-context` is deprecated",
 					),
 				},
 			);

--- a/packages/cli/src/commands/set_context.ts
+++ b/packages/cli/src/commands/set_context.ts
@@ -2,6 +2,7 @@ import type yargs from "yargs";
 import { applyContext, type Context } from "../context.js";
 import { log } from "../log.js";
 import type { CommonProps } from "../types.js";
+import { getCliName } from "../utils/cli_name.js";
 
 /**
  * `set-context` is **deprecated** in favor of `link`. It is intentionally left
@@ -19,8 +20,7 @@ type SetContextProps = {
 };
 
 export const command = "set-context";
-export const describe =
-	"Deprecated: use `neonctl link`. Set the .neon context (raw write).";
+export const describe = `Deprecated: use \`${getCliName()} link\`. Set the .neon context (raw write).`;
 export const builder = (argv: yargs.Argv) =>
 	argv.usage("$0 set-context [options]").options({
 		"project-id": {
@@ -39,9 +39,9 @@ export const builder = (argv: yargs.Argv) =>
 
 export const handler = (props: CommonProps & SetContextProps) => {
 	log.warning(
-		"`neonctl set-context` is deprecated and will be removed in a future release. " +
-			"Use `neonctl link` instead — it verifies inputs and infers the org for you " +
-			"(or `neonctl link --no-checks` for the same write-without-checks behavior).",
+		`\`${getCliName()} set-context\` is deprecated and will be removed in a future release. ` +
+			`Use \`${getCliName()} link\` instead — it verifies inputs and infers the org for you ` +
+			`(or \`${getCliName()} link --no-checks\` for the same write-without-checks behavior).`,
 	);
 	const context: Context = {
 		projectId: props.projectId,

--- a/packages/cli/src/current_branch_fast_path.test.ts
+++ b/packages/cli/src/current_branch_fast_path.test.ts
@@ -85,7 +85,7 @@ describe("tryCurrentBranchFastPath", () => {
 			tryCurrentBranchFastPath(ARGV("status", "--current-branch"), cwd),
 		).toBe(true);
 		expect(out.join("")).toBe("");
-		expect(err.join("")).toContain("Run `neonctl checkout <branch>`");
+		expect(err.join("")).toContain("Run `neon checkout <branch>`");
 		expect(process.exitCode).toBe(1);
 	});
 

--- a/packages/cli/src/current_branch_fast_path.ts
+++ b/packages/cli/src/current_branch_fast_path.ts
@@ -4,6 +4,7 @@ import {
 	readContextFile,
 } from "./context.js";
 import { log } from "./log.js";
+import { getCliName } from "./utils/cli_name.js";
 
 /**
  * Offline fast path for `(config) status --current-branch` (used by shell prompts).
@@ -43,7 +44,7 @@ export const tryCurrentBranchFastPath = (
 		process.stdout.write(`${branch}\n`);
 	} else {
 		log.info(
-			"No branch pinned. Run `neonctl checkout <branch>` to pin a branch and pull its env vars.",
+			`No branch pinned. Run \`${getCliName()} checkout <branch>\` to pin a branch and pull its env vars.`,
 		);
 		process.exitCode = 1;
 	}

--- a/packages/cli/src/dev/env.test.ts
+++ b/packages/cli/src/dev/env.test.ts
@@ -287,7 +287,7 @@ describe("resolveDevEnv", () => {
 	it('tier 3: no neon.ts and no project/branch -> empty vars + a "link a branch" note', async () => {
 		const result = await resolveDevEnv({ cwd });
 		expect(result.vars).toEqual({});
-		expect(result.skipped?.reason).toMatch(/neonctl link/);
+		expect(result.skipped?.reason).toMatch(/neon link/);
 	});
 
 	it("tier 2: no neon.ts but project + branch -> pooled + unpooled DATABASE_URL", async () => {
@@ -429,7 +429,7 @@ describe("resolveDevEnv", () => {
 				branchId: BRANCH_ID,
 				api,
 			}),
-		).rejects.toThrow(/auth.*neonctl deploy/s);
+		).rejects.toThrow(/auth.*neon deploy/s);
 	});
 
 	it("tier 1 match: neon.ts enables auth the branch already has -> injects, no throw", async () => {

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -7,6 +7,7 @@ import {
 } from "@neon/env/runtime";
 
 import { log } from "../log.js";
+import { getCliName } from "../utils/cli_name.js";
 
 export type DevEnvContext = {
 	cwd: string;
@@ -85,7 +86,7 @@ export const resolveNeonEnvVars = async (
 		if (!ctx.projectId || !ctx.branchId) {
 			throw new MissingBranchContextError(
 				"Found a neon.ts but could not resolve the project/branch. " +
-					"Run `neonctl link` and `neonctl checkout <branch>`, or pass " +
+					`Run \`${getCliName()} link\` and \`${getCliName()} checkout <branch>\`, or pass ` +
 					"--project-id / --branch.",
 			);
 		}
@@ -117,8 +118,8 @@ export const resolveNeonEnvVars = async (
 	}
 
 	throw new MissingBranchContextError(
-		"No project/branch context found. Link a branch (`neonctl link` / " +
-			"`neonctl checkout`) or pass --project-id and --branch.",
+		`No project/branch context found. Link a branch (\`${getCliName()} link\` / ` +
+			`\`${getCliName()} checkout\`) or pass --project-id and --branch.`,
 	);
 };
 
@@ -166,8 +167,8 @@ export const resolveDevEnv = async (
 				vars: {},
 				skipped: {
 					reason:
-						"no linked Neon branch — run `neonctl link`, then " +
-						"`neonctl checkout <branch>`, to inject DATABASE_URL and friends",
+						`no linked Neon branch — run \`${getCliName()} link\`, then ` +
+						`\`${getCliName()} checkout <branch>\`, to inject DATABASE_URL and friends`,
 				},
 			};
 		}
@@ -226,8 +227,8 @@ const assertPolicyMatchesBranch = async (
 	throw new DevEnvMismatchError(
 		`Your neon.ts declares ${names} for branch ${ctx.branchId}, but the branch ` +
 			"does not have it yet, so the matching env vars cannot be injected. " +
-			"Provision it first with `neonctl deploy` (or `neonctl config apply`), " +
-			"then re-run `neonctl dev`.",
+			`Provision it first with \`${getCliName()} deploy\` (or \`${getCliName()} config apply\`), ` +
+			`then re-run \`${getCliName()} dev\`.`,
 	);
 };
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,3 @@
-import { basename } from "node:path";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 import {
@@ -28,6 +27,7 @@ import {
 import { showHelp } from "./help.js";
 import { log } from "./log.js";
 import pkg from "./pkg.js";
+import { getCliName } from "./utils/cli_name.js";
 import { fillInArgs, resolveApiKeyFromEnv } from "./utils/middlewares.js";
 
 const NO_SUBCOMMANDS_VERBS = [
@@ -193,7 +193,7 @@ builder = builder
 	.group("version", "Global options:")
 	.alias("version", "v")
 	.completion()
-	.scriptName(basename(process.argv[1]) === "neon" ? "neon" : "neonctl")
+	.scriptName(getCliName())
 	.epilog(
 		"For more information, visit https://neon.com/docs/reference/neon-cli",
 	)

--- a/packages/cli/src/psql/command/cmd_meta.test.ts
+++ b/packages/cli/src/psql/command/cmd_meta.test.ts
@@ -935,8 +935,8 @@ describe("\\copyright", () => {
 		expect(out).toMatch(/Copyright/);
 		expect(out).toContain("PostgreSQL Database Management System");
 		expect(out).toContain("PostgreSQL Global Development Group");
-		// neonctl attribution block appended after the upstream notice.
-		expect(out).toContain("neonctl");
+		// neon attribution block appended after the upstream notice.
+		expect(out).toContain("neon");
 		expect(out).toContain("Neon (https://neon.tech)");
 		expect(out).toContain("Databricks");
 	});

--- a/packages/cli/src/psql/command/cmd_meta.ts
+++ b/packages/cli/src/psql/command/cmd_meta.ts
@@ -800,12 +800,12 @@ PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
  * here on purpose (see the project's LICENSE file for terms).
  */
 const NEON_NOTICE = `
-This is an embedded psql reimplementation that ships with neonctl, the
+This is an embedded psql reimplementation that ships with neon, the
 command-line interface for Neon (https://neon.tech). Neon is part of
 Databricks (https://www.databricks.com).
 
 It is an independent reimplementation of psql and is not affiliated with
-or endorsed by the PostgreSQL Global Development Group. See the neonctl
+or endorsed by the PostgreSQL Global Development Group. See the neon
 LICENSE file for distribution terms.
 `;
 

--- a/packages/cli/src/psql/core/mainloop.ts
+++ b/packages/cli/src/psql/core/mainloop.ts
@@ -331,7 +331,7 @@ const isHelpKeyword = (line: string): boolean => {
 };
 
 const HELP_TEXT =
-	"You are using psql-ts, the embedded TypeScript psql in neonctl.\n" +
+	"You are using psql-ts, the embedded TypeScript psql in neon.\n" +
 	"Type:  \\copyright for distribution terms\n" +
 	"       \\h for help with SQL commands\n" +
 	"       \\? for help with psql commands\n" +

--- a/packages/cli/src/psql/core/startup.test.ts
+++ b/packages/cli/src/psql/core/startup.test.ts
@@ -412,7 +412,7 @@ describe("applyStartupArgs", () => {
 		const parsed = ok(parseStartupArgs([]));
 		const settings = buildBaseSettings();
 		applyStartupArgs(parsed, settings, baseConn);
-		expect(settings.vars.get("VERSION")).toMatch(/^psql-ts \(neonctl\) /);
+		expect(settings.vars.get("VERSION")).toMatch(/^psql-ts \(neon\) /);
 		expect(settings.vars.get("VERSION_NAME")).toMatch(/^\d+\.\d+\.\d+$/);
 		expect(settings.vars.get("VERSION_NUM")).toMatch(/^\d+$/);
 	});

--- a/packages/cli/src/psql/core/startup.ts
+++ b/packages/cli/src/psql/core/startup.ts
@@ -332,7 +332,7 @@ export const CLIENT_VERSION = "1.0.0";
 // `embedded-ts` label in place of a real PG build number since this is a
 // reimplementation, not a compiled psql. Distinct from the `:VERSION` psql
 // variable (the client-identity string seeded from CLIENT_VERSION).
-const VERSION_STRING = `psql (PostgreSQL) embedded-ts (neonctl ${CLIENT_VERSION})`;
+const VERSION_STRING = `psql (PostgreSQL) embedded-ts (neon ${CLIENT_VERSION})`;
 
 const pushAction = (acts: StartupAction[], a: StartupAction): void => {
 	acts.push(a);

--- a/packages/cli/src/psql/core/syncVars.test.ts
+++ b/packages/cli/src/psql/core/syncVars.test.ts
@@ -120,7 +120,7 @@ describe("setStartupVars", () => {
 	test("seeds VERSION / VERSION_NAME / VERSION_NUM from the client version", () => {
 		const vars = createVarStore();
 		setStartupVars(vars, "2.22.0");
-		expect(vars.get("VERSION")).toBe("psql-ts (neonctl) 2.22.0");
+		expect(vars.get("VERSION")).toBe("psql-ts (neon) 2.22.0");
 		expect(vars.get("VERSION_NAME")).toBe("2.22.0");
 		expect(vars.get("VERSION_NUM")).toBe("22200");
 	});

--- a/packages/cli/src/psql/core/syncVars.ts
+++ b/packages/cli/src/psql/core/syncVars.ts
@@ -110,16 +110,16 @@ export const syncConnectionVars = (vars: VarStore, conn: Connection): void => {
  * identifier is real and traceable to the shipped binary, while keeping
  * upstream's variable *shapes*:
  *
- *   - `VERSION`      → `psql-ts (neonctl) <clientVersion>` — a banner that
+ *   - `VERSION`      → `psql-ts (neon) <clientVersion>` — a banner that
  *     names the implementation so users can tell they are on the embedded
- *     TS port, mirroring the startup banner's `psql-ts (neonctl, …)` shape.
+ *     TS port, mirroring the startup banner's `psql-ts (neon, …)` shape.
  *   - `VERSION_NAME` → `<clientVersion>` (e.g. `2.22.0`).
  *   - `VERSION_NUM`  → the same version mapped into PG's NNMMPP integer form
  *     (`2.22.0` → `22200`) via {@link clientVersionNum}, so a script doing a
  *     numeric `:VERSION_NUM` comparison gets a monotonic integer.
  */
 export const setStartupVars = (vars: VarStore, clientVersion: string): void => {
-	vars.set("VERSION", `psql-ts (neonctl) ${clientVersion}`);
+	vars.set("VERSION", `psql-ts (neon) ${clientVersion}`);
 	vars.set("VERSION_NAME", clientVersion);
 	vars.set("VERSION_NUM", String(clientVersionNum(clientVersion)));
 };

--- a/packages/cli/src/psql/index.ts
+++ b/packages/cli/src/psql/index.ts
@@ -378,7 +378,7 @@ const writeStartupBanner = (
 	// Client identifier. Matches upstream's `psql (18.4, server X.Y)` shape
 	// but signals that this is the embedded TS implementation so users can tell
 	// when they're on the fallback path.
-	out.write(`psql-ts (neonctl, server ${serverVersion})\n`);
+	out.write(`psql-ts (neon, server ${serverVersion})\n`);
 
 	const tls = connection.getTlsInfo();
 	if (tls) {

--- a/packages/cli/src/utils/branch_picker.test.ts
+++ b/packages/cli/src/utils/branch_picker.test.ts
@@ -29,9 +29,9 @@ describe("pickBranchInteractively", () => {
 			pickBranchInteractively([], {
 				message: "Which branch would you like to check out?",
 				nonInteractiveMessage:
-					"No branch specified. Pass a branch name or id (e.g. `neonctl checkout main`), " +
+					"No branch specified. Pass a branch name or id (e.g. `neon checkout main`), " +
 					"or run interactively to pick one from a list.",
 			}),
-		).rejects.toThrow(/neonctl checkout main/);
+		).rejects.toThrow(/neon checkout main/);
 	});
 });

--- a/packages/cli/src/utils/cli_name.test.ts
+++ b/packages/cli/src/utils/cli_name.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getCliName } from "./cli_name.js";
+
+describe("getCliName", () => {
+	const originalArgv1 = process.argv[1];
+
+	afterEach(() => {
+		process.argv[1] = originalArgv1;
+	});
+
+	it("returns 'neonctl' only when invoked literally as neonctl", () => {
+		process.argv[1] = "/usr/local/bin/neonctl";
+		expect(getCliName()).toBe("neonctl");
+	});
+
+	it("returns 'neon' when invoked as neon", () => {
+		process.argv[1] = "/usr/local/bin/neon";
+		expect(getCliName()).toBe("neon");
+	});
+
+	it("returns 'neon' for any other invocation name (e.g. index.js in tests)", () => {
+		process.argv[1] = "/repo/packages/cli/dist/index.js";
+		expect(getCliName()).toBe("neon");
+	});
+
+	it("returns 'neon' for an arbitrary renamed binary (does not echo)", () => {
+		process.argv[1] = "/opt/tools/HelloWorld";
+		expect(getCliName()).toBe("neon");
+	});
+
+	it("applies basename, not a raw path compare", () => {
+		process.argv[1] = "/some/deep/path/to/neonctl";
+		expect(getCliName()).toBe("neonctl");
+	});
+
+	it("does not throw when argv[1] is undefined", () => {
+		// @ts-expect-error deliberately clearing to exercise the `?? ""` guard
+		process.argv[1] = undefined;
+		expect(getCliName()).toBe("neon");
+	});
+});

--- a/packages/cli/src/utils/cli_name.ts
+++ b/packages/cli/src/utils/cli_name.ts
@@ -1,0 +1,16 @@
+import { basename } from "node:path";
+
+/**
+ * The name this CLI was invoked as: `neon` (current) or `neonctl` (legacy alias).
+ *
+ * Use this for any user-facing string that suggests a command to run — help text,
+ * error hints, and especially `--agent` `next_command_template` values, which an agent
+ * executes verbatim. Hardcoding `neonctl` breaks those on installs of the `neon` package,
+ * which no longer ships a `neonctl` binary (removed in `neon@2.38.0`).
+ *
+ * Derived from `process.argv[1]`, which is fixed for the process lifetime, so the result
+ * is stable whether this is called at module load or per invocation. Mirrors the name used
+ * for yargs `.scriptName()` in `index.ts`.
+ */
+export const getCliName = (): string =>
+	basename(process.argv[1] ?? "") === "neonctl" ? "neonctl" : "neon";

--- a/packages/cli/src/utils/esbuild.ts
+++ b/packages/cli/src/utils/esbuild.ts
@@ -5,7 +5,7 @@ import { basename, join } from "node:path";
 import which from "which";
 
 const NOT_FOUND =
-	"esbuild not found. neonctl ships esbuild for most platforms; if you see " +
+	"esbuild not found. neon ships esbuild for most platforms; if you see " +
 	"this, install esbuild and ensure it is on your PATH (e.g. `npm i -g " +
 	"esbuild`), or set NEON_ESBUILD_PATH to an esbuild binary.";
 

--- a/packages/config/e2e/errors.e2e.test.ts
+++ b/packages/config/e2e/errors.e2e.test.ts
@@ -22,7 +22,7 @@ describe("e2e — error wrapping against real Neon API", () => {
 				expect(p.message).toContain(
 					"https://console.neon.tech/app/settings/api-keys",
 				);
-				expect(p.message).toContain("neonctl auth");
+				expect(p.message).toContain("neon auth");
 			}
 		},
 	);

--- a/packages/config/src/lib/wrap-neon-error.test.ts
+++ b/packages/config/src/lib/wrap-neon-error.test.ts
@@ -32,7 +32,7 @@ describe("wrapNeonError — HTTP status mapping", () => {
 		expect(p.message).toContain(
 			"https://console.neon.tech/app/settings/api-keys",
 		);
-		expect(p.message).toContain("neonctl auth");
+		expect(p.message).toContain("neon auth");
 		expect(p.message).toContain("req-1");
 		expect(p.details.status).toBe(401);
 		expect(p.details.requestId).toBe("req-1");

--- a/packages/config/src/lib/wrap-neon-error.ts
+++ b/packages/config/src/lib/wrap-neon-error.ts
@@ -56,7 +56,7 @@ export function wrapNeonError(
 				[
 					`${context.op} failed: the Bearer token sent to the Neon API was rejected.`,
 					apiSummaryWithRequestId,
-					"Either (a) generate or rotate an API key at https://console.neon.tech/app/settings/api-keys and set NEON_API_KEY / pass --api-key, or (b) re-run `npx neonctl auth` to refresh the OAuth token in `~/.config/neonctl/credentials.json` (OAuth tokens expire).",
+					"Either (a) generate or rotate an API key at https://console.neon.tech/app/settings/api-keys and set NEON_API_KEY / pass --api-key, or (b) re-run `npx neon auth` to refresh the OAuth token in `~/.config/neonctl/credentials.json` (OAuth tokens expire).",
 				].join(" "),
 				{ cause: err, details: httpDetails(context, httpInfo) },
 			);

--- a/packages/env/src/lib/cli/resolve-context.ts
+++ b/packages/env/src/lib/cli/resolve-context.ts
@@ -50,12 +50,12 @@ export function resolveContext(
 	const missing: string[] = [];
 	if (!projectId) {
 		missing.push(
-			"project id — pass `--project-id`, set `NEON_PROJECT_ID`, or add `projectId` to `.neon` (run `npx neonctl link`).",
+			"project id — pass `--project-id`, set `NEON_PROJECT_ID`, or add `projectId` to `.neon` (run `npx neon link`).",
 		);
 	}
 	if (!branch) {
 		missing.push(
-			"branch — pass `--branch`, set `NEON_BRANCH`/`NEON_BRANCH_ID`, or add `branch` to `.neon` (run `npx neonctl link` / `neonctl checkout <branch>`).",
+			"branch — pass `--branch`, set `NEON_BRANCH`/`NEON_BRANCH_ID`, or add `branch` to `.neon` (run `npx neon link` / `neon checkout <branch>`).",
 		);
 	}
 	if (!projectId || !branch) return { ok: false, missing };

--- a/packages/env/src/lib/env.ts
+++ b/packages/env/src/lib/env.ts
@@ -618,7 +618,7 @@ export async function fetchEnvKeys(
 				ErrorCode.NotFound,
 				[
 					`fetchEnv: branch policy enables auth but no Neon Auth integration is enabled on branch ${branch.name} (${branch.id}).`,
-					"Enable it via `apply(config, { projectId, branchId })` (or `npx neonctl …`), in the Neon Console — then re-run fetchEnv. Or return auth.enabled=false.",
+					"Enable it via `apply(config, { projectId, branchId })` (or `npx neon …`), in the Neon Console — then re-run fetchEnv. Or return auth.enabled=false.",
 				].join(" "),
 				{
 					details: { projectId, branchId: branch.id },


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #360
- [x] That issue was marked as `status: accepting prs`
- [x] Steps in CONTRIBUTING.md were taken

## Overview

The `neon` package dropped the `neonctl` binary in 2.38.0, but a lot of our
own output still told people to run `neonctl …` — which now just fails with
"command not found." The worst case was `neon link --agent`: it handed agents
a `next_command_template` starting with `neonctl`, and agents run that line
as-is.

This swaps those command names for `neon`. Instead of hardcoding it, a small
`getCliName()` helper reads how the CLI was actually invoked, so the `neonctl`
compatibility package still shows `neonctl` while everyone else sees `neon`.
The same fix covers help text, error hints, the psql banners, and the
`npx neonctl …` hints in `@neon/env` and `@neon/config`.

`getCliName()` only ever returns `neon` or `neonctl` — it deliberately does
not echo an arbitrary invocation name (e.g. a renamed/aliased binary). We
show the canonical package name because the invocation name isn't always a
runnable command (e.g. `node dist/index.js`, `npx`, or a wrapper), and a
suggested command has to be something the reader can actually run.

Left untouched: the `~/.config/neonctl` config directory, the OAuth client id,
the User-Agent, and the `neonctl` package itself — those are identity, not
suggestions.

## Tests

- Unit test for `getCliName()`.
- Updated the affected assertions and snapshots; all suites pass.

This pull request and its description were written by Isaac.
