### PR TITLE
fix: depend on neon-init through the workspace protocol

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -167,63 +167,18 @@ gh workflow run neon-pkgs.yml --repo databricks/secure-public-registry-releases-
 > `@neon/functions`, then `@neon/ai-sdk-provider`). Valid `package` values are the
 > choices in the workflow's `workflow_dispatch` input (each maintained package, plus `dry-run`).
 
-**Publish order: leaf deps first, the CLI last.** The build packs from source (internal `@neon/*`
-deps are `workspace:*`), so ordering doesn't affect whether a run *succeeds* — but for npm
-consumers to resolve cleanly, publish a dependency before its dependents:
+**Publish order: leaf deps first, the CLI last.** The build packs from source (every internal dep
+is `workspace:*`), so ordering doesn't affect whether a run *succeeds* — but for npm consumers to
+resolve cleanly, publish a dependency before its dependents:
 `@neon/config` → `@neon/config-runtime` / `@neon/env` → `neon` → `neonctl`.
 Publishing `neon` also ships the standalone binaries and GitHub release; publish the compatibility
-package only after `npm view neon version` confirms the matching primary package. `neon-init` is
-special — see below.
+package only after `npm view neon version` confirms the matching primary package.
 
 **Homebrew needs nothing from you.** `brew install neonctl` is a homebrew-core formula that builds
 from the npm `neonctl` tarball, and Homebrew's bot bumps it within a day of each publish. The
 compatibility package deliberately keeps both the `neonctl` and `neon` commands so the formula keeps
 working untouched — see [`docs/neonctl-compatibility-shim.md`](../../../docs/neonctl-compatibility-shim.md)
 before changing its `bin` map.
-
-#### ⚠️ When the release bumps `neon-init` (the lockfile catch-22)
-
-`packages/cli` pins **`neon-init` to a published version** (not `workspace:*`). `changeset version`
-bumps `neon-init` and rewrites the CLI's pin, **but doesn't touch `pnpm-lock.yaml`** — so the merged
-release PR leaves `main`'s lockfile pointing at the old `neon-init` while `packages/cli/package.json`
-wants the new one. The publish workflow runs `pnpm install --frozen-lockfile` over the **whole**
-workspace before packing any package, so it fails with `ERR_PNPM_OUTDATED_LOCKFILE` for **every**
-dispatch. And you can't just `pnpm install` to fix the lockfile, because the new `neon-init` isn't on
-npm yet (pnpm 10's `link-workspace-packages=false` makes it try to *fetch*). Catch-22.
-
-**Break it in this order:**
-
-1. **Publish `neon-init` first from a throwaway ref with a consistent lockfile.** Branch off `main`,
-   revert *only* the CLI's `neon-init` pin back to the currently-published version (so `package.json`
-   matches the still-old lockfile), push, and dispatch with `ref=<that-branch>`:
-
-   ```bash
-   git checkout -b chore/tmp-publish-neon-init main
-   # edit packages/cli/package.json: "neon-init": "<new>" → "<current-published>"
-   git commit -am "chore: temp CLI neon-init pin to publish neon-init@<new> (do not merge)"
-   git push -u origin HEAD
-   gh workflow run neon-pkgs.yml --repo databricks/secure-public-registry-releases-eng \
-     -f package=neon-init -f ref=chore/tmp-publish-neon-init
-   # after npm view neon-init version shows <new>: delete the branch, never merge it
-   ```
-
-   This publishes **only** `neon-init`; the CLI is never published from this ref.
-2. **Sync the lockfile on `main`.** Now that the new `neon-init` resolves, regenerate and land a tiny
-   PR (its CI passes because the lockfile finally matches):
-
-   ```bash
-   git checkout main && git pull
-   pnpm install --lockfile-only          # updates only the neon-init entry
-   git checkout -b chore/sync-lockfile-neon-init-<new>
-   git commit -am "chore: sync lockfile for neon-init@<new>"
-   # open PR, wait for green CI, merge
-   ```
-
-3. **Publish the rest from `main`** leaf-first / CLI-last (see order above).
-
-If the release does **not** touch `neon-init`, skip all of this — the lockfile stays consistent and
-you publish straight from `main`. The permanent fix is to move the CLI's `neon-init` dep to
-`workspace:*` like every other internal package.
 
 After each run succeeds, confirm with `npm view <pkg> version` — if it still shows the old version,
 you ran a dry-run (missing/`dry-run` `package` input); re-dispatch with the real `-f package=<name>`.
