### PR TITLE
Require an explicit apiKey in the config packages

### DIFF
--- a/.changeset/pure-config-credential-resolution.md
+++ b/.changeset/pure-config-credential-resolution.md
@@ -1,0 +1,35 @@
+---
+"@neon/config": minor
+"@neon/config-runtime": minor
+"@neon/env": minor
+---
+
+Require an explicit `apiKey` — these packages no longer read `NEON_API_KEY` or `~/.config/neonctl/credentials.json`
+
+`@neon/config` is documented as the pure half of the config toolchain, and `@neon/env`'s root
+export as "never reads `process.env` or a file", but `createNeonApiFromOptions` reached for an
+ambient credential when none was passed. That made `inspect`, `plan`, `apply`, `pushConfig`,
+`pullConfig` and `fetchEnv` authenticate as whoever last ran `neon auth`, with no way for an
+embedder to opt out.
+
+`createNeonApiFromOptions(operation, { apiKey, apiHost })` now requires `apiKey` and throws
+`PLATFORM_MISSING_API_KEY` without one. It reads no environment variables and no files.
+`apiHost` no longer falls back to `NEON_API_HOST`. `resolveApiKey` is removed from
+`@neon/config/v1`.
+
+**If you were relying on the fallback**, resolve the key where you already know your users'
+conventions and pass it in:
+
+```ts
+import { apply } from "@neon/config-runtime/v1";
+
+await apply(config, {
+  projectId,
+  branchId,
+  apiKey: process.env.NEON_API_KEY, // your call, not the library's
+});
+```
+
+The `neon` and `neon-env` CLIs are unaffected — both resolve the key themselves and always
+passed it explicitly. `neon-env`'s `--api-key` still defaults to `NEON_API_KEY` and then the
+Neon CLI's stored credentials, now via its own `resolveApiKey`.

--- a/.changeset/pure-config-credential-resolution.md
+++ b/.changeset/pure-config-credential-resolution.md
@@ -14,8 +14,11 @@ embedder to opt out.
 
 `createNeonApiFromOptions(operation, { apiKey, apiHost })` now requires `apiKey` and throws
 `PLATFORM_MISSING_API_KEY` without one. It reads no environment variables and no files.
-`apiHost` no longer falls back to `NEON_API_HOST`. `resolveApiKey` is removed from
-`@neon/config/v1`.
+`resolveApiKey` is removed from `@neon/config/v1`.
+
+`apiHost` is unchanged in spirit: still optional, still defaulting to production
+(`https://console.neon.tech/api/v2`). Only the ambient `NEON_API_HOST` lookup is gone — pass
+`apiHost` explicitly to target a non-production API.
 
 **If you were relying on the fallback**, resolve the key where you already know your users'
 conventions and pass it in:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,17 @@ the same thing with a subpath:
 | `@neon/env` | Package consumers — apps, build scripts, a `neon.ts` policy | None. Never reads `process.env` or a file |
 | `@neon/env/runtime` | Our own tooling — the `neon-env` CLI, `packages/cli`, anything resolving one branch repeatedly | Reads an env source; mints and revokes branch credentials |
 
+**Credentials are always passed in, never discovered.** `@neon/config`, `@neon/config-runtime`
+and the `@neon/env` root export read **no environment variables and no files** to find a Neon
+API key. `createNeonApiFromOptions` takes an explicit `apiKey` and raises
+`PLATFORM_MISSING_API_KEY` without one; it does not consult `NEON_API_KEY` or
+`~/.config/neonctl/credentials.json`. Resolving *where* a key comes from belongs to whatever
+embeds these packages, because only it knows which ambient sources its users expect — and a
+library that silently authenticates as whoever last ran `neon auth` is a library you cannot
+safely embed. The three implementations in this repo are `packages/cli` (`ensureAuth` +
+`resolveApiKeyFromEnv`), `packages/env`'s CLI (`src/lib/cli/resolve-api-key.ts`), and
+`packages/init` (`src/lib/auth.ts`). Copy one rather than pushing the lookup back down.
+
 Before adding an export to `@neon/env`, or reaching into one of its internals from
 `packages/cli`, read **[`packages/env/CONTRIBUTING.md`](packages/env/CONTRIBUTING.md)**. It has
 the test for which side a change belongs on, why the credential-reuse logic cannot live on the

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -143,7 +143,9 @@ const live = await inspect(target);
 | `plan(config, options)` | Returns the dry-run diff — what `apply` would do for the branch, with no mutations. Returns a `PushResult` whose `applied` holds the plan and `conflicts` holds blocking drift. |
 | `apply(config, options)` | Reconciles your local `neon.ts` policy onto the branch. Pass `updateExisting` to auto-confirm overriding existing remote settings and `allowProtectedBranch` to auto-confirm applying to a protected branch. |
 
-`options` requires both `projectId` and `branchId` (a Neon branch id, `br-…`). Resolve branch names to ids before calling. The Neon API key resolves via the `apiKey` option → `NEON_API_KEY` → `~/.config/neonctl/credentials.json`.
+`options` requires both `projectId` and `branchId` (a Neon branch id, `br-…`). Resolve branch names to ids before calling.
+
+**Pass `apiKey` explicitly** (or inject your own `api` adapter). This package reads no environment variables and no files on your behalf — it will not pick up `NEON_API_KEY` or `~/.config/neonctl/credentials.json`, and omitting the key raises `PLATFORM_MISSING_API_KEY`. Resolving where a credential comes from belongs to the application or CLI embedding this package, because only it knows which ambient sources its users expect. `packages/cli` and `packages/env`'s `neon-env` both implement that chain; the latter's `src/lib/cli/resolve-api-key.ts` is a ~60-line reference implementation of flag → `NEON_API_KEY` → stored credentials.
 
 ## Lower-level engine
 
