### PR TITLE
feat(cli): seed `config init` from a branch with `--from-branch`

### DIFF
--- a/.changeset/config-init-from-branch.md
+++ b/.changeset/config-init-from-branch.md
@@ -1,0 +1,7 @@
+---
+"neon": minor
+---
+
+`neon config init --from-branch` seeds `neon.ts` from a branch's live Neon state instead of asking which services to declare. It uses the branch pinned in `.neon`, `--branch <name|id>`, or the project's default branch, and declares what the branch actually reports: Neon Auth, the Data API, and object-storage buckets with their access levels, plus the branch's compute settings in the policy closure.
+
+Three things it cannot declare are surfaced rather than guessed: deployed functions are listed as a commented-out block (the branch has no local `source` path), the AI Gateway is mentioned in a header comment (a branch has no readable enabled state for it), and a `protected` branch is reported as a comment instead of a policy field. `--from-branch` conflicts with `--services`, and it is the only mode of `config init` that calls the Neon API.

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -8,6 +8,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { PassThrough } from "node:stream";
+import { fileURLToPath } from "node:url";
 import type {
 	ComputeSettings,
 	CreateBranchInput,
@@ -29,7 +30,8 @@ import type {
 	NeonProjectSnapshot,
 	NeonRoleSnapshot,
 } from "@neon/config";
-import type { NeonApi } from "@neon/config-runtime";
+import { resolveConfig } from "@neon/config";
+import { loadConfigFromFile, type NeonApi } from "@neon/config-runtime";
 import stripAnsi from "strip-ansi";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -38,6 +40,7 @@ import {
 	applyCmd,
 	applyPolicyOnCreate,
 	createBranchFromPolicyOnCheckout,
+	initCmd,
 	planCmd,
 	status,
 } from "./config.js";
@@ -776,6 +779,195 @@ describe("config commands", () => {
 		// Nothing written: --no-env-pull leaves the working tree untouched.
 		expect(existsSync(join(cwd, ".env.local"))).toBe(false);
 		expect(existsSync(join(cwd, ".env"))).toBe(false);
+	});
+});
+
+/**
+ * A branch that has something worth seeding: Neon Auth and the Data API on, one bucket, one
+ * deployed function, and the branch marked protected.
+ */
+class LoadedBranchNeonApi extends FakeNeonApi {
+	override async listBranches(): Promise<NeonBranchSnapshot[]> {
+		return [
+			{
+				id: BRANCH_ID,
+				name: BRANCH_NAME,
+				isDefault: true,
+				protected: true,
+			},
+		];
+	}
+
+	override async getNeonAuth(): Promise<NeonAuthSnapshot> {
+		return {
+			projectId: "auth-project",
+			jwksUrl: "https://auth.fake.neon.tech/.well-known/jwks.json",
+			baseUrl: "https://auth.fake.neon.tech",
+		};
+	}
+
+	override async getNeonDataApi(): Promise<NeonDataApiSnapshot> {
+		return { url: "https://dataapi.fake.neon.tech", status: "ready" };
+	}
+
+	override async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
+		return [
+			// Hyphenated on purpose: a real Neon bucket name is not a JS identifier, and a
+			// bare `user-uploads:` key would be a syntax error in the emitted policy.
+			{ name: "user-uploads", accessLevel: "public_read" },
+			{ name: "backups", accessLevel: "private" },
+		];
+	}
+
+	override async listBranchFunctions(): Promise<NeonFunctionSnapshot[]> {
+		return [
+			{
+				id: "fn-resize",
+				slug: "resize",
+				name: "Resize Image",
+				invocationUrl: "https://fake.neon.tech/functions/resize",
+			},
+		];
+	}
+}
+
+describe("config init --from-branch", () => {
+	let cwd: string;
+
+	beforeEach(() => {
+		cwd = mkdtempSync(join(tmpdir(), "neonctl-from-branch-"));
+	});
+
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+	});
+
+	const seedProps = (api: NeonApi) => ({
+		cwd,
+		install: false,
+		fromBranch: true,
+		apiClient: fakeApiClient as never,
+		projectId: PROJECT_ID,
+		runtimeApi: api,
+	});
+
+	it("declares the services the branch actually has", async () => {
+		await initCmd(seedProps(new LoadedBranchNeonApi()));
+
+		const source = readFileSync(join(cwd, "neon.ts"), "utf8");
+		expect(source).toContain("auth: true,");
+		expect(source).toContain("dataApi: true,");
+		expect(source).toContain('"user-uploads": { access: "public_read" },');
+		expect(source).toContain('backups: { access: "private" },');
+		expect(source).toContain(
+			`Seeded by \`neon config init --from-branch\` from ${BRANCH_NAME}`,
+		);
+	});
+
+	it("lists deployed functions as a comment, since source cannot round-trip", async () => {
+		await initCmd(seedProps(new LoadedBranchNeonApi()));
+
+		const source = readFileSync(join(cwd, "neon.ts"), "utf8");
+		expect(source).toContain("// main has 1 deployed function.");
+		expect(source).toContain(
+			'//   resize: { name: "Resize Image", source: "./resize.ts" },',
+		);
+		// Commented out, so the policy does not declare a function with no source on disk.
+		expect(source).not.toMatch(/^\s+functions: \{/m);
+		// And no handler is invented for it.
+		expect(existsSync(join(cwd, "resize.ts"))).toBe(false);
+	});
+
+	it("reports `protected` as a comment instead of declaring it", async () => {
+		await initCmd(seedProps(new LoadedBranchNeonApi()));
+
+		const source = readFileSync(join(cwd, "neon.ts"), "utf8");
+		expect(source).toContain("// main is protected on Neon.");
+		expect(source).not.toMatch(/protected: true/);
+	});
+
+	it("carries the branch's compute settings into the policy closure", async () => {
+		await initCmd(seedProps(new FakeNeonApi()));
+
+		const source = readFileSync(join(cwd, "neon.ts"), "utf8");
+		expect(source).toContain("branch: () => ({");
+		expect(source).toContain("autoscalingLimitMinCu: 0.25,");
+		expect(source).toContain('suspendTimeout: "5m",');
+		// The AI Gateway has no readable per-branch state, so it is never declared — only
+		// mentioned in the header comment as something to add by hand.
+		expect(source).not.toMatch(/^\s+aiGateway: true,/m);
+		expect(source).toContain(
+			"// `preview: { aiGateway: true }` if the policy should declare it.",
+		);
+	});
+
+	// A seeded policy that doesn't load is worse than no seed: the emitted values come from
+	// live state, so a mis-serialized compute setting or bucket name only fails when
+	// `config plan` imports the file. Load it through the CLI's own loader.
+	//
+	// The temp project lives under the package's `node_modules` so jiti resolves
+	// `@neon/config/v1` by walking up as it would in a user's project, and so a directory
+	// left by a crashed run can never be committed.
+	it("writes a policy that loads and resolves", async () => {
+		const packageRoot = fileURLToPath(new URL("../../", import.meta.url));
+		const project = mkdtempSync(
+			join(packageRoot, "node_modules", ".neon-from-branch-"),
+		);
+		try {
+			await initCmd({
+				...seedProps(new LoadedBranchNeonApi()),
+				cwd: project,
+			});
+
+			const { config } = await loadConfigFromFile({
+				path: join(project, "neon.ts"),
+			});
+			const resolved = resolveConfig(config, {
+				name: "preview",
+				exists: false,
+				isDefault: false,
+			});
+
+			expect(resolved.authEnabled).toBe(true);
+			expect(resolved.dataApiEnabled).toBe(true);
+			expect(resolved.preview?.buckets).toEqual([
+				{ name: "user-uploads", access: "public_read" },
+				{ name: "backups", access: "private" },
+			]);
+			expect(resolved.preview?.functions).toEqual([]);
+			expect(resolved.postgres?.computeSettings).toMatchObject({
+				autoscalingLimitMinCu: 0.25,
+				suspendTimeout: "5m",
+			});
+			// Read but deliberately not declared.
+			expect(resolved.protected).toBeUndefined();
+		} finally {
+			rmSync(project, { recursive: true, force: true });
+		}
+	});
+
+	it("leaves an existing neon.ts untouched without calling the API", async () => {
+		const original = "export default { auth: true };\n";
+		writeFileSync(join(cwd, "neon.ts"), original);
+
+		// `runtimeApi` is omitted: a read would have to build a real adapter and fail.
+		await initCmd({
+			cwd,
+			install: false,
+			fromBranch: true,
+			apiClient: fakeApiClient as never,
+			projectId: PROJECT_ID,
+		});
+
+		expect(readFileSync(join(cwd, "neon.ts"), "utf8")).toBe(original);
+	});
+
+	it("fails with guidance when no project is resolved", async () => {
+		await expect(
+			initCmd({ cwd, install: false, fromBranch: true }),
+		).rejects.toThrow(/--from-branch needs a project/);
+
+		expect(existsSync(join(cwd, "neon.ts"))).toBe(false);
 	});
 });
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -17,8 +17,8 @@ import {
 } from "@neon/config-runtime";
 import chalk from "chalk";
 import type yargs from "yargs";
