### PR TITLE
feat(cli): scaffold the services a project picks in `config init`

### DIFF
--- a/.changeset/config-init-services.md
+++ b/.changeset/config-init-services.md
@@ -1,0 +1,7 @@
+---
+"neon": minor
+---
+
+`neon config init` now asks which Neon services the scaffolded `neon.ts` should declare — Managed Better Auth, AI Gateway, Functions, Object Storage — and writes them into the policy. Selecting Functions also scaffolds the `hello.ts` handler the declared function points at.
+
+`--services auth,ai-gateway,functions,storage` picks them without a prompt, `--services none` scaffolds the bare starter policy, and a run with no TTY (CI, an agent) keeps writing exactly the file it wrote before.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -456,9 +456,55 @@ export default defineConfig({
 });
 ```
 
-Three sub-commands plus two top-level aliases drive it:
+### Getting a `neon.ts` (`config init`)
+
+`neon config init` scaffolds the policy and installs `@neon/config` / `@neon/env`, so a project can go straight to `plan` / `apply`. It is purely local — no auth, no API calls. In an interactive terminal it asks which services the policy should declare:
+
+```
+? Which Neon services should neon.ts declare? (space to toggle, enter to confirm) ›
+◯   Managed Better Auth
+     Authentication with users and sessions stored in Postgres.
+◯   Functions
+     Long-running, without timeouts, and closer to your database.
+◯   Object Storage
+     S3-compatible blob storage that branches with your projects.
+◯   AI Gateway
+     All models, one API, one bill. Powered by Databricks. Not available on the Neon free plan.
+```
+
+Selecting nothing is a valid answer: you get the starter policy, which is also what a non-interactive run (CI, no TTY) writes. Pass `--services` to skip the prompt anywhere:
 
 ```bash
+# Pick interactively (TTY) or take the starter policy (CI)
+neon config init
+
+# Declare services with no prompt
+neon config init --services auth,functions,storage,ai-gateway
+
+# Explicitly ask for the bare starter policy
+neon config init --services none
+
+# Scaffold but print the install command instead of running it
+neon config init --no-install
+```
+
+Choosing **Functions** also writes the handler the policy points at, since `source` is only resolved when `apply` bundles it — a declared function with no file on disk fails at deploy:
+
+```ts
+// hello.ts
+export default async function hello(): Promise<Response> {
+  return new Response('Hello from Neon Functions');
+}
+```
+
+An existing `neon.ts` (or `hello.ts`) is never overwritten.
+
+Four sub-commands plus two top-level aliases drive it:
+
+```bash
+# Scaffold a neon.ts and install the config packages (local only)
+neon config init
+
 # Inspect the branch's live Neon state (read-only — never mutates)
 neon config status
 
@@ -612,7 +658,7 @@ All sub-commands honor the [global options](#global-options), including `--outpu
 | checkout                                                                   |                                                                                                              | Pin a branch in `.neon`            |
 | diff                                                                       |                                                                                                              | Git-style schema diff vs a branch  |
 | [link](https://neon.com/docs/reference/cli-link)                           |                                                                                                              | Link a directory to a project      |
-| config                                                                     | `status`, `plan`, `apply`                                                                                    | Drive a branch from `neon.ts`      |
+| config                                                                     | `init`, `status`, `plan`, `apply`                                                                            | Drive a branch from `neon.ts`      |
 | deploy                                                                     |                                                                                                              | Alias for `config apply`           |
 | bootstrap                                                                  |                                                                                                              | Scaffold a project from a template |
 | bucket                                                                     | `create`, `list`, `delete`, `object list`, `object get`, `object put`, `object delete` (incl. `--recursive`) | Manage buckets and their objects   |

--- a/packages/cli/src/commands/__snapshots__/config.init.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/config.init.test.ts.snap
@@ -1,3 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`config init > --services runs offline end to end 1`] = `""`;
+
 exports[`config init > runs offline end to end and scaffolds into the working directory 1`] = `""`;

--- a/packages/cli/src/commands/config.init.test.ts
+++ b/packages/cli/src/commands/config.init.test.ts
@@ -142,8 +142,11 @@ describe("config init", () => {
 			'hello: { name: "Hello World", source: "./hello.ts" }',
 		);
 		expect(content).not.toContain("aiGateway");
-		expect(readFileSync(join(workspace, "hello.ts"), "utf8")).toContain(
-			"async fetch(): Promise<Response>",
+		expect(readFileSync(join(workspace, "hello.ts"), "utf8")).toBe(
+			`export default async function hello(): Promise<Response> {
+  return new Response("Hello from Neon Functions");
+}
+`,
 		);
 	});
 

--- a/packages/cli/src/commands/config.init.test.ts
+++ b/packages/cli/src/commands/config.init.test.ts
@@ -7,6 +7,9 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveConfig } from "@neon/config";
+import { loadConfigFromFile } from "@neon/config-runtime";
 import { afterEach, beforeEach, describe, expect } from "vitest";
 import { test } from "../test_utils/fixtures";
 import { hasNeonConfigFile, initCmd } from "./config";
@@ -126,6 +129,192 @@ describe("config init", () => {
 		expect(existsSync(join(workspace, "neon.ts"))).toBe(true);
 	});
 
