### PR TITLE
feat(sdk): add a userAgent option so callers can identify themselves

### DIFF
--- a/.changeset/olive-moons-shake.md
+++ b/.changeset/olive-moons-shake.md
@@ -1,0 +1,7 @@
+---
+"@neon/sdk": minor
+---
+
+Add a `userAgent` option so applications built on the SDK can identify themselves.
+
+Neon attributes API traffic to a caller by user agent, but the SDK sent none and its config exposed no way to set one, so every SDK-backed tool was indistinguishable from a direct API call. `createNeonClient({ apiKey, userAgent: "my-cli/1.2.0" })` now sets the header on every request the client makes, including raw calls that reuse `neon.client`. Unset by default, so nothing changes for existing callers.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -45,9 +45,23 @@ const { project, connectionString } = data;
 | `retries` | `number` | `2` | Automatic retries on always-safe statuses (`423`, `429`, `503`) with backoff. |
 | `orgId` | `string` | — | Default organization, applied to project create/list and as the transfer source org. Overridable per call. |
 | `baseUrl` | `string` | `https://console.neon.tech/api/v2` | Override the API base URL. |
+| `userAgent` | `string` | — | Product token sent as `User-Agent` on every request, e.g. `my-cli/1.2.0`. See below. |
 | `fetch` | `typeof fetch` | global `fetch` | Custom fetch implementation (proxies, tests, non-global runtimes). |
 
 Every option except `apiKey` is also accepted **per call** via the last `options` argument (`{ throwOnError?, waitForReadiness?, signal? }`), overriding the client default.
