### PR TITLE
Name the database Lakebase Postgres, and stop calling Neon a platform

### DIFF
--- a/.changeset/lakebase-postgres-terminology.md
+++ b/.changeset/lakebase-postgres-terminology.md
@@ -15,4 +15,4 @@ Copy only, no behaviour change beyond one error message string.
 - `@neon/config` and `@neon/config-runtime`: "Config-as-Code for the Neon Platform" is now "Config-as-Code for Neon", in the npm descriptions, the README, and the `v1` doc comments.
 - `@neon/config`: the validation error `Invalid Neon platform config:` is now `Invalid Neon config:`. Anything matching on that string needs updating.
 - `neon-init`: `neon-init auth` is described as "Manage Neon authentication"; the signup prompt no longer calls Neon "a serverless Postgres provider"; two bootstrap template blurbs say Lakebase Postgres.
-- `neon-new`: README names Lakebase Postgres.
+- `neon-new`: README says "a claimable Lakebase Postgres database on Neon" — claimable databases are Neon-only, so the access path is named.

--- a/.changeset/lakebase-postgres-terminology.md
+++ b/.changeset/lakebase-postgres-terminology.md
@@ -1,0 +1,18 @@
+---
+"neon": patch
+"@neon/config": patch
+"@neon/config-runtime": patch
+"@neon/env": patch
+"neon-init": patch
+"neon-new": patch
+---
+
+Name the database Lakebase Postgres, and stop calling Neon a platform
+
+Copy only, no behaviour change beyond one error message string.
+
+- `neon`: the npm description no longer says "Neon Serverless Postgres"; the README names the primitives the CLI manages.
+- `@neon/config` and `@neon/config-runtime`: "Config-as-Code for the Neon Platform" is now "Config-as-Code for Neon", in the npm descriptions, the README, and the `v1` doc comments.
+- `@neon/config`: the validation error `Invalid Neon platform config:` is now `Invalid Neon config:`. Anything matching on that string needs updating.
+- `neon-init`: `neon-init auth` is described as "Manage Neon authentication"; the signup prompt no longer calls Neon "a serverless Postgres provider"; two bootstrap template blurbs say Lakebase Postgres.
+- `neon-new`: README names Lakebase Postgres.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # Neon CLI
 