+	test("--services declares the selected services and scaffolds the function source", async () => {
+		await initCmd({
+			cwd: workspace,
+			install: false,
+			services: "auth,functions",
+		});
+
+		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
+		expect(content).toContain("auth: true");
+		expect(content).toContain(
+			'hello: { name: "Hello World", source: "./hello.ts" }',
+		);
+		expect(content).not.toContain("aiGateway");
+		expect(readFileSync(join(workspace, "hello.ts"), "utf8")).toContain(
+			"async fetch(): Promise<Response>",
+		);
+	});
+
+	test("--services storage declares the bucket with its default visibility", async () => {
+		await initCmd({ cwd: workspace, install: false, services: "storage" });
+
+		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
+		expect(content).toContain('assets: { access: "private" }');
+		// Object storage needs no source file, unlike functions.
+		expect(existsSync(join(workspace, "hello.ts"))).toBe(false);
+	});
+
+	test("--services none writes the same file as a non-interactive run", async () => {
+		const bare = mkdtempSync(join(tmpdir(), "neonctl-config-init-bare-"));
+		try {
+			await initCmd({ cwd: workspace, install: false, services: "none" });
+			await initCmd({ cwd: bare, install: false });
+
+			expect(readFileSync(join(workspace, "neon.ts"), "utf8")).toBe(
+				readFileSync(join(bare, "neon.ts"), "utf8"),
+			);
+		} finally {
+			rmSync(bare, { recursive: true, force: true });
+		}
+	});
+
+	test("an unknown service fails before anything is written", async () => {
+		await expect(
+			initCmd({
+				cwd: workspace,
+				install: false,
+				services: "auth,vectors",
+			}),
+		).rejects.toThrow(/Unknown service vectors/);
+
+		expect(existsSync(join(workspace, "neon.ts"))).toBe(false);
+	});
+
+	test("the picker chooses the services when --services is omitted", async () => {
+		await initCmd({
+			cwd: workspace,
+			install: false,
+			pickServices: () => Promise.resolve(["ai-gateway"]),
+		});
+
+		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
+		expect(content).toContain("aiGateway: true");
+		expect(content).toContain("auth: false");
+	});
+
+	test("an empty selection falls back to the starter policy", async () => {
+		await initCmd({
+			cwd: workspace,
+			install: false,
+			pickServices: () => Promise.resolve([]),
+		});
+
+		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
+		expect(content).toContain("auth: false");
+		expect(content).not.toContain("preview");
+	});
+
+	test("never prompts when the project already has a neon.ts", async () => {
+		writeFileSync(join(workspace, "neon.ts"), "export default {};\n");
+		let picked = 0;
+
+		await initCmd({
+			cwd: workspace,
+			install: false,
+			pickServices: () => {
+				picked += 1;
+				return Promise.resolve(["auth"]);
+			},
+		});
+
+		expect(picked).toBe(0);
+	});
+
+	test("leaves an existing hello.ts untouched", async () => {
+		const original = "export default { async fetch() {} };\n";
+		writeFileSync(join(workspace, "hello.ts"), original);
+
+		await initCmd({
+			cwd: workspace,
+			install: false,
+			services: "functions",
+		});
+
+		expect(readFileSync(join(workspace, "hello.ts"), "utf8")).toBe(
+			original,
+		);
+		expect(readFileSync(join(workspace, "neon.ts"), "utf8")).toContain(
+			'source: "./hello.ts"',
+		);
+	});
+
+	// A scaffold that renders the right string but doesn't *load* is still broken:
+	// `defineConfig` validates at module-eval time, so an unknown key or a bad function slug
+	// only surfaces when `config plan` imports the file. Scaffold each variant for real and
+	// load it through the same loader the CLI uses.
+	//
+	// The temp project lives under the package's own `node_modules` so jiti resolves
+	// `@neon/config/v1` by walking up exactly as it would in a user's project — and so a
+	// directory left behind by a crashed run can never be committed.
+	test("every scaffolded policy loads and resolves", async () => {
+		const packageRoot = fileURLToPath(new URL("../../", import.meta.url));
+		const cases: { services: string; expected: Record<string, unknown> }[] =
+			[
+				{
+					services: "none",
+					expected: {
+						authEnabled: false,
+						aiGateway: false,
+						functions: [],
+						buckets: [],
+					},
+				},
+				{
+					services: "auth",
+					expected: {
+						authEnabled: true,
+						aiGateway: false,
+						functions: [],
+						buckets: [],
+					},
+				},
+				{
+					services: "auth,ai-gateway,functions,storage",
+					expected: {
+						authEnabled: true,
+						aiGateway: true,
+						functions: ["hello:./hello.ts"],
+						buckets: ["assets:private"],
+					},
+				},
+			];
+
+		for (const { services, expected } of cases) {
+			const project = mkdtempSync(
+				join(packageRoot, "node_modules", ".neon-config-init-"),
+			);
+			try {
+				await initCmd({ cwd: project, install: false, services });
+
+				const { config } = await loadConfigFromFile({
+					path: join(project, "neon.ts"),
+				});
+				const resolved = resolveConfig(config, {
+					name: "dev",
+					exists: false,
+					isDefault: false,
+				});
+
+				expect({
+					authEnabled: resolved.authEnabled,
+					aiGateway: resolved.preview?.aiGatewayEnabled ?? false,
+					functions: (resolved.preview?.functions ?? []).map(
+						(fn) => `${fn.slug}:${fn.source}`,
+					),
+					buckets: (resolved.preview?.buckets ?? []).map(
+						(bucket) => `${bucket.name}:${bucket.access}`,
+					),
+				}).toEqual(expected);
+				// The starter policy's branch closure is part of what has to survive loading.
+				expect(resolved.ttlSeconds).toBe(7 * 24 * 60 * 60);
+			} finally {
+				rmSync(project, { recursive: true, force: true });
+			}
+		}
+	});
+
 	test("hasNeonConfigFile detects each supported config filename", () => {
 		expect(hasNeonConfigFile(workspace)).toBe(false);
 		for (const name of ["neon.ts", "neon.mts", "neon.js", "neon.mjs"]) {
@@ -153,5 +342,24 @@ describe("config init", () => {
 
 		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
 		expect(content).toContain("@neon/config/v1");
+	});
+
+	// `--services` must reach the scaffolder through yargs, and must stay offline:
+	// selecting the AI Gateway does not check the account's plan (init has no API client).
+	test("--services runs offline end to end", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"config",
+				"init",
+				"--no-install",
+				"--services",
+				"ai-gateway,storage",
+			],
+			{ unreachableHost: true, code: 0, cwd: workspace },
+		);
+
+		const content = readFileSync(join(workspace, "neon.ts"), "utf8");
+		expect(content).toContain("aiGateway: true");
+		expect(content).toContain('assets: { access: "private" }');
 	});
 });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -19,6 +19,17 @@ import chalk from "chalk";
 import type yargs from "yargs";
 import { getApiClient } from "../api.js";
 import { toNeonConfigView } from "../config_format.js";