@@ -159,7 +161,6 @@ import {
   pullConfig,
   loadConfigFromFile,
   createRealNeonApi,
-  resolveApiKey,
   PlatformError,
   ErrorCode,
   errors,

--- a/packages/config/src/lib/auth.test.ts
+++ b/packages/config/src/lib/auth.test.ts
@@ -1,185 +1,66 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import {
-	createNeonApiFromOptions,
-	readNeonctlCredentials,
-	resolveApiKey,
-} from "./auth.js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createNeonApiFromOptions } from "./auth.js";
+import { ErrorCode, PlatformError } from "./errors.js";
 import { createRealNeonApi } from "./neon-api-real.js";
-import { makeTempRepo, stubCleanNeonEnv } from "./test-utils.js";
+import { stubCleanNeonEnv } from "./test-utils.js";
 
 vi.mock("./neon-api-real.js", async (importOriginal) => {
 	const actual = await importOriginal<typeof import("./neon-api-real.js")>();
 	return { ...actual, createRealNeonApi: vi.fn(() => ({}) as never) };
 });
 
-const cleanups: Array<() => void> = [];
-afterEach(() => {
-	while (cleanups.length > 0) cleanups.shift()?.();
-});
-
 beforeEach(() => {
 	stubCleanNeonEnv();
 });
 
-function setupHome(files: Record<string, string | null>): string {
-	const repo = makeTempRepo(files);
-	cleanups.push(repo.cleanup);
-	return repo.root;
-}
+describe("createNeonApiFromOptions — the API key must be explicit", () => {
+	const created = createRealNeonApi as unknown as ReturnType<typeof vi.fn>;
 
-describe("readNeonctlCredentials", () => {
-	test("reads access_token from <home>/.config/neonctl/credentials.json by default", () => {
-		const home = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				access_token: "oauth-token-abc",
-				refresh_token: "rt-xyz",
-			}),
-		});
-		vi.stubEnv("HOME", home);
-		const creds = readNeonctlCredentials();
-		expect(creds?.access_token).toBe("oauth-token-abc");
-		expect(creds?.refresh_token).toBe("rt-xyz");
+	test("builds an adapter from the apiKey option", () => {
+		createNeonApiFromOptions("op", { apiKey: "napi_k" });
+		expect(created).toHaveBeenCalledWith({ apiKey: "napi_k" });
 	});
 
-	test("honours NEONCTL_CONFIG_DIR over the default location", () => {
-		const home = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				access_token: "default-loc",
-			}),
-			"custom/credentials.json": JSON.stringify({
-				access_token: "from-env-dir",
-			}),
-		});
-		vi.stubEnv("HOME", home);
-		vi.stubEnv("NEONCTL_CONFIG_DIR", `${home}/custom`);
-		const creds = readNeonctlCredentials();
-		expect(creds?.access_token).toBe("from-env-dir");
+	test("trims whitespace around the key", () => {
+		createNeonApiFromOptions("op", { apiKey: "  napi_k  " });
+		expect(created).toHaveBeenCalledWith({ apiKey: "napi_k" });
 	});
 
-	test("honours explicit configDir over the env var", () => {
-		const home = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				access_token: "default-loc",
-			}),
-			"env/credentials.json": JSON.stringify({
-				access_token: "from-env-dir",
-			}),
-			"opt/credentials.json": JSON.stringify({
-				access_token: "from-option",
-			}),
-		});
-		vi.stubEnv("HOME", home);
-		vi.stubEnv("NEONCTL_CONFIG_DIR", `${home}/env`);
-		const creds = readNeonctlCredentials({ configDir: `${home}/opt` });
-		expect(creds?.access_token).toBe("from-option");
+	test("throws MissingApiKey when no key is given", () => {
+		expect(() => createNeonApiFromOptions("pushConfig")).toThrow(
+			PlatformError,
+		);
+		try {
+			createNeonApiFromOptions("pushConfig");
+		} catch (err) {
+			expect((err as PlatformError).code).toBe(ErrorCode.MissingApiKey);
+			expect((err as PlatformError).message).toContain("pushConfig");
+		}
+		expect(created).not.toHaveBeenCalled();
 	});
 
