### PR TITLE
Let a neon.ts function declare packages the bundler must leave alone

### DIFF
--- a/.changeset/lucky-pugs-observe.md
+++ b/.changeset/lucky-pugs-observe.md
@@ -26,6 +26,6 @@ export default defineConfig({
 
 Every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed. `neon deploy`, `neon config apply`, `buildFunctionBundle`, and `neon dev` all apply the same list, so a local run bundles like a deploy.
 
-**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. The option is for imports that are never evaluated; a dependency the handler needs has to be made bundleable instead.
+**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. The option unblocks an import that is never evaluated; it does not make a dependency usable. A dependency the handler actually calls has to be bundled — which a pure-JavaScript package can be, and a package backed by a native `.node` binary cannot, by any bundler.
 
 Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time.

--- a/.changeset/lucky-pugs-observe.md
+++ b/.changeset/lucky-pugs-observe.md
@@ -1,0 +1,31 @@
+---
+"@neon/config": minor
+"@neon/config-runtime": minor
+"neon": minor
+---
+
+Add `externalPackages` to a `neon.ts` function, for dependencies esbuild cannot bundle
+
+A function's `source` is bundled at deploy time, and some packages cannot be bundled at all: a native `.node` addon has no esbuild loader, and a library may reference an optional peer dependency on a code path the function never takes. Both fail the deploy with a resolve or loader error naming the package, and neither is fixable from the function's own source — there was no way to opt a package out.
+
+`externalPackages` is that escape hatch, and the deploy-time counterpart of Next.js's `serverExternalPackages`:
+
+```ts
+export default defineConfig({
+  preview: {
+    functions: {
+      agent: {
+        name: "Agent",
+        source: "./functions/agent.ts",
+        externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+      },
+    },
+  },
+});
+```
+
+Every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed. `neon deploy`, `neon config apply`, `buildFunctionBundle`, and `neon dev` all apply the same list, so a local run bundles like a deploy.
+
+**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. The option is for imports that are never evaluated; a dependency the handler needs has to be made bundleable instead.
+
+Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -529,7 +529,7 @@ neon deploy --branch my-feature --update-existing
 
 Function deploys declared under `preview.functions` are bundled by neon's own esbuild helper and uploaded as part of `apply`, so the policy stays declarative and the packaged CLI never has to embed esbuild's native binary.
 
-When a package cannot be bundled — a native addon with no esbuild loader, or an optional peer dependency a library references on an untaken code path — list it in that function's `externalPackages` and the bundler leaves the import alone. `neon dev` honours the same list. It does not make the package resolvable in the deployed archive (there is no `node_modules` next to the bundle), so it suits an import that is never evaluated; see [`@neon/config`](../config/README.md#unbundleable-dependencies-externalpackages).
+When a package cannot be bundled — a native addon with no esbuild loader, or an optional peer dependency a library references on an untaken code path — list it in that function's `externalPackages` and the bundler leaves the import alone. `neon dev` honours the same list. It does not make the package resolvable in the deployed archive (there is no `node_modules` next to the bundle), so it only unblocks an import that is never evaluated — a dependency the handler actually calls has to be bundled, and a natively-backed one cannot be. See [`@neon/config`](../config/README.md#unbundleable-dependencies-externalpackages).
 
 ## Scaffold a project (`bootstrap`)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -529,6 +529,8 @@ neon deploy --branch my-feature --update-existing
 
 Function deploys declared under `preview.functions` are bundled by neon's own esbuild helper and uploaded as part of `apply`, so the policy stays declarative and the packaged CLI never has to embed esbuild's native binary.
 
+When a package cannot be bundled — a native addon with no esbuild loader, or an optional peer dependency a library references on an untaken code path — list it in that function's `externalPackages` and the bundler leaves the import alone. `neon dev` honours the same list. It does not make the package resolvable in the deployed archive (there is no `node_modules` next to the bundle), so it suits an import that is never evaluated; see [`@neon/config`](../config/README.md#unbundleable-dependencies-externalpackages).
+
 ## Scaffold a project (`bootstrap`)
 
 `neon bootstrap` copies a Neon starter template into a new (or current) directory — conceptually like `degit`, but it only pulls from a small set of templates we maintain in the public [`neondatabase/examples`](https://github.com/neondatabase/examples) repo. It requires no Neon login: it just downloads files from GitHub.

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -52,7 +52,13 @@ import { autoPullEnvAfterPin } from "./env.js";
  * neonctl snapshot, which resolves esbuild dynamically at deploy time.
  */
 const neonctlBundler: FunctionBundler = async (fn) =>
-	zipBundle(await bundleEntry(fn.source));
+	zipBundle(
+		await bundleEntry(fn.source, {
+			...(fn.externalPackages
+				? { externalPackages: fn.externalPackages }
+				: {}),
+		}),
+	);
 
 const INSPECT_FIELDS = ["project", "branch", "config"] as const;
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -267,10 +267,14 @@ const plannedToUnit = (
 		// base) so reconcile can tell a real change from a no-op save. A search-mode function
 		// re-planned with a different base must hash identically, or it would be needlessly
 		// restarted — see reconcile().
+		...(fn.externalPackages
+			? { externalPackages: fn.externalPackages }
+			: {}),
 		configKey: JSON.stringify({
 			source: fn.source,
 			port: fn.port ?? null,
 			env: fn.env,
+			externalPackages: fn.externalPackages ?? null,
 		}),
 	};
 };
@@ -303,6 +307,11 @@ const buildChildEnv = (
 export type ServedUnit = {
 	slug: string | null;
 	source: string;
+	/**
+	 * Packages to leave unbundled, from the function's `neon.ts` `externalPackages`. Absent
+	 * in single-source mode (`--source` has no policy to read it from).
+	 */
+	externalPackages?: string[];
 	bundleDir: string;
 	childEnv: NodeJS.ProcessEnv;
 	label: string | null;
@@ -359,7 +368,11 @@ const runSupervisor = async (
 	const bundleAndStart = async (r: RunningUnit): Promise<void> => {
 		let bundlePath: string;
 		try {
-			bundlePath = await writeBundle(r.unit.source, r.unit.bundleDir);
+			bundlePath = await writeBundle(
+				r.unit.source,
+				r.unit.bundleDir,
+				r.unit.externalPackages,
+			);
 		} catch (err) {
 			r.status = "error";
 			logUnit(
@@ -670,8 +683,11 @@ const spawnChild = (
 const writeBundle = async (
 	source: string,
 	bundleDir: string,
+	externalPackages?: readonly string[],
 ): Promise<string> => {
-	const files = await bundleEntry(source);
+	const files = await bundleEntry(source, {
+		...(externalPackages ? { externalPackages } : {}),
+	});
 	mkdirSync(bundleDir, { recursive: true });
 	// bundleEntry emits a single `index.mjs` (no source map). The `.mjs` extension makes Node
 	// load it as ESM directly, so no `package.json` `"type": "module"` marker is needed.

--- a/packages/cli/src/dev/functions.test.ts
+++ b/packages/cli/src/dev/functions.test.ts
@@ -46,6 +46,31 @@ describe("resolveFunctionsFromConfig", () => {
 		expect(resolved?.configPath).toBe(join(cwd, "neon.ts"));
 	});
 
+	it("mirrors externalPackages so a local bundle matches a deploy", async () => {
+		writeWorkspace(
+			cwd,
+			`export default {
+        preview: {
+          functions: {
+            hello: {
+              name: 'Hello',
+              source: './hello.ts',
+              externalPackages: ['microsandbox'],
+            },
+            bare: { name: 'Bare', source: './bare.ts' },
+          },
+        },
+      };\n`,
+			["hello.ts", "bare.ts"],
+		);
+
+		const resolved = await resolveFunctionsFromConfig(cwd);
+		const bySlug = new Map(resolved?.functions.map((f) => [f.slug, f]));
+		expect(bySlug.get("hello")?.externalPackages).toEqual(["microsandbox"]);
+		// Absent, not empty, when the policy does not declare it.
+		expect(bySlug.get("bare")).not.toHaveProperty("externalPackages");
+	});
+
 	it("resolves each function with an absolute source and its dev settings", async () => {
 		writeWorkspace(
 			cwd,

--- a/packages/cli/src/dev/functions.ts
+++ b/packages/cli/src/dev/functions.ts
@@ -19,6 +19,12 @@ export type PlannedFunction = {
 	source: string;
 	port?: number;
 	env: Record<string, string>;
+	/**
+	 * The function's `neon.ts` `externalPackages`, mirrored so a local bundle is built with
+	 * the same `external` list as a deploy. Without it, `neon dev` would fail to bundle a
+	 * function that deploys fine — the failure `externalPackages` exists to fix.
+	 */
+	externalPackages?: string[];
 };
 
 /**
@@ -73,6 +79,9 @@ export const resolveFunctionsFromConfig = async (
 				? { port: devPort(fn.dev) as number }
 				: {}),
 			env: { ...fn.env },
+			...(fn.externalPackages
+				? { externalPackages: [...fn.externalPackages] }
+				: {}),
 		};
 	});
 

--- a/packages/cli/src/utils/esbuild.test.ts
+++ b/packages/cli/src/utils/esbuild.test.ts
@@ -51,6 +51,17 @@ beforeAll(() => {
 		].join("\n"),
 	);
 	writeFileSync(join(dir, "broken.ts"), "export default {\n");
+	// Imports a package that is not installed anywhere, so it can only bundle when the
+	// specifier is declared external.
+	writeFileSync(
+		join(dir, "needs-external.ts"),
+		[
+			'import { greet } from "./helper";',
+			'import { thing } from "not-installed-anywhere";',
+			"export default { greet, thing };",
+			"",
+		].join("\n"),
+	);
 });
 afterAll(() => {
 	rmSync(dir, { recursive: true, force: true });
@@ -87,6 +98,37 @@ describe("bundleEntry", () => {
 			`Failed to bundle function from ${source}`,
 		);
 		expect(err.message).not.toContain("esbuild not found");
+	});
+
+	test("fails on an unresolvable dependency when externalPackages is not set", async () => {
+		// The baseline the option exists to fix: this is the deploy-time bundle failure.
+		await expect(
+			bundleEntry(join(dir, "needs-external.ts"), npmDeps),
+		).rejects.toThrow(/Could not resolve "not-installed-anywhere"/);
+	});
+
+	test("externalPackages leaves the named package unbundled and still inlines the rest", async () => {
+		const out = await bundleEntry(join(dir, "needs-external.ts"), {
+			...npmDeps,
+			externalPackages: ["not-installed-anywhere"],
+		});
+		const js = strFromU8(out["index.mjs"]);
+		expect(js).toContain("not-installed-anywhere");
+		expect(js).toContain("hi from helper");
+	});
+
+	test("externalPackages reaches the binary path as --external flags", async () => {
+		await withEnv(ESBUILD_BIN, async () => {
+			const out = await bundleEntry(join(dir, "needs-external.ts"), {
+				isPackaged: () => true,
+				loadEsbuild: () =>
+					Promise.reject(new Error("should not be called")),
+				externalPackages: ["not-installed-anywhere"],
+			});
+			const js = strFromU8(out["index.mjs"]);
+			expect(js).toContain("not-installed-anywhere");
+			expect(js).toContain("hi from helper");
+		});
 	});
 
 	test("packaged mode uses the binary and never imports the esbuild module", async () => {

--- a/packages/cli/src/utils/esbuild.ts
+++ b/packages/cli/src/utils/esbuild.ts
@@ -30,6 +30,17 @@ export type BundleDeps = {
 	loadEsbuild: (name: string) => Promise<EsbuildModule>;
 };
 
+/**
+ * Bundling knobs a caller may set, alongside the injectable deps. `externalPackages` comes
+ * from a function's `neon.ts` `externalPackages` and is handed to esbuild's `external`, so
+ * a package esbuild cannot bundle (a native addon, an optional peer on an untaken code
+ * path) stops failing the build. It does NOT become resolvable in the deployed archive —
+ * see `FunctionDef.externalPackages` in @neon/config.
+ */
+export type BundleOptions = Partial<BundleDeps> & {
+	externalPackages?: readonly string[];
+};
+
 const defaultDeps: BundleDeps = {
 	// @yao-pkg/pkg defines process.pkg inside the packaged binary.
 	isPackaged: () => (process as { pkg?: unknown }).pkg !== undefined,
@@ -55,6 +66,7 @@ const toFilesByBasename = (
 const bundleViaModule = async (
 	source: string,
 	loadEsbuild: BundleDeps["loadEsbuild"],
+	externalPackages: readonly string[],
 ): Promise<Record<string, Uint8Array>> => {
 	// esbuild is resolved by a COMPUTED specifier, never the literal string
 	// 'esbuild'. Both rollup (bundle step) and @yao-pkg/pkg (binary step)
@@ -91,6 +103,8 @@ const bundleViaModule = async (
 			// Functions runtime has no node_modules). Node built-ins stay external on
 			// platform:'node'. The banner re-creates require/__filename/__dirname for bundled CJS.
 			banner: { js: ESM_CJS_INTEROP_BANNER },
+			// Only what the policy declared unbundleable; everything else is still inlined.
+			external: [...externalPackages],
 			logLevel: "silent",
 		})
 		.catch((err: unknown) => {
@@ -148,6 +162,7 @@ const runEsbuild = (
 
 const bundleViaBinary = async (
 	source: string,
+	externalPackages: readonly string[],
 ): Promise<Record<string, Uint8Array>> => {
 	const bin = resolveEsbuild();
 	const outDir = mkdtempSync(join(tmpdir(), "neon-fn-bundle-"));
@@ -161,6 +176,8 @@ const bundleViaBinary = async (
 			"--format=esm",
 			"--platform=node",
 			`--banner:js=${ESM_CJS_INTEROP_BANNER}`,
+			// One flag per package, mirroring the module path's `external` array.
+			...externalPackages.map((pkg) => `--external:${pkg}`),
 			"--log-level=error",
 		]);
 		if (code !== 0) {
@@ -183,13 +200,17 @@ const bundleViaBinary = async (
 // binary (and platforms esbuild can't run on) shell out to an esbuild binary.
 export const bundleEntry = async (
 	source: string,
-	deps: BundleDeps = defaultDeps,
+	options: BundleOptions = {},
 ): Promise<Record<string, Uint8Array>> => {
-	if (deps.isPackaged()) return bundleViaBinary(source);
+	const isPackaged = options.isPackaged ?? defaultDeps.isPackaged;
+	const loadEsbuild = options.loadEsbuild ?? defaultDeps.loadEsbuild;
+	const externalPackages = options.externalPackages ?? [];
+	if (isPackaged()) return bundleViaBinary(source, externalPackages);
 	try {
-		return await bundleViaModule(source, deps.loadEsbuild);
+		return await bundleViaModule(source, loadEsbuild, externalPackages);
 	} catch (err) {
-		if (err instanceof ModuleNotAvailable) return bundleViaBinary(source);
+		if (err instanceof ModuleNotAvailable)
+			return bundleViaBinary(source, externalPackages);
 		throw err;
 	}
 };

--- a/packages/config-runtime/README.md
+++ b/packages/config-runtime/README.md
@@ -17,7 +17,7 @@ npm install @neon/config-runtime
 - `inspect` / `plan` / `apply` — read the current branch state, diff a policy against it, and apply the changes.
 - `pullConfig` / `pushConfig` — lower-level pull/push primitives.
 - `createBranch` — create a branch to target.
-- `buildFunctionBundle` — bundle Neon Functions for deploy.
+- `buildFunctionBundle` — bundle Neon Functions for deploy. Honours the function's `externalPackages`, passing each entry to esbuild's `external`.
 
 ```ts
 import { inspect, plan, apply } from "@neon/config-runtime/v1";

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -14,13 +14,17 @@ afterAll(() => {
 	rmSync(dir, { recursive: true, force: true });
 });
 
-function fn(source: string): ResolvedFunctionConfig {
+function fn(
+	source: string,
+	externalPackages?: string[],
+): ResolvedFunctionConfig {
 	return {
 		slug: "fn1",
 		name: "Hello World",
 		source,
 		env: {},
 		runtime: "nodejs24",
+		...(externalPackages ? { externalPackages } : {}),
 	};
 }
 
@@ -61,5 +65,57 @@ describe("buildFunctionBundle", () => {
 		await expect(
 			buildFunctionBundle(fn(join(dir, "does-not-exist.ts"))),
 		).rejects.toThrow(/Failed to bundle function "fn1"/);
+	});
+
+	test("fails to bundle an unresolvable dependency when it is not declared external", async () => {
+		const source = join(dir, "needs-external.ts");
+		writeFileSync(
+			source,
+			[
+				"import { thing } from 'not-installed-anywhere';",
+				"export default { fetch(): Response { return new Response(String(thing)); } };",
+			].join("\n"),
+		);
+
+		// The baseline for the test below: without `externalPackages` this is exactly the
+		// deploy-time failure the option exists to fix.
+		await expect(buildFunctionBundle(fn(source))).rejects.toThrow(
+			/Could not resolve "not-installed-anywhere"/,
+		);
+	});
+
+	test("leaves a declared external package unbundled instead of failing to resolve it", async () => {
+		const source = join(dir, "needs-external.ts");
+
+		const bundle = await buildFunctionBundle(
+			fn(source, ["not-installed-anywhere"]),
+		);
+
+		const files = unzipSync(bundle);
+		const js = new TextDecoder().decode(files["index.mjs"]);
+		// The import survives into the output rather than being followed and inlined.
+		expect(js).toContain("not-installed-anywhere");
+	});
+
+	test("bundles everything not named in externalPackages", async () => {
+		const helper = join(dir, "still-bundled.ts");
+		writeFileSync(helper, "export const marker = 'inlined by esbuild';\n");
+		const source = join(dir, "mixed-externals.ts");
+		writeFileSync(
+			source,
+			[
+				"import { marker } from './still-bundled.js';",
+				"import { thing } from 'not-installed-anywhere';",
+				"export default { fetch(): Response { return new Response(marker + thing); } };",
+			].join("\n"),
+		);
+
+		const bundle = await buildFunctionBundle(
+			fn(source, ["not-installed-anywhere"]),
+		);
+
+		const js = new TextDecoder().decode(unzipSync(bundle)["index.mjs"]);
+		expect(js).toContain("inlined by esbuild");
+		expect(js).toContain("not-installed-anywhere");
 	});
 });

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -74,6 +74,11 @@ export async function buildFunctionBundle(
 			// `platform: "node"`. The banner re-creates require/__filename/__dirname so
 			// bundled CommonJS deps work inside the ESM output.
 			banner: { js: ESM_CJS_INTEROP_BANNER },
+			// Packages the policy declared unbundleable (native addons, optional peers on
+			// dead code paths). Their imports survive into the bundle and resolve against a
+			// directory with no node_modules, so reaching one at runtime throws — which is
+			// the documented contract of `FunctionDef.externalPackages`, not a bug here.
+			external: [...(fn.externalPackages ?? [])],
 			logLevel: "silent",
 		});
 	} catch (cause) {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -63,7 +63,14 @@ export default defineConfig({
 });
 ```
 
-**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. That makes the option right for an import that is never evaluated, and wrong for a dependency the handler needs — for which the answer is to make the package bundleable.
+**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. The option unblocks an import that is never evaluated; it does not make a dependency usable.
+
+A dependency the handler actually calls has to be bundled, and whether that is possible depends on what it is:
+
+- **Pure JavaScript** — bundling is the normal case, and a failure is usually something specific and fixable in the entry.
+- **Backed by a native `.node` binary** — cannot be bundled by any bundler; the binary is a compiled object the platform loads from a real path. Such a package cannot work on Functions until the archive can carry files alongside the bundle. Listing it here does not help, it only moves the error from deploy to invoke.
+
+A native package may also bundle without needing this option at all. `sharp` loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
 
 Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. `neon dev` applies the same list, so a local run bundles like a deploy.
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -43,6 +43,30 @@ A policy is split into a **static** existential set and a **dynamic** `branch` c
 
 Service toggles accept `true` / `{}` / `{ enabled: true }` (enabled) and `false` / `{ enabled: false }` (disabled). Function slugs (record keys) must match `^[a-z0-9]{1,20}$`.
 
+### Unbundleable dependencies (`externalPackages`)
+
+A function's `source` is bundled with esbuild at deploy time, and some packages cannot be bundled at all: a native `.node` addon has no esbuild loader, and a library may reference an optional peer dependency on a code path the function never takes. Either one fails the deploy with a resolve or loader error naming the package, and neither is fixable from the function's own source.
+
+`externalPackages` is the escape hatch, and the deploy-time counterpart of Next.js's `serverExternalPackages` — every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed:
+
+```ts
+export default defineConfig({
+  preview: {
+    functions: {
+      agent: {
+        name: "Agent",
+        source: "./functions/agent.ts",
+        externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+      },
+    },
+  },
+});
+```
+
+**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. That makes the option right for an import that is never evaluated, and wrong for a dependency the handler needs — for which the answer is to make the package bundleable.
+
+Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. `neon dev` applies the same list, so a local run bundles like a deploy.
+
 ### Data API
 
 `dataApi` accepts the same boolean/toggle forms **or** an object that selects the auth provider and reusable runtime `settings`:

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -130,6 +130,64 @@ describe("resolveConfig", () => {
 		});
 	});
 
+	test("passes externalPackages through to the resolved function", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./functions/hello-world.ts",
+						externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions).toEqual([
+			{
+				slug: "fn1",
+				name: "Hello World",
+				source: "./functions/hello-world.ts",
+				env: {},
+				externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+				runtime: "nodejs24",
+			},
+		]);
+	});
+
+	test("omits externalPackages entirely when the policy does not declare it", () => {
+		const config = defineConfig({
+			preview: {
+				functions: { fn1: { name: "Hello", source: "./hello.ts" } },
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		// Absent rather than `[]`, so an existing policy resolves to the shape it always did.
+		expect(resolved.preview?.functions[0]).not.toHaveProperty(
+			"externalPackages",
+		);
+	});
+
+	test("copies externalPackages so mutating the policy array cannot reach the resolved config", () => {
+		const externalPackages = ["microsandbox"];
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						externalPackages,
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		externalPackages.push("mutated-after-resolve");
+		expect(resolved.preview?.functions[0]?.externalPackages).toEqual([
+			"microsandbox",
+		]);
+	});
+
 	test("applies per-branch function runtime tuning", () => {
 		const config = defineConfig({
 			preview: {

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -341,6 +341,11 @@ function resolveFunctionConfig(
 		source: def.source,
 		env: { ...(def.env ?? {}) },
 		runtime: tuning.runtime ?? DEFAULT_FUNCTION_RUNTIME,
+		// Copied only when declared, so a policy without it resolves unchanged. Both
+		// bundlers read it; `neon dev` mirrors it so a local run bundles like a deploy.
+		...(def.externalPackages
+			? { externalPackages: [...def.externalPackages] }
+			: {}),
 		// Passed through untouched (no defaults); only `neon dev` reads it.
 		...(def.dev ? { dev: def.dev } : {}),
 	};

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -100,6 +100,90 @@ describe("configInputSchema", () => {
 		expect(result.success).toBe(true);
 	});
 
+	test("accepts externalPackages with bare, scoped, and subpath specifiers", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: [
+							"microsandbox",
+							"@scope/pkg",
+							"pkg/sub",
+						],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts an empty externalPackages list", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: [],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects a relative path in externalPackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: ["./local-module.js"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(formatZodIssues(result.error).join("\n")).toMatch(
+				/not a relative or absolute path/,
+			);
+		}
+	});
+
+	test("rejects an absolute path in externalPackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: ["/opt/thing.js"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a non-string entry in externalPackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: [42],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
 	test("rejects an unknown key in the function dev block (e.g. removed `portless`)", () => {
 		const result = configInputSchema.safeParse({
 			preview: {

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -203,6 +203,27 @@ const functionDevConfigSchema = z.strictObject({
 	port: devPortSchema.optional(),
 });
 
+/**
+ * A package the bundler must leave alone. Accepts what esbuild's `external` accepts for a
+ * package — a bare name, a scope, or a subpath — and rejects a relative or absolute path,
+ * which names a local module rather than a dependency and is never the right thing to
+ * externalize (the bundle would ship an import of a file that isn't deployed).
+ */
+const externalPackageSchema = z
+	.string()
+	.min(1)
+	.refine((value) => !value.startsWith(".") && !value.startsWith("/"), {
+		error: 'must be a package name such as "microsandbox" or "@scope/pkg", not a relative or absolute path',
+	});
+
+/**
+ * Per-function list of packages esbuild leaves unresolved at deploy time. See
+ * {@link FunctionDef.externalPackages} for when this is the right tool — the deployed
+ * archive has no `node_modules`, so an externalized package must never be reached at
+ * runtime.
+ */
+const functionExternalPackagesSchema = z.array(externalPackageSchema);
+
 const runtimeSchema = z.literal("nodejs24");
 
 /**
@@ -214,6 +235,7 @@ export const functionDefSchema = z.strictObject({
 	name: z.string().min(1).max(255),
 	source: z.string().min(1),
 	env: functionEnvSchema.optional(),
+	externalPackages: functionExternalPackagesSchema.optional(),
 	dev: functionDevConfigSchema.optional(),
 });
 

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -335,6 +335,31 @@ export interface FunctionDef {
 	 */
 	env?: Record<string, string>;
 	/**
+	 * Packages the bundler must leave alone, by name — the deploy-time equivalent of
+	 * Next.js's `serverExternalPackages`. Every entry is passed to esbuild's `external`,
+	 * so the import survives into the bundle instead of being followed.
+	 *
+	 * Reach for this when bundling a package is impossible rather than merely undesirable.
+	 * The cases that come up: a native `.node` addon or a `node-gyp` dependency esbuild has
+	 * no loader for, and an optional peer dependency a library references on a code path
+	 * this function never takes. Both fail the deploy at bundle time with a resolve or
+	 * loader error naming the package, and neither is fixable from the function's own
+	 * source.
+	 *
+	 * **An external package is not resolvable at runtime.** The deployed archive is a
+	 * single `index.mjs` with no `node_modules` beside it, so anything listed here throws
+	 * `Cannot find module` if the function actually reaches it. That makes this safe for
+	 * an import that is never evaluated, and wrong for a dependency the handler needs —
+	 * for which the answer is to make the package bundleable, not to externalize it.
+	 *
+	 * Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`,
+	 * `pkg/sub`), matching esbuild. A relative or absolute path is rejected at validation
+	 * time: those are local modules, and a local module that cannot be bundled is a
+	 * different problem.
+	 * @example ["microsandbox", "@mongodb-js/zstd"]
+	 */
+	externalPackages?: string[];
+	/**
 	 * Local-development settings used by `neon dev` when serving every function from
 	 * `neon.ts`. Ignored at deploy time. See {@link FunctionDevConfig}.
 	 */
@@ -515,6 +540,12 @@ export interface ResolvedFunctionConfig {
 	name: string;
 	source: string;
 	env: Record<string, string>;
+	/**
+	 * Packages the bundler leaves unresolved, passed through from
+	 * {@link FunctionDef.externalPackages}. Absent rather than empty when undeclared, so a
+	 * policy that never mentions it resolves to the same shape it always did.
+	 */
+	externalPackages?: string[];
 	runtime: FunctionRuntime;
 	/**
 	 * Local-development settings, passed through untouched from {@link FunctionDef.dev}

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -348,9 +348,20 @@ export interface FunctionDef {
 	 *
 	 * **An external package is not resolvable at runtime.** The deployed archive is a
 	 * single `index.mjs` with no `node_modules` beside it, so anything listed here throws
-	 * `Cannot find module` if the function actually reaches it. That makes this safe for
-	 * an import that is never evaluated, and wrong for a dependency the handler needs —
-	 * for which the answer is to make the package bundleable, not to externalize it.
+	 * `Cannot find module` if the function actually reaches it. This option therefore only
+	 * unblocks an import that is never evaluated; it does not make a dependency usable.
+	 *
+	 * A dependency the handler actually calls has to be bundled, and whether that is
+	 * possible depends on what it is. A pure-JavaScript package can be bundled, and a
+	 * failure to do so is usually something specific and fixable. A package backed by a
+	 * native `.node` binary cannot be bundled by anything — the binary is a compiled
+	 * object the platform loads from a real path — so such a package cannot work on
+	 * Functions until the deployed archive can carry files alongside the bundle. Do not
+	 * reach for `externalPackages` to try: it moves the error from deploy to invoke.
+	 *
+	 * Note that a native package may bundle without ever needing this option. `sharp`, for
+	 * instance, loads its binary through `createRequire`, which esbuild does not follow, so
+	 * it bundles cleanly and then fails at invoke with "Could not load the sharp module".
 	 *
 	 * Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`,
 	 * `pkg/sub`), matching esbuild. A relative or absolute path is rejected at validation


### PR DESCRIPTION
## The problem

A function's `source` is bundled with esbuild at deploy time, and some packages cannot be bundled. Two cases come up:

- a native `.node` addon or a `node-gyp` dependency esbuild has no loader for
- an optional peer dependency a library references on a code path the function never takes

Both fail the deploy at bundle time, and neither is fixable from the function's own source. There was no way to opt a package out — `FunctionDef` was `{ name, source, env, dev }`.

Hit while deploying Vercel's [eve](https://github.com/vercel/eve) agent framework onto a Function. eve's build reaches its optional sandbox peers, which pull native artifacts:

```
ERROR: No loader is configured for ".node" files: node_modules/@mongodb-js/zstd/build/Release/zstd.node
ERROR: Could not resolve "node-liblzma"
```

Nothing in the function's source imports those. The only way through today is to install stub packages under the real names, which is a workaround for a missing option rather than a fix.

## The interface

`externalPackages` on a static function definition, the deploy-time counterpart of Next.js's `serverExternalPackages`:

```ts
import { defineConfig } from "@neon/config/v1";

export default defineConfig({
  preview: {
    functions: {
      agent: {
        name: "Agent",
        source: "./functions/agent.ts",
        externalPackages: ["microsandbox", "@mongodb-js/zstd"],
      },
    },
  },
});
```

Every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed. Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`).

A relative or absolute path is rejected at validation time — a local module that cannot be bundled is a different problem, and externalizing it would ship an import of a file that is never deployed:

```
preview.functions.fn1.externalPackages.0: must be a package name such as
"microsandbox" or "@scope/pkg", not a relative or absolute path
```

### What this does and does not buy you

The deployed archive is a single `index.mjs` with no `node_modules` beside it, so an external package throws `Cannot find module` if the function reaches it. **The option unblocks an import that is never evaluated; it does not make a dependency usable.**

A dependency the handler actually calls has to be bundled, and whether that is possible depends on what it is. A pure-JavaScript package can be. A package backed by a native `.node` binary cannot be, by any bundler — the binary is a compiled object the platform loads from a real path. Listing such a package here does not help; it moves the error from deploy to invoke.

Worth knowing: a native package may never reach this option at all. `sharp` loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly (40 KB) and then fails at invoke with `Could not load the "sharp" module`. Verified.

### Where it applies

All four bundling paths honour the list, so behaviour does not depend on which one you hit:

| Path | Change |
| --- | --- |
| `buildFunctionBundle` (`@neon/config-runtime`) | `external` from `fn.externalPackages` |
| CLI esbuild **module** path | same, via `bundleEntry`'s new `externalPackages` option |
| CLI esbuild **binary** path (packaged CLI) | one `--external:<pkg>` flag per entry |
| `neon dev` | mirrored through `PlannedFunction` → `ServedUnit` |

`neon dev` matters: without it a local run would fail to bundle a function that deploys fine — the exact failure this option exists to fix. It is also folded into the dev reconciler's `configKey`, so editing the list restarts the child instead of being treated as a no-op save.

### Shape compatibility

`externalPackages` is optional on `ResolvedFunctionConfig` and copied only when declared, following `dev` rather than `env`. A policy that never mentions it resolves to exactly the shape it did before, so no existing assertion or plan output changes. The array is copied on resolve, so mutating the policy array afterwards cannot reach the resolved config.

## Verification

`pnpm build`, `pnpm lint:ci`, and `pnpm test:ci` are green (3,990 tests). New coverage, each paired with a baseline test asserting the failure the option removes:

- `packages/config/src/lib/schema.test.ts` — bare, scoped, and subpath specifiers accepted; empty list accepted; relative path, absolute path, and non-string entry rejected
- `packages/config/src/lib/define-config.test.ts` — pass-through, omitted when undeclared, and the defensive copy
- `packages/config-runtime/src/lib/function-bundle.test.ts` — fails to resolve without the option, bundles with it, and still inlines everything not named
- `packages/cli/src/utils/esbuild.test.ts` — the same three through `bundleEntry`, including the packaged binary path
- `packages/cli/src/dev/functions.test.ts` — `neon dev` mirrors the list

**Deployed live** against a real branch (`aws-us-east-2`) with the CLI built from this branch, same policy either way:

```
=== BASELINE: policy WITHOUT externalPackages ===
ERROR: Failed to bundle function from src/index.ts. Build failed with 1 error:
src/index.ts:2:46: ERROR: Could not resolve "not-installed-anywhere"

=== WITH externalPackages ===
Applied changes
  + function extdep
```

The deployed function served requests, and the specifier was still present in the bundle rather than inlined. The throwaway function was deleted afterwards.

## The follow-up this enables, and four things a spike established

Reviewers will reasonably ask whether the option should also **ship** the named packages into the archive, the way Next.js pairs `serverExternalPackages` with output file tracing. It should, eventually. I spiked it against the live runtime to find out what that costs, and threw the spike away. Four facts came out, all worth recording before anyone designs it:

1. **The runtime does resolve `node_modules` from inside the archive.** A function importing an unbundled `ms` returned `{"ok":true,"oneDayInMs":86400000}` when the package was shipped as `node_modules/ms/**` in the zip. So the current single-file limit is a property of our bundler, not of the platform — tracing is viable.
2. **The runtime is `linux-arm64`.** sharp reported it: `Could not load the "sharp" module using the linux-arm64 runtime`. It is not documented anywhere I could find, and it decides which prebuilt binaries a tracer would have to ship.
3. **Node's resolver cannot find these packages, so a tracer cannot use it.** `require.resolve("@img/sharp-linux-arm64")` and `.../package.json` both fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`, because the package exports only `./sharp.node`. Every `@img/*` platform package behaves this way. Tracing has to resolve package *directories* on disk — which is why `@vercel/nft` exists and why a naive implementation silently ships nothing.
4. **Cross-platform install is a user-facing problem, not an implementation detail.** npm refuses foreign-platform optional deps from a Mac (`npm error notsup Valid libc: glibc / Actual libc: undefined`) without `--force`, and `--force` replaced the host binaries rather than adding to them. So a native package traced from a laptop ships the wrong architecture. That needs a deliberate answer — deploy from Linux CI, an architecture check at deploy time, or platform-side install — rather than being discovered by users as a runtime crash.

That is a materially larger change with real design decisions in it, so I kept it out of this PR. Nothing here forecloses it: `externalPackages` is the prerequisite either way, and its meaning does not change when shipping is added, since `serverExternalPackages` also means external-and-shipped.

## Flagged

- **`neon functions deploy --src <path>` gets no equivalent flag.** That command bypasses `neon.ts`, so there is no policy to read the list from. Adding `--external` is easy if wanted; I left it out to keep the surface to the declarative path.
- **`ResolvedFunctionConfig` gains an optional field.** Anything hand-constructing that type is unaffected; anything switching exhaustively over its keys is not.
- **Fact 2 above is probably worth documenting on the Functions docs page** independently of this PR. Users picking prebuilt binaries have no way to learn the architecture today except by deploying and reading a crash.