+import {
+	FUNCTION_FILENAME,
+	FUNCTION_SLUG,
+	FUNCTION_TEMPLATE,
+	NEON_SERVICES,
+	type NeonService,
+	NO_SERVICES,
+	parseServices,
+	REQUIRED_PACKAGES,
+	renderNeonConfig,
+} from "../config_template.js";
 
 import { contextBranch, readContextFile } from "../context.js";
 import { isCi } from "../env.js";
@@ -41,6 +52,7 @@ import {
 	resolvePackageManager,
 	runCommand,
 } from "../utils/package_manager.js";
+import { pickServicesInteractively } from "../utils/service_picker.js";
 import { zipBundle } from "../utils/zip.js";
 import { writer } from "../writer.js";
 import { autoPullEnvAfterPin } from "./env.js";
@@ -149,19 +161,6 @@ export const envPullFlag = {
 
 // ── `config init` ─────────────────────────────────────────────────────────────
 
-/**
- * The published npm packages a `neon.ts` project needs — the `@neon/*` org names.
- *
- * ⚠️ These ship to users the next time `neonctl` is released, so do NOT release
- * neonctl until `@neon/config` and `@neon/env` are published to npm — otherwise
- * `config init` would install packages that don't exist yet. (The libraries are
- * mid-migration from `@neondatabase/*`; track their publish before cutting a CLI
- * release.)
- */
-const CONFIG_PACKAGE = "@neon/config";
-const ENV_PACKAGE = "@neon/env";
-const REQUIRED_PACKAGES = [CONFIG_PACKAGE, ENV_PACKAGE] as const;
-
 /** package.json fields a dependency can be declared in. */
 const DEPENDENCY_FIELDS = [
 	"dependencies",
@@ -176,29 +175,6 @@ const NEON_CONFIG_FILENAMES = ["neon.ts", "neon.mts", "neon.js", "neon.mjs"];
 /** Whether `dir` already has a Neon config file the runtime would load. */
 export const hasNeonConfigFile = (dir: string): boolean =>
 	NEON_CONFIG_FILENAMES.some((name) => existsSync(join(dir, name)));
-
-/** Starter `neon.ts` written by `config init` when a project has none. */
-const NEON_CONFIG_TEMPLATE = `import { defineConfig } from "${CONFIG_PACKAGE}/v1";
-
-export default defineConfig({
-  // Declare your Neon services here
-  auth: false,
-  // Branch policy: per-branch tuning
-  branch: (branch) => {
-    if (branch.isDefault) {
-      // Default branch: no overrides, uses project defaults
-      return {};
-    }
-    if (!branch.exists) {
-      // New non-default branches: auto-expire
-      // Run \`neon checkout <name>\` to create a new branch with these settings
-      return { ttl: "7d" };
-    }
-    // Existing branch: no changes
-    return {};
-  },
-});
-`;
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
@@ -240,6 +216,58 @@ export type ConfigInitProps = {
 	install?: boolean;
 	/** Injected command runner (tests). Defaults to the real spawn-based runner. */
 	run?: typeof runCommand;
+	/**
+	 * Raw `--services` value: comma-separated {@link NEON_SERVICES} names, or `none` for the
+	 * bare starter policy. When omitted, {@link resolveServices} picks interactively on a TTY
+	 * and falls back to the starter policy otherwise.
+	 */
+	services?: string;
+	/** Injected service picker (tests). Wins over the TTY check; production omits it. */
+	pickServices?: () => Promise<NeonService[]>;
+};
+
+/**
+ * Which services the scaffolded policy declares. `--services` always wins so a script or an
+ * agent gets the same result without a TTY; an injected picker is next (tests); the real
+ * picker only runs on an interactive terminal outside CI. Everything else scaffolds the
+ * starter policy, which is what `config init` has always written.
+ */
+const resolveServices = async (
+	props: ConfigInitProps,
+): Promise<NeonService[]> => {
+	if (props.services !== undefined) {
+		return parseServices(props.services);
+	}
+	if (props.pickServices) {
+		return props.pickServices();
+	}
+	if (isCi() || !process.stdout.isTTY) {
+		return [];
+	}
+	return pickServicesInteractively();
+};
+
+/**
+ * Write the hello-world handler the scaffolded `preview.functions` entry points at. An
+ * existing `hello.ts` is left alone: the declared function keeps pointing at it, which is the
+ * better outcome than overwriting a file the user wrote.
+ */
+const scaffoldFunction = (cwd: string): void => {
+	const path = join(cwd, FUNCTION_FILENAME);
+	if (existsSync(path)) {
+		log.info(
+			"Found an existing %s — leaving it untouched; the %s function points at it.",
+			FUNCTION_FILENAME,
+			FUNCTION_SLUG,
+		);
+		return;
+	}
+	writeFileSync(path, FUNCTION_TEMPLATE);
+	log.info(
+		"Created %s — the source of the %s function.",
+		FUNCTION_FILENAME,
+		FUNCTION_SLUG,
+	);
 };
 
 /**
@@ -251,15 +279,25 @@ export const initCmd = async (props: ConfigInitProps): Promise<void> => {
 	const cwd = props.cwd ?? process.cwd();
 	const run = props.run ?? runCommand;
 
-	// 1. Scaffold neon.ts unless the project already has a Neon config file.
+	// 1. Scaffold neon.ts unless the project already has a Neon config file. Resolving the
+	// services (which may prompt) happens only when there is something to write — asking
+	// which services to declare and then declaring nothing would be a lie.
 	const existing = NEON_CONFIG_FILENAMES.find((name) =>
 		existsSync(join(cwd, name)),
 	);
 	if (existing) {
 		log.info("Found an existing %s — leaving it untouched.", existing);
 	} else {
-		writeFileSync(join(cwd, "neon.ts"), NEON_CONFIG_TEMPLATE);
-		log.info("Created neon.ts with a starter policy.");
+		const services = await resolveServices(props);
+		writeFileSync(join(cwd, "neon.ts"), renderNeonConfig(services));
+		if (services.length === 0) {
+			log.info("Created neon.ts with a starter policy.");
+		} else {
+			log.info("Created neon.ts declaring %s.", services.join(", "));
+		}
+		if (services.includes("functions")) {
+			scaffoldFunction(cwd);
+		}
 	}
 
 	// 2. Make sure the config packages are installed.
@@ -373,6 +411,13 @@ export const builder = (argv: yargs.Argv) =>
 							"On by default; use --no-install to just print the command.",
 						type: "boolean",
 						default: true,
+					},
+					services: {
+						describe:
+							`Services the scaffolded neon.ts declares, comma-separated: ${NEON_SERVICES.join(", ")}. ` +
+							`Pass "${NO_SERVICES}" for the bare starter policy. Omitted: pick interactively on a ` +
+							"terminal, starter policy in CI or without a TTY.",
+						type: "string",
 					},
 				}),
 			(args) => initCmd(args as any),

--- a/packages/cli/src/config_template.test.ts
+++ b/packages/cli/src/config_template.test.ts
@@ -14,8 +14,8 @@ describe("parseServices", () => {
 	it("canonicalizes order and drops duplicates", () => {
 		expect(parseServices("storage,auth,storage,ai-gateway")).toEqual([
 			"auth",
-			"ai-gateway",
 			"storage",
+			"ai-gateway",
 		]);
 	});
 
@@ -25,7 +25,7 @@ describe("parseServices", () => {
 
 	it("rejects an unknown service by name, listing the supported values", () => {
 		expect(() => parseServices("auth,data-api")).toThrow(
-			/Unknown service data-api\. Supported values: auth, ai-gateway, functions, storage, none\./,
+			/Unknown service data-api\. Supported values: auth, functions, storage, ai-gateway, none\./,
 		);
 	});
 

--- a/packages/cli/src/config_template.test.ts
+++ b/packages/cli/src/config_template.test.ts
@@ -72,7 +72,6 @@ export default defineConfig({
   // Declare your Neon services here
   auth: true,
   preview: {
-    // Always available on the branch; provisioning needs a paid plan
     aiGateway: true,
     functions: {
       hello: { name: "Hello World", source: "./hello.ts" },

--- a/packages/cli/src/config_template.test.ts
+++ b/packages/cli/src/config_template.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	NEON_SERVICES,
+	parseServices,
+	renderNeonConfig,
+} from "./config_template.js";
+
+describe("parseServices", () => {
+	it("accepts a comma-separated list, tolerating whitespace", () => {
+		expect(parseServices("auth, functions")).toEqual(["auth", "functions"]);
+	});
+
+	it("canonicalizes order and drops duplicates", () => {
+		expect(parseServices("storage,auth,storage,ai-gateway")).toEqual([
+			"auth",
+			"ai-gateway",
+			"storage",
+		]);
+	});
+
+	it('reads "none" as no services', () => {
+		expect(parseServices("none")).toEqual([]);
+	});
+
+	it("rejects an unknown service by name, listing the supported values", () => {
+		expect(() => parseServices("auth,data-api")).toThrow(
+			/Unknown service data-api\. Supported values: auth, ai-gateway, functions, storage, none\./,
+		);
+	});
+
+	it('refuses "none" alongside a real service', () => {
+		expect(() => parseServices("none,auth")).toThrow(
+			/cannot be combined with other services/,
+		);
+	});
+});
+
+describe("renderNeonConfig", () => {
+	it("renders the starter policy when nothing is selected", () => {
+		expect(
+			renderNeonConfig([]),
+		).toBe(`import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  // Declare your Neon services here
+  auth: false,
+  // Branch policy: per-branch tuning
+  branch: (branch) => {
+    if (branch.isDefault) {
+      // Default branch: no overrides, uses project defaults
+      return {};
+    }
+    if (!branch.exists) {
+      // New non-default branches: auto-expire
+      // Run \`neon checkout <name>\` to create a new branch with these settings
+      return { ttl: "7d" };
+    }
+    // Existing branch: no changes
+    return {};
+  },
+});
+`);
+	});
+
+	it("renders every service, with the bucket's default visibility spelled out", () => {
+		expect(
+			renderNeonConfig(NEON_SERVICES),
+		).toBe(`import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  // Declare your Neon services here
+  auth: true,
+  preview: {
+    // Always available on the branch; provisioning needs a paid plan
+    aiGateway: true,
+    functions: {
+      hello: { name: "Hello World", source: "./hello.ts" },
+    },
+    buckets: {
+      // "private" is the default; use "public_read" for anonymous reads
+      assets: { access: "private" },
+    },
+  },
+  // Branch policy: per-branch tuning
+  branch: (branch) => {
+    if (branch.isDefault) {
+      // Default branch: no overrides, uses project defaults
+      return {};
+    }
+    if (!branch.exists) {
+      // New non-default branches: auto-expire
+      // Run \`neon checkout <name>\` to create a new branch with these settings
+      return { ttl: "7d" };
+    }
+    // Existing branch: no changes
+    return {};
+  },
+});
+`);
+	});
+
+	it("omits the preview block when only auth is selected", () => {
+		const rendered = renderNeonConfig(["auth"]);
+		expect(rendered).toContain("auth: true,");
+		expect(rendered).not.toContain("preview");
+	});
+
+	it("emits a preview block with only the selected preview features", () => {
+		const rendered = renderNeonConfig(["storage"]);
+		expect(rendered).toContain("auth: false,");
+		expect(rendered).toContain("preview: {");
+		expect(rendered).toContain('assets: { access: "private" },');
+		expect(rendered).not.toContain("aiGateway");
+		expect(rendered).not.toContain("functions");
+	});
+});

--- a/packages/cli/src/config_template.ts
+++ b/packages/cli/src/config_template.ts
@@ -1,0 +1,154 @@
+/**
+ * The published npm packages a `neon.ts` project needs — the `@neon/*` org names.
+ *
+ * ⚠️ These ship to users the next time `neonctl` is released, so do NOT release
+ * neonctl until `@neon/config` and `@neon/env` are published to npm — otherwise
+ * `config init` would install packages that don't exist yet. (The libraries are
+ * mid-migration from `@neondatabase/*`; track their publish before cutting a CLI
+ * release.)
+ */
+export const CONFIG_PACKAGE = "@neon/config";
+export const ENV_PACKAGE = "@neon/env";
+export const REQUIRED_PACKAGES = [CONFIG_PACKAGE, ENV_PACKAGE] as const;
+
+/**
+ * A Neon service `config init` can declare in the `neon.ts` it scaffolds, spelled the way a
+ * user types it in `--services`. Kebab-case rather than the `neon.ts` field names (`aiGateway`,
+ * `buckets`) so the flag reads like a flag; {@link renderNeonConfig} owns the mapping.
+ *
+ * Postgres is absent because every branch has it, and `dataApi` is absent because enabling it
+ * with the default `authProvider: "neon"` requires `auth` — a pairing the picker would have to
+ * enforce rather than offer.
+ */
+export const NEON_SERVICES = [
+	"auth",
+	"ai-gateway",
+	"functions",
+	"storage",
+] as const;
+export type NeonService = (typeof NEON_SERVICES)[number];
+
+/** `--services none`: declare nothing, i.e. scaffold the bare starter policy. */
+export const NO_SERVICES = "none";
+
+/** Slug, display name, and source path of the function scaffolded for `functions`. */
+export const FUNCTION_SLUG = "hello";
+export const FUNCTION_NAME = "Hello World";
+export const FUNCTION_FILENAME = "hello.ts";
+
+/** Name of the bucket scaffolded for `storage`. */
+export const BUCKET_NAME = "assets";
+
+/**
+ * Parse a `--services` value into a canonical service list: comma-separated
+ * {@link NEON_SERVICES} names, or {@link NO_SERVICES} on its own for none.
+ *
+ * Unknown names are rejected here rather than silently dropped — a typo'd service would
+ * otherwise scaffold a policy missing exactly the service the user asked for. The result is
+ * deduplicated and ordered by {@link NEON_SERVICES} so the rendered file doesn't depend on the
+ * order they were typed in.
+ */
+export const parseServices = (raw: string): NeonService[] => {
+	const names = raw
+		.split(",")
+		.map((name) => name.trim())
+		.filter((name) => name !== "");
+
+	if (names.includes(NO_SERVICES)) {
+		if (names.length > 1) {
+			throw new Error(
+				`--services ${NO_SERVICES} cannot be combined with other services.`,
+			);
+		}
+		return [];
+	}
+
+	const unknown = names.filter(
+		(name) => !NEON_SERVICES.includes(name as NeonService),
+	);
+	if (unknown.length > 0) {
+		throw new Error(
+			`Unknown service${unknown.length === 1 ? "" : "s"} ${unknown.join(", ")}. ` +
+				`Supported values: ${NEON_SERVICES.join(", ")}, ${NO_SERVICES}.`,
+		);
+	}
+
+	return NEON_SERVICES.filter((service) => names.includes(service));
+};
+
+/** The `preview` block for the selected services, or "" when none of them is a preview feature. */
+const renderPreview = (services: readonly NeonService[]): string => {
+	const lines: string[] = [];
+
+	if (services.includes("ai-gateway")) {
+		lines.push(
+			"    // Always available on the branch; provisioning needs a paid plan",
+			"    aiGateway: true,",
+		);
+	}
+	if (services.includes("functions")) {
+		lines.push(
+			"    functions: {",
+			`      ${FUNCTION_SLUG}: { name: "${FUNCTION_NAME}", source: "./${FUNCTION_FILENAME}" },`,
+			"    },",
+		);
+	}
+	if (services.includes("storage")) {
+		lines.push(
+			"    buckets: {",
+			`      // "private" is the default; use "public_read" for anonymous reads`,
+			`      ${BUCKET_NAME}: { access: "private" },`,
+			"    },",
+		);
+	}
+
+	if (lines.length === 0) {
+		return "";
+	}
+	return `${["  preview: {", ...lines, "  },"].join("\n")}\n`;
+};
+
+/**
+ * Render the `neon.ts` policy `config init` writes. With no services this is the starter
+ * policy — an explicit `auth: false`, no `preview` block, and a `branch` closure that gives
+ * new non-default branches a 7-day TTL — so the picker's "skip everything" answer and a
+ * non-interactive run produce the identical file.
+ */
+export const renderNeonConfig = (services: readonly NeonService[]): string =>
+	`import { defineConfig } from "${CONFIG_PACKAGE}/v1";
+
+export default defineConfig({
+  // Declare your Neon services here
+  auth: ${services.includes("auth")},
+${renderPreview(services)}  // Branch policy: per-branch tuning
+  branch: (branch) => {
+    if (branch.isDefault) {
+      // Default branch: no overrides, uses project defaults
+      return {};
+    }
+    if (!branch.exists) {
+      // New non-default branches: auto-expire
+      // Run \`neon checkout <name>\` to create a new branch with these settings
+      return { ttl: "7d" };
+    }
+    // Existing branch: no changes
+    return {};
+  },
+});
+`;
+
+/**
+ * The handler written alongside `neon.ts` when `functions` is selected. It has to exist:
+ * `FunctionDef.source` is only resolved when `config apply` / `deploy` bundles it, so a
+ * declared function with no file on disk fails at deploy time rather than at authoring time.
+ *
+ * `fetch` takes no parameter on purpose — a scaffold that ships an unused `req` fails the
+ * typecheck of any project running with `noUnusedParameters`. Add it back when the handler
+ * needs the request.
+ */
+export const FUNCTION_TEMPLATE = `export default {
+  async fetch(): Promise<Response> {
+    return new Response("Hello from Neon Functions");
+  },
+};
+`;

--- a/packages/cli/src/config_template.ts
+++ b/packages/cli/src/config_template.ts
@@ -81,10 +81,7 @@ const renderPreview = (services: readonly NeonService[]): string => {
 	const lines: string[] = [];
 
 	if (services.includes("ai-gateway")) {
-		lines.push(
-			"    // Always available on the branch; provisioning needs a paid plan",
-			"    aiGateway: true,",
-		);
+		lines.push("    aiGateway: true,");
 	}
 	if (services.includes("functions")) {
 		lines.push(

--- a/packages/cli/src/config_template.ts
+++ b/packages/cli/src/config_template.ts
@@ -139,13 +139,12 @@ ${renderPreview(services)}  // Branch policy: per-branch tuning
  * `FunctionDef.source` is only resolved when `config apply` / `deploy` bundles it, so a
  * declared function with no file on disk fails at deploy time rather than at authoring time.
  *
- * `fetch` takes no parameter on purpose — a scaffold that ships an unused `req` fails the
- * typecheck of any project running with `noUnusedParameters`. Add it back when the handler
- * needs the request.
+ * A default-exported function rather than `export default { fetch }`: both are resolved (see
+ * `resolveFetchHandler`), and the bare function is less to read and less to get wrong. It is
+ * named rather than anonymous so a project's linter has nothing to say about it, and takes no
+ * parameter because a scaffold shipping an unused `req` fails a `noUnusedParameters` project.
  */
-export const FUNCTION_TEMPLATE = `export default {
-  async fetch(): Promise<Response> {
-    return new Response("Hello from Neon Functions");
-  },
-};
+export const FUNCTION_TEMPLATE = `export default async function hello(): Promise<Response> {
+  return new Response("Hello from Neon Functions");
+}
 `;

--- a/packages/cli/src/config_template.ts
+++ b/packages/cli/src/config_template.ts
@@ -22,9 +22,9 @@ export const REQUIRED_PACKAGES = [CONFIG_PACKAGE, ENV_PACKAGE] as const;
  */
 export const NEON_SERVICES = [
 	"auth",
-	"ai-gateway",
 	"functions",
 	"storage",
+	"ai-gateway",
 ] as const;
 export type NeonService = (typeof NEON_SERVICES)[number];
 

--- a/packages/cli/src/utils/service_picker.ts
+++ b/packages/cli/src/utils/service_picker.ts
@@ -1,0 +1,70 @@
+import prompts from "prompts";
+import { NEON_SERVICES, type NeonService } from "../config_template.js";
+
+/**
+ * The picker's rows, in {@link NEON_SERVICES} order. Titles use the product names from the
+ * CLI's README ("Managed Better Auth", "Object Storage") rather than the `neon.ts` field
+ * names, since this is the list a user reads before they've seen a policy.
+ */
+const CHOICES: { value: NeonService; title: string; description: string }[] = [
+	{
+		value: "auth",
+		title: "Managed Better Auth",
+		description: "Users, sessions, and OAuth providers managed by Neon",
+	},
+	{
+		value: "ai-gateway",
+		title: "AI Gateway",
+		description:
+			"One OpenAI-compatible endpoint; provisioning needs a paid plan",
+	},
+	{
+		value: "functions",
+		title: "Functions",
+		description:
+			"Scaffolds hello.ts and declares it as a deployable function",
+	},
+	{
+		value: "storage",
+		title: "Object Storage",
+		description: "A branchable private bucket named assets",
+	},
+];
+
+/**
+ * Ask which services the scaffolded `neon.ts` should declare. Selecting nothing is a real
+ * answer — it yields the bare starter policy — so an empty list returns empty rather than
+ * re-prompting. Aborting (Ctrl-C) exits 1, matching the prompts in `link`.
+ *
+ * Callers guard the TTY themselves (see `initCmd`); this function assumes it may prompt.
+ */
+export const pickServicesInteractively = async (): Promise<NeonService[]> => {
+	const { services } = await prompts({
+		onState: (state: { aborted: boolean }) => {
+			if (state.aborted) {
+				// Restore the cursor prompts hid, then exit — otherwise the terminal is
+				// left without one for the rest of the session.
+				process.stdout.write("\x1B[?25h");
+				process.stdout.write("\n");
+				process.exit(1);
+			}
+		},
+		type: "multiselect",
+		name: "services",
+		message:
+			"Which Neon services should neon.ts declare? (space to toggle, enter to confirm)",
+		instructions: false,
+		choices: CHOICES.map((choice) => ({
+			value: choice.value,
+			title: choice.title,
+			description: choice.description,
+		})),
+	});
+
+	if (!Array.isArray(services)) {
+		throw new Error("Aborted: no services selected.");
+	}
+	// Order by NEON_SERVICES rather than selection order so the rendered neon.ts is
+	// independent of the order the rows were toggled in.
+	return NEON_SERVICES.filter((service) => services.includes(service));
+};

--- a/packages/cli/src/utils/service_picker.ts
+++ b/packages/cli/src/utils/service_picker.ts
@@ -10,24 +10,26 @@ const CHOICES: { value: NeonService; title: string; description: string }[] = [
 	{
 		value: "auth",
 		title: "Managed Better Auth",
-		description: "Users, sessions, and OAuth providers managed by Neon",
-	},
-	{
-		value: "ai-gateway",
-		title: "AI Gateway",
 		description:
-			"One OpenAI-compatible endpoint; provisioning needs a paid plan",
+			"Authentication with users and sessions stored in Postgres.",
 	},
 	{
 		value: "functions",
 		title: "Functions",
 		description:
-			"Scaffolds hello.ts and declares it as a deployable function",
+			"Long-running, without timeouts, and closer to your database.",
 	},
 	{
 		value: "storage",
 		title: "Object Storage",
-		description: "A branchable private bucket named assets",
+		description:
+			"S3-compatible blob storage that branches with your projects.",
+	},
+	{
+		value: "ai-gateway",
+		title: "AI Gateway",
+		description:
+			"All models, one API, one bill. Powered by Databricks. Not available on the Neon free plan.",
 	},
 ];
 


### PR DESCRIPTION
## Problem

`neon config init` writes the same file into every project. The template is a module-level constant with no inputs, so a project that uses Neon Auth, the AI Gateway, Functions, or Object Storage gets a policy that declares none of them and has to be hand-edited immediately:

```ts
export default defineConfig({
  // Declare your Neon services here
  auth: false,
  branch: (branch) => { /* 7d TTL on new non-default branches */ },
});
```

The comment tells you to declare services; the command that wrote the comment could have.

## What it does now

On an interactive terminal, `config init` asks which services the policy should declare before writing it (the description shows under the focused row):

```
? Which Neon services should neon.ts declare? (space to toggle, enter to confirm) ›
◯   Managed Better Auth
     Authentication with users and sessions stored in Postgres.
◯   Functions
     Long-running, without timeouts, and closer to your database.
◯   Object Storage
     S3-compatible blob storage that branches with your projects.
◯   AI Gateway
     All models, one API, one bill. Powered by Databricks. Not available on the Neon free plan.
```

Selecting nothing is a real answer: it produces the byte-identical starter policy, so the picker can be dismissed with a single Enter and nothing changes.

## Interface

```bash
neon config init                                    # picker on a TTY, starter policy otherwise
neon config init --services auth,functions          # no prompt, anywhere
neon config init --services none                    # explicit starter policy
```

`--services` exists because the picker is invisible to the largest caller. `config init` is run by agents and by `neon init --agent`, neither of which has a TTY, and a flag is how they reach the same behaviour. Values are `auth`, `functions`, `storage`, `ai-gateway`, plus `none`; unknown names are rejected before anything is written, listing the supported values.

Selecting everything renders:

```ts
import { defineConfig } from "@neon/config/v1";

export default defineConfig({
  // Declare your Neon services here
  auth: true,
  preview: {
    aiGateway: true,
    functions: {
      hello: { name: "Hello World", source: "./hello.ts" },
    },
    buckets: {
      // "private" is the default; use "public_read" for anonymous reads
      assets: { access: "private" },
    },
  },
  // Branch policy: per-branch tuning
  branch: (branch) => {
    if (branch.isDefault) {
      return {};
    }
    if (!branch.exists) {
      return { ttl: "7d" };
    }
    return {};
  },
});
```

`functions` also writes the handler, because a declared function with no file on disk is not a working policy — `FunctionDef.source` is never validated at authoring time, it is resolved by esbuild when `config apply` / `deploy` bundles it, so the failure would land at deploy with a module-resolution error:

```ts
// hello.ts
export default async function hello(): Promise<Response> {
  return new Response("Hello from Neon Functions");
}
```

`resolveFetchHandler` accepts either a default-exported function or `export default { fetch }`; the function is the smaller thing to read and to edit. It is named rather than anonymous so a project's linter has nothing to say about it, and takes no parameter so the scaffold survives a project with `noUnusedParameters`. An existing `hello.ts` is never overwritten — including one written in the `{ fetch }` style — and the policy points at the one already there.

`storage` needs no file: a bucket is a record key. Its default access level is written out explicitly (`access: "private"`) rather than left implicit, so the field to change for public reads is visible.

The AI Gateway's plan requirement is stated on the picker row, not in the generated file — in the file it would sit above a declaration it doesn't explain.

### What does not change

- No TTY, or `CI` set: identical file to before, no prompt, no new output.
- An existing `neon.ts` / `neon.mts` / `neon.js` / `neon.mjs`: left untouched, and the picker never runs — asking which services to declare and then declaring nothing would be a lie.
- `config init` stays offline. It never gains an API client, which is why picking the AI Gateway does not check whether the account can provision one (see below).
- `neon link` calls `initCmd` at the end of its interactive flow, so it now offers the same picker after you accept "manage this project as code". Aborting the picker exits 1, matching every other prompt in `link`.

## Also in here

- **The CLI README now documents `config init`.** It had no coverage of the command at all: the "Config as code" section jumped straight to `status` / `plan` / `apply`, and the command table's `config` row omitted `init`. The new subsection covers the picker, `--services`, the scaffolded handler, and the never-overwrite rule.
- `CONFIG_PACKAGE`, `ENV_PACKAGE`, and `REQUIRED_PACKAGES` moved from `commands/config.ts` into the new `config_template.ts` with their release warning intact. The rendered import line and the install list have to name the same package; two copies would drift.
- `dataApi` is deliberately not offered. With the default `authProvider: "neon"` it is a type error unless `auth` is also on, so it needs a dependent prompt rather than a checkbox. Nothing about it changes here.

## Verification

Base `fc7e47c`. `pnpm --filter neon test:ci` (3176 passed, 6 skipped), `pnpm lint:ci`, `tsc --noEmit`.

Behaviours covered by the new tests:

- `--services` renders the selected services; `--services none` produces a file byte-identical to a non-interactive run
- an unknown service name throws and leaves no `neon.ts` behind
- the picker's result is what gets rendered, and an empty selection yields the starter policy
- an existing `neon.ts` skips the picker entirely; an existing `hello.ts` is not overwritten
- every scaffolded variant *loads*: the test scaffolds for real, then reads the file back through the loader the CLI uses and asserts the resolved services. A string assertion cannot catch an unknown key or a bad function slug, because `defineConfig` validates at module-eval time
- `--services ai-gateway,storage` end to end against an unreachable API host, proving the flag plumbs through yargs and the command is still offline

Driven by hand on a real pty (`script`), which is the part no test covers: the picker renders, space toggles, Enter with nothing selected writes the starter policy and exits 0, Ctrl-D/abort exits 1 and writes nothing, and toggling Managed Better Auth + Functions produced the policy above plus `hello.ts`. Re-checked at 80 columns after the copy change — `prompts` wraps the AI Gateway description on a word boundary and keeps the indent.

The scaffolded function was run both ways, because whether a bare default export works is a property of two different runtimes:

```
$ neon dev
  hello                http://localhost:8788
$ curl -i http://localhost:8788/
HTTP/1.1 200 OK
Hello from Neon Functions

$ neon config apply           # smoke org, real project, deleted after
Applied changes
  + function hello
Function URLs
  • hello: https://br-spring-sunset-axrspwwq-hello.compute.c-4.us-east-2.aws.neon.tech/
$ curl -i https://br-spring-sunset-axrspwwq-hello.compute.c-4.us-east-2.aws.neon.tech/
HTTP/2 200
Hello from Neon Functions
```

Every rendered variant was also loaded against the workspace `@neon/config` outside the test suite; all six resolve, with the 7-day TTL from the branch closure intact.

## For your attention

- **Picking the AI Gateway can produce a policy that fails at first apply.** `config apply` refuses to provision it on a Free plan, and `config init` has no API client to check the plan with — keeping it offline is worth more than pre-flighting one service. The row says it isn't available on the free plan; the failure, when it comes, comes from `apply` with its own message.
- **`neon link` gained a prompt.** It is inside a flow that is already interactive and already asked whether to manage the project as code, but it is a UX change to a second command.
- **`neon init` still asks its own narrower feature question** (`Database` / `Database + Neon Auth`, persisted as `_init.features` in `.neon`) and does not write a `neon.ts`. Two commands now ask overlapping questions with different lists. Reconciling them — most likely by having `neon init` delegate to `config init` — is a follow-up, not something this PR settles.
- **`FunctionDef.source`'s doc comment in `@neon/config` is wrong about the entry shapes.** It offers `export default { fetch }` or `export async function handler(req)`, but `resolveFetchHandler` rejects a named `handler` export (there is a test asserting it does) and accepts a default-exported function, which the comment doesn't mention. Not touched here; worth a separate fix so the type docs match the runtime.