+
+### Identifying your application
+
+Neon attributes API traffic to a caller by user agent. If you are building a tool, integration, or service on this SDK and want its usage counted separately from direct API calls, set `userAgent`:
+
+```ts
+const neon = createNeonClient({
+  apiKey: process.env.NEON_API_KEY!,
+  userAgent: "my-cli/1.2.0",
+});
+```
+
+It applies to every request the client makes, including raw calls that reuse `neon.client`. Left unset, requests carry whatever your runtime's `fetch` sends by default — `node` on Node.js — and are indistinguishable from any other client.
 
 ## The result model
 

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -28,6 +28,14 @@ export interface NeonConfig<Throw extends boolean = false> {
 	retries?: number;
 	/** Override the API base URL. Defaults to `https://console.neon.tech/api/v2`. */
 	baseUrl?: string;
+	/**
+	 * Product token sent as `User-Agent` on every request, for example `my-cli/1.2.0`.
+	 *
+	 * Neon attributes API traffic to a caller by user agent, so anything built on this
+	 * SDK that wants its usage counted separately from direct API use has to set this.
+	 * Unset by default, which means requests carry whatever the runtime's `fetch` sends.
+	 */
+	userAgent?: string;
 	/** Custom `fetch` implementation (e.g. for proxies, tests, or non-global runtimes). */
 	fetch?: typeof fetch;
 	/**
@@ -45,6 +53,9 @@ export function resolveConfig(config: NeonConfig<boolean>): ResolvedConfig {
 		createConfig({
 			auth,
 			baseUrl: config.baseUrl ?? DEFAULT_BASE_URL,
+			...(config.userAgent
+				? { headers: { "User-Agent": config.userAgent } }
+				: {}),
 			...(config.fetch ? { fetch: config.fetch } : {}),
 		}),
 	);

--- a/packages/sdk/src/neon/user-agent.test.ts
+++ b/packages/sdk/src/neon/user-agent.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { getProject } from "../client/raw.gen.js";
+import { createNeonClient } from "./client.js";
+
+/** Records the request the client would have sent, and answers it. */
+function neonRecording(userAgent?: string) {
+	const requests: Request[] = [];
+	const neon = createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		...(userAgent ? { userAgent } : {}),
+		fetch: async (input, init) => {
+			requests.push(new Request(input, init));
+			return new Response(JSON.stringify({ project: { id: "p-1" } }), {
+				status: 200,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+	return { neon, requests };
+}
+
+describe("userAgent", () => {
+	it("is sent on ergonomic resource calls", async () => {
+		const { neon, requests } = neonRecording("my-cli/1.2.0");
+
+		await neon.projects.get("p-1");
+
+		expect(requests[0]?.headers.get("User-Agent")).toBe("my-cli/1.2.0");
+	});
+
+	it("is sent on raw calls, which share the configured client", async () => {
+		const { neon, requests } = neonRecording("my-cli/1.2.0");
+
+		await getProject({ client: neon.client, path: { project_id: "p-1" } });
+
+		expect(requests[0]?.headers.get("User-Agent")).toBe("my-cli/1.2.0");
+	});
+
+	it("does not set the header when unset, leaving the runtime default", async () => {
+		const { neon, requests } = neonRecording();
+
+		await neon.projects.get("p-1");
+
+		expect(requests[0]?.headers.has("User-Agent")).toBe(false);
+	});
+
+	it("does not disturb the Authorization header", async () => {
+		const { neon, requests } = neonRecording("my-cli/1.2.0");
+
+		await neon.projects.get("p-1");
+
+		expect(requests[0]?.headers.get("Authorization")).toBe("Bearer test");
+	});
+});


### PR DESCRIPTION
## Problem

Neon attributes API traffic to a caller by user agent — that is what makes CLI, MCP, and console traffic separable from direct API use in `fact_segment_api_events`. `@neon/sdk` sends no user agent, and `NeonConfig` accepts `apiKey`, `throwOnError`, `waitForReadiness`, `wait`, `retries`, `baseUrl`, `fetch`, and `orgId` — no `headers`, no `userAgent`. There is no supported way for an application built on this SDK to say who it is.

The consequence, from the shipped 1.4.0 artifact:

```
with userAgent : {"ua":"mcp-server-neon/1.0.0","auth":"Bearer test-key"}
without        : {"ua":"node","auth":"Bearer test-key"}
```

Every SDK consumer currently reports as `node` and lands in the undifferentiated `API` bucket.

This is not hypothetical. `mcp-server-neon` migrated to this SDK on 2026-07-22 and lost its attribution the same hour: `MCP` requests fell from 567,330/day to 19,957/day and distinct users from 14,815 to 587, while combined `MCP` + `API` users stayed flat (26,161 → 25,630). Its usage and its backend error rate — the only reliability signal that server has — have been measuring 4% of real traffic since. It is working around this gap by wrapping `fetch` ([mcp-server-neon#311](https://github.com/neondatabase/mcp-server-neon/pull/311)).

## The interface

```ts
const neon = createNeonClient({
  apiKey: process.env.NEON_API_KEY!,
  userAgent: "my-cli/1.2.0", // default: unset
});
```

| Option | Type | Default | Applies to |
|---|---|---|---|
| `userAgent` | `string` | — | `User-Agent` on every request the client makes |

It is set on the config passed to `createClient`, and `mergeHeaders(_config.headers, options.headers)` runs per request, so it covers the ergonomic namespaces and raw calls that reuse `neon.client` alike:

```ts
const neon = createNeonClient({ apiKey, userAgent: "my-cli/1.2.0" });

await neon.projects.get("p-1");                                  // sent
await getProject({ client: neon.client, path: { project_id } }); // sent
```

Nothing changes for existing callers. When `userAgent` is unset no header is added and requests carry the runtime default, exactly as today. Callers already passing a custom `fetch` are unaffected; a per-request header still wins over the client default, since `mergeHeaders` takes config first.

## Why an option rather than a default

The SDK could send `@neon/sdk/<version>` on its own. It deliberately doesn't, in this PR.

The control plane derives `api_source` from the user agent. Giving every existing SDK caller a new, uniform user agent changes how all of that traffic classifies, on the deploy of a patch release, with no way for a consumer to opt out of the reclassification. That is an analytics migration, and it wants to be decided with the data owners rather than shipped as a side effect of adding an option.

An opt-in option has no such effect: traffic only moves when a consumer chooses to identify itself, which is the point.

## Verification

Base `7ee4de5`. `pnpm --filter @neon/sdk build`, `test:ci` (37 passed), `test:types` (14 passed, no type errors), and `pnpm lint:ci` across 558 files all clean.

Four unit tests, each asserting on the `Request` the client actually constructed:

- an ergonomic call (`projects.get`) carries the configured user agent
- a raw call sharing `neon.client` carries it too
- unset adds no header at all, leaving the runtime default
- `Authorization` is unaffected

The first two were confirmed red before the change (`expected null to be 'my-cli/1.2.0'`); the last two pass either way and are there as controls.

Separately, the output quoted above came from `dist/index.js` after a real build, driven against a local HTTP server — the option survives bundling, which the source-level tests would not have caught.

Not verified against the live control plane: nothing exposes what user agent Neon recorded for a request, so the end-to-end claim rests on the header being on the wire. The observable confirmation will be the `MCP` series in `api_activity_daily` recovering once mcp-server-neon deploys.

## For your attention

- **`userAgent` is not accepted per call**, only on the client. Per-call overrides in this SDK are `{ throwOnError?, waitForReadiness?, signal? }`, and a caller's identity does not vary per request. Anyone who needs that can still pass `headers` on the individual raw call.
- **No validation on the string.** An invalid token would be rejected by the runtime's `fetch`, not here. Adding a format check would mean encoding RFC 9110 product-token rules for no case anyone has hit.
- **This does not fix existing consumers**, only unblocks them. `neonctl` and anything else in this monorepo built on the SDK still send `node` until each sets the option; whether they should is a separate change.