-	test("returns null when the file is missing", () => {
-		const home = setupHome({ ".config/neonctl/.keep": "" });
-		vi.stubEnv("HOME", home);
-		expect(readNeonctlCredentials()).toBeNull();
+	test("throws when the key is whitespace-only", () => {
+		expect(() => createNeonApiFromOptions("op", { apiKey: "   " })).toThrow(
+			PlatformError,
+		);
+		expect(created).not.toHaveBeenCalled();
 	});
 
-	test("returns null on malformed JSON instead of throwing", () => {
-		const home = setupHome({
-			".config/neonctl/credentials.json": "not json",
-		});
-		vi.stubEnv("HOME", home);
-		expect(readNeonctlCredentials()).toBeNull();
-	});
-
-	test("returns null when access_token is missing or empty", () => {
-		const home = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				refresh_token: "rt-only",
-			}),
-		});
-		vi.stubEnv("HOME", home);
-		expect(readNeonctlCredentials()).toBeNull();
-		const home2 = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				access_token: "",
-			}),
-		});
-		vi.stubEnv("HOME", home2);
-		expect(readNeonctlCredentials()).toBeNull();
-	});
-
-	test("returns null when no home dir resolvable", () => {
-		// `stubCleanNeonEnv()` already cleared HOME and USERPROFILE.
-		expect(readNeonctlCredentials()).toBeNull();
-	});
-
-	test("falls back to USERPROFILE on Windows-style env", () => {
-		const winHome = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				access_token: "win-token",
-			}),
-		});
-		vi.stubEnv("USERPROFILE", winHome);
-		const creds = readNeonctlCredentials();
-		expect(creds?.access_token).toBe("win-token");
-	});
-});
-
-describe("resolveApiKey — priority chain", () => {
-	test("explicit option wins over env wins over credentials.json", () => {
-		const home = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				access_token: "from-file",
-			}),
-		});
-		vi.stubEnv("HOME", home);
-		vi.stubEnv("NEON_API_KEY", "from-env");
-		expect(resolveApiKey({ apiKey: "from-option" })).toEqual({
-			token: "from-option",
-			source: "option",
-		});
-
-		expect(resolveApiKey()).toEqual({ token: "from-env", source: "env" });
-
-		vi.stubEnv("NEON_API_KEY", undefined);
-		expect(resolveApiKey()).toEqual({
-			token: "from-file",
-			source: "neonctl",
-		});
-	});
-
-	test("returns null when no source provides a token", () => {
-		const home = setupHome({ ".config/neonctl/.keep": "" });
-		vi.stubEnv("HOME", home);
-		expect(resolveApiKey()).toBeNull();
-	});
-
-	test("treats whitespace-only option / env as missing", () => {
-		const home = setupHome({
-			".config/neonctl/credentials.json": JSON.stringify({
-				access_token: "from-file",
-			}),
-		});
-		vi.stubEnv("HOME", home);
-		vi.stubEnv("NEON_API_KEY", "   ");
-		expect(resolveApiKey({ apiKey: "   " })).toEqual({
-			token: "from-file",
-			source: "neonctl",
-		});
-	});
-
-	test("trims whitespace around the resolved token", () => {
-		const home = setupHome({ ".config/neonctl/.keep": "" });
-		vi.stubEnv("HOME", home);
-		expect(resolveApiKey({ apiKey: "  napi_x  " })).toEqual({
-			token: "napi_x",
-			source: "option",
-		});
+	// The point of the package boundary: an ambient credential must not be picked up.
+	// Resolving NEON_API_KEY is the caller's job (see packages/cli, packages/init).
+	test("ignores NEON_API_KEY in the environment", () => {
+		vi.stubEnv("NEON_API_KEY", "napi_from_env");
+		expect(() => createNeonApiFromOptions("fetchEnv")).toThrow(
+			PlatformError,
+		);
+		expect(created).not.toHaveBeenCalled();
 	});
 });
 
 describe("createNeonApiFromOptions — host resolution", () => {
 	const created = createRealNeonApi as unknown as ReturnType<typeof vi.fn>;
 
-	test("explicit apiHost option wins over NEON_API_HOST", () => {
-		vi.stubEnv("NEON_API_HOST", "https://env.example/api/v2");
+	test("uses the explicit apiHost option", () => {
 		createNeonApiFromOptions("op", {
 			apiKey: "napi_k",
 			apiHost: "https://opt.example/api/v2",
@@ -190,16 +71,7 @@ describe("createNeonApiFromOptions — host resolution", () => {
 		});
 	});
 
-	test("falls back to NEON_API_HOST when no option is given", () => {
-		vi.stubEnv("NEON_API_HOST", "https://env.example/api/v2");
-		createNeonApiFromOptions("op", { apiKey: "napi_k" });
-		expect(created).toHaveBeenCalledWith({
-			apiKey: "napi_k",
-			baseUrl: "https://env.example/api/v2",
-		});
-	});
-
-	test("passes no baseUrl when neither option nor env is set (prod default)", () => {
+	test("passes no baseUrl when the option is absent (prod default)", () => {
 		createNeonApiFromOptions("op", { apiKey: "napi_k" });
 		expect(created).toHaveBeenCalledWith({ apiKey: "napi_k" });
 	});
@@ -215,12 +87,14 @@ describe("createNeonApiFromOptions — host resolution", () => {
 		});
 	});
 
-	test("treats an empty / whitespace apiHost as unset, falling through to env", () => {
-		vi.stubEnv("NEON_API_HOST", "https://env.example/api/v2");
+	test("treats an empty / whitespace apiHost as unset", () => {
 		createNeonApiFromOptions("op", { apiKey: "napi_k", apiHost: "   " });
-		expect(created).toHaveBeenCalledWith({
-			apiKey: "napi_k",
-			baseUrl: "https://env.example/api/v2",
-		});
+		expect(created).toHaveBeenCalledWith({ apiKey: "napi_k" });
+	});
+
+	test("ignores NEON_API_HOST in the environment", () => {
+		vi.stubEnv("NEON_API_HOST", "https://env.example/api/v2");
+		createNeonApiFromOptions("op", { apiKey: "napi_k" });
+		expect(created).toHaveBeenCalledWith({ apiKey: "napi_k" });
 	});
 });

--- a/packages/config/src/lib/auth.ts
+++ b/packages/config/src/lib/auth.ts
@@ -1,96 +1,6 @@
-import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { ErrorCode, PlatformError } from "./errors.js";
 import type { NeonApi } from "./neon-api.js";
 import { createRealNeonApi } from "./neon-api-real.js";
-
-/**
- * Minimal shape of `~/.config/neonctl/credentials.json` we read. `neonctl` writes more
- * fields (refresh_token, expires_at, …) but only `access_token` is what we need — it's a
- * Bearer token the Neon API accepts on the same endpoints `napi_*` API keys do.
- */
-export interface NeonctlCredentials {
-	access_token: string;
-	[key: string]: unknown;
-}
-
-/**
- * Locate and read the OAuth credentials neonctl writes after `neon auth`.
- *
- * Resolution:
- * 1. `options.configDir` (explicit override — mirrors neonctl's `--config-dir` flag).
- * 2. `NEONCTL_CONFIG_DIR` environment variable.
- * 3. `<home>/.config/neonctl/credentials.json` (the neonctl default; `home` reads
- *    `HOME`, falling back to `USERPROFILE` for Windows parity).
- *
- * Returns `null` (never throws) when the file is missing, unreadable, malformed, or has
- * no `access_token` — so callers can use this as a quiet fallback in a resolution chain
- * without try/catch noise.
- */
-export function readNeonctlCredentials(
-	options: { configDir?: string } = {},
-): NeonctlCredentials | null {
-	const home = process.env.HOME ?? process.env.USERPROFILE;
-	const configDir =
-		options.configDir ??
-		process.env.NEONCTL_CONFIG_DIR ??
-		(home ? resolve(home, ".config", "neonctl") : undefined);
-	if (!configDir) return null;
-
-	const credentialsPath = resolve(configDir, "credentials.json");
-	if (!existsSync(credentialsPath)) return null;
-
-	let raw: string;
-	try {
-		raw = readFileSync(credentialsPath, "utf-8");
-	} catch {
-		return null;
-	}
-
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(raw);
-	} catch {
-		return null;
-	}
-
-	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
-		return null;
-	const obj = parsed as Record<string, unknown>;
-	if (typeof obj.access_token !== "string" || obj.access_token === "")
-		return null;
-	return obj as NeonctlCredentials;
-}
-
-/**
- * Resolution chain for the Bearer token sent to the Neon API. Each entry wins over the
- * next:
- *
- * 1. `options.apiKey` (explicit).
- * 2. `NEON_API_KEY` environment variable.
- * 3. `access_token` from `~/.config/neonctl/credentials.json` (or `NEONCTL_CONFIG_DIR`).
- *
- * Returns `null` when no source provides one. Callers wrap the null case in a
- * `PLATFORM_MISSING_API_KEY` error with a message tailored to the operation.
- */
-export function resolveApiKey(
-	options: { apiKey?: string; configDir?: string } = {},
-): { token: string; source: "option" | "env" | "neonctl" } | null {
-	if (options.apiKey && options.apiKey.trim() !== "") {
-		return { token: options.apiKey.trim(), source: "option" };
-	}
-	const envKey = process.env.NEON_API_KEY;
-	if (typeof envKey === "string" && envKey.trim() !== "") {
-		return { token: envKey.trim(), source: "env" };
-	}
-	const creds = readNeonctlCredentials(
-		options.configDir ? { configDir: options.configDir } : {},
-	);
-	if (creds) {
-		return { token: creds.access_token, source: "neonctl" };
-	}
-	return null;
-}
 
 /** Trim trailing slashes and surrounding whitespace; treat empty as unset. */
 function normalizeApiHost(url: string | undefined): string | undefined {
@@ -99,17 +9,20 @@ function normalizeApiHost(url: string | undefined): string | undefined {
 }
 
 /**
- * Resolve the Neon API key via the standard chain (option → `NEON_API_KEY` env →
- * `~/.config/neonctl/credentials.json`) and construct a real {@link NeonApi} adapter from
- * it, or throw a uniform `PLATFORM_MISSING_API_KEY` error if no key can be found.
+ * Build a real {@link NeonApi} adapter from an explicit API key, or throw a uniform
+ * `PLATFORM_MISSING_API_KEY` error when the caller didn't supply one.
  *
- * The API host is resolved via: `options.apiHost` → `NEON_API_HOST` env → production
- * default (`https://console.neon.tech/api/v2`).
+ * **This function is pure with respect to its environment**: it reads no environment
+ * variables and no files. Everything it needs arrives in `options`. Resolving *where* a
+ * credential comes from — a flag, `NEON_API_KEY`, a credentials file on disk — is the
+ * caller's job, because only the caller knows which of those its users expect. See
+ * `packages/cli` (`ensureAuth` + `resolveApiKeyFromEnv`) and `packages/init`
+ * (`src/lib/auth.ts`) for the two implementations in this repo.
  *
  * Used by `pullConfig`, `pushConfig`, `fetchEnv`, and `branch` to build their default
- * `NeonApi` when the caller doesn't inject one. `operation` is the calling function's
- * name (e.g. `"pushConfig"`, `"branch"`) — it's prepended to the error message so users
- * can tell which call surfaced the missing key.
+ * adapter when the caller doesn't inject one. `operation` is the calling function's name
+ * (e.g. `"pushConfig"`, `"branch"`) — it's prepended to the error message so users can tell
+ * which call surfaced the missing key.
  */
 export function createNeonApiFromOptions(
 	operation: string,
@@ -118,25 +31,22 @@ export function createNeonApiFromOptions(
 		apiHost?: string;
 	} = {},
 ): NeonApi {
-	const resolved = resolveApiKey(
-		options.apiKey ? { apiKey: options.apiKey } : {},
-	);
-	if (resolved) {
-		const baseUrl =
-			normalizeApiHost(options.apiHost) ??
-			normalizeApiHost(process.env.NEON_API_HOST);
-		return createRealNeonApi({
-			apiKey: resolved.token,
-			...(baseUrl ? { baseUrl } : {}),
-		});
+	const apiKey = options.apiKey?.trim();
+	if (!apiKey) {
+		throw new PlatformError(
+			ErrorCode.MissingApiKey,
+			[
+				`${operation} was not given a Neon API key.`,
+				"Pass `apiKey` explicitly, or inject your own `api` adapter (e.g. an in-memory fake for tests).",
+				"This package never reads NEON_API_KEY or a credentials file on your behalf — resolve the key in your own application or CLI and pass it in.",
+				"Generate a key at https://console.neon.tech/app/settings/api-keys.",
+			].join(" "),
+		);
 	}
-	throw new PlatformError(
-		ErrorCode.MissingApiKey,
-		[
-			`${operation} has no Neon API key to work with.`,
-			"Tried (in order): `apiKey` option, NEON_API_KEY env, and `~/.config/neonctl/credentials.json`.",
-			"Either pass `apiKey` directly, set NEON_API_KEY, run `npx neonctl auth` to populate the credentials file, or pass a custom `api` adapter (e.g. an in-memory fake for tests).",
-			"Generate a key at https://console.neon.tech/app/settings/api-keys.",
-		].join(" "),
-	);
+
+	const baseUrl = normalizeApiHost(options.apiHost);
+	return createRealNeonApi({
+		apiKey,
+		...(baseUrl ? { baseUrl } : {}),
+	});
 }

--- a/packages/config/src/lib/auth.ts
+++ b/packages/config/src/lib/auth.ts
@@ -19,6 +19,11 @@ function normalizeApiHost(url: string | undefined): string | undefined {
  * `packages/cli` (`ensureAuth` + `resolveApiKeyFromEnv`) and `packages/init`
  * (`src/lib/auth.ts`) for the two implementations in this repo.
  *
+ * `apiHost` stays **optional** and defaults to production
+ * (`https://console.neon.tech/api/v2`, applied by {@link createRealNeonApi}) — only pass it
+ * to target a non-production API. It is the *ambient* `NEON_API_HOST` lookup that's gone,
+ * not the default.
+ *
  * Used by `pullConfig`, `pushConfig`, `fetchEnv`, and `branch` to build their default
  * adapter when the caller doesn't inject one. `operation` is the calling function's name
  * (e.g. `"pushConfig"`, `"branch"`) — it's prepended to the error message so users can tell

--- a/packages/config/src/v1.test.ts
+++ b/packages/config/src/v1.test.ts
@@ -66,7 +66,6 @@ describe("@neon/config public value surface", () => {
 			  "isPartialBranchCreateError",
 			  "isPlatformError",
 			  "loadConfigFromFile",
-			  "resolveApiKey",
 			  "resolveConfig",
 			  "schemas",
 			]

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -100,7 +100,7 @@ export const schemas = {
 } as const;
 
 // ─── Lower-level adapters ──────────────────────────────────────────────────────
-export { createNeonApiFromOptions, resolveApiKey } from "./lib/auth.js";
+export { createNeonApiFromOptions } from "./lib/auth.js";
 // ─── Credentials (pure scope derivation; Preview) ─────────────────────────────
 export type { CredentialFeatureFlags } from "./lib/credentials.js";
 export {

--- a/packages/env/src/lib/cli/commands.test.ts
+++ b/packages/env/src/lib/cli/commands.test.ts
@@ -158,4 +158,27 @@ describe("runEnvExport", () => {
 		expect(result.exitCode).not.toBe(0);
 		expect(result.stderr).toContain("could not resolve");
 	});
+
+	// `@neon/config` raises a library-shaped error ("this package never reads
+	// NEON_API_KEY on your behalf") that is the opposite of what a `neon-env` user needs
+	// to hear, since this CLI does read it. No `api` is injected here, so the real
+	// adapter is constructed — and refuses — before any request is made.
+	test("explains this CLI's own key chain when no key resolves", async () => {
+		const { projectId } = seededFake();
+		const root = setup({
+			"package.json": "{}",
+			".neon": JSON.stringify({ projectId, branch: "main" }),
+			"neon.ts": policy(),
+		});
+
+		const result = await runEnvExport({ format: "json" }, { cwd: root });
+
+		expect(result.exitCode).not.toBe(0);
+		expect(result.stderr).toContain("No Neon API key");
+		expect(result.stderr).toContain("--api-key");
+		expect(result.stderr).toContain("NEON_API_KEY");
+		expect(result.stderr).toContain("credentials.json");
+		// The library's phrasing must not leak through to a CLI user.
+		expect(result.stderr).not.toContain("This package never reads");
+	});
 });

--- a/packages/env/src/lib/cli/commands.ts
+++ b/packages/env/src/lib/cli/commands.ts
@@ -10,6 +10,7 @@ import {
 	PlatformError,
 } from "@neon/config/v1";
 import { fetchEnvReusingSecrets } from "../reuse-secrets.js";
+import { resolveApiKey } from "./resolve-api-key.js";
 import { resolveContext } from "./resolve-context.js";
 
 /** File `env run` reads to layer one-time auth keys. Matches the Vercel/Next.js convention. */
@@ -24,7 +25,8 @@ export interface CommandEnv {
 	cwd: string;
 	/**
 	 * When set, used directly as the NeonApi. When omitted, the real adapter is built from
-	 * `options.apiKey ?? NEON_API_KEY` inside `fetchEnv`.
+	 * the key {@link resolveApiKey} resolves (`--api-key` → `NEON_API_KEY` → the Neon CLI's
+	 * stored credentials).
 	 */
 	api?: NeonApi;
 }
@@ -42,8 +44,9 @@ export interface CommandResult {
 
 /**
  * Inputs needed to resolve a branch and fetch its env, shared by `run` and `export`: an
- * optional explicit `neon.ts` path, project/branch overrides, and an API key (otherwise
- * resolved from `.neon` / `NEON_*` env by the CLI and `NEON_API_KEY` by `fetchEnv`).
+ * optional explicit `neon.ts` path, project/branch overrides, and an API key. Everything
+ * ambient — `.neon`, `NEON_*` env, the Neon CLI's stored credentials — is resolved by the
+ * CLI (see `resolveContext` and `resolveApiKey`), never by the library.
  */
 export interface EnvResolveOptions {
 	configPath?: string;
@@ -192,12 +195,15 @@ async function loadConfigAndFetchEnv(
 	const fileEnv = existsSync(envFileSource)
 		? parseEnvFile(readFileSync(envFileSource, "utf-8"))
 		: {};
+	const apiKey = resolveApiKey({
+		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+	});
 	const { vars } = await fetchEnvReusingSecrets(config, {
 		projectId: resolved.projectId,
 		branch: resolved.branch,
 		env: { ...process.env, ...fileEnv },
 		...(ctx.api ? { api: ctx.api } : {}),
-		...(options.apiKey ? { apiKey: options.apiKey } : {}),
+		...(apiKey ? { apiKey } : {}),
 	});
 	return vars;
 }

--- a/packages/env/src/lib/cli/commands.ts
+++ b/packages/env/src/lib/cli/commands.ts
@@ -297,6 +297,21 @@ function handleError(err: unknown): CommandResult {
 		return errorResult(err, `Missing context: ${err.message}`, 3);
 	if (err instanceof ConfigLoadError)
 		return errorResult(err, `Failed to load config: ${err.message}`, 4);
+	// The library's own wording is right for a library ("this package never reads
+	// NEON_API_KEY on your behalf") and wrong here: `neon-env` does read it. Render the
+	// chain this CLI actually implements, the same way an unresolved context is rendered.
+	if (err instanceof PlatformError && err.code === ErrorCode.MissingApiKey) {
+		return errorResult(
+			err,
+			[
+				"No Neon API key. `neon-env` looks for one in this order:",
+				"  - the `--api-key` flag",
+				"  - the `NEON_API_KEY` environment variable",
+				"  - `credentials.json` in `NEONCTL_CONFIG_DIR` (else `~/.config/neonctl`) — run `neon auth` to create it",
+			].join("\n"),
+			EXIT_CODE_BY_PLATFORM_ERROR_CODE[ErrorCode.MissingApiKey] ?? 1,
+		);
+	}
 	if (err instanceof PlatformError) {
 		const exitCode = EXIT_CODE_BY_PLATFORM_ERROR_CODE[err.code];
 		if (exitCode !== undefined)

--- a/packages/env/src/lib/cli/resolve-api-key.test.ts
+++ b/packages/env/src/lib/cli/resolve-api-key.test.ts
@@ -1,0 +1,97 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { resolveApiKey } from "./resolve-api-key.js";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.shift()?.();
+});
+
+/** A temp home containing `.config/neonctl/credentials.json` with the given contents. */
+function makeHome(credentials: string | null): string {
+	const root = mkdtempSync(join(tmpdir(), "neon-env-apikey-"));
+	cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+	const dir = resolve(root, ".config", "neonctl");
+	mkdirSync(dir, { recursive: true });
+	if (credentials !== null) {
+		writeFileSync(resolve(dir, "credentials.json"), credentials);
+	}
+	return root;
+}
+
+const token = (access_token: string) => JSON.stringify({ access_token });
+
+describe("resolveApiKey — precedence", () => {
+	test("flag wins over env wins over stored credentials", () => {
+		const home = makeHome(token("from-file"));
+		const env = { HOME: home, NEON_API_KEY: "from-env" };
+
+		expect(resolveApiKey({ apiKey: "from-flag", env })).toBe("from-flag");
+		expect(resolveApiKey({ env })).toBe("from-env");
+		expect(resolveApiKey({ env: { HOME: home } })).toBe("from-file");
+	});
+
+	test("honours NEONCTL_CONFIG_DIR over the default location", () => {
+		const home = makeHome(token("default-loc"));
+		const custom = mkdtempSync(join(tmpdir(), "neon-env-cfg-"));
+		cleanups.push(() => rmSync(custom, { recursive: true, force: true }));
+		writeFileSync(
+			resolve(custom, "credentials.json"),
+			token("from-env-dir"),
+		);
+
+		expect(
+			resolveApiKey({ env: { HOME: home, NEONCTL_CONFIG_DIR: custom } }),
+		).toBe("from-env-dir");
+	});
+
+	test("falls back to USERPROFILE on Windows-style env", () => {
+		const home = makeHome(token("win-token"));
+		expect(resolveApiKey({ env: { USERPROFILE: home } })).toBe("win-token");
+	});
+
+	test("treats whitespace-only flag and env as missing", () => {
+		const home = makeHome(token("from-file"));
+		expect(
+			resolveApiKey({
+				apiKey: "   ",
+				env: { HOME: home, NEON_API_KEY: "  " },
+			}),
+		).toBe("from-file");
+	});
+
+	test("trims the resolved value", () => {
+		expect(resolveApiKey({ apiKey: "  napi_x  ", env: {} })).toBe("napi_x");
+	});
+});
+
+describe("resolveApiKey — returns undefined rather than throwing", () => {
+	test("no source provides a key", () => {
+		const home = makeHome(null);
+		expect(resolveApiKey({ env: { HOME: home } })).toBeUndefined();
+	});
+
+	test("no home directory resolvable", () => {
+		expect(resolveApiKey({ env: {} })).toBeUndefined();
+	});
+
+	test("malformed JSON", () => {
+		const home = makeHome("not json");
+		expect(resolveApiKey({ env: { HOME: home } })).toBeUndefined();
+	});
+
+	test("credentials file has no access_token, or an empty one", () => {
+		const noToken = makeHome(JSON.stringify({ refresh_token: "rt-only" }));
+		expect(resolveApiKey({ env: { HOME: noToken } })).toBeUndefined();
+
+		const emptyToken = makeHome(token(""));
+		expect(resolveApiKey({ env: { HOME: emptyToken } })).toBeUndefined();
+	});
+
+	test("credentials file is a JSON array, not an object", () => {
+		const home = makeHome("[]");
+		expect(resolveApiKey({ env: { HOME: home } })).toBeUndefined();
+	});
+});

--- a/packages/env/src/lib/cli/resolve-api-key.ts
+++ b/packages/env/src/lib/cli/resolve-api-key.ts
@@ -1,0 +1,63 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Resolve the Neon API key for a `neon-env` CLI invocation. Precedence (each wins over the
+ * next): `--api-key` flag → `NEON_API_KEY` → `access_token` from the Neon CLI's
+ * `credentials.json`.
+ *
+ * The CLI owns this resolution — `@neon/config` and `@neon/env` are deliberately
+ * environment- and filesystem-agnostic and only ever accept an explicit `apiKey`, so the
+ * ambient sources a *user* expects have to be read here. This mirrors `resolveContext`,
+ * which does the same for project and branch.
+ *
+ * Returns `undefined` rather than throwing when nothing provides a key: the caller passes
+ * it straight through, and the library raises the uniform `PLATFORM_MISSING_API_KEY` error.
+ */
+export function resolveApiKey(options: {
+	apiKey?: string;
+	env?: NodeJS.ProcessEnv;
+}): string | undefined {
+	const env = options.env ?? process.env;
+	return (
+		nonEmpty(options.apiKey) ??
+		nonEmpty(env.NEON_API_KEY) ??
+		readStoredAccessToken(env)
+	);
+}
+
+/**
+ * Read `access_token` from the Neon CLI's credentials file, the same location and
+ * precedence `neon auth` writes to: `NEONCTL_CONFIG_DIR` → `<home>/.config/neonctl`
+ * (`HOME`, falling back to `USERPROFILE` for Windows parity).
+ *
+ * Never throws — a missing, unreadable, malformed, or token-less file is simply "no key",
+ * so this can sit in a resolution chain without try/catch noise.
+ */
+function readStoredAccessToken(env: NodeJS.ProcessEnv): string | undefined {
+	const home = env.HOME ?? env.USERPROFILE;
+	const configDir =
+		nonEmpty(env.NEONCTL_CONFIG_DIR) ??
+		(home ? resolve(home, ".config", "neonctl") : undefined);
+	if (!configDir) return undefined;
+
+	const credentialsPath = resolve(configDir, "credentials.json");
+	if (!existsSync(credentialsPath)) return undefined;
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(credentialsPath, "utf-8"));
+	} catch {
+		return undefined;
+	}
+
+	if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed))
+		return undefined;
+	return nonEmpty((parsed as Record<string, unknown>).access_token as string);
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed === "" ? undefined : trimmed;
+}


### PR DESCRIPTION
## The problem

`AGENTS.md` describes `@neon/config` as *"pure, side-effect-free"*, calls the pure/imperative split *"load-bearing"*, and states that the `@neon/env` root export has **"None. Never reads `process.env` or a file"** for side effects.

`createNeonApiFromOptions` did both:

```ts
// packages/config/src/lib/auth.ts — before
const envKey = process.env.NEON_API_KEY;          // ambient credential
const creds  = readNeonctlCredentials();          // readFileSync(~/.config/neonctl/credentials.json)
normalizeApiHost(process.env.NEON_API_HOST);      // ambient host
```

Every default-adapter path ran through it — `inspect`, `plan`, `apply`, `pushConfig`, `pullConfig`, `fetchEnv`, `branch`. So a library embedding these packages, given no key, would silently authenticate **as whoever last ran `neon auth` on that machine**, with no way to opt out. On a machine with more than one Neon account that is a wrong-account write, not just a surprise.

Worse, the lookup ignored the caller's own config location. `createApiFromOptions` forwarded only `apiKey` and `apiHost`, never `configDir` — so even a caller that had explicitly pointed somewhere else got `~/.config/neonctl/credentials.json` read behind its back.

`packages/config-runtime` has **zero** `process.env` and zero filesystem reads of its own — all of its impurity was inherited from this one function.

---

## Every DX surface this touches

### 1. Library APIs — breaking

| Surface | Before | After |
| --- | --- | --- |
| `createNeonApiFromOptions(op, { apiKey })` | `apiKey` optional; fell back to `NEON_API_KEY`, then `credentials.json` | `apiKey` required; throws `PLATFORM_MISSING_API_KEY`. Reads no env, no files |
| `createNeonApiFromOptions(op, { apiHost })` | Optional; fell back to `NEON_API_HOST`, then prod | **Unchanged in effect** — still optional, still defaults to prod (`https://console.neon.tech/api/v2`). Only the `NEON_API_HOST` lookup is gone |
| `resolveApiKey` (exported from `@neon/config/v1`) | Public export | **Removed** |
| `readNeonctlCredentials` | Package-internal | Removed |
| `inspect` / `plan` / `apply` / `pushConfig` / `pullConfig` with no `apiKey` and no `api` | Silently authenticated from the ambient environment | Throws `PLATFORM_MISSING_API_KEY` |
| `fetchEnv` / `fetchEnvReusingSecrets` with no `apiKey` and no `api` | Same | Same |
| Caller passes an explicit `apiKey` or injects `api` | Worked | **Unchanged.** This is every call site in this repo |

### 2. `neon-env` CLI — behavior identical, error message fixed

| Path | Before | After |
| --- | --- | --- |
| `neon-env run\|export --api-key <k>` | Works | **Unchanged** |
| `neon-env run\|export` with `NEON_API_KEY` set | Worked — via the *library* fallback | **Unchanged** — now resolved by the CLI itself |
| `neon-env run\|export` with only `credentials.json` | Worked — via the library fallback | **Unchanged** — now resolved by the CLI itself |
| Exit code when no key resolves | `1` | `1` |
| **Message when no key resolves** | *"This package never reads NEON_API_KEY or a credentials file on your behalf"* — the opposite of what `--api-key`'s own help promises | The chain this CLI implements (below) |

The `--api-key` flag is documented as *"defaults to NEON_API_KEY"*, and that default was **entirely** the removed library fallback — `commands.ts` only forwarded the flag when it was a string. Preserving it meant giving the CLI its own resolver, mirroring the `resolve-context.ts` sitting beside it that already resolves project and branch by the same flag → env → file shape:

```ts
// packages/env/src/lib/cli/resolve-api-key.ts — internal to the package, not a new public export
export function resolveApiKey(options: {
  apiKey?: string;
  env?: NodeJS.ProcessEnv;
}): string | undefined;
```

Returns `undefined` rather than throwing, so the library still raises the one uniform error — which `handleError` now renders in the CLI's own terms:

```
$ neon-env export            # no key anywhere
No Neon API key. `neon-env` looks for one in this order:
  - the `--api-key` flag
  - the `NEON_API_KEY` environment variable
  - `credentials.json` in `NEONCTL_CONFIG_DIR` (else `~/.config/neonctl`) — run `neon auth` to create it
```

### 3. `neon` CLI — no behavior change

A separate code path from the `neon-env` bin, so worth stating explicitly rather than implying.

| Command | Before | After |
| --- | --- | --- |
| `neon deploy` / `config apply` / `config plan` / `status` | `ensureAuth` sets `props.apiKey`; `applyCmd` threads it (`commands/config.ts:512`) | **Unchanged** |
| `neon env pull` | `ensureAuth` → `commands/env.ts:149` → `dev/env.ts:33` | **Unchanged** |
| `neon checkout`, `neon diff`, everything else | Explicit key throughout | **Unchanged** |
| `--api-host` / `NEON_API_HOST` | CLI's own global option already defaults to `process.env.NEON_API_HOST ?? prod` (`index.ts:88`), so `props.apiHost` is always set | **Unchanged** — the CLI never depended on the library's env lookup |

One narrow case does change, and it is the bug being fixed:

| Scenario | Before | After |
| --- | --- | --- |
| `neon dev --config-dir <dir-without-credentials>`, while `~/.config/neonctl/credentials.json` exists | Library silently read the **default** dir and injected env — from a possibly different account than `--config-dir` selected | No key resolves, so `resolveDevEnv` degrades to running without env injection (it catches everything but `DevEnvMismatchError`) |

`--config-dir` is now honored end to end instead of being quietly bypassed.

### 4. Docs

| File | Change |
| --- | --- |
| `packages/config/README.md` | Drops `resolveApiKey` from the export list; replaces the "key resolves via `apiKey` → `NEON_API_KEY` → `credentials.json`" sentence with the explicit-key rule and a pointer to the reference implementation |
| `AGENTS.md` | New invariant under the existing pure/imperative table: *"Credentials are always passed in, never discovered"*, naming the three implementations (`packages/cli`, `packages/env`, `packages/init`) so the lookup doesn't get pushed back down |
| Changeset | Documents the break and the migration; states explicitly that `apiHost` still defaults to prod |

---

## Migration

Only affects code calling these packages **directly with no `apiKey`**:

```ts
import { apply } from "@neon/config-runtime/v1";

await apply(config, {
  projectId,
  branchId,
  apiKey: process.env.NEON_API_KEY, // your call, not the library's
});
```

`packages/env/src/lib/cli/resolve-api-key.ts` is a ~60-line reference implementation for anyone who wants the full flag → env → credentials-file chain back.

Changeset bumps `@neon/config`, `@neon/config-runtime` and `@neon/env` **minor** (breaking under 0.x).

---

## Verification

**CI: 11/11 green, including Live Neon e2e** — the suite that runs `@neon/config`, `@neon/config-runtime`, `@neon/env`, `@neon/sdk` and the `neon` CLI against the **real Neon Management API**, creating and destroying projects. That is the load-bearing check here: it proves the default-adapter paths still authenticate now that the ambient fallback is gone.

**Live, against a throwaway project, using the binaries built from this branch** (project and scoped key deleted afterwards):

| Check | Result |
| --- | --- |
| `neon deploy` (incl. automatic env pull) | Applied Neon Auth + Data API, wrote all 6 vars |
| `neon env pull` | Wrote all 6 vars |
| `neon-env export --api-key <k>` | 6 vars |
| `neon-env export` with `NEON_API_KEY` | 6 vars — the moved behavior |
| `neon-env export` with neither | Fails with the new CLI-specific message |

**Local:**

- `pnpm build` + `pnpm --filter neon build` — clean
- `pnpm test:ci` — **3,974 passed**, 0 failed, across all 10 packages
- `pnpm lint:ci` (`biome ci --error-on-warnings`) — clean
- Purity proven against the **built output**, not the source: `rg 'process\.env|readFileSync|existsSync'` returns nothing in `packages/config/dist/lib/auth.js` or anywhere in `packages/config-runtime/dist`
- A script against the built `dist` confirms `NEON_API_KEY` and `NEON_API_HOST` in the environment are both ignored

**New tests:** 10 for `resolveApiKey`; 1 asserting the library's phrasing cannot leak back into the `neon-env` error; `auth.test.ts` rewritten with explicit guards that the two env vars are ignored.

That the pre-existing suite passes unchanged is itself evidence that nothing **in this repo** relied on the fallback — it was only ever reachable by external callers.

---

## Flagging

- **Breaking for direct library consumers.** Intentional, and the reason for the minor bump. A caller relying on the implicit lookup now gets a loud `PLATFORM_MISSING_API_KEY` at the call site instead of a silent wrong-account request — but it is a behavior change on a published package.
- **`neon dev`'s degrade message is now slightly off in one rare case.** When no key resolves it reports `could not reach Neon (<detail>)`, which reads as connectivity rather than a missing credential. Left alone deliberately: it is a debug-level degrade in a narrow configuration, and fixing it means editing a third command's error surface in a PR that is already touching two.
- **`loadConfigFromFile` still reads the filesystem** and still defaults `stopAt` to `homedir()`. Deliberately out of scope: it is an explicit loader whose entire job is reading a file, it is opt-in, and `config-runtime` only re-exports it rather than calling it. Worth a separate look if we want the ambient `homedir()` default gone too.