-The `neon` package is a command-line interface that lets you manage [Neon Serverless Postgres](https://neon.tech/) directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
+The `neon` package is a command-line interface that lets you manage [Neon](https://neon.tech/) — Lakebase Postgres, Object Storage, Functions, Managed Better Auth, and the AI Gateway — directly from the terminal. For the complete documentation, see [Neon CLI](https://neon.tech/docs/reference/neon-cli).
 
 The legacy `neonctl` package is a lightweight compatibility package that depends
 on this package and invokes the same CLI entry point. The implementation and

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "neon",
   "version": "2.38.5",
-  "description": "CLI tool for Neon Serverless Postgres",
+  "description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
   "keywords": [
     "neon",
     "neonctl",

--- a/packages/cli/src/commands/bootstrap.test.ts
+++ b/packages/cli/src/commands/bootstrap.test.ts
@@ -53,8 +53,8 @@ const FIXTURE: Record<string, FixtureFile> = {
 
 const MANIFEST_YAML = `templates:
   - id: hono
-    title: "Hono API (Drizzle, Neon Postgres) on Neon Functions"
-    description: "A Hono API using Drizzle ORM and Neon Postgres, ready to deploy as a Neon Function."
+    title: "Hono API (Drizzle, Lakebase Postgres) on Neon Functions"
+    description: "A Hono API using Drizzle ORM and Lakebase Postgres, ready to deploy as a Neon Function."
     services:
       - Postgres
       - Functions
@@ -275,7 +275,7 @@ describe("bootstrap", () => {
 		expect(code, stderr).toBe(0);
 		expect(stdout).toContain("hono");
 		expect(stdout).toContain(
-			"A Hono API using Drizzle ORM and Neon Postgres",
+			"A Hono API using Drizzle ORM and Lakebase Postgres",
 		);
 		// The services from the manifest are surfaced alongside each template.
 		expect(stdout).toContain("[Postgres · Functions]");

--- a/packages/config-runtime/src/lib/fake-neon-api.ts
+++ b/packages/config-runtime/src/lib/fake-neon-api.ts
@@ -41,7 +41,7 @@ type SeedBranch = Omit<NeonBranchSnapshot, "protected"> & {
  * - Each project has a single read-write endpoint per branch (Neon's default), an `orgId`
  *   on the project, default endpoint settings, and a fixed region.
  * - Branches inherit endpoint defaults from the project when no explicit settings are set
- *   at create-time. This mirrors the real Neon platform.
+ *   at create-time. This mirrors the real Neon API.
  *
  * The fake records a call log (`history`) so tests can assert on the exact sequence of API
  * operations that `pushConfig` performs.

--- a/packages/config-runtime/src/v1.ts
+++ b/packages/config-runtime/src/v1.ts
@@ -1,6 +1,6 @@
 /**
- * `@neon/config-runtime/v1` — the imperative runtime for Config-as-Code on the
- * Neon Platform.
+ * `@neon/config-runtime/v1` — the imperative runtime for Config-as-Code on
+ * Neon.
  *
  * `@neon/config` is the **authoring** surface: `defineConfig`, types, and schemas
  * you import from `neon.ts`. It is intentionally free of heavy/native dependencies.

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,6 +1,6 @@
 # @neon/config
 
-Config-as-Code for the Neon Platform. A repo-local `neon.ts` exports a TypeScript policy function describing a branch's desired state. This package exposes **functions** to inspect, diff, and deploy that policy against the Neon API.
+Config-as-Code for Neon. A repo-local `neon.ts` exports a TypeScript policy function describing a branch's desired state. This package exposes **functions** to inspect, diff, and deploy that policy against the Neon API.
 
 > No CLI commands ship here, and the package is **filesystem- and env-agnostic**: it never reads `.neon` files or `NEON_*` environment variables. You pass `projectId` and the target branch explicitly (resolve them in your CLI, e.g. neon). This package is functions only.
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@neon/config",
 	"version": "0.10.1",
-	"description": "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
+	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",
 		"database",

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -225,7 +225,7 @@ describe("resolveConfig", () => {
 		if (!(caught instanceof ConfigValidationError)) throw caught;
 
 		// The user-visible message is exactly what the CLI prints.
-		expect(caught.message).toContain("Invalid Neon platform config:");
+		expect(caught.message).toContain("Invalid Neon config:");
 		const issue = caught.issues.join("\n");
 		// Points at the exact path…
 		expect(issue).toContain("preview.functions.hello.env.test");

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -107,7 +107,7 @@ type PreviewAutocomplete<Preview> = (Preview extends { functions: infer F }
 		: unknown);
 
 /**
- * Validate and freeze a Neon Platform branch policy.
+ * Validate and freeze a Neon branch policy.
  *
  * Used at the top of `neon.ts`:
  * ```ts

--- a/packages/config/src/lib/errors.ts
+++ b/packages/config/src/lib/errors.ts
@@ -113,7 +113,7 @@ export class ConfigValidationError extends PlatformError {
 	constructor(issues: readonly string[]) {
 		super(
 			"PLATFORM_INVALID_CONFIG",
-			`Invalid Neon platform config:\n  - ${issues.join("\n  - ")}`,
+			`Invalid Neon config:\n  - ${issues.join("\n  - ")}`,
 		);
 		this.issues = issues;
 	}

--- a/packages/config/src/lib/fake-neon-api.ts
+++ b/packages/config/src/lib/fake-neon-api.ts
@@ -40,7 +40,7 @@ type SeedBranch = Omit<NeonBranchSnapshot, "protected"> & {
  * - Each project has a single read-write endpoint per branch (Neon's default), an `orgId`
  *   on the project, default endpoint settings, and a fixed region.
  * - Branches inherit endpoint defaults from the project when no explicit settings are set
- *   at create-time. This mirrors the real Neon platform.
+ *   at create-time. This mirrors the real Neon API.
  *
  * The fake records a call log (`history`) so tests can assert on the exact sequence of API
  * operations that `pushConfig` performs.

--- a/packages/config/src/lib/loader.test.ts
+++ b/packages/config/src/lib/loader.test.ts
@@ -56,7 +56,7 @@ describe("loadConfigFromFile", () => {
 			);
 			const message =
 				error instanceof Error ? error.message : String(error);
-			expect(message).toContain("Invalid Neon platform config");
+			expect(message).toContain("Invalid Neon config");
 			expect(message).toContain("preview.functions.hello-world");
 			expect(message).toContain(
 				"function slug must be 1-20 lowercase letters and digits (no hyphens or other characters)",

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1357,15 +1357,15 @@ const HTTP_STATUS_TEXT: Record<number, string> = {
 	503: "Service Unavailable",
 };
 
-/** AWS region where Neon platform features are currently available in beta. */
+/** AWS region where Neon features are currently available in beta. */
 const PLATFORM_BETA_REGION_ID = "aws-us-east-2";
 
 const PLATFORM_BETA_REGION_GUIDANCE =
-	"Neon platform features (Functions and Object Storage) are currently in beta and only available in the AWS US East (Ohio) region " +
+	"Neon features (Functions and Object Storage) are currently in beta and only available in the AWS US East (Ohio) region " +
 	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to link or create a new project in that region.`;
 
 const PLATFORM_BETA_REGION_GUIDANCE_SHORT =
-	"Neon platform features are currently in beta and only available in the AWS US East (Ohio) region " +
+	"Neon features are currently in beta and only available in the AWS US East (Ohio) region " +
 	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to link or create a new project in that region.`;
 
 /**

--- a/packages/config/src/lib/neon-api.ts
+++ b/packages/config/src/lib/neon-api.ts
@@ -140,7 +140,7 @@ export interface EnableDataApiInput {
 }
 
 /**
- * A branchable object-storage bucket (Preview). Backed by the Neon Platform
+ * A branchable object-storage bucket (Preview). Backed by Neon's
  * branchable-storage service.
  */
 export interface NeonBucketSnapshot {

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -63,7 +63,7 @@ type DurationField<Suggestions extends DurationString> =
  *
  * Mirrors the subset of {@link https://api-docs.neon.tech/reference/getting-started-with-neon-api Neon endpoint}
  * fields that we expose as IaC primitives. Anything left undefined falls back to the project's
- * `default_endpoint_settings` (which themselves fall back to Neon platform defaults).
+ * `default_endpoint_settings` (which themselves fall back to Neon defaults).
  */
 export interface ComputeSettings {
 	/**
@@ -88,7 +88,7 @@ export interface ComputeSettings {
 	 *   `<integer><unit>` (units: `s`, `m`, `h`, `d`, `w`). A **unit is required** — for raw
 	 *   seconds pass a `number`, not a string.
 	 * - `number` — custom timeout in **seconds**, must be in `60`–`604800` (1 minute to 1 week)
-	 * - `undefined` — use the Neon platform default (currently 300s / 5 minutes)
+	 * - `undefined` — use the Neon default (currently 300s / 5 minutes)
 	 *
 	 * Whichever form you use, the resolved timeout must fall in `60`–`604800` seconds (the Neon
 	 * API limit); the suggestions are all within that band, anything else is checked at apply.

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -1,5 +1,5 @@
 /**
- * `@neon/config/v1` — the v1 public API for Config-as-Code on the Neon Platform.
+ * `@neon/config/v1` — the v1 public API for Config-as-Code on Neon.
  *
  * Usage in `neon.ts`:
  * ```ts

--- a/packages/env/src/lib/fake-neon-api.ts
+++ b/packages/env/src/lib/fake-neon-api.ts
@@ -41,7 +41,7 @@ type SeedBranch = Omit<NeonBranchSnapshot, "protected"> & {
  * - Each project has a single read-write endpoint per branch (Neon's default), an `orgId`
  *   on the project, default endpoint settings, and a fixed region.
  * - Branches inherit endpoint defaults from the project when no explicit settings are set
- *   at create-time. This mirrors the real Neon platform.
+ *   at create-time. This mirrors the real Neon API.
  *
  * The fake records a call log (`history`) so tests can assert on the exact sequence of API
  * operations that `pushConfig` performs.

--- a/packages/init/src/cli.ts
+++ b/packages/init/src/cli.ts
@@ -192,7 +192,7 @@ const cli = yargs(hideBin(process.argv))
 	// -----------------------------------------------------------------------
 	.command(
 		"auth",
-		"Manage Neon platform authentication",
+		"Manage Neon authentication",
 		(y) =>
 			y
 				.options(jsonOption)

--- a/packages/init/src/lib/bootstrap.ts
+++ b/packages/init/src/lib/bootstrap.ts
@@ -83,7 +83,7 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 		id: "hono",
 		title: "REST API",
 		description:
-			"A Hono REST API on Neon Functions, backed by Neon Postgres via Drizzle.",
+			"A Hono REST API on Neon Functions, backed by Lakebase Postgres via Drizzle.",
 		tools: ["Hono", "Drizzle"],
 		services: ["Postgres", "Functions"],
 		requires: ["database", "functions"],
@@ -113,7 +113,7 @@ export const FALLBACK_TEMPLATES: BootstrapTemplate[] = [
 		id: "mastra",
 		title: "Personal-assistant agent",
 		description:
-			"A Mastra agent that streams chat through the Neon AI Gateway and uses Mastra Memory on Neon Postgres to remember you across threads.",
+			"A Mastra agent that streams chat through the Neon AI Gateway and uses Mastra Memory on Lakebase Postgres to remember you across threads.",
 		tools: ["Mastra", "Mastra Memory"],
 		services: ["Postgres", "Functions", "AI Gateway"],
 		requires: ["database", "functions", "ai-gateway"],

--- a/packages/init/src/lib/phases/auth.ts
+++ b/packages/init/src/lib/phases/auth.ts
@@ -166,7 +166,7 @@ export async function handleAuthPhase(
 				},
 			],
 			context:
-				"Neon is a serverless Postgres provider. A free account is required to continue.",
+				"Neon is a complete set of cloud backend primitives built around Lakebase Postgres. A free account is required to continue.",
 			responseMapping: {
 				existing_account: {
 					action: {

--- a/packages/init/src/lib/phases/getting-started.ts
+++ b/packages/init/src/lib/phases/getting-started.ts
@@ -49,7 +49,7 @@ export async function handleGettingStartedPhase(
 					id: "select_or_create_project",
 					description: [
 						"List existing Neon projects in the selected organization using the CLI command below (replace <org-id> with the selected org ID).",
-						"IMPORTANT: Neon platform features (Functions, Object Storage, and AI Gateway) are currently in beta and only available in the AWS us-east-2 region (more regions coming shortly). Projects must have region_id 'aws-us-east-2' and be created on or after 2026-06-15.",
+						"IMPORTANT: Neon features (Functions, Object Storage, and AI Gateway) are currently in beta and only available in the AWS us-east-2 region (more regions coming shortly). Projects must have region_id 'aws-us-east-2' and be created on or after 2026-06-15.",
 						"Filter the project list to ONLY show projects where region_id is 'aws-us-east-2' AND created_at is on or after '2026-06-15'.",
 						"If eligible projects exist, present them alongside a 'Create new project' option.",
 						"If no eligible projects exist, tell the user and proceed directly to creating a new one.",

--- a/packages/neon-new/README.md
+++ b/packages/neon-new/README.md
@@ -43,7 +43,7 @@ Import the SDK:
 import { instantPostgres } from "neon-new/sdk";
 ```
 
-Create a claimable Neon Postgres database and save credentials to your .env:
+Create a claimable Lakebase Postgres database and save credentials to your .env:
 
 ```ts
 await instantPostgres({

--- a/packages/neon-new/README.md
+++ b/packages/neon-new/README.md
@@ -43,7 +43,7 @@ Import the SDK:
 import { instantPostgres } from "neon-new/sdk";
 ```
 
-Create a claimable Lakebase Postgres database and save credentials to your .env:
+Create a claimable Lakebase Postgres database on Neon and save credentials to your .env:
 
 ```ts
 await instantPostgres({


### PR DESCRIPTION
Fifth repo in the terminology sweep, after [agent-skills#65](https://github.com/neondatabase/agent-skills/pull/65), [neon-for-agent-platforms#24](https://github.com/neondatabase/neon-for-agent-platforms/pull/24), and [examples#242](https://github.com/neondatabase/examples/pull/242) (all merged), plus [mcp-server-neon#314](https://github.com/neondatabase/mcp-server-neon/pull/314).

## Problem

Two naming rules, and this repo broke both in **published** metadata.

**The database is Lakebase Postgres** — one database, reached either through Neon (free plan, full set of backend primitives) or through Databricks. The `neon` CLI's npm description said:

```
"description": "CLI tool for Neon Serverless Postgres"
```

**Neon is never "a platform."** It is not separate from the Databricks Platform, so the phrasing cannot ship. `@neon/config`'s npm description said:

```
"description": "Config-as-Code for the Neon Platform. ..."
```

Both are on npm right now, on the registry page and in every search result. Two more were in front of users at first contact — the `neon-init` signup prompt told them *"Neon is a serverless Postgres provider"*, and `neon-init auth --help` offered to *"Manage Neon platform authentication"*.

## What changed

22 files, copy only, plus one error string. Nothing renamed.

### Published package metadata

```diff
# packages/cli/package.json
- "CLI tool for Neon Serverless Postgres"
+ "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres"

# packages/config/package.json
- "Config-as-Code for the Neon Platform. Define a `neon.ts` policy and ..."
+ "Config-as-Code for Neon. Define a `neon.ts` policy and ..."
```

Dropping "Postgres" from the `neon` description costs nothing for discovery — `keywords` already carries `postgres`, `database`, and `serverless`.

### CLI surface

```console
$ neon-init --help
  neon-init auth             Manage Neon authentication        # was "Manage Neon platform authentication"
```

The signup prompt, shown before a user has an account:

> Neon is a complete set of cloud backend primitives built around Lakebase Postgres. A free account is required to continue.

Two `neon init` bootstrap template blurbs now say Lakebase Postgres, matching the same strings in [examples#242](https://github.com/neondatabase/examples/pull/242):

> A Hono REST API on Neon Functions, backed by Lakebase Postgres via Drizzle.

### One behaviour-visible change

```diff
- Invalid Neon platform config:
-   - <issues>
+ Invalid Neon config:
+   - <issues>
```

`@neon/config`'s validation error. Both test assertions updated with it. Anything matching on that string breaks — called out in the changeset.

### Doc comments and internals

`@neon/config/v1`, `@neon/config-runtime/v1`, `defineConfig`, and the bucket type no longer describe their subject as "the Neon Platform". "Neon platform features (Functions, Object Storage, AI Gateway)" is now "Neon features" in the beta-region messages. Three test fakes said "This mirrors the real Neon platform"; they now say "the real Neon API".

A changeset marks all six affected packages `patch`, since none of this reaches users until a release.

## Where it says "on Neon", and where it doesn't

Lakebase Postgres is reachable through Neon or through Databricks, so a sentence that is only true of the Neon path has to name it. The test applied to each string: **would this sentence also be true of Lakebase Postgres on Databricks?**

One string in this repo failed it:

```diff
# packages/neon-new/README.md
- Create a claimable Lakebase Postgres database and save credentials to your .env:
+ Create a claimable Lakebase Postgres database on Neon and save credentials to your .env:
```

Claimable databases are a Neon-only feature, and that sentence sits in an SDK section that names no access path near it.

Everywhere else the sentence already establishes Neon, so it stays bare:

| String | Why it needs nothing |
|---|---|
| "A Hono REST API on **Neon Functions**, backed by Lakebase Postgres via Drizzle." | Neon named in the same clause |
| "...streams chat through the **Neon AI Gateway** and uses Mastra Memory on Lakebase Postgres..." | Neon named in the same clause |
| "**Neon** is a complete set of cloud backend primitives built around Lakebase Postgres." | definitional, and true on both paths |
| "CLI tool for **Neon**, the cloud backend primitives built around Lakebase Postgres" | Neon named |
| "lets you manage **[Neon]** — Lakebase Postgres, Object Storage, Functions..." | Neon named |

## The one instance I did not fix, and why

`packages/sdk` still contains "Neon Platform" once:

> Buckets are managed by the Neon Platform branchable-storage service.

That text is not authored here. It lives in `packages/sdk/spec/neon-openapi.json`, which `spec:pull` fetches verbatim from `https://neon.com/api_spec/release/v2.json`, and flows into `packages/sdk/src/client/sdk.gen.ts`, whose first line reads `// This file is auto-generated by @hey-api/openapi-ts`. Editing either would be reverted by the next `spec:pull` or `generate`, and would put the SDK Spec Drift check in disagreement with the published spec.

**Fixing it means changing the bucket endpoint description in the Neon public API spec upstream.** That is a `neon-cloud` change, not a change here, and it will propagate into this SDK on the next spec pull. Flagging rather than papering over.

## Deliberately left alone

- **`@neondatabase/serverless` and the "serverless" keyword.** The driver is genuinely named that; only the database was renamed.
- **`neonctl`'s description** ("Compatibility command for the Neon CLI") and the deprecated-package notices, which are accurate.
- **`CHANGELOG.md` files.** Released entries are a historical record.
- **One `'Summarize "serverless postgres" in the schema.'`** in an ai-sdk-provider e2e test. That's an LLM prompt string, arbitrary test input.

## Verification

Everything the repo gates on, at `b963101`:

```
pnpm lint:ci      biome ci --error-on-warnings — 557 files checked, clean
pnpm build        all 16 packages built
pnpm test:ci      3,222 tests passed across 10 packages, 9 skipped, 0 failed
```

Per-package: `cli` 115 files / 3,153 tests, `config` 13, `init` 13, `neon-new` 8, `env` 7, `config-runtime` 6, `sdk` 5, `ai-sdk-provider` 3, `functions` 1, `neonctl` 1.

Then the part a diff can't confirm — that the strings users see actually changed. Ran the built CLI:

```console
$ node packages/init/dist/cli.js --help
  neon-init auth             Manage Neon authentication
```

And grepped the built artifacts, which is what ships to npm:

```
stale terms across packages/*/dist:
  packages/sdk/dist/client/sdk.gen.d.ts:1      # upstream spec, see above
  packages/sdk/dist/client/sdk.gen.js:1        # upstream spec, see above
```

Nothing else. The new strings are present in `packages/init/dist/lib/bootstrap.js` and `.../phases/auth.js`.

Not verified: `test:e2e:live` was not run — it needs real Neon credentials and provisions real projects. No changed line participates in control flow; the only non-comment changes are a description field, help text, prompt copy, template blurbs, and one error message whose assertions are covered by the unit suite.

## For your attention

- **The `Invalid Neon config:` rename is the only thing here that can break a consumer**, and only one matching on the error text. It felt worse to leave a banned phrase in an error users see, but it's a judgment call and easy to revert on its own.
- **75 Dependabot vulnerabilities on `main`** (2 critical, 36 high) reported on push. Untouched and unrelated.