-import { getApiClient } from "../api.js";
-import { toNeonConfigView } from "../config_format.js";
+import { getApiClient, type NeonApiClient } from "../api.js";
+import { type NeonConfigView, toNeonConfigView } from "../config_format.js";
 import {
 	FUNCTION_FILENAME,
 	FUNCTION_SLUG,
@@ -29,6 +29,7 @@ import {
 	parseServices,
 	REQUIRED_PACKAGES,
 	renderNeonConfig,
+	renderNeonConfigFromView,
 } from "../config_template.js";
 
 import { contextBranch, readContextFile } from "../context.js";
@@ -224,6 +225,24 @@ export type ConfigInitProps = {
 	services?: string;
 	/** Injected service picker (tests). Wins over the TTY check; production omits it. */
 	pickServices?: () => Promise<NeonService[]>;
+	/**
+	 * `--from-branch`: seed the policy from a branch's live Neon state instead of asking.
+	 * The one path in `config init` that reaches the API — {@link isConfigInit} stops
+	 * skipping auth and project resolution when it is set.
+	 */
+	fromBranch?: boolean;
+	/**
+	 * Branch scoping for `--from-branch`, supplied by the `config` command's `--project-id` /
+	 * `--branch` options, the `.neon` context middleware, and the global auth middleware. All
+	 * optional because every other path in this command runs with none of it.
+	 */
+	apiClient?: NeonApiClient;
+	apiKey?: string;
+	apiHost?: string;
+	projectId?: string;
+	branch?: string;
+	/** Injected NeonApi adapter (tests). Production omits it so it's built from credentials. */
+	runtimeApi?: NeonApi;
 };
 
 /**
@@ -271,9 +290,48 @@ const scaffoldFunction = (cwd: string): void => {
 };
 
 /**
+ * Read a branch's live state and render it as a `neon.ts`. The read goes through the same
+ * {@link liveConfigView} as `config status`, so a seeded policy declares exactly what
+ * `config status --config-json` reports — including what it cannot report (see
+ * {@link renderNeonConfigFromView}).
+ */
+const seedFromBranch = async (
+	props: ConfigInitProps,
+): Promise<{ source: string; seeded: boolean; branchName: string }> => {
+	const { apiClient, projectId } = props;
+	if (!apiClient || !projectId) {
+		throw new Error(
+			"--from-branch needs a project. Pass --project-id, or run `neon link` to pin one in .neon.",
+		);
+	}
+
+	const ref = await resolveBranchRef({
+		apiClient,
+		projectId,
+		...(props.branch !== undefined ? { branch: props.branch } : {}),
+	});
+	if (ref.usedDefault) {
+		log.info(
+			"No branch pinned or passed — seeding from the project's default branch %s.",
+			ref.branchName,
+		);
+	}
+
+	const { live, view } = await liveConfigView({
+		projectId,
+		branchId: ref.branchId,
+		...(props.apiKey ? { apiKey: props.apiKey } : {}),
+		...(props.apiHost ? { apiHost: props.apiHost } : {}),
+		...(props.runtimeApi ? { runtimeApi: props.runtimeApi } : {}),
+	});
+	const rendered = renderNeonConfigFromView(view, live.branch.name);
+	return { ...rendered, branchName: live.branch.name };
+};
+
+/**
  * Scaffold a `neon.ts` policy and make sure the Neon config packages are
  * installed, so a project can go straight to `neon config plan` / `apply`.
- * Purely local — it never touches the Neon API (see {@link isConfigInit}).
+ * Local-only unless `--from-branch` is set (see {@link isConfigInit}).
  */
 export const initCmd = async (props: ConfigInitProps): Promise<void> => {
 	const cwd = props.cwd ?? process.cwd();
@@ -287,6 +345,17 @@ export const initCmd = async (props: ConfigInitProps): Promise<void> => {
 	);
 	if (existing) {
 		log.info("Found an existing %s — leaving it untouched.", existing);
+	} else if (props.fromBranch) {
+		const { source, seeded, branchName } = await seedFromBranch(props);
+		writeFileSync(join(cwd, "neon.ts"), source);
+		if (seeded) {
+			log.info("Created neon.ts from the live state of %s.", branchName);
+		} else {
+			log.info(
+				"%s declares no services and no branch settings — created neon.ts with the starter policy instead.",
+				branchName,
+			);
+		}
 	} else {
 		const services = await resolveServices(props);
 		writeFileSync(join(cwd, "neon.ts"), renderNeonConfig(services));
@@ -419,12 +488,60 @@ export const builder = (argv: yargs.Argv) =>
 							"terminal, starter policy in CI or without a TTY.",
 						type: "string",
 					},
+					"from-branch": {
+						describe:
+							"Seed neon.ts from a branch's live Neon state instead of asking. Uses the " +
+							"branch pinned in .neon, or --branch <name|id>, or the project's default " +
+							"branch. The only mode of `config init` that calls the Neon API.",
+						type: "boolean",
+						// No `default`: yargs counts a defaulted key as provided, so
+						// `default: false` makes `conflicts` reject every `--services` run.
+						conflicts: "services",
+					},
 				}),
 			(args) => initCmd(args as any),
 		);
 
 export const handler = (args: yargs.Argv) => {
 	return args;
+};
+
+/**
+ * A branch's live state, plus that state projected into the `neon.ts`-shaped
+ * {@link NeonConfigView}. Shared by `config status` and `config init --from-branch` so both
+ * read the branch through one path: what `status --config-json` prints is exactly what
+ * `init --from-branch` writes.
+ *
+ * The pulled `config` carries the branch's tuning inside a closure that JSON can't render, so
+ * it is resolved against the live branch target first.
+ */
+const liveConfigView = async (opts: {
+	projectId: string;
+	branchId: string;
+	apiKey?: string;
+	apiHost?: string;
+	runtimeApi?: NeonApi;
+}): Promise<{
+	live: Awaited<ReturnType<typeof inspect>>;
+	view: NeonConfigView;
+}> => {
+	const live = await inspect({
+		projectId: opts.projectId,
+		branchId: opts.branchId,
+		...(opts.apiKey ? { apiKey: opts.apiKey } : {}),
+		...(opts.apiHost ? { apiHost: opts.apiHost } : {}),
+		...(opts.runtimeApi ? { api: opts.runtimeApi } : {}),
+	});
+	const resolved = resolveConfig(live.config, {
+		name: live.branch.name,
+		id: live.branch.id,
+		exists: true,
+		isDefault: live.branch.isDefault,
+		isProtected: live.branch.protected,
+		...(live.branch.parent ? { parentId: live.branch.parent } : {}),
+		...(live.branch.expiresAt ? { expiresAt: live.branch.expiresAt } : {}),
+	});
+	return { live, view: toNeonConfigView(resolved, live.preview) };
 };
 
 const loadConfig = async (props: ConfigProps): Promise<Config> => {
@@ -469,28 +586,13 @@ export const status = async (props: ConfigProps): Promise<void> => {
 	if (!props.configJson) {
 		announceTargetBranch(props, branch, "Inspecting branch");
 	}
-	const branchId = branch.branchId;
-	const live = await inspect({
+	const { live, view: configView } = await liveConfigView({
 		projectId: props.projectId,
-		branchId,
+		branchId: branch.branchId,
 		...(props.apiKey ? { apiKey: props.apiKey } : {}),
 		...(props.apiHost ? { apiHost: props.apiHost } : {}),
-		...(props.runtimeApi ? { api: props.runtimeApi } : {}),
+		...(props.runtimeApi ? { runtimeApi: props.runtimeApi } : {}),
 	});
-
-	// The pulled `config` carries the branch's tuning inside a closure that JSON can't
-	// render. Resolve it against the live branch target to get the concrete settings, then
-	// project both that and the separately-pulled preview state into a neon.ts-shaped view.
-	const resolved = resolveConfig(live.config, {
-		name: live.branch.name,
-		id: live.branch.id,
-		exists: true,
-		isDefault: live.branch.isDefault,
-		isProtected: live.branch.protected,
-		...(live.branch.parent ? { parentId: live.branch.parent } : {}),
-		...(live.branch.expiresAt ? { expiresAt: live.branch.expiresAt } : {}),
-	});
-	const configView = toNeonConfigView(resolved, live.preview);
 
 	// `--config-json`: emit just the neon.ts-shaped config to stdout (script-friendly,
 	// copy-paste-able), regardless of the global --output.

--- a/packages/cli/src/config_template.format.test.ts
+++ b/packages/cli/src/config_template.format.test.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import type { NeonConfigView } from "./config_format.js";
+import {
+	FUNCTION_TEMPLATE,
+	NEON_SERVICES,
+	type NeonService,
+	renderNeonConfig,
+	renderNeonConfigFromView,
+} from "./config_template.js";
+
+/**
+ * Both renderers build TypeScript by concatenating strings, so indentation is only as correct
+ * as the person who typed the spaces. Rather than assert a handful of expected files, run every
+ * variant through Biome — the formatter this repo already uses — and require it to change
+ * nothing. A miscounted space, a missing trailing comma, or a line long enough to need
+ * wrapping all fail here instead of landing in a user's project.
+ *
+ * The style is passed explicitly (2-space indentation) rather than inherited from
+ * `biome.json`, because the repo formats its own sources with tabs while the file we emit into
+ * someone else's project uses spaces. That makes the flags the contract, not our config.
+ */
+const biomeBin = (): string => {
+	// packages/cli/src → repo root. Biome is a root devDependency, so pnpm links it there.
+	const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+	const bin = join(repoRoot, "node_modules", ".bin", "biome");
+	if (!existsSync(bin)) {
+		throw new Error(
+			`Biome not found at ${bin}. Run \`pnpm install\` at the repository root.`,
+		);
+	}
+	return bin;
+};
+
+const format = (source: string): string =>
+	execFileSync(
+		biomeBin(),
+		[
+			"format",
+			"--stdin-file-path=neon.ts",
+			"--indent-style=space",
+			"--indent-width=2",
+		],
+		{ input: source, encoding: "utf8" },
+	);
+
+/** Every subset of the pickable services, so no combination of blocks goes unchecked. */
+const serviceSubsets = (): NeonService[][] => {
+	const subsets: NeonService[][] = [];
+	for (let mask = 0; mask < 1 << NEON_SERVICES.length; mask++) {
+		subsets.push(NEON_SERVICES.filter((_, i) => mask & (1 << i)));
+	}
+	return subsets;
+};
+
+/** Live-state shapes that exercise each seeded block, alone and together. */
+const views: { name: string; view: NeonConfigView; branch: string }[] = [
+	{ name: "empty", view: {}, branch: "main" },
+	{
+		name: "services only",
+		view: { auth: true, dataApi: true },
+		branch: "main",
+	},
+	{
+		name: "buckets and functions",
+		view: {
+			preview: {
+				buckets: {
+					"user-uploads": { access: "public_read" },
+					backups: { access: "private" },
+				},
+				functions: {
+					resize: { name: "Resize Image" },
+					thumb: { name: "Thumb" },
+				},
+			},
+		},
+		branch: "preview",
+	},
+	{
+		name: "branch tuning",
+		view: {
+			branch: {
+				parent: "main",
+				ttl: "7d",
+				protected: true,
+				postgres: {
+					computeSettings: {
+						autoscalingLimitMinCu: 0.25,
+						autoscalingLimitMaxCu: 4,
+						suspendTimeout: "5m",
+					},
+				},
+			},
+		},
+		branch: "dev",
+	},
+	{
+		name: "everything",
+		view: {
+			auth: true,
+			dataApi: true,
+			preview: {
+				buckets: { assets: { access: "private" } },
+				functions: { hello: { name: "Hello World" } },
+				credentials: [{ id: "credshort", scopes: ["storage:read"] }],
+			},
+			branch: {
+				parent: "main",
+				protected: true,
+				postgres: { computeSettings: { suspendTimeout: false } },
+			},
+		},
+		branch: "main",
+	},
+];
+
+/**
+ * Invariants a formatter does not check but a generated file still has to hold: spaces only
+ * (the emitted file must not mix in a tab), no trailing whitespace, and exactly one closing
+ * newline so the file is a clean diff the first time someone edits it.
+ */
+const expectCleanWhitespace = (source: string): void => {
+	expect(source).not.toMatch(/\t/);
+	expect(source).not.toMatch(/[ ]+$/m);
+	expect(source.endsWith("\n")).toBe(true);
+	expect(source.endsWith("\n\n")).toBe(false);
+	for (const line of source.split("\n")) {
+		const leading = line.match(/^ */)?.[0].length ?? 0;
+		expect(leading % 2, `odd indentation on: ${line}`).toBe(0);
+	}
+};
+
+describe("the scaffolded neon.ts is already formatted", () => {
+	it.each(
+		serviceSubsets().map((s) => [s.join("+") || "none", s] as const),
+	)("services: %s", (_label, services) => {
+		const source = renderNeonConfig([...services]);
+		expect(format(source)).toBe(source);
+		expectCleanWhitespace(source);
+	});
+
+	it("the scaffolded function handler", () => {
+		expect(format(FUNCTION_TEMPLATE)).toBe(FUNCTION_TEMPLATE);
+		expectCleanWhitespace(FUNCTION_TEMPLATE);
+	});
+
+	it.each(
+		views.map((v) => [v.name, v] as const),
+	)("seeded from a branch: %s", (_label, { view, branch }) => {
+		const { source } = renderNeonConfigFromView(view, branch);
+		expect(format(source)).toBe(source);
+		expectCleanWhitespace(source);
+	});
+});

--- a/packages/cli/src/config_template.test.ts
+++ b/packages/cli/src/config_template.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 
+import type { NeonConfigView } from "./config_format.js";
 import {
 	NEON_SERVICES,
 	parseServices,
 	renderNeonConfig,
+	renderNeonConfigFromView,
 } from "./config_template.js";
 
 describe("parseServices", () => {
@@ -112,5 +114,99 @@ export default defineConfig({
 		expect(rendered).toContain('assets: { access: "private" },');
 		expect(rendered).not.toContain("aiGateway");
 		expect(rendered).not.toContain("functions");
+	});
+});
+
+describe("renderNeonConfigFromView", () => {
+	it("renders a branch's live state as a policy", () => {
+		const view: NeonConfigView = {
+			auth: true,
+			dataApi: true,
+			preview: {
+				buckets: { uploads: { access: "public_read" } },
+				functions: { resize: { name: "Resize Image" } },
+				credentials: [{ id: "credfake0000", scopes: ["storage:read"] }],
+			},
+			branch: {
+				parent: "main",
+				protected: true,
+				postgres: {
+					computeSettings: {
+						autoscalingLimitMaxCu: 4,
+						suspendTimeout: "5m",
+					},
+				},
+			},
+		};
+
+		const { source, seeded } = renderNeonConfigFromView(view, "preview");
+
+		expect(seeded).toBe(true);
+		expect(source).toBe(`import { defineConfig } from "@neon/config/v1";
+
+// Seeded by \`neon config init --from-branch\` from preview.
+// The AI Gateway is not readable from a branch (always available, credential-gated), so add
+// \`preview: { aiGateway: true }\` if the policy should declare it.
+// preview is protected on Neon. Not declared here: a policy \`protected\` would
+// apply to every branch this policy is applied to.
+export default defineConfig({
+  auth: true,
+  dataApi: true,
+  preview: {
+    buckets: {
+      uploads: { access: "public_read" },
+    },
+    // preview has 1 deployed function.
+    // Declaring one needs the local source path, which the branch does not know:
+    // functions: {
+    //   resize: { name: "Resize Image", source: "./resize.ts" },
+    // },
+  },
+  branch: () => ({
+    parent: "main",
+    postgres: {
+      computeSettings: {
+        autoscalingLimitMaxCu: 4,
+        suspendTimeout: "5m",
+      },
+    },
+  }),
+});
+`);
+		// Issued credentials are live state, not policy — they must never be emitted.
+		expect(source).not.toContain("credfake0000");
+	});
+
+	it("falls back to the starter policy for a branch with nothing to seed", () => {
+		const { source, seeded } = renderNeonConfigFromView({}, "main");
+
+		expect(seeded).toBe(false);
+		expect(source).toBe(renderNeonConfig([]));
+	});
+
+	it("quotes a bucket name that isn't a valid identifier", () => {
+		const { source } = renderNeonConfigFromView(
+			{
+				preview: {
+					buckets: {
+						"smoke-uploads": { access: "private" },
+						assets: { access: "private" },
+					},
+				},
+			},
+			"main",
+		);
+
+		// A bare `smoke-uploads:` key is a subtraction, i.e. a syntax error.
+		expect(source).toContain('"smoke-uploads": { access: "private" },');
+		expect(source).toContain('assets: { access: "private" },');
+	});
+
+	it("omits the branch closure when the branch carries no tuning", () => {
+		const { source } = renderNeonConfigFromView({ auth: true }, "main");
+
+		expect(source).toContain("  auth: true,\n});");
+		expect(source).not.toContain("branch:");
+		expect(source).not.toContain("protected");
 	});
 });

--- a/packages/cli/src/config_template.ts
+++ b/packages/cli/src/config_template.ts
@@ -1,3 +1,5 @@
+import type { NeonConfigView } from "./config_format.js";
+
 /**
  * The published npm packages a `neon.ts` project needs — the `@neon/*` org names.
  *
@@ -133,6 +135,146 @@ ${renderPreview(services)}  // Branch policy: per-branch tuning
   },
 });
 `;
+
+/** Render a scalar the way it has to appear in TypeScript source. */
+const renderScalar = (value: string | number | boolean): string =>
+	typeof value === "string" ? `"${value}"` : String(value);
+
+/**
+ * Render an object key. Live names are not identifiers: a Neon bucket may be called
+ * `smoke-uploads`, which as a bare key is a subtraction and a syntax error. Anything that
+ * isn't a plain identifier gets quoted.
+ */
+const renderKey = (name: string): string =>
+	/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) ? name : JSON.stringify(name);
+
+/**
+ * The `branch` closure for a policy seeded from live state, or "" when the branch carries no
+ * tuning worth declaring.
+ *
+ * `protected` is read but never declared: it is a fact about one branch, while a policy
+ * `protected` applies to every branch the policy runs against. It becomes a comment instead.
+ */
+const renderSeededBranch = (view: NeonConfigView): string => {
+	const settings: string[] = [];
+	if (view.branch?.parent !== undefined) {
+		settings.push(`    parent: ${renderScalar(view.branch.parent)},`);
+	}
+	if (view.branch?.ttl !== undefined) {
+		settings.push(`    ttl: ${renderScalar(view.branch.ttl)},`);
+	}
+
+	const compute = view.branch?.postgres?.computeSettings;
+	const computeFields = Object.entries(compute ?? {}).filter(
+		([, value]) => value !== undefined,
+	);
+	if (computeFields.length > 0) {
+		settings.push("    postgres: {", "      computeSettings: {");
+		for (const [field, value] of computeFields) {
+			settings.push(`        ${field}: ${renderScalar(value)},`);
+		}
+		settings.push("      },", "    },");
+	}
+
+	if (settings.length === 0) {
+		return "";
+	}
+	return ["  branch: () => ({", ...settings, "  }),"].join("\n").concat("\n");
+};
+
+/** The `preview` block for a policy seeded from live state. */
+const renderSeededPreview = (
+	view: NeonConfigView,
+	branchName: string,
+): string => {
+	const lines: string[] = [];
+
+	const buckets = Object.entries(view.preview?.buckets ?? {});
+	if (buckets.length > 0) {
+		lines.push("    buckets: {");
+		for (const [name, bucket] of buckets) {
+			lines.push(
+				`      ${renderKey(name)}: { access: "${bucket.access}" },`,
+			);
+		}
+		lines.push("    },");
+	}
+
+	// A deployed function cannot be declared from live state: `source` is a path in the
+	// user's project and the branch only knows the uploaded bundle. Listing the slugs as a
+	// commented-out block is the most a read-back can honestly produce.
+	const functions = Object.entries(view.preview?.functions ?? {});
+	if (functions.length > 0) {
+		lines.push(
+			`    // ${branchName} has ${functions.length} deployed function${functions.length === 1 ? "" : "s"}.`,
+			"    // Declaring one needs the local source path, which the branch does not know:",
+			"    // functions: {",
+			...functions.map(
+				([slug, fn]) =>
+					`    //   ${renderKey(slug)}: { name: "${fn.name}", source: "./${slug}.ts" },`,
+			),
+			"    // },",
+		);
+	}
+
+	if (lines.length === 0) {
+		return "";
+	}
+	return ["  preview: {", ...lines, "  },"].join("\n").concat("\n");
+};
+
+/**
+ * Render a `neon.ts` from a branch's live state (`config init --from-branch`).
+ *
+ * Only what the branch can actually report is declared. Three things are deliberately
+ * absent, each for its own reason:
+ *
+ * - **The AI Gateway** has no branch-level enabled state to read — it is always available and
+ *   credential-gated — so `pullConfig` cannot tell whether a policy would enable it.
+ * - **Functions** cannot round-trip (no `source` path on the remote); they are listed as a
+ *   commented-out block.
+ * - **`protected`** is branch state rather than policy intent, so it is reported as a comment.
+ *
+ * A branch with nothing to report (no services, no tuning) renders the starter policy rather
+ * than an empty `defineConfig({})`: seeding found nothing, and the caller says so.
+ */
+export const renderNeonConfigFromView = (
+	view: NeonConfigView,
+	branchName: string,
+): { source: string; seeded: boolean } => {
+	const services = [
+		view.auth ? "  auth: true," : "",
+		view.dataApi ? "  dataApi: true," : "",
+	].filter((line) => line !== "");
+	const preview = renderSeededPreview(view, branchName);
+	const branch = renderSeededBranch(view);
+
+	if (services.length === 0 && preview === "" && branch === "") {
+		return { source: renderNeonConfig([]), seeded: false };
+	}
+
+	const protectedNote = view.branch?.protected
+		? `// ${branchName} is protected on Neon. Not declared here: a policy \`protected\` would\n// apply to every branch this policy is applied to.\n`
+		: "";
+	const body = [
+		...services,
+		...(preview === "" ? [] : [preview.trimEnd()]),
+		...(branch === "" ? [] : [branch.trimEnd()]),
+	].join("\n");
+
+	return {
+		source: `import { defineConfig } from "${CONFIG_PACKAGE}/v1";
+
+// Seeded by \`neon config init --from-branch\` from ${branchName}.
+// The AI Gateway is not readable from a branch (always available, credential-gated), so add
+// \`preview: { aiGateway: true }\` if the policy should declare it.
+${protectedNote}export default defineConfig({
+${body}
+});
+`,
+		seeded: true,
+	};
+};
 
 /**
  * The handler written alongside `neon.ts` when `functions` is selected. It has to exist:

--- a/packages/cli/src/config_template.ts
+++ b/packages/cli/src/config_template.ts
@@ -78,33 +78,60 @@ export const parseServices = (raw: string): NeonService[] => {
 	return NEON_SERVICES.filter((service) => names.includes(service));
 };
 
+/**
+ * One indentation level in the emitted `neon.ts`. Two spaces, which is what every renderer
+ * here produces and what `config_template.format.test.ts` holds them to.
+ */
+const INDENT = "  ";
+
+/**
+ * Prefix each line with `level` indentation levels. Nesting is expressed as a number at the
+ * one place that knows the structure, rather than as literal spaces at every push site — a
+ * miscounted space is otherwise invisible in review and only shows up in a user's file.
+ */
+const at = (level: number, ...lines: string[]): string[] =>
+	lines.map((line) => INDENT.repeat(level) + line);
+
+/** Wrap `body` in an object-literal block named `key`, indented from `level`. */
+const block = (level: number, key: string, body: string[]): string[] => [
+	...at(level, `${key}: {`),
+	...body,
+	...at(level, "},"),
+];
+
 /** The `preview` block for the selected services, or "" when none of them is a preview feature. */
 const renderPreview = (services: readonly NeonService[]): string => {
 	const lines: string[] = [];
 
 	if (services.includes("ai-gateway")) {
-		lines.push("    aiGateway: true,");
+		lines.push(...at(2, "aiGateway: true,"));
 	}
 	if (services.includes("functions")) {
 		lines.push(
-			"    functions: {",
-			`      ${FUNCTION_SLUG}: { name: "${FUNCTION_NAME}", source: "./${FUNCTION_FILENAME}" },`,
-			"    },",
+			...block(2, "functions", [
+				...at(
+					3,
+					`${FUNCTION_SLUG}: { name: "${FUNCTION_NAME}", source: "./${FUNCTION_FILENAME}" },`,
+				),
+			]),
 		);
 	}
 	if (services.includes("storage")) {
 		lines.push(
-			"    buckets: {",
-			`      // "private" is the default; use "public_read" for anonymous reads`,
-			`      ${BUCKET_NAME}: { access: "private" },`,
-			"    },",
+			...block(2, "buckets", [
+				...at(
+					3,
+					`// "private" is the default; use "public_read" for anonymous reads`,
+					`${BUCKET_NAME}: { access: "private" },`,
+				),
+			]),
 		);
 	}
 
 	if (lines.length === 0) {
 		return "";
 	}
-	return `${["  preview: {", ...lines, "  },"].join("\n")}\n`;
+	return `${block(1, "preview", lines).join("\n")}\n`;
 };
 
 /**
@@ -158,10 +185,10 @@ const renderKey = (name: string): string =>
 const renderSeededBranch = (view: NeonConfigView): string => {
 	const settings: string[] = [];
 	if (view.branch?.parent !== undefined) {
-		settings.push(`    parent: ${renderScalar(view.branch.parent)},`);
+		settings.push(...at(2, `parent: ${renderScalar(view.branch.parent)},`));
 	}
 	if (view.branch?.ttl !== undefined) {
-		settings.push(`    ttl: ${renderScalar(view.branch.ttl)},`);
+		settings.push(...at(2, `ttl: ${renderScalar(view.branch.ttl)},`));
 	}
 
 	const compute = view.branch?.postgres?.computeSettings;
@@ -169,17 +196,24 @@ const renderSeededBranch = (view: NeonConfigView): string => {
 		([, value]) => value !== undefined,
 	);
 	if (computeFields.length > 0) {
-		settings.push("    postgres: {", "      computeSettings: {");
-		for (const [field, value] of computeFields) {
-			settings.push(`        ${field}: ${renderScalar(value)},`);
-		}
-		settings.push("      },", "    },");
+		settings.push(
+			...block(2, "postgres", [
+				...block(
+					3,
+					"computeSettings",
+					computeFields.flatMap(([field, value]) =>
+						at(4, `${field}: ${renderScalar(value)},`),
+					),
+				),
+			]),
+		);
 	}
 
 	if (settings.length === 0) {
 		return "";
 	}
-	return ["  branch: () => ({", ...settings, "  }),"].join("\n").concat("\n");
+	// An arrow returning an object literal, so the closing line is `}),` rather than `},`.
+	return `${[...at(1, "branch: () => ({"), ...settings, ...at(1, "}),")].join("\n")}\n`;
 };
 
 /** The `preview` block for a policy seeded from live state. */
@@ -191,13 +225,18 @@ const renderSeededPreview = (
 
 	const buckets = Object.entries(view.preview?.buckets ?? {});
 	if (buckets.length > 0) {
-		lines.push("    buckets: {");
-		for (const [name, bucket] of buckets) {
-			lines.push(
-				`      ${renderKey(name)}: { access: "${bucket.access}" },`,
-			);
-		}
-		lines.push("    },");
+		lines.push(
+			...block(
+				2,
+				"buckets",
+				buckets.flatMap(([name, bucket]) =>
+					at(
+						3,
+						`${renderKey(name)}: { access: "${bucket.access}" },`,
+					),
+				),
+			),
+		);
 	}
 
 	// A deployed function cannot be declared from live state: `source` is a path in the
@@ -206,21 +245,24 @@ const renderSeededPreview = (
 	const functions = Object.entries(view.preview?.functions ?? {});
 	if (functions.length > 0) {
 		lines.push(
-			`    // ${branchName} has ${functions.length} deployed function${functions.length === 1 ? "" : "s"}.`,
-			"    // Declaring one needs the local source path, which the branch does not know:",
-			"    // functions: {",
-			...functions.map(
-				([slug, fn]) =>
-					`    //   ${renderKey(slug)}: { name: "${fn.name}", source: "./${slug}.ts" },`,
+			...at(
+				2,
+				`// ${branchName} has ${functions.length} deployed function${functions.length === 1 ? "" : "s"}.`,
+				"// Declaring one needs the local source path, which the branch does not know:",
+				"// functions: {",
+				...functions.map(
+					([slug, fn]) =>
+						`//   ${renderKey(slug)}: { name: "${fn.name}", source: "./${slug}.ts" },`,
+				),
+				"// },",
 			),
-			"    // },",
 		);
 	}
 
 	if (lines.length === 0) {
 		return "";
 	}
-	return ["  preview: {", ...lines, "  },"].join("\n").concat("\n");
+	return `${block(1, "preview", lines).join("\n")}\n`;
 };
 
 /**

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -56,9 +56,21 @@ export const isCurrentBranchProbe = (args: {
  * never calls the Neon API. Gated on the exact command path so the global auth
  * middleware and the single-project resolver can skip it (it runs with no API
  * client), mirroring {@link isCurrentBranchProbe}.
+ *
+ * `--from-branch` is the exception: it seeds the policy from a branch's live state, so it
+ * needs both credentials and a resolved project. The raw argv is checked alongside the parsed
+ * flag because this runs from middleware that executes before validation, where the parsed
+ * value may not be populated yet (the same reason `analytics.ts` scans argv for
+ * `--current-branch`).
  */
-export const isConfigInit = (args: { _: (string | number)[] }): boolean =>
-	args._[0] === "config" && args._[1] === "init";
+export const isConfigInit = (args: {
+	_: (string | number)[];
+	fromBranch?: boolean;
+}): boolean =>
+	args._[0] === "config" &&
+	args._[1] === "init" &&
+	args.fromBranch !== true &&
+	!process.argv.includes("--from-branch");
 
 /**
  * `neon profile …` manages credentials on disk and never calls the Neon API, so the global

--- a/packages/cli/src/utils/enrichers.ts
+++ b/packages/cli/src/utils/enrichers.ts
@@ -84,13 +84,23 @@ export type ResolvedBranchRef = {
 	usedDefault: boolean;
 };
 
+/**
+ * What resolving a branch reference actually needs. Narrower than
+ * {@link BranchScopeProps} on purpose: every command's props satisfy it, and a caller that
+ * holds only a client and a project (e.g. `config init --from-branch`) can call it without
+ * inventing an `output` / `contextFile` / `apiKey` it has no use for.
+ */
+export type BranchRefProps = {
+	apiClient: CommonProps["apiClient"];
+	projectId: string;
+	branch?: string | number;
+	id?: string | number;
+};
+
 export const resolveBranchRef = async (
-	props: BranchScopeProps,
+	props: BranchRefProps,
 ): Promise<ResolvedBranchRef> => {
-	const branch =
-		"branch" in props && typeof props.branch === "string"
-			? props.branch
-			: (props as any).id;
+	const branch = typeof props.branch === "string" ? props.branch : props.id;
 
 	const { data } = await props.apiClient.listProjectBranches({
 		projectId: props.projectId,


### PR DESCRIPTION
## Problem

`config init` scaffolds for a greenfield project. A project already running on Neon — Auth on, a couple of buckets, tuned compute — gets the same empty policy and has to reconstruct by hand what the CLI can already read. `config status --config-json` prints that branch in `neon.ts` shape and even calls the output "copy-paste-able":

```json
{
  "auth": true,
  "preview": { "buckets": { "rebase-uploads": { "access": "private" } } }
}
```

Nothing turned it into a file.

## What it does now

```bash
neon config init --from-branch                     # branch pinned in .neon, else project default
neon config init --from-branch --branch dev        # by name
neon config init --from-branch --branch br-a-b-123 # by id
neon config init --from-branch --project-id <id> --branch dev
```

`--from-branch` is a boolean rather than taking a ref, because `config` already declares `--project-id` and `--branch` ("Branch ID or name"), `enrichFromContext` pre-fills `--branch` from `.neon`, and `resolveBranchRef` already resolves name-or-id and falls back to the project's default. A second selector on the same command would make `--from-branch dev --branch main` meaningless. It `conflicts` with `--services`: one reads services off the branch, the other declares them.

Output from a live branch with Neon Auth and one bucket (real run, smoke org):

```ts
import { defineConfig } from "@neon/config/v1";

// Seeded by `neon config init --from-branch` from main.
// The AI Gateway is not readable from a branch (always available, credential-gated), so add
// `preview: { aiGateway: true }` if the policy should declare it.
export default defineConfig({
  auth: true,
  preview: {
    buckets: {
      "rebase-uploads": { access: "private" },
    },
  },
});
```

```
$ neon config plan
INFO: → Planning against branch main (br-silent-glade-axkm16jr)
INFO: No changes — branch main already matches the policy.

Utilized services: Postgres, Neon Auth, Object Storage
```

That no-op plan is the property worth having: seeding then planning describes the branch it came from.

## What it refuses to invent

A read-back can produce a *plausible* policy or a *true* one. Three fields would have to be guessed, so each is surfaced as a comment instead of a declaration:

| Live fact | Why it isn't declared |
|---|---|
| Deployed functions | `FunctionDef.source` is a path in the user's project; the branch only has the uploaded bundle. `pullConfig` reports `{ slug, name }` and no source |
| AI Gateway | It has no per-branch enabled state — always available, credential-gated — so `pullConfig` cannot tell whether a policy would enable it |
| `protected` | A fact about one branch. A policy `protected` applies to every branch the policy runs against |

```ts
  preview: {
    // main has 1 deployed function.
    // Declaring one needs the local source path, which the branch does not know:
    // functions: {
    //   resize: { name: "Resize Image", source: "./resize.ts" },
    // },
  },
// main is protected on Neon. Not declared here: a policy `protected` would
// apply to every branch this policy is applied to.
```

Two more, for the same reason:

- **`ttl` is never emitted.** `pullConfig` deliberately doesn't map `expiresAt` (an absolute timestamp) onto the policy `ttl` (a creation-time duration) — there's a regression test for it. So a seeded policy has no TTL rule, rather than a wrong one.
- **Issued credentials are dropped.** They're in the view so `config status` can show them; they are not authorable.

What *is* declared: `auth`, `dataApi`, `preview.buckets` with their access levels, and `parent` / compute settings in the branch closure:

```ts
  branch: () => ({
    parent: "main",
    postgres: {
      computeSettings: {
        autoscalingLimitMinCu: 0.25,
        suspendTimeout: "5m",
      },
    },
  }),
```

A branch with nothing to report (a fresh project) writes the starter policy and says so, rather than emitting `defineConfig({})`:

```
INFO: main declares no services and no branch settings — created neon.ts with the starter policy instead.
```

## Also in here

- **The offline guard is now flag-aware.** `isConfigInit` keyed purely off the command path (`config init`), which is what let the auth middleware skip login and `fillSingleProject` skip project resolution. `--from-branch` needs both, so the predicate excludes it — checking the parsed flag *and* the raw argv, because the middleware runs before validation (the same reason `analytics.ts` scans argv for `--current-branch`). Every other `config init` run stays exactly as offline as it was.
- **`resolveBranchRef` takes a narrower type.** It only ever used `apiClient`, `projectId`, `branch`, and `id`, but demanded a full `BranchScopeProps`, so a caller holding just a client and a project would have had to fabricate an `output` / `contextFile` / `apiKey`. New `BranchRefProps` names what it uses; every existing caller satisfies it unchanged, and its `(props as any).id` cast is gone.
- **`status` and `--from-branch` share one read** (`liveConfigView`). They have to agree — the whole premise is that the seed is what `status --config-json` shows — and `status`'s inspect/resolve/project sequence is now called by both instead of copied.
- **`--from-branch` has no yargs `default`.** yargs counts a defaulted key as provided, so `default: false` made `conflicts: "services"` reject *every* `--services` run.
- **The scaffolded `neon.ts` is held to a formatter.** Both renderers concatenate TypeScript, and the seeded policy nests four levels deep, so indentation was only as correct as the spaces someone typed. Every variant — all 16 service subsets, the handler, and five live-state shapes — now runs through Biome in a test and has to come back unchanged, alongside whitespace invariants a formatter doesn't check (spaces only, no trailing whitespace, exactly one closing newline). Nesting is now expressed as a level rather than literal spaces at each push site. No output changed: all 21 variants were already byte-identical to Biome's, which is what made this a guard rather than a fix.

## Verification

Rebased onto `98e785e` (`neon@2.41.0`), so this is verified against `main` as it stands, including the explicit-`apiKey` requirement in the config packages (#368) and the profile / config-directory move (#373) — both of which touch how this path gets credentials.

`pnpm --filter neon test:ci` (3226 passed, 6 skipped), `pnpm lint:ci`, `tsc --noEmit`. The formatter guard was checked against itself: widening one indentation level to three spaces fails six of its variants, and restoring it passes all 22.

New tests, as behaviours:

- a branch with Auth, the Data API, two buckets and a deployed function renders each in its right place — declared, or commented with the reason
- a deployed function is not declared and no handler is invented for it
- `protected` appears as a comment and never as a field
- compute settings land in the closure; the AI Gateway is never declared, only mentioned
- a bucket name that isn't a JS identifier is quoted
- an empty view renders the starter policy and reports `seeded: false`
- an existing `neon.ts` short-circuits before any API call
- no resolvable project fails with the flag to pass, writing nothing
- the seeded policy **loads**: written for real, then read back through the CLI's own loader and resolved, asserting the services, bucket access levels, compute settings, and that `protected` did not survive

Live run against a real project in the smoke org (`org-old-flower-82714815`, created and deleted), on the rebased build:

- Neon Auth enabled and a bucket created on `main`, then `--from-branch` → the policy above, and `config plan` reported no changes
- `--from-branch --services auth` → `Arguments from-branch and services are mutually exclusive`
- the offline guard, as a differential against an unreachable API host: plain `config init --services none` still writes its file and exits 0, while `config init --from-branch` fails with "Could not reach the Neon API" and writes nothing. That is the flag-aware predicate working in both directions on the real binary
- earlier runs (pre-rebase, same code) also covered `--branch dev` seeding from a second branch and picking up `parent: "main"`, and a bare project falling back to the starter policy

**A live run caught the bug this PR would otherwise have shipped.** The bucket was called `smoke-uploads`, and the first version emitted `smoke-uploads: { access: "private" }` — a bare hyphenated key, which is a subtraction and a syntax error. Every unit test had used identifier-safe names. Keys are now quoted when they aren't identifiers, the fake's bucket is hyphenated so the load test covers it, and the tests fail without the fix.

Not verified: `config apply` from a seeded policy onto a *different* branch. `plan` against the source branch is the round-trip that matters here; applying elsewhere is ordinary `apply` behaviour and unchanged.

## For your attention

- **A seeded policy is a description, not a decision.** `parent` and compute settings come from one branch and are declared for all of them. That is the useful reading of "seed a policy", but it is a reading — the header comment names the branch so the file says where it came from.
- **Functions are the weakest part of the output.** A project with functions gets a policy that silently omits them until someone uncomments the block and points `source` at real files. The alternative (emitting a path that doesn't exist) fails at deploy with an esbuild resolve error, which is worse.
- **`--from-branch` makes `config init` a network command in one mode.** The guard is a predicate rather than a command-path check now; if a third mode ever needs credentials, that predicate is where it goes.
- **Not in `neon@2.41.0`.** The service picker shipped there; this is unreleased and needs its own bump. The changeset is included.