@@ -236,11 +191,12 @@ who does.
   `-f package=<name>` (and `-f ref=main`), once per bumped package. A `dry-run` (or input-less)
   dispatch goes green and prints a "Publish …" step but lands nothing on npm — verify with
   `npm view <pkg> version`, not the green check.
-- **A release that bumps `neon-init` needs the ordering dance** (publish `neon-init` from a
-  throwaway consistent ref → sync lockfile PR → publish the rest). The CLI pins `neon-init` to a
-  published version, so `changeset version` leaves `main`'s lockfile stale and every publish's
-  `frozen-lockfile` install fails until it's fixed. See "When the release bumps `neon-init`" in
-  step 7.
+- **Never pin an internal package to a published version.** `packages/cli` pinned `neon-init` that
+  way through 2.39.0, and `changeset version` rewriting the pin without touching `pnpm-lock.yaml`
+  broke `--frozen-lockfile` for the whole workspace — every CI job and every publish dispatch —
+  with no way to repair it until the new `neon-init` was published from a throwaway ref. Every
+  internal dep is `workspace:*` now; keep it that way. `pnpm pack` substitutes the real version at
+  publish time, so nothing about the tarball depends on the pin.
 - **CHANGELOG version gaps** can happen when a prior PR bumped `package.json` directly without a
   changeset (e.g. `ai-sdk-provider` jumped 0.2.0 → 0.4.0 in the log, skipping 0.3.0). Surface it;
   don't try to backfill.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,7 +303,7 @@ and so ignores package `exports`.
 -   **Coverage**: needs `@vitest/coverage-v8` because the root CI runs `pnpm test:ci --coverage` (the flag is appended to every package's `test:ci`). Pin it to the package's `vitest` major.
 -   **Standalone binaries**: `pnpm --filter neon bundle` (`node pkg.js`) Rollup-bundles `dist/cli.js` and cross-compiles `linux-x64`, `linux-arm64`, `macos-x64`, and `win-x64` via `@yao-pkg/pkg`; targets/assets are declared in the package's `pkg` block. The binaries are named after the package, so they ship as `neon-<target>`.
 -   **Conformance tests** (`tests/psql-conformance`) need Docker/testcontainers and are excluded from the default Vitest run; run them explicitly with `pnpm --filter <name> test:conformance`.
--   **Sibling deps**: the `@neon/*` packages are `workspace:*`; only `neon-init` is still pinned to a published version (see the lockfile catch-22 below). Switching it to `workspace:*` is a planned follow-up.
+-   **Sibling deps**: every internal dependency — the `@neon/*` packages and `neon-init` — is `workspace:*`. `neon-init` was pinned to a published version until it caused a release-blocking lockfile trap; keep it on the workspace protocol. `pnpm pack` rewrites the protocol to the exact version at publish time, so the tarball is unaffected either way.
 
 ### The SDK package (`packages/sdk`)
 
@@ -425,46 +425,27 @@ To cut one:
 The `release` Claude Code skill (`.claude/skills/release/`) automates this end to end,
 including a git-vs-npm check that flags packages which changed but lack a changeset.
 
-### Publish order — the `neon-init` lockfile trap
+### Publish order
 
-**Publish leaf dependencies first, the CLI last, and mind `neon-init`.** All internal
-`@neon/*` deps are `workspace:*` (linked locally, never a registry round-trip), so they don't
-constrain ordering for the build. **The one exception is `packages/cli`, which pins `neon-init`
-to a _published_ version** (e.g. `"neon-init": "0.20.2"`), not `workspace:*`. That single
-registry pin creates a chicken-and-egg whenever a release bumps `neon-init`:
+**Publish leaf dependencies first, the CLI last:**
+`@neon/config` → `@neon/config-runtime` / `@neon/env` → `neon` → `neonctl`.
+Publishing `neon` also ships the standalone binaries and the GitHub release; publish the
+compatibility package only after `npm view neon version` confirms the matching primary package.
+Verify each with `npm view <pkg> version`.
 
-- `changeset version` bumps `neon-init` **and** rewrites the CLI's pin to the new version
-  (`updateInternalDependencies: "patch"`), but **does not** update `pnpm-lock.yaml`.
-- So the moment the release PR merges, `main`'s lockfile still points at the **old** `neon-init`
-  while `packages/cli/package.json` wants the new one. The publish workflow's
-  `pnpm install --frozen-lockfile` (whole workspace) then fails with `ERR_PNPM_OUTDATED_LOCKFILE`
-  — for **every** package, since it installs the whole workspace before packing any one of them.
-- You can't fix the lockfile by running `pnpm install`, because the new `neon-init` isn't on npm
-  yet (pnpm 10 defaults `link-workspace-packages=false`, so it tries to *fetch* it). And you
-  can't publish the new `neon-init` because the frozen install is broken. Catch-22.
+Ordering is a courtesy to npm consumers, not a build constraint. Every internal dependency is
+`workspace:*`, so a package is always built and packed against workspace source and never makes a
+registry round-trip for a sibling.
 
-**Correct order when a release bumps `neon-init`:**
-
-1. **Publish `neon-init` first, from a throwaway ref where the lockfile is consistent.** Branch
-   off `main`, temporarily revert only the CLI's `neon-init` pin back to the currently-published
-   version (so `package.json` matches the still-old lockfile), push, and dispatch
-   `-f package=neon-init -f ref=<that-branch>`. This publishes **only** `neon-init` — the CLI is
-   never published from this throwaway ref. Delete the branch afterwards; never merge it.
-2. **Sync the lockfile on `main`.** Now that the new `neon-init` is on npm, `pnpm install
-   --lockfile-only` resolves it. Open a tiny `chore: sync lockfile for neon-init@<version>` PR
-   (this is exactly what such historical PRs are). Its CI now passes because the lockfile matches.
-3. **Publish the rest from `main`**, leaf-first, CLI last:
-   `@neon/config` → `@neon/config-runtime` / `@neon/env` → `neon` → `neonctl`.
-   Publishing `neon` also ships the standalone binaries and the GitHub release; publish the
-   compatibility package only after `npm view neon version` confirms the matching primary
-   package. Verify each with `npm view <pkg> version`.
-
-If a release does **not** touch `neon-init`, none of this applies — the lockfile stays consistent
-(`workspace:*` deps don't change it) and you can publish leaf-first / CLI-last straight from `main`.
-
-**The permanent fix** is to make the CLI depend on `neon-init` via `workspace:*` like every other
-internal package (see the pinned-sibling note under the CLI package above); until that lands,
-follow the ordering above.
+**Never pin an internal package to a published version.** `packages/cli` pinned `neon-init` that
+way until 2.39.0, and it deadlocked every release that bumped `neon-init`: `changeset version`
+rewrote the pin without touching `pnpm-lock.yaml`, so `pnpm install --frozen-lockfile` failed with
+`ERR_PNPM_OUTDATED_LOCKFILE` across the whole workspace — every CI job and every publish, not just
+the CLI's — and `pnpm install` could not repair it, because pnpm 10 defaults
+`link-workspace-packages=false` and tried to fetch a version that was unpublished precisely because
+the install was broken. Breaking that required publishing from a throwaway ref with the pin
+reverted. `workspace:*` cannot reach that state: the lockfile records `link:../init` and no version
+appears in it at all.
 
 ### Publishing the CLI (`neon` + the `neonctl` compatibility package)
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,7 +64,7 @@
     "cliui": "8.0.1",
     "diff": "5.2.0",
     "fflate": "^0.8.3",
-    "neon-init": "0.20.5",
+    "neon-init": "workspace:*",
     "open": "^10.2.0",
     "openid-client": "6.8.1",
     "pg-protocol": "^1.14.0",

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -40,6 +40,7 @@
 	"scripts": {
 		"build": "node scripts/set-vsx-gallery.mjs && tsc --noEmit && tsdown",
 		"build:internal": "node scripts/set-vsx-gallery.mjs https://cursor-vsx-proxy.cloud.databricks.com/gallery && tsc --noEmit && tsdown",
+		"prepare": "npm run build",
 		"pretest": "node scripts/set-vsx-gallery.mjs",
 		"test": "vitest --passWithNoTests",
 		"test:ci": "vitest run --passWithNoTests",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
         specifier: ^0.8.3
         version: 0.8.3
       neon-init:
-        specifier: 0.20.5
-        version: 0.20.5
+        specifier: workspace:*
+        version: link:../init
       open:
         specifier: ^10.2.0
         version: 10.2.0
@@ -3321,11 +3321,6 @@ packages:
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
-
-  neon-init@0.20.5:
-    resolution: {integrity: sha512-QlZ0UsHjOzCOs/6a48ddfJs0mscK2mPnAd+EJpL/b3iWIeS9Foirs3/tlf/PyLawh0w4iaBVhsFnV92QoHuw6g==}
-    engines: {node: '>=20.19.0'}
-    hasBin: true
 
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
@@ -7079,18 +7074,6 @@ snapshots:
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
-
-  neon-init@0.20.5:
-    dependencies:
-      '@clack/core': 0.4.2
-      '@clack/prompts': 0.10.1
-      add-mcp: 1.5.1
-      execa: 9.6.0
-      fflate: 0.8.3
-      picocolors: 1.1.1
-      yaml: 2.9.0
-      yargs: 18.0.0
-      yoctocolors: 2.1.2
 
   node-abi@3.92.0:
     dependencies:


### PR DESCRIPTION
## The problem

`packages/cli` was the one package in the repo that depended on a sibling by published version — `"neon-init": "0.20.5"` — while every other internal dependency, including the four `@neon/*` packages in the same `dependencies` block, used `workspace:*`.

That single pin deadlocked any release that bumped `neon-init`. `changeset version` rewrites the pin (`updateInternalDependencies: "patch"`) and does not touch `pnpm-lock.yaml`, so the branch immediately fails `--frozen-lockfile` — which is every CI job and every publish dispatch, since the workflow installs the whole workspace before packing any package:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
  - neon-init (lockfile: 0.20.4, manifest: 0.20.5)
```

`pnpm install` could not repair it. pnpm 10 defaults `link-workspace-packages=false`, so a bare version spec is fetched from the registry rather than linked, and the version it needed was unpublished precisely because the install was broken. Releasing 2.39.0 required publishing `neon-init` from a throwaway branch with the pin reverted, then landing a lockfile-sync commit — a procedure `AGENTS.md` and the in-repo release skill documented to follow rather than a bug to fix.

## The change

```diff
-    "neon-init": "0.20.5",
+    "neon-init": "workspace:*",
```

The lockfile stops recording a version for it:

```diff
       neon-init:
-        specifier: 0.20.5
-        version: 0.20.5
+        specifier: workspace:*
+        version: link:../init
```

`neon-init` no longer appears in the `packages:` or `snapshots:` sections at all, so no `neon-init` version bump can make `pnpm-lock.yaml` stale again. The failure mode is removed rather than documented.

### `packages/init` has to build itself now

Linking changes where the CLI's copy of `neon-init` comes from. A registry tarball ships `dist/` prebuilt; a symlink to `packages/init` exposes only what that package has built. Nothing built it, because until now nothing linked to it, and the CLI's `Test` and `Live Neon e2e` jobs don't run the root `build` first:

```
src/commands/init.ts(7,8): error TS2307: Cannot find module 'neon-init'
src/commands/bootstrap.ts(14,8): error TS2307: Cannot find module 'neon-init/bootstrap'
```

The repo already has one answer for this, and `packages/init` was the only linked package missing it:

```jsonc
// packages/init/package.json
"prepare": "npm run build",
```

`@neon/sdk`, `@neon/config`, `@neon/config-runtime`, `@neon/env`, and `@neon/functions` all carry that exact line, which is why a plain `pnpm install` leaves every one of them importable. `packages/init` now does too.

## Nothing changes for consumers

`pnpm pack` substitutes the workspace protocol with the exact current version, so the published manifest is identical to what npm already serves for `neon@2.39.0`:

```jsonc
// packed from this branch          // npm view neon@2.39.0
"neon-init": "0.20.5"               "neon-init": "0.20.5"
```

The packed `neon-init` manifest is unchanged too: `prepare` is stripped at pack time and does not appear in the tarball, so it never runs for anyone installing `neon-init` from npm. It only runs on a workspace install.

**No changeset.** Neither tarball changes, so there is nothing to publish. `neon` stays at 2.39.0 and `neon-init` at 0.20.5.

## Also in here

`AGENTS.md` and `.claude/skills/release/SKILL.md` both carried the workaround procedure — throwaway-ref publish, lockfile-sync PR, then the real publish — and `AGENTS.md` named this change as the pending permanent fix. That procedure is now unreachable, so it is deleted from both rather than left as instructions that would mislead. Each keeps a short note recording why an internal package must not be pinned to a published version.

## Verification

Against `564c1a5`:

- `pnpm build`, `pnpm lint:ci`, and `pnpm test:ci` pass — 3,874 tests, of which 3,157 are the CLI's.
- `pnpm --filter neon typecheck` passes, which is what exercises the `neon-init/bootstrap` path mapping through the new symlink.
- `pnpm pack` on `packages/cli` and `packages/init`, compared against `npm view neon@2.39.0 dependencies` and the published `neon-init` manifest.

The suite was re-run after deleting every package's `dist/` and reinstalling, so `packages/init/dist` existed only because `prepare` produced it. That step matters: the first run of this branch passed locally against a `dist/` left behind by an earlier build and hid the missing-module failure entirely until CI ran.

The fix was also tested against the failure it removes rather than only against the current tree. A throwaway changeset bumping `neon-init` to 0.20.6 was applied, `pnpm changeset version` run, and then:

```
$ pnpm install --frozen-lockfile
Done in 10.2s using pnpm v10.30.3
```

The same sequence under the old pin is what produced the `ERR_PNPM_OUTDATED_LOCKFILE` above. The throwaway changeset and the versions it bumped were reverted; the branch contains no version changes.

Not verified: an actual publish dispatch from this branch. The releases workflow packs from a ref, and `pnpm pack` output was compared directly instead.

## For your attention

- **Development now resolves `neon-init` from workspace source, not from the last published tarball.** A local `packages/init` change reaches the CLI's tests immediately. That is the behaviour every other internal dependency already has, and it means a `packages/init` regression surfaces in CLI tests before release rather than after.
- **`prepare` makes `pnpm install` slower by one `packages/init` build** (~0.6s locally) and runs again before each pack. Same cost the five sibling packages already impose.
- **`packages/init` has a `build:internal` variant** that points the VSX gallery at the Databricks proxy. `prepare` runs the public `build`, so an install after `build:internal` reverts `dist/` to the public gallery. That is what already happens to anyone running the root `pnpm build`.