### PR TITLE
Add `neon profile`, and move the config directory to ~/.config/neon

### DIFF
--- a/.changeset/cli-profiles-and-config-dir.md
+++ b/.changeset/cli-profiles-and-config-dir.md
@@ -1,0 +1,46 @@
+---
+"@neon/config": minor
+"@neon/env": patch
+"neon-init": patch
+"neon": minor
+"neonctl": minor
+---
+
+Add `neon profile`, and move the config directory to `~/.config/neon`
+
+**Profiles.** The CLI could only hold one Neon account, so anyone with two built their own
+workaround out of `--config-dir` and shell aliases. A profile is now just a pointer to a
+credentials file:
+
+```bash
+neon auth --profile work     # create or re-authenticate
+neon profile list            # names, accounts, and where each one's credentials live
+neon profile remove work     # revoke the token, delete the file, drop the entry
+neon deploy --profile work   # or NEON_PROFILE=work
+```
+
+Selection is per invocation — `--profile`, else `NEON_PROFILE`, else `DEFAULT` — so there is
+no stored "active profile" to disagree with what you typed.
+
+`DEFAULT` **is** `credentials.json`, not a copy of it, and `profiles.json` is only created
+once a second profile exists. An install with one account is unchanged, on disk and in
+behaviour, and there is no migration step.
+
+`neon profile remove` revokes the refresh token at the authorization server rather than only
+deleting the file, and it deletes a credentials file only if the CLI created it — a profile
+pointing at a directory you already had is unlinked and left alone, and says so.
+
+**Config directory.** New installs use `$XDG_CONFIG_HOME/neon`, else `~/.config/neon`. An
+existing `neonctl` directory is still read, **in place** — nothing is moved, copied, or
+deleted, so no second copy of a credential can go stale behind you. An explicitly chosen
+directory (`--config-dir`, `NEON_CONFIG_DIR`, `NEONCTL_CONFIG_DIR`) is exact and never falls
+back.
+
+This also fixes three readers that disagreed about where the directory was: `neon` honoured
+`XDG_CONFIG_HOME` but not `NEONCTL_CONFIG_DIR`, `neon-env` honoured the env var but not XDG,
+and `neon-init` hardcoded `~/.config/neonctl`. With `XDG_CONFIG_HOME` set, the CLI wrote
+credentials somewhere the other two never looked. `@neon/config/paths` is now the single
+implementation; `neon-init` matches it inline rather than taking on the dependency.
+
+Credentials files are now written `0600` instead of `0700` — a credential needs read and
+write, never execute.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,6 +287,28 @@ the same thing with a subpath:
 | `@neon/env` | Package consumers — apps, build scripts, a `neon.ts` policy | None. Never reads `process.env` or a file |
 | `@neon/env/runtime` | Our own tooling — the `neon-env` CLI, `packages/cli`, anything resolving one branch repeatedly | Reads an env source; mints and revokes branch credentials |
 
+`@neon/config` has the same shape, and for the same reason:
+
+| Entry point | For | Side effects |
+| --- | --- | --- |
+| `@neon/config` / `@neon/config/v1` | `neon.ts` policies, apps, anything embedding the toolchain | None. Never reads `process.env` or a file |
+| `@neon/config/paths` | Our own CLIs — `packages/cli`, `packages/env` | Reads env vars and stats the filesystem to locate the config directory |
+
+`paths` exists because three readers each grew their own answer to "where is the config
+directory" and all three disagreed: the CLI honoured `XDG_CONFIG_HOME` but not
+`NEONCTL_CONFIG_DIR`, `@neon/env` honoured the env var but not XDG, and `neon-init`
+hardcoded `~/.config/neonctl`. With `XDG_CONFIG_HOME` set, the CLI wrote credentials
+somewhere the other two never looked. Add a reader to that module rather than to a fourth
+private copy. (`neon-init` still has an inline copy, deliberately — it has no workspace
+dependencies and taking one on `@neon/config` would pull `@neon/sdk`, `zod` and `jiti` into
+its install footprint for a file path. That copy disappears when the package folds into
+`packages/cli`.)
+
+The directory is `neon`; `neonctl` is the pre-rename name and is **read forever, in place**.
+Nothing is moved, copied, or deleted, so a second copy of a credential can never go stale
+behind the first. An explicitly chosen directory is exact and never falls back — a CI run
+pointed at a scratch directory must not pick up a developer's credentials.
+
 **Credentials are always passed in, never discovered.** `@neon/config`, `@neon/config-runtime`
 and the `@neon/env` root export read **no environment variables and no files** to find a Neon
 API key. `createNeonApiFromOptions` takes an explicit `apiKey` and raises

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -591,11 +591,57 @@ neon snapshots schedule set --branch main --schedule '[{"frequency":"weekly","da
 
 All sub-commands honor the [global options](#global-options), including `--output json|yaml|table`.
 
+## Profiles
+
+The CLI holds one Neon account by default. A profile adds another, and is nothing more than a pointer to a credentials file:
+
+```
+~/.config/neon/
+├── credentials.json          # this IS the DEFAULT profile
+├── credentials.work.json     # created by `neon auth --profile work`
+└── profiles.json             # created only once a second profile exists
+```
+
+```bash
+neon auth --profile work     # create it, or sign in again
+neon profile list
+neon profile remove work
+```
+
+```console
+$ neon profile list
+Profiles
+┌────────┬─────────┬──────────────────────┬──────────┬──────────────────────────────────────┐
+│ Active │ Name    │ Account              │ SignedIn │ Credentials                          │
+├────────┼─────────┼──────────────────────┼──────────┼──────────────────────────────────────┤
+│ *      │ DEFAULT │ me@example.com       │ yes      │ ~/.config/neon/credentials.json      │
+├────────┼─────────┼──────────────────────┼──────────┼──────────────────────────────────────┤
+│        │ work    │ me@work.example.com  │ yes      │ ~/.config/neon/credentials.work.json │
+└────────┴─────────┴──────────────────────┴──────────┴──────────────────────────────────────┘
+```
+
+Select one per invocation with `--profile`, or per shell with `NEON_PROFILE`. There is no `profile use` command and nothing is stored about which profile is "current", so what you type is always what runs.
+
+Entries in `profiles.json` are paths, and a path may point anywhere — which is how you adopt a directory you already have, without moving or re-authenticating anything:
+
+```json
+{
+  "version": 1,
+  "profiles": {
+    "DEFAULT": { "credentials": "credentials.json" },
+    "work": { "credentials": "../neonctl-work/credentials.json" }
+  }
+}
+```
+
+`neon profile remove` revokes the refresh token at the authorization server, not just locally. It deletes the credentials file only when the CLI created it: an adopted path like the one above is unlinked and left on disk, and the command says so. Removing the last named profile deletes `profiles.json`, returning you to the single-account layout. `neon profile remove DEFAULT` signs you out.
+
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                                  | Description                        |
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
 | [auth](https://neon.com/docs/reference/cli-auth)                           |                                                                                                              | Authenticate                       |
+| profile                                                                    | `list`, `remove`                                                                                             | Manage named sets of credentials   |
 | [projects](https://neon.com/docs/reference/cli-projects)                   | `list`, `create`, `update`, `delete`, `get`                                                                  | Manage projects                    |
 | [ip-allow](https://neon.com/docs/reference/cli-ip-allow)                   | `list`, `add`, `remove`, `reset`                                                                             | Manage IP Allow                    |
 | [me](https://neon.com/docs/reference/cli-me)                               |                                                                                                              | Show current user                  |
@@ -625,7 +671,8 @@ Global options are supported with any Neon CLI command.
 | Option                      | Description                                                 | Type    | Default                        |
 | :-------------------------- | :---------------------------------------------------------- | :------ | :----------------------------- |
 | [-o, --output](#output)     | Set the Neon CLI output format (`json`, `yaml`, or `table`) | string  | table                          |
-| [--config-dir](#config-dir) | Path to the Neon CLI configuration directory                | string  | `/home/<user>/.config/neonctl` |
+| [--config-dir](#config-dir) | Path to the Neon CLI configuration directory                | string  | `/home/<user>/.config/neon`    |
+| [--profile](#profile)       | Named credentials to use, from `profiles.json`              | string  | `DEFAULT`                      |
 | [--api-key](#api-key)       | Neon API key                                                | string  | ""                             |
 | [--analytics](#analytics)   | Manage analytics                                            | boolean | true                           |
 | [-v, --version](#version)   | Show the Neon CLI version number                            | boolean | -                              |
@@ -641,11 +688,26 @@ Global options are supported with any Neon CLI command.
 
 - <a id="config-dir"></a>`--config-dir`
 
-  Specifies the path to the `neon` configuration directory. To view the default configuration directory containing you `credentials.json` file, run `neon --help`. The credentials file is created when you authenticate using the `neon auth` command. This option is only necessary if you move your `neon` configuration file to a location other than the default.
+  Specifies the path to the `neon` configuration directory, which holds the `credentials.json` written by `neon auth`. The default is `$XDG_CONFIG_HOME/neon`, or `~/.config/neon`; run `neon --help` to see the resolved path. This option is only necessary if you keep your configuration somewhere else.
+
+  The directory was called `neonctl` before the CLI was renamed. An existing one is still read, and is used **in place** — nothing is moved or copied, so there is never a second credentials file to go stale. A directory you pass explicitly is used exactly as given and never falls back to the legacy name, so pointing a CI run at a scratch directory cannot pick up local credentials.
 
   ```bash
-  neon projects list --config-dir /home/dtprice/.config/neonctl
+  neon projects list --config-dir /home/dtprice/.config/neon
   ```
+
+- <a id="profile"></a>`--profile`
+
+  Selects a named set of credentials, for holding more than one Neon account at a time. A profile is a pointer to a credentials file, recorded in `profiles.json` next to it.
+
+  ```bash
+  neon auth --profile work        # create it, or sign in again
+  neon profile list               # names, accounts, and where each one's credentials live
+  neon projects list --profile work
+  NEON_PROFILE=work neon projects list
+  ```
+
+  Precedence is `--profile`, then `NEON_PROFILE`, then `DEFAULT`. `DEFAULT` is plain `credentials.json`, so an install with a single account needs no `profiles.json` and behaves exactly as before. See [Profiles](#profiles) to list or remove them.
 
 - <a id="api-key"></a>`--api-key`
 

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -1,9 +1,8 @@
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
 
 import { Analytics, type TrackParams } from "@segment/analytics-node";
 import { getApiClient, isNeonApiError } from "./api.js";
-import { CREDENTIALS_FILE } from "./config.js";
+import { credentialsPath } from "./config.js";
 import { isCurrentBranchProbe } from "./context.js";
 import { getGithubEnvVars, isCi } from "./env.js";
 import type { ErrorCode } from "./errors.js";
@@ -96,8 +95,7 @@ export const analyticsMiddleware = async (args: {
 	}
 
 	try {
-		const credentialsPath = join(args.configDir, CREDENTIALS_FILE);
-		const credentials = readFileSync(credentialsPath, {
+		const credentials = readFileSync(credentialsPath(args.configDir), {
 			encoding: "utf-8",
 		});
 		userId = JSON.parse(credentials).user_id;

--- a/packages/cli/src/auth.ts
+++ b/packages/cli/src/auth.ts
@@ -69,6 +69,46 @@ export const refreshToken = async (
 	);
 };
 
+/**
+ * Invalidate a refresh token at the authorization server (RFC 7009).
+ *
+ * Best-effort by design, and it returns a boolean rather than throwing: the usual reason to
+ * revoke is that a profile is being removed, and a revoke that fails — offline, token
+ * already dead, server unreachable — must not leave the local entry stranded. Deleting the
+ * file alone would only stop *us* using the token; this stops anyone.
+ */
+export const revokeToken = async (
+	{ oauthHost, clientId, allowUnsafeTls }: AuthProps,
+	tokenSet: ExtendedTokenSet,
+): Promise<boolean> => {
+	const token = tokenSet.refresh_token;
+	if (typeof token !== "string" || token === "") return false;
+	try {
+		const configuration = await client.discovery(
+			new URL(oauthHost),
+			clientId,
+			{ token_endpoint_auth_method: "none" },
+			client.None(),
+			{
+				timeout: SERVER_TIMEOUT,
+				execute: allowUnsafeTls
+					? [client.allowInsecureRequests]
+					: undefined,
+			},
+		);
+		await client.tokenRevocation(configuration, token, {
+			token_type_hint: "refresh_token",
+		});
+		return true;
+	} catch (err) {
+		log.debug(
+			"Token revocation failed: %s",
+			err instanceof Error ? err.message : String(err),
+		);
+		return false;
+	}
+};
+
 export const auth = async ({
 	oauthHost,
 	clientId,

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -1,6 +1,5 @@
 import { createHash } from "node:crypto";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import type yargs from "yargs";
 
 import type { NeonApiClient } from "../api.js";
@@ -8,10 +7,23 @@ import type { NeonApiClient } from "../api.js";
 import { getApiClient } from "../api.js";
 import { auth, refreshToken } from "../auth.js";
 import { setAuthContext } from "../auth_context.js";
-import { CREDENTIALS_FILE } from "../config.js";
-import { isConfigInit, isCurrentBranchProbe } from "../context.js";
+import { credentialsPath as defaultCredentialsPath } from "../config.js";
+import {
+	isConfigInit,
+	isCurrentBranchProbe,
+	isProfileCommand,
+} from "../context.js";
 import { isCi } from "../env.js";
 import { log } from "../log.js";
+import {
+	assertValidProfileName,
+	DEFAULT_PROFILE,
+	newProfileCredentialsPath,
+	readProfiles,
+	resolveProfile,
+	selectProfileName,
+	upsertProfile,
+} from "../profiles.js";
 import type { ExtendedTokenSet } from "../types.js";
 import { extendTokenSet } from "../utils/auth.js";
 
@@ -24,6 +36,26 @@ type AuthProps = {
 	forceAuth?: boolean;
 	"force-auth"?: boolean;
 	allowUnsafeTls?: boolean;
+	profile?: string;
+};
+
+/**
+ * The credentials file this invocation reads and writes: the selected profile's, falling
+ * back to plain `credentials.json` when no profile was named and none is declared. An
+ * unknown profile name is a hard error rather than a silent write to the default file —
+ * a typo must not authenticate the wrong account.
+ */
+const credentialsPathFor = ({
+	configDir,
+	profile,
+}: {
+	configDir: string;
+	profile?: string;
+}): string => {
+	const name = selectProfileName(profile);
+	if (name === DEFAULT_PROFILE && !readProfiles(configDir))
+		return defaultCredentialsPath(configDir);
+	return resolveProfile(configDir, name).credentialsPath;
 };
 
 export const command = "auth";
@@ -45,6 +77,7 @@ export const authFlow = async ({
 	forceAuth,
 	"force-auth": forceAuthKebab,
 	allowUnsafeTls,
+	profile,
 }: AuthProps) => {
 	const allowInteractiveAuth = forceAuth ?? forceAuthKebab;
 	if (!allowInteractiveAuth && isCi()) {
@@ -56,9 +89,20 @@ export const authFlow = async ({
 		allowUnsafeTls,
 	});
 
-	const credentialsPath = join(configDir, CREDENTIALS_FILE);
+	// A named profile that doesn't exist yet is created here rather than erroring: `neon
+	// auth --profile work` is how you make one, so it must work before there is anything
+	// to look up.
+	const profileName = selectProfileName(profile);
+	const isNamed = profileName !== DEFAULT_PROFILE;
+	if (isNamed) assertValidProfileName(profileName);
+	const credentialsPath =
+		isNamed && !readProfiles(configDir)?.profiles[profileName]
+			? newProfileCredentialsPath(configDir, profileName)
+			: credentialsPathFor({ configDir, profile });
+
+	let identity: { id?: string; email?: string } = {};
 	try {
-		await preserveCredentials(
+		identity = await preserveCredentials(
 			credentialsPath,
 			tokenSet,
 			getApiClient({
@@ -70,29 +114,44 @@ export const authFlow = async ({
 		log.error("Failed to save credentials");
 		return "";
 	}
+
+	if (isNamed) {
+		upsertProfile(configDir, profileName, {
+			credentials: credentialsPath,
+			...(identity.email ? { label: identity.email } : {}),
+			...(identity.id ? { userId: identity.id } : {}),
+		});
+		log.info('Saved profile "%s" (%s)', profileName, credentialsPath);
+	}
 	log.info("Auth complete");
 	return tokenSet.access_token || "";
 };
 
+/**
+ * Persist the token set and return the account it belongs to, so a named profile can be
+ * labelled with an email. The credentials file records only `user_id` — a UUID with no
+ * email — which is why identifying a stored profile offline is otherwise impossible.
+ */
 const preserveCredentials = async (
 	path: string,
 	credentials: ExtendedTokenSet,
 	apiClient: NeonApiClient,
-) => {
+): Promise<{ id?: string; email?: string }> => {
 	const {
-		data: { id },
+		data: { id, email },
 	} = await apiClient.getCurrentUserInfo();
 	const contents = JSON.stringify({
 		// Cast to a plain record: we intentionally spread the credentials object.
 		...(credentials as Record<string, unknown>),
 		user_id: id,
 	});
-	// correctly sets needed permissions for the credentials file
+	// Owner-only. A credentials file needs read/write, never execute.
 	writeFileSync(path, contents, {
-		mode: 0o700,
+		mode: 0o600,
 	});
 	log.debug("Saved credentials to %s", path);
 	log.debug("Credentials MD5 hash: %s", md5hash(contents));
+	return { ...(id ? { id } : {}), ...(email ? { email } : {}) };
 };
 
 const handleExistingToken = async (
@@ -179,6 +238,12 @@ export const ensureAuth = async (
 		return;
 	}
 
+	// `profile` reads and edits credential files on disk. Authenticating first would mean
+	// a browser login just to list profiles, and would make a lapsed profile unremovable.
+	if (isProfileCommand(props)) {
+		return;
+	}
+
 	// `dev` runs a function locally. It injects the selected branch's env vars
 	// when credentials happen to be available, but must never trigger an
 	// interactive login: use an API key or existing stored credentials if
@@ -211,7 +276,7 @@ export const ensureAuth = async (
 		return;
 	}
 
-	const credentialsPath = join(props.configDir, CREDENTIALS_FILE);
+	const credentialsPath = credentialsPathFor(props);
 
 	// Handle case when credentials file exists
 	if (existsSync(credentialsPath)) {
@@ -291,11 +356,20 @@ export const ensureAuth = async (
 };
 
 /**
- * Deletes the credentials file at the specified path
- * @param configDir Directory where credentials file is stored
+ * Delete the credentials backing a profile — used by the 401 handler to clear a token the
+ * API has rejected, so the next command re-authenticates instead of failing again.
+ *
+ * @param configDir Directory the credentials live in
+ * @param profile Profile whose credentials to clear. Defaults to the selected one.
  */
-export const deleteCredentials = (configDir: string): void => {
-	const credentialsPath = join(configDir, CREDENTIALS_FILE);
+export const deleteCredentials = (
+	configDir: string,
+	profile?: string,
+): void => {
+	const credentialsPath = credentialsPathFor({
+		configDir,
+		...(profile ? { profile } : {}),
+	});
 	try {
 		if (existsSync(credentialsPath)) {
 			rmSync(credentialsPath);

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -20,6 +20,7 @@ import * as link from "./link.js";
 import * as neonAuth from "./neon_auth.js";
 import * as operations from "./operations.js";
 import * as orgs from "./orgs.js";
+import * as profile from "./profile.js";
 import * as projects from "./projects.js";
 import * as psql from "./psql.js";
 import * as roles from "./roles.js";
@@ -31,6 +32,7 @@ import * as vpcEndpoints from "./vpc_endpoints.js";
 
 export default [
 	auth,
+	profile,
 	api,
 	users,
 	orgs,

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -1,0 +1,181 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import prompts from "prompts";
+import type yargs from "yargs";
+
+import { revokeToken } from "../auth.js";
+import { isCi } from "../env.js";
+import { log } from "../log.js";
+import {
+	DEFAULT_PROFILE,
+	listProfiles,
+	onlyDefaultRemains,
+	profilesFilePath,
+	readProfiles,
+	resolveProfile,
+	selectProfileName,
+} from "../profiles.js";
+import type { CommonProps, ExtendedTokenSet } from "../types.js";
+import { writer } from "../writer.js";
+
+type ProfileProps = CommonProps & {
+	configDir: string;
+	profile?: string;
+	oauthHost: string;
+	clientId: string;
+	allowUnsafeTls?: boolean;
+};
+
+export const command = "profile";
+export const aliases = ["profiles"];
+export const describe = "Manage named sets of Neon credentials";
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 profile <sub-command> [options]")
+		.command(
+			"list",
+			"List profiles, the account each holds, and where its credentials live",
+			(y) => y,
+			async (args) => await list(args as unknown as ProfileProps),
+		)
+		.command(
+			"remove <name>",
+			"Revoke a profile's token and remove it",
+			(y) =>
+				y
+					.positional("name", {
+						describe: "Profile to remove",
+						type: "string",
+						demandOption: true,
+					})
+					.option("yes", {
+						alias: "y",
+						describe: "Skip the confirmation prompt",
+						type: "boolean",
+						default: false,
+					}),
+			async (args) =>
+				await remove(
+					args as unknown as ProfileProps & {
+						name: string;
+						yes: boolean;
+					},
+				),
+		)
+		.demandCommand(1, "Run `neon profile --help` to see the subcommands.");
+
+export const handler = (_args: yargs.Arguments) => {
+	/* subcommands only */
+};
+
+const list = async (props: ProfileProps) => {
+	const active = selectProfileName(props.profile);
+	const rows = listProfiles(props.configDir).map((p) => ({
+		active: p.name === active ? "*" : "",
+		name: p.name,
+		account: p.label ?? p.userId ?? "-",
+		credentials: p.credentialsPath,
+		signedIn: existsSync(p.credentialsPath) ? "yes" : "no",
+	}));
+
+	writer(props).end(rows, {
+		title: "Profiles",
+		fields: ["active", "name", "account", "signedIn", "credentials"],
+	});
+};
+
+const remove = async (props: ProfileProps & { name: string; yes: boolean }) => {
+	const { name } = props;
+	// Resolve before touching anything: an unknown name must fail having deleted nothing.
+	const profile = resolveProfile(props.configDir, name);
+
+	if (!props.yes) {
+		if (isCi()) {
+			throw new Error(
+				"Refusing to remove a profile without confirmation in CI. Pass --yes.",
+			);
+		}
+		const who = profile.label ?? profile.userId ?? "unknown account";
+		const { ok } = await prompts({
+			type: "confirm",
+			name: "ok",
+			message: `Remove profile "${name}" (${who})?`,
+			initial: false,
+		});
+		if (!ok) {
+			log.info("Cancelled.");
+			return;
+		}
+	}
+
+	// 1. Revoke upstream, so the token dies rather than merely becoming unreachable by us.
+	//    Best-effort: a profile is often removed precisely because its access already broke.
+	const revoked = await revokeStoredToken(profile.credentialsPath, props);
+	log.info(
+		revoked
+			? "Revoked the OAuth token"
+			: "Could not revoke the OAuth token — removing locally anyway",
+	);
+
+	// 2. Delete the credentials file only if we created it. A profile pointing outside the
+	//    config directory was adopted from elsewhere; unlink it and say so, because the
+	//    secret is still on disk and silence would imply otherwise.
+	if (existsSync(profile.credentialsPath)) {
+		if (isInsideConfigDir(props.configDir, profile.credentialsPath)) {
+			rmSync(profile.credentialsPath);
+			log.info("Deleted %s", profile.credentialsPath);
+		} else {
+			log.info(
+				"Left %s on disk — not created by neon",
+				profile.credentialsPath,
+			);
+		}
+	}
+
+	// 3. Drop the entry, and the file once nothing but DEFAULT is left — the mirror image
+	//    of creating it lazily, so a single-account install ends up with no profiles.json.
+	const path = profilesFilePath(props.configDir);
+	const file = readProfiles(props.configDir);
+	if (file?.profiles[name]) {
+		delete file.profiles[name];
+		if (onlyDefaultRemains(file)) {
+			rmSync(path);
+			log.info('Removed "%s" — no profiles left, deleted %s', name, path);
+		} else {
+			writeFileSync(path, `${JSON.stringify(file, null, 2)}\n`, {
+				mode: 0o600,
+			});
+			log.info('Removed "%s" from %s', name, path);
+		}
+	} else if (name === DEFAULT_PROFILE) {
+		log.info("Signed out of DEFAULT");
+	}
+};
+
+const revokeStoredToken = async (
+	credentialsPath: string,
+	props: ProfileProps,
+): Promise<boolean> => {
+	if (!existsSync(credentialsPath)) return false;
+	let tokenSet: ExtendedTokenSet;
+	try {
+		tokenSet = JSON.parse(readFileSync(credentialsPath, "utf8"));
+	} catch {
+		return false;
+	}
+	return await revokeToken(
+		{
+			oauthHost: props.oauthHost,
+			clientId: props.clientId,
+			...(props.allowUnsafeTls
+				? { allowUnsafeTls: props.allowUnsafeTls }
+				: {}),
+		},
+		tokenSet,
+	);
+};
+
+/** Whether a credentials file is one the CLI created, rather than an adopted path. */
+const isInsideConfigDir = (configDir: string, file: string): boolean =>
+	`${resolve(file)}/`.startsWith(`${resolve(configDir)}/`);

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,22 +1,39 @@
 import { existsSync, mkdirSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { configDir, resolveConfigFile } from "@neon/config/paths";
 import type yargs from "yargs";
 
 import { isCi } from "./env.js";
 
 export const CREDENTIALS_FILE = "credentials.json";
 
-export const defaultDir = join(
-	process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
-	"neonctl",
-);
+/**
+ * Default for `--config-dir`: `$XDG_CONFIG_HOME/neon`, else `~/.config/neon`.
+ *
+ * The directory was called `neonctl` until the CLI was renamed. An existing one is still
+ * read — see {@link credentialsPath} — but it is never written to, moved, or deleted.
+ */
+export const defaultDir = configDir();
+
+/**
+ * Where this invocation's `credentials.json` lives.
+ *
+ * When `--config-dir` was left at its default, an existing file in the legacy `neonctl`
+ * directory is used **in place**: an install that predates the rename keeps working, and
+ * its credentials are never duplicated into a second location where one copy could go
+ * stale while another tool still reads it.
+ *
+ * A `--config-dir` the user actually passed is used exactly as given. Falling back out of
+ * an explicitly chosen directory would defeat the reason for choosing it — a CI run
+ * pointed at a scratch directory must never pick up a developer's real credentials.
+ */
+export const credentialsPath = (dir: string): string =>
+	resolveConfigFile(CREDENTIALS_FILE, dir === defaultDir ? {} : { dir }).path;
 
 export const ensureConfigDir = ({
-	"config-dir": configDir,
+	"config-dir": configDirArg,
 	"force-auth": forceAuth,
 }: yargs.Arguments<{ "config-dir": string }>) => {
-	if (!existsSync(configDir) && (!isCi() || forceAuth)) {
-		mkdirSync(configDir, { recursive: true });
+	if (!existsSync(configDirArg) && (!isCi() || forceAuth)) {
+		mkdirSync(configDirArg, { recursive: true });
 	}
 };

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -60,6 +60,17 @@ export const isCurrentBranchProbe = (args: {
 export const isConfigInit = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "config" && args._[1] === "init";
 
+/**
+ * `neon profile …` manages credentials on disk and never calls the Neon API, so the global
+ * auth middleware must skip it — mirroring {@link isConfigInit}.
+ *
+ * More than a nicety: without this, listing your profiles would launch a browser login, and
+ * removing a broken profile would demand you sign into it first. Removing a profile whose
+ * access has already lapsed is the main reason to remove one.
+ */
+export const isProfileCommand = (args: { _: (string | number)[] }): boolean =>
+	args._[0] === "profile" || args._[0] === "profiles";
+
 const CONTEXT_FILE = ".neon";
 const GITIGNORE_FILE = ".gitignore";
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -94,6 +94,12 @@ builder = builder
 		type: "string",
 		default: defaultDir,
 	})
+	.option("profile", {
+		describe:
+			"Named credentials to use, from profiles.json (default: NEON_PROFILE, else DEFAULT)",
+		group: "Global options:",
+		type: "string",
+	})
 	.option("force-auth", {
 		describe: "Force authentication",
 		type: "boolean",

--- a/packages/cli/src/profiles.test.ts
+++ b/packages/cli/src/profiles.test.ts
@@ -1,0 +1,230 @@
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+	DEFAULT_PROFILE,
+	listProfiles,
+	newProfileCredentialsPath,
+	onlyDefaultRemains,
+	readProfiles,
+	removeProfileEntry,
+	resolveProfile,
+	selectProfileName,
+	upsertProfile,
+} from "./profiles.js";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.shift()?.();
+	vi.unstubAllEnvs();
+});
+
+function makeDir(files: Record<string, string> = {}): string {
+	const root = mkdtempSync(join(tmpdir(), "neon-profiles-"));
+	cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+	for (const [name, contents] of Object.entries(files)) {
+		const path = resolve(root, name);
+		mkdirSync(resolve(path, ".."), { recursive: true });
+		writeFileSync(path, contents);
+	}
+	return root;
+}
+
+const creds = (who: string) => JSON.stringify({ access_token: who });
+
+describe("selectProfileName", () => {
+	test("flag wins over NEON_PROFILE wins over DEFAULT", () => {
+		expect(selectProfileName("flag", { NEON_PROFILE: "env" })).toBe("flag");
+		expect(selectProfileName(undefined, { NEON_PROFILE: "env" })).toBe(
+			"env",
+		);
+		expect(selectProfileName(undefined, {})).toBe(DEFAULT_PROFILE);
+	});
+
+	test("whitespace-only values are treated as unset", () => {
+		expect(selectProfileName("  ", { NEON_PROFILE: "  " })).toBe(
+			DEFAULT_PROFILE,
+		);
+	});
+});
+
+describe("resolveProfile", () => {
+	// The single-account case: no profiles.json at all, and everything still works.
+	test("DEFAULT resolves to credentials.json with no profiles file", () => {
+		const dir = makeDir({ "credentials.json": creds("me") });
+		const p = resolveProfile(dir, DEFAULT_PROFILE);
+		expect(p.credentialsPath).toBe(resolve(dir, "credentials.json"));
+		expect(p.declared).toBe(false);
+	});
+
+	test("a declared profile resolves through its pointer", () => {
+		const dir = makeDir({
+			"credentials.json": creds("me"),
+			"credentials.work.json": creds("work"),
+			"profiles.json": JSON.stringify({
+				version: 1,
+				profiles: {
+					DEFAULT: { credentials: "credentials.json" },
+					work: {
+						credentials: "credentials.work.json",
+						label: "work@example.com",
+					},
+				},
+			}),
+		});
+		const p = resolveProfile(dir, "work");
+		expect(p.credentialsPath).toBe(resolve(dir, "credentials.work.json"));
+		expect(p.label).toBe("work@example.com");
+		expect(p.declared).toBe(true);
+	});
+
+	// The property that makes adopting an existing config dir a one-line edit.
+	test("a pointer may escape the config directory", () => {
+		const outside = makeDir({ "credentials.json": creds("adopted") });
+		const dir = makeDir({
+			"profiles.json": JSON.stringify({
+				version: 1,
+				profiles: {
+					other: { credentials: `${outside}/credentials.json` },
+				},
+			}),
+		});
+		expect(resolveProfile(dir, "other").credentialsPath).toBe(
+			resolve(outside, "credentials.json"),
+		);
+	});
+
+	test("an unknown name throws and names the known profiles", () => {
+		const dir = makeDir({
+			"profiles.json": JSON.stringify({
+				version: 1,
+				profiles: { DEFAULT: { credentials: "credentials.json" } },
+			}),
+		});
+		expect(() => resolveProfile(dir, "nope")).toThrow(
+			/Unknown profile "nope"/,
+		);
+		expect(() => resolveProfile(dir, "nope")).toThrow(/DEFAULT/);
+	});
+
+	test("DEFAULT still works when profiles.json omits it", () => {
+		const dir = makeDir({
+			"credentials.json": creds("me"),
+			"profiles.json": JSON.stringify({
+				version: 1,
+				profiles: { work: { credentials: "credentials.work.json" } },
+			}),
+		});
+		expect(resolveProfile(dir, DEFAULT_PROFILE).credentialsPath).toBe(
+			resolve(dir, "credentials.json"),
+		);
+	});
+
+	// A broken profiles.json must not lock the user out of `neon auth`.
+	test("a malformed profiles.json is ignored rather than fatal", () => {
+		const dir = makeDir({
+			"credentials.json": creds("me"),
+			"profiles.json": "not json",
+		});
+		expect(readProfiles(dir)).toBeNull();
+		expect(resolveProfile(dir, DEFAULT_PROFILE).credentialsPath).toBe(
+			resolve(dir, "credentials.json"),
+		);
+	});
+});
+
+describe("upsertProfile", () => {
+	test("creates profiles.json lazily and pins DEFAULT explicitly", () => {
+		const dir = makeDir({ "credentials.json": creds("me") });
+		upsertProfile(dir, "work", {
+			credentials: newProfileCredentialsPath(dir, "work"),
+			label: "work@example.com",
+		});
+
+		const file = JSON.parse(
+			readFileSync(resolve(dir, "profiles.json"), "utf8"),
+		);
+		expect(file.profiles.DEFAULT.credentials).toBe("credentials.json");
+		expect(file.profiles.work.credentials).toBe("credentials.work.json");
+		expect(file.profiles.work.label).toBe("work@example.com");
+	});
+
+	test("stores paths relative to profiles.json, and keeps outside paths absolute", () => {
+		const outside = makeDir({ "credentials.json": creds("adopted") });
+		const dir = makeDir({ "credentials.json": creds("me") });
+		upsertProfile(dir, "other", {
+			credentials: resolve(outside, "credentials.json"),
+		});
+		const file = JSON.parse(
+			readFileSync(resolve(dir, "profiles.json"), "utf8"),
+		);
+		// Relative is fine as long as it resolves back to the same file.
+		expect(resolveProfile(dir, "other").credentialsPath).toBe(
+			resolve(outside, "credentials.json"),
+		);
+		expect(file.profiles.other.credentials).toBeTruthy();
+	});
+
+	test("rejects a name that would escape the filename", () => {
+		const dir = makeDir({});
+		expect(() =>
+			upsertProfile(dir, "../evil", { credentials: "x" }),
+		).toThrow(/Invalid profile name/);
+	});
+
+	test("writes profiles.json owner-only", () => {
+		const dir = makeDir({ "credentials.json": creds("me") });
+		upsertProfile(dir, "work", { credentials: "credentials.work.json" });
+		const { mode } = require("node:fs").statSync(
+			resolve(dir, "profiles.json"),
+		);
+		expect(mode & 0o777).toBe(0o600);
+	});
+});
+
+describe("removeProfileEntry / onlyDefaultRemains", () => {
+	test("removes an entry and reports when only DEFAULT is left", () => {
+		const dir = makeDir({ "credentials.json": creds("me") });
+		upsertProfile(dir, "work", { credentials: "credentials.work.json" });
+
+		expect(removeProfileEntry(dir, "work")).toBe(true);
+		const file = readProfiles(dir);
+		expect(file).not.toBeNull();
+		expect(onlyDefaultRemains(file!)).toBe(true);
+	});
+
+	test("returns false for an entry that isn't there", () => {
+		const dir = makeDir({ "credentials.json": creds("me") });
+		expect(removeProfileEntry(dir, "ghost")).toBe(false);
+	});
+});
+
+describe("listProfiles", () => {
+	test("reports the implicit DEFAULT when there is no profiles.json", () => {
+		const dir = makeDir({ "credentials.json": creds("me") });
+		const all = listProfiles(dir);
+		expect(all.map((p) => p.name)).toEqual([DEFAULT_PROFILE]);
+	});
+
+	test("always includes DEFAULT even when profiles.json omits it", () => {
+		const dir = makeDir({
+			"credentials.json": creds("me"),
+			"profiles.json": JSON.stringify({
+				version: 1,
+				profiles: { work: { credentials: "credentials.work.json" } },
+			}),
+		});
+		expect(
+			listProfiles(dir)
+				.map((p) => p.name)
+				.sort(),
+		).toEqual(["DEFAULT", "work"]);
+	});
+});

--- a/packages/cli/src/profiles.ts
+++ b/packages/cli/src/profiles.ts
@@ -1,0 +1,257 @@
+/**
+ * # Profiles — several Neon accounts in one config directory
+ *
+ * A profile is **a pointer to a credentials file**. Nothing more. That constraint is what
+ * keeps the feature small: there is no mirror, no per-profile directory tree, no persistent
+ * "active profile" state to fall out of sync, and no migration.
+ *
+ * ```
+ * ~/.config/neon/
+ * ├── credentials.json          # this IS the DEFAULT profile, not a copy of it
+ * ├── credentials.work.json     # created by `neon auth --profile work`
+ * └── profiles.json             # created only once a second profile exists
+ * ```
+ *
+ * `profiles.json` maps a name to a path, and the path may point anywhere — which is what
+ * makes adopting an existing directory a one-line edit rather than an import command:
+ *
+ * ```json
+ * {
+ *   "version": 1,
+ *   "profiles": {
+ *     "DEFAULT": { "credentials": "credentials.json" },
+ *     "work": {
+ *       "credentials": "../neonctl-databricks/credentials.json",
+ *       "label": "someone@example.com"
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * ## Selection
+ *
+ * `--profile` → `NEON_PROFILE` → `DEFAULT`. Per invocation, like `AWS_PROFILE`; there is no
+ * `profile use` command, so nothing persists that could disagree with what you typed.
+ *
+ * ## Compatibility
+ *
+ * An install with no `profiles.json` is already a valid `DEFAULT`-only state: `DEFAULT`
+ * resolves to `credentials.json` in the config directory (including an existing one in the
+ * legacy `neonctl` directory — see `@neon/config/paths`). Nothing is created until a second
+ * profile is, and nothing is ever moved.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { resolveConfigFile } from "@neon/config/paths";
+import { credentialsPath, defaultDir } from "./config.js";
+import { log } from "./log.js";
+
+export const PROFILES_FILE = "profiles.json";
+
+/** The implicit profile. Backed by plain `credentials.json`, with or without a profiles file. */
+export const DEFAULT_PROFILE = "DEFAULT";
+
+/** Profile names become part of a filename, so keep them boring. */
+const NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export type ProfileEntry = {
+	/** Path to the credentials file, relative to `profiles.json` or absolute. */
+	credentials: string;
+	/** Account email, captured at login. Display only. */
+	label?: string;
+	/** Neon user id, captured at login. Display only. */
+	userId?: string;
+};
+
+export type ProfilesFile = {
+	version: 1;
+	profiles: Record<string, ProfileEntry>;
+};
+
+export type ResolvedProfile = {
+	name: string;
+	/** Absolute path to this profile's credentials file. */
+	credentialsPath: string;
+	label?: string;
+	userId?: string;
+	/** True when the profile comes from `profiles.json` rather than the implicit default. */
+	declared: boolean;
+};
+
+/** Which profile this invocation should use: `--profile` → `NEON_PROFILE` → `DEFAULT`. */
+export const selectProfileName = (
+	flag?: string,
+	env: NodeJS.ProcessEnv = process.env,
+): string => nonEmpty(flag) ?? nonEmpty(env.NEON_PROFILE) ?? DEFAULT_PROFILE;
+
+export const assertValidProfileName = (name: string): void => {
+	if (!NAME_PATTERN.test(name)) {
+		throw new Error(
+			`Invalid profile name "${name}". Use letters, digits, dot, dash or underscore, starting with a letter or digit.`,
+		);
+	}
+};
+
+/** Where `profiles.json` lives for this config directory (whether or not it exists yet). */
+export const profilesFilePath = (dir: string): string =>
+	resolveConfigFile(PROFILES_FILE, dir === defaultDir ? {} : { dir }).path;
+
+/**
+ * Read `profiles.json`, or `null` when there isn't one — the normal single-account state.
+ * A malformed file is reported and treated as absent rather than breaking every command;
+ * the worst case is that a named profile is "not found", which is recoverable, whereas
+ * throwing here would lock the user out of `neon auth` itself.
+ */
+export const readProfiles = (dir: string): ProfilesFile | null => {
+	const path = profilesFilePath(dir);
+	if (!existsSync(path)) return null;
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		)
+			throw new Error("not an object");
+		const profiles = (parsed as ProfilesFile).profiles;
+		if (
+			profiles === null ||
+			typeof profiles !== "object" ||
+			Array.isArray(profiles)
+		)
+			throw new Error("missing `profiles`");
+		return { version: 1, profiles };
+	} catch (err) {
+		log.warning(
+			"Ignoring malformed %s: %s",
+			path,
+			err instanceof Error ? err.message : String(err),
+		);
+		return null;
+	}
+};
+
+/** Resolve a profile to an absolute credentials path. Throws when a named profile is unknown. */
+export const resolveProfile = (dir: string, name: string): ResolvedProfile => {
+	const file = readProfiles(dir);
+	const entry = file?.profiles[name];
+
+	if (entry) {
+		return {
+			name,
+			credentialsPath: resolveEntryPath(dir, entry.credentials),
+			...(entry.label ? { label: entry.label } : {}),
+			...(entry.userId ? { userId: entry.userId } : {}),
+			declared: true,
+		};
+	}
+
+	// DEFAULT works with no profiles.json at all, and keeps working when one exists but
+	// doesn't mention it — that is the pre-profiles behaviour, unchanged.
+	if (name === DEFAULT_PROFILE) {
+		return {
+			name,
+			credentialsPath: credentialsPath(dir),
+			declared: false,
+		};
+	}
+
+	const known = file
+		? Object.keys(file.profiles).join(", ")
+		: DEFAULT_PROFILE;
+	throw new Error(
+		`Unknown profile "${name}". Known profiles: ${known}. Create it with \`neon auth --profile ${name}\`.`,
+	);
+};
+
+/** Default location for a new named profile's credentials file. */
+export const newProfileCredentialsPath = (dir: string, name: string): string =>
+	resolve(dir, `credentials.${name}.json`);
+
+/**
+ * Record a profile, creating `profiles.json` if this is the first named one.
+ *
+ * When the file is created, `DEFAULT` is written explicitly and pointed at wherever
+ * `credentials.json` actually is. That matters for an install predating the directory
+ * rename: `profiles.json` is created in `neon/` while the credentials are still in
+ * `neonctl/`, so `DEFAULT` is recorded as `../neonctl/credentials.json` rather than a
+ * relative name that would resolve to a file that isn't there.
+ */
+export const upsertProfile = (
+	dir: string,
+	name: string,
+	entry: { credentials: string; label?: string; userId?: string },
+): void => {
+	assertValidProfileName(name);
+	const path = profilesFilePath(dir);
+	const file = readProfiles(dir) ?? {
+		version: 1 as const,
+		profiles: {
+			[DEFAULT_PROFILE]: {
+				credentials: relativeToProfiles(path, credentialsPath(dir)),
+			},
+		},
+	};
+
+	file.profiles[name] = {
+		credentials: relativeToProfiles(path, entry.credentials),
+		...(entry.label ? { label: entry.label } : {}),
+		...(entry.userId ? { userId: entry.userId } : {}),
+	};
+
+	writeProfiles(path, file);
+};
+
+/** Remove an entry. Returns false when it wasn't there. */
+export const removeProfileEntry = (dir: string, name: string): boolean => {
+	const path = profilesFilePath(dir);
+	const file = readProfiles(dir);
+	if (!file?.profiles[name]) return false;
+	delete file.profiles[name];
+	writeProfiles(path, file);
+	return true;
+};
+
+/**
+ * True when only `DEFAULT` is left, so `profiles.json` no longer earns its place. Mirrors
+ * lazy creation: a single-account install has no profiles file, before or after.
+ */
+export const onlyDefaultRemains = (file: ProfilesFile): boolean => {
+	const names = Object.keys(file.profiles);
+	return (
+		names.length === 0 ||
+		(names.length === 1 && names[0] === DEFAULT_PROFILE)
+	);
+};
+
+export const listProfiles = (dir: string): ResolvedProfile[] => {
+	const file = readProfiles(dir);
+	if (!file) return [resolveProfile(dir, DEFAULT_PROFILE)];
+	const names = Object.keys(file.profiles);
+	if (!names.includes(DEFAULT_PROFILE)) names.unshift(DEFAULT_PROFILE);
+	return names.map((name) => resolveProfile(dir, name));
+};
+
+const writeProfiles = (path: string, file: ProfilesFile): void => {
+	writeFileSync(path, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+};
+
+const resolveEntryPath = (dir: string, entry: string): string =>
+	isAbsolute(entry) ? entry : resolve(profilesDir(dir), entry);
+
+/** `profiles.json` may sit in the legacy directory, so entries resolve against its own dir. */
+const profilesDir = (dir: string): string =>
+	resolve(profilesFilePath(dir), "..");
+
+/** Keep entries relative when they sit near `profiles.json`; absolute paths stay absolute. */
+const relativeToProfiles = (profilesPath: string, target: string): string => {
+	const rel = relative(resolve(profilesPath, ".."), target);
+	return rel && !isAbsolute(rel) ? rel : target;
+};
+
+function nonEmpty(value: string | undefined): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed === "" ? undefined : trimmed;
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -26,6 +26,9 @@
       // reuse / revocation), which is a subpath export so an app importing
       // `@neon/env` is never offered it.
       "@neon/env/runtime": ["node_modules/@neon/env/dist/runtime"],
+      // And `@neon/config/paths`, the implementor-only half of `@neon/config` that
+      // knows where the config directory lives (the pure root export must not).
+      "@neon/config/paths": ["node_modules/@neon/config/dist/paths"],
       // Same story for the test-only harness, which is source-only.
       "@neon/e2e-harness": ["node_modules/@neon/e2e-harness/src/index"]
     },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -32,6 +32,11 @@
 			"types": "./dist/v1.d.ts",
 			"import": "./dist/v1.js",
 			"default": "./dist/v1.js"
+		},
+		"./paths": {
+			"types": "./dist/paths.d.ts",
+			"import": "./dist/paths.js",
+			"default": "./dist/paths.js"
 		}
 	},
 	"files": [

--- a/packages/config/src/paths.test.ts
+++ b/packages/config/src/paths.test.ts
@@ -1,0 +1,188 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { configDir, legacyConfigDir, resolveConfigFile } from "./paths.js";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.shift()?.();
+});
+
+/** A temp home. `where` seeds `credentials.json` into the named config dirs. */
+function makeHome(where: Array<"neon" | "neonctl"> = []): string {
+	const root = mkdtempSync(join(tmpdir(), "neon-paths-"));
+	cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+	for (const name of where) {
+		const dir = resolve(root, ".config", name);
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, "credentials.json"), `{"from":"${name}"}`);
+	}
+	return root;
+}
+
+const tmpDir = () => {
+	const d = mkdtempSync(join(tmpdir(), "neon-paths-explicit-"));
+	cleanups.push(() => rmSync(d, { recursive: true, force: true }));
+	return d;
+};
+
+describe("configDir — precedence", () => {
+	test("defaults to <home>/.config/neon", () => {
+		const home = makeHome();
+		expect(configDir({ env: { HOME: home } })).toBe(
+			resolve(home, ".config", "neon"),
+		);
+	});
+
+	test("honours XDG_CONFIG_HOME over <home>/.config", () => {
+		const home = makeHome();
+		const xdg = tmpDir();
+		expect(configDir({ env: { HOME: home, XDG_CONFIG_HOME: xdg } })).toBe(
+			join(xdg, "neon"),
+		);
+	});
+
+	test("falls back to USERPROFILE on Windows-style env", () => {
+		const home = makeHome();
+		expect(configDir({ env: { USERPROFILE: home } })).toBe(
+			resolve(home, ".config", "neon"),
+		);
+	});
+
+	test("NEON_CONFIG_DIR wins over the computed default", () => {
+		const home = makeHome();
+		const custom = tmpDir();
+		expect(
+			configDir({ env: { HOME: home, NEON_CONFIG_DIR: custom } }),
+		).toBe(custom);
+	});
+
+	test("NEONCTL_CONFIG_DIR is still honoured, but NEON_CONFIG_DIR wins", () => {
+		const legacyVar = tmpDir();
+		const currentVar = tmpDir();
+		expect(configDir({ env: { NEONCTL_CONFIG_DIR: legacyVar } })).toBe(
+			legacyVar,
+		);
+		expect(
+			configDir({
+				env: {
+					NEONCTL_CONFIG_DIR: legacyVar,
+					NEON_CONFIG_DIR: currentVar,
+				},
+			}),
+		).toBe(currentVar);
+	});
+
+	test("an explicit dir option beats every environment variable", () => {
+		const flag = tmpDir();
+		expect(
+			configDir({
+				dir: flag,
+				env: {
+					HOME: makeHome(),
+					NEON_CONFIG_DIR: tmpDir(),
+					NEONCTL_CONFIG_DIR: tmpDir(),
+					XDG_CONFIG_HOME: tmpDir(),
+				},
+			}),
+		).toBe(flag);
+	});
+
+	test("whitespace-only values are treated as unset", () => {
+		const home = makeHome();
+		expect(
+			configDir({
+				dir: "   ",
+				env: { HOME: home, NEON_CONFIG_DIR: "  " },
+			}),
+		).toBe(resolve(home, ".config", "neon"));
+	});
+});
+
+describe("legacyConfigDir", () => {
+	test("is the sibling neonctl directory by default", () => {
+		const home = makeHome();
+		expect(legacyConfigDir({ env: { HOME: home } })).toBe(
+			resolve(home, ".config", "neonctl"),
+		);
+	});
+
+	// An explicitly chosen directory has no legacy counterpart — `--config-dir /tmp/ci`
+	// silently reading ~/.config/neonctl would defeat the point of passing the flag.
+	test("is undefined when the directory was chosen explicitly", () => {
+		expect(legacyConfigDir({ dir: tmpDir() })).toBeUndefined();
+		expect(
+			legacyConfigDir({ env: { NEON_CONFIG_DIR: tmpDir() } }),
+		).toBeUndefined();
+		expect(
+			legacyConfigDir({ env: { NEONCTL_CONFIG_DIR: tmpDir() } }),
+		).toBeUndefined();
+	});
+});
+
+describe("resolveConfigFile", () => {
+	test("prefers an existing file in neon/", () => {
+		const home = makeHome(["neon", "neonctl"]);
+		const r = resolveConfigFile("credentials.json", {
+			env: { HOME: home },
+		});
+		expect(r.path).toBe(
+			resolve(home, ".config", "neon", "credentials.json"),
+		);
+		expect(r.isLegacy).toBe(false);
+		expect(r.exists).toBe(true);
+	});
+
+	// The load-bearing case: an existing install keeps using its file where it already is.
+	test("uses an existing legacy file in place", () => {
+		const home = makeHome(["neonctl"]);
+		const r = resolveConfigFile("credentials.json", {
+			env: { HOME: home },
+		});
+		expect(r.path).toBe(
+			resolve(home, ".config", "neonctl", "credentials.json"),
+		);
+		expect(r.isLegacy).toBe(true);
+		expect(r.exists).toBe(true);
+	});
+
+	test("points at neon/ when the file exists in neither — new files land there", () => {
+		const home = makeHome();
+		const r = resolveConfigFile("profiles.json", { env: { HOME: home } });
+		expect(r.path).toBe(resolve(home, ".config", "neon", "profiles.json"));
+		expect(r.isLegacy).toBe(false);
+		expect(r.exists).toBe(false);
+	});
+
+	test("never searches the legacy directory when a directory was given explicitly", () => {
+		const home = makeHome(["neonctl"]);
+		const empty = tmpDir();
+		const r = resolveConfigFile("credentials.json", {
+			dir: empty,
+			env: { HOME: home },
+		});
+		expect(r.path).toBe(resolve(empty, "credentials.json"));
+		expect(r.isLegacy).toBe(false);
+		expect(r.exists).toBe(false);
+	});
+
+	test("resolves per file, not per directory", () => {
+		// credentials.json only in legacy, profiles.json only in current: each resolves
+		// independently, so a half-populated new directory cannot strand the old one.
+		const home = makeHome(["neonctl"]);
+		const currentDir = resolve(home, ".config", "neon");
+		mkdirSync(currentDir, { recursive: true });
+		writeFileSync(resolve(currentDir, "profiles.json"), "{}");
+
+		const creds = resolveConfigFile("credentials.json", {
+			env: { HOME: home },
+		});
+		const profiles = resolveConfigFile("profiles.json", {
+			env: { HOME: home },
+		});
+
+		expect(creds.isLegacy).toBe(true);
+		expect(profiles.isLegacy).toBe(false);
+	});
+});

--- a/packages/config/src/paths.ts
+++ b/packages/config/src/paths.ts
@@ -1,0 +1,139 @@
+/**
+ * # `@neon/config/paths` — where the Neon CLIs keep their files on disk
+ *
+ * **Implementor-only, and deliberately impure.** This subpath reads environment variables
+ * and touches the filesystem, which the root `@neon/config` export must never do — the same
+ * split as `@neon/env` (pure) versus `@neon/env/runtime` (stateful). Import it from a CLI,
+ * never from a `neon.ts` policy. It imports nothing from the rest of the package, so pulling
+ * it in costs one module.
+ *
+ * It exists because three separate readers each grew their own answer to "where is the
+ * config directory", and all three disagreed: `packages/cli` honoured `XDG_CONFIG_HOME` but
+ * not `NEONCTL_CONFIG_DIR`, `packages/env` honoured the env var but not XDG, and
+ * `packages/init` hardcoded `~/.config/neonctl`. With `XDG_CONFIG_HOME` set, the CLI wrote
+ * credentials somewhere the other two never looked.
+ *
+ * ## The directory
+ *
+ * `neon` is the current name; `neonctl` is the legacy one, kept readable forever. Resolution,
+ * each entry winning over the next:
+ *
+ * 1. An explicit directory (a `--config-dir` flag) — **exact**, no legacy fallback.
+ * 2. `NEON_CONFIG_DIR` — exact.
+ * 3. `NEONCTL_CONFIG_DIR` (legacy name) — exact.
+ * 4. `$XDG_CONFIG_HOME/neon`, else `<home>/.config/neon`.
+ *
+ * An explicitly chosen directory is never paired with a fallback: `--config-dir /tmp/ci` that
+ * quietly read `~/.config/neonctl` would defeat the point of passing it.
+ *
+ * ## The files
+ *
+ * {@link resolveConfigFile} answers "which path should I use for this file", and it is the
+ * same answer for reading and writing:
+ *
+ * - Present in `neon/` → use it.
+ * - Present only in `neonctl/` → **use it there, in place.** An existing credentials file is
+ *   never copied or moved, so nothing is left behind to go stale and no other tool starts
+ *   reading an abandoned token.
+ * - Present in neither → the new location. New files only ever appear under `neon/`.
+ */
+
+import { existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/** Current directory name. New files are created here. */
+export const CONFIG_DIR_NAME = "neon";
+
+/** Legacy directory name, read forever so existing installs keep working untouched. */
+export const LEGACY_CONFIG_DIR_NAME = "neonctl";
+
+export interface ConfigPathOptions {
+	/**
+	 * An explicit directory, e.g. from a `--config-dir` flag. Used exactly as given: no
+	 * environment variables are consulted and the legacy directory is never searched.
+	 */
+	dir?: string;
+	/** Environment to read. Defaults to `process.env`. Injectable for tests. */
+	env?: NodeJS.ProcessEnv;
+}
+
+/** Where files are created. See the module docs for the precedence. */
+export function configDir(options: ConfigPathOptions = {}): string {
+	const explicit = explicitDir(options);
+	if (explicit) return explicit;
+	return join(configHome(options.env ?? process.env), CONFIG_DIR_NAME);
+}
+
+/**
+ * The legacy directory, or `undefined` when the location was chosen explicitly (in which
+ * case there is no legacy counterpart to fall back to).
+ */
+export function legacyConfigDir(
+	options: ConfigPathOptions = {},
+): string | undefined {
+	if (explicitDir(options)) return undefined;
+	return join(configHome(options.env ?? process.env), LEGACY_CONFIG_DIR_NAME);
+}
+
+export interface ResolvedConfigFile {
+	/** The path to use, for both reading and writing. */
+	path: string;
+	/** The directory `path` lives in. */
+	dir: string;
+	/** True when the file was found in the legacy `neonctl` directory. */
+	isLegacy: boolean;
+	/** Whether the file exists at `path` right now. */
+	exists: boolean;
+}
+
+/**
+ * Resolve one file inside the config directory. Prefers the current location, falls back to
+ * an existing legacy file **in place**, and otherwise points at the current location so new
+ * files are created there.
+ */
+export function resolveConfigFile(
+	fileName: string,
+	options: ConfigPathOptions = {},
+): ResolvedConfigFile {
+	const dir = configDir(options);
+	const current = resolve(dir, fileName);
+	if (existsSync(current))
+		return { path: current, dir, isLegacy: false, exists: true };
+
+	const legacyDir = legacyConfigDir(options);
+	if (legacyDir) {
+		const legacy = resolve(legacyDir, fileName);
+		if (existsSync(legacy))
+			return {
+				path: legacy,
+				dir: legacyDir,
+				isLegacy: true,
+				exists: true,
+			};
+	}
+
+	return { path: current, dir, isLegacy: false, exists: false };
+}
+
+/** `$XDG_CONFIG_HOME`, else `<home>/.config`. Falls back to a relative `.config` with no home. */
+function configHome(env: NodeJS.ProcessEnv): string {
+	const xdg = nonEmpty(env.XDG_CONFIG_HOME);
+	if (xdg) return xdg;
+	const home = nonEmpty(env.HOME) ?? nonEmpty(env.USERPROFILE);
+	return home ? join(home, ".config") : ".config";
+}
+
+function explicitDir(options: ConfigPathOptions): string | undefined {
+	const env = options.env ?? process.env;
+	return (
+		nonEmpty(options.dir) ??
+		nonEmpty(env.NEON_CONFIG_DIR) ??
+		nonEmpty(env.NEONCTL_CONFIG_DIR)
+	);
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed === "" ? undefined : trimmed;
+}

--- a/packages/config/tsdown.config.ts
+++ b/packages/config/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	entry: [
 		"src/index.ts",
 		"src/v1.ts",
+		"src/paths.ts",
 		"src/lib/**/*.ts",
 		"!src/**/*.test.*",
 		"!src/**/*.test-d.*",

--- a/packages/env/src/lib/cli/resolve-api-key.test.ts
+++ b/packages/env/src/lib/cli/resolve-api-key.test.ts
@@ -9,11 +9,19 @@ afterEach(() => {
 	while (cleanups.length > 0) cleanups.shift()?.();
 });
 
-/** A temp home containing `.config/neonctl/credentials.json` with the given contents. */
-function makeHome(credentials: string | null): string {
+/**
+ * A temp home containing `.config/<dirName>/credentials.json`.
+ *
+ * Defaults to the legacy `neonctl` directory: every existing test below was written against
+ * it, so their continuing to pass is the backward-compatibility check.
+ */
+function makeHome(
+	credentials: string | null,
+	dirName: "neon" | "neonctl" = "neonctl",
+): string {
 	const root = mkdtempSync(join(tmpdir(), "neon-env-apikey-"));
 	cleanups.push(() => rmSync(root, { recursive: true, force: true }));
-	const dir = resolve(root, ".config", "neonctl");
+	const dir = resolve(root, ".config", dirName);
 	mkdirSync(dir, { recursive: true });
 	if (credentials !== null) {
 		writeFileSync(resolve(dir, "credentials.json"), credentials);
@@ -50,6 +58,67 @@ describe("resolveApiKey — precedence", () => {
 	test("falls back to USERPROFILE on Windows-style env", () => {
 		const home = makeHome(token("win-token"));
 		expect(resolveApiKey({ env: { USERPROFILE: home } })).toBe("win-token");
+	});
+
+	// The config directory is `neon`; `neonctl` is the pre-rename name, still read so an
+	// existing install keeps working. Every other test here seeds the legacy directory.
+	test("reads the current .config/neon directory", () => {
+		const home = makeHome(token("from-neon"), "neon");
+		expect(resolveApiKey({ env: { HOME: home } })).toBe("from-neon");
+	});
+
+	test("prefers .config/neon over the legacy .config/neonctl", () => {
+		const home = makeHome(token("from-neonctl"), "neonctl");
+		const currentDir = resolve(home, ".config", "neon");
+		mkdirSync(currentDir, { recursive: true });
+		writeFileSync(
+			resolve(currentDir, "credentials.json"),
+			token("from-neon"),
+		);
+		expect(resolveApiKey({ env: { HOME: home } })).toBe("from-neon");
+	});
+
+	// This is the divergence the shared resolver fixes: `neon` honoured XDG_CONFIG_HOME
+	// while this package didn't, so with it set the two looked in different places.
+	test("honours XDG_CONFIG_HOME, matching the neon CLI", () => {
+		const xdg = mkdtempSync(join(tmpdir(), "neon-env-xdg-"));
+		cleanups.push(() => rmSync(xdg, { recursive: true, force: true }));
+		const dir = resolve(xdg, "neon");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(resolve(dir, "credentials.json"), token("from-xdg"));
+
+		const home = makeHome(token("from-home"));
+		expect(
+			resolveApiKey({ env: { HOME: home, XDG_CONFIG_HOME: xdg } }),
+		).toBe("from-xdg");
+	});
+
+	test("NEON_CONFIG_DIR wins over NEONCTL_CONFIG_DIR", () => {
+		const legacyVar = mkdtempSync(join(tmpdir(), "neon-env-legacyvar-"));
+		const currentVar = mkdtempSync(join(tmpdir(), "neon-env-currentvar-"));
+		cleanups.push(() =>
+			rmSync(legacyVar, { recursive: true, force: true }),
+		);
+		cleanups.push(() =>
+			rmSync(currentVar, { recursive: true, force: true }),
+		);
+		writeFileSync(
+			resolve(legacyVar, "credentials.json"),
+			token("legacy-var"),
+		);
+		writeFileSync(
+			resolve(currentVar, "credentials.json"),
+			token("current-var"),
+		);
+
+		expect(
+			resolveApiKey({
+				env: {
+					NEONCTL_CONFIG_DIR: legacyVar,
+					NEON_CONFIG_DIR: currentVar,
+				},
+			}),
+		).toBe("current-var");
 	});
 
 	test("treats whitespace-only flag and env as missing", () => {

--- a/packages/env/src/lib/cli/resolve-api-key.ts
+++ b/packages/env/src/lib/cli/resolve-api-key.ts
@@ -1,10 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { resolveConfigFile } from "@neon/config/paths";
 
 /**
  * Resolve the Neon API key for a `neon-env` CLI invocation. Precedence (each wins over the
  * next): `--api-key` flag → `NEON_API_KEY` → `access_token` from the Neon CLI's
- * `credentials.json`.
+ * `credentials.json`, located by `@neon/config/paths`.
  *
  * The CLI owns this resolution — `@neon/config` and `@neon/env` are deliberately
  * environment- and filesystem-agnostic and only ever accept an explicit `apiKey`, so the
@@ -27,21 +27,25 @@ export function resolveApiKey(options: {
 }
 
 /**
- * Read `access_token` from the Neon CLI's credentials file, the same location and
- * precedence `neon auth` writes to: `NEONCTL_CONFIG_DIR` → `<home>/.config/neonctl`
- * (`HOME`, falling back to `USERPROFILE` for Windows parity).
+ * Read `access_token` from the Neon CLI's credentials file.
  *
- * Never throws — a missing, unreadable, malformed, or token-less file is simply "no key",
+ * Location resolution is delegated to `@neon/config/paths` so this agrees with the `neon`
+ * CLI itself — `NEON_CONFIG_DIR` / `NEONCTL_CONFIG_DIR`, else `$XDG_CONFIG_HOME/neon`, else
+ * `~/.config/neon`, with an existing legacy `neonctl` directory still read. Rolling that
+ * lookup by hand here is how the two drifted in the first place: this file honoured the env
+ * var but not XDG, while the CLI honoured XDG but not the env var, so with
+ * `XDG_CONFIG_HOME` set they disagreed about where credentials lived.
+ *
+ * Reads only `DEFAULT` — a profile is a CLI-invocation concept, and `neon-env` has no
+ * `--profile` of its own to read one from.
+ *
+ * Never throws: a missing, unreadable, malformed, or token-less file is simply "no key",
  * so this can sit in a resolution chain without try/catch noise.
  */
 function readStoredAccessToken(env: NodeJS.ProcessEnv): string | undefined {
-	const home = env.HOME ?? env.USERPROFILE;
-	const configDir =
-		nonEmpty(env.NEONCTL_CONFIG_DIR) ??
-		(home ? resolve(home, ".config", "neonctl") : undefined);
-	if (!configDir) return undefined;
-
-	const credentialsPath = resolve(configDir, "credentials.json");
+	const { path: credentialsPath } = resolveConfigFile("credentials.json", {
+		env,
+	});
 	if (!existsSync(credentialsPath)) return undefined;
 
 	let parsed: unknown;

--- a/packages/init/src/lib/auth.ts
+++ b/packages/init/src/lib/auth.ts
@@ -53,26 +53,54 @@ export async function isAuthenticated(): Promise<boolean> {
 }
 
 /**
- * Gets the OAuth access token from neonctl's stored credentials
+ * Gets the OAuth access token from the Neon CLI's stored credentials.
+ *
+ * Kept inline rather than importing `@neon/config/paths`: this package has no workspace
+ * dependencies, and taking one on `@neon/config` would pull `@neon/sdk`, `zod` and `jiti`
+ * into the install footprint of a package whose only need here is a file path. The
+ * resolution below must stay identical to `packages/config/src/paths.ts`, which is the
+ * canonical implementation — and it collapses entirely once this package folds into
+ * `packages/cli`.
  */
 async function getNeonctlAccessToken(): Promise<string | null> {
 	try {
-		const homeDir = process.env.HOME || process.env.USERPROFILE;
-		if (!homeDir) return null;
-
-		const credentialsPath = resolve(
-			homeDir,
-			".config",
-			"neonctl",
-			"credentials.json",
-		);
-		if (!existsSync(credentialsPath)) return null;
-
-		const credentials = JSON.parse(readFileSync(credentialsPath, "utf-8"));
-		return credentials.access_token || null;
+		for (const path of credentialsCandidates()) {
+			if (!existsSync(path)) continue;
+			const credentials = JSON.parse(readFileSync(path, "utf-8"));
+			if (credentials.access_token) return credentials.access_token;
+		}
+		return null;
 	} catch {
 		return null;
 	}
+}
+
+/**
+ * Where the Neon CLI may keep `credentials.json`, most specific first: an explicitly
+ * configured directory, else `$XDG_CONFIG_HOME`/`~/.config` under the current `neon`
+ * directory and then the legacy `neonctl` one. An explicit directory is exact — it never
+ * falls back to the legacy name.
+ */
+function credentialsCandidates(): string[] {
+	const env = process.env;
+	const explicit =
+		trimmed(env.NEON_CONFIG_DIR) ?? trimmed(env.NEONCTL_CONFIG_DIR);
+	if (explicit) return [resolve(explicit, "credentials.json")];
+
+	const home = trimmed(env.HOME) ?? trimmed(env.USERPROFILE);
+	const base =
+		trimmed(env.XDG_CONFIG_HOME) ??
+		(home ? resolve(home, ".config") : null);
+	if (!base) return [];
+	return [
+		resolve(base, "neon", "credentials.json"),
+		resolve(base, "neonctl", "credentials.json"),
+	];
+}
+
+function trimmed(value: string | undefined): string | null {
+	const v = value?.trim();
+	return v ? v : null;
 }
 
 /**


### PR DESCRIPTION
## The problem

The CLI holds one Neon account. Anyone with two — a personal account and a work one, say — has to build their own workaround out of `--config-dir` and shell aliases, and those aliases only exist in an interactive shell. Every script, CI job, agent, and `npx` invocation silently falls back to whichever account happens to be in the default directory.

While adding profiles I found the directory itself is not agreed on. Three readers, three different answers:

| Reader | `NEON*_CONFIG_DIR` | `XDG_CONFIG_HOME` | Path |
|---|---|---|---|
| `packages/cli/src/config.ts` | **no** | yes | `$XDG_CONFIG_HOME/neonctl` |
| `packages/env/.../resolve-api-key.ts` | yes | **no** | `~/.config/neonctl` |
| `packages/init/src/lib/auth.ts` | **no** | **no** | `~/.config/neonctl`, hardcoded |

With `XDG_CONFIG_HOME` set, **the CLI writes credentials somewhere the other two never look.** That is a bug today, independent of this feature. The `init` one also assembles its path from segments, so it doesn't appear in a grep for `.config/neonctl` — which is the argument for one shared implementation rather than four careful ones.

---

## Profiles

A profile is **a pointer to a credentials file. Nothing more.** That constraint is what keeps this small: no mirror, no per-profile directory tree, no stored "active profile" that can disagree with what you typed, and no migration.

```bash
neon auth --profile work        # create it, or sign in again
neon profile list
neon profile remove work
neon deploy --profile work      # or NEON_PROFILE=work
```

```console
$ neon profile list
Profiles
┌────────┬─────────┬─────────────────────┬──────────┬────────────────────────────────────────┐
│ Active │ Name    │ Account             │ SignedIn │ Credentials                            │
├────────┼─────────┼─────────────────────┼──────────┼────────────────────────────────────────┤
│ *      │ DEFAULT │ me@example.com      │ yes      │ ~/.config/neon/credentials.json        │
├────────┼─────────┼─────────────────────┼──────────┼────────────────────────────────────────┤
│        │ work    │ work@example.com    │ yes      │ ~/.config/neon/credentials.work.json   │
└────────┴─────────┴─────────────────────┴──────────┴────────────────────────────────────────┘
```

Selection is per invocation — `--profile`, else `NEON_PROFILE`, else `DEFAULT` — the AWS model. There is deliberately no `profile use`.

### On disk

```
~/.config/neon/
├── credentials.json          # this IS the DEFAULT profile, not a copy of it
├── credentials.work.json     # created by `neon auth --profile work`
└── profiles.json             # created only once a second profile exists
```

Because `DEFAULT` *is* `credentials.json`, an install with one account needs no `profiles.json`, gets none, and behaves exactly as it does today. Nothing to migrate, no upgrade step, no re-login.

Entries are paths, and **a path may point anywhere** — which is how you adopt a directory you already have, with no file moves and no re-authentication:

```json
{
  "version": 1,
  "profiles": {
    "DEFAULT": { "credentials": "credentials.json" },
    "work": { "credentials": "../neonctl-work/credentials.json", "label": "work@example.com" }
  }
}
```

`label` is captured from `/users/me` at login. It exists because a credentials file records only `user_id` — a UUID, no email — so a stored profile is otherwise unidentifiable offline.

### `neon profile remove` does three things a text editor can't

Deleting the entry by hand leaves `credentials.work.json` on disk holding a live refresh token: pointer gone, secret kept.

1. **Revokes** the refresh token at the authorization server (RFC 7009). Best-effort and never fatal — the usual reason to remove a profile is that its access already lapsed.
2. **Deletes the credentials file only if the CLI created it.** An adopted path outside the config directory is unlinked and *left alone*, and the command says so, because the secret is still there.
3. **Drops the entry**, and deletes `profiles.json` once only `DEFAULT` remains — the mirror image of creating it lazily.

`neon profile remove DEFAULT` is the log-out the CLI never had. `deleteCredentials` existed but was only wired to the 401 auto-clear path.

`neon profile …` skips the auth middleware entirely. Without that, listing profiles would launch a browser login, and a lapsed profile would be unremovable without first signing into it.

---

## Config directory

New location is `$XDG_CONFIG_HOME/neon`, else `~/.config/neon`. The binary and the package are both `neon`; the directory was the last piece of legacy drift.

| | Behaviour |
|---|---|
| Read | `neon/<file>` if present, else `neonctl/<file>` |
| Write | **Wherever the file already is.** Only genuinely new files are created under `neon/` |
| Migrate | Never. Nothing is moved, copied, or deleted |
| Explicit `--config-dir` / `NEON_CONFIG_DIR` / `NEONCTL_CONFIG_DIR` | Exact — never falls back |
| Env | `NEON_CONFIG_DIR` wins; `NEONCTL_CONFIG_DIR` still honoured |

Two decisions worth reviewing:

**Fallback is per file, not per directory.** A directory-level check breaks the moment anything creates `~/.config/neon` for an unrelated reason and then resolves to an empty directory while the credentials sit next door.

**An existing file is used in place rather than copied forward.** Copying would leave a second credentials file behind that nothing updates — and a stale credential that another tool still reads is exactly the failure mode this is meant to prevent.

`@neon/config/paths` is the single implementation, exposed as an implementor-only subpath so the pure root export stays pure — the same split as `@neon/env` vs `@neon/env/runtime`, and now documented in `AGENTS.md`. `packages/init` keeps an inline copy on purpose: it has no workspace dependencies, and taking one on `@neon/config` would pull `@neon/sdk`, `zod` and `jiti` into its install footprint for a file path. That copy disappears when the package folds into `packages/cli`.

Also: credentials files are now written `0600` instead of `0700`. A credential needs read and write, never execute.

---

## Verification

**Nine scenarios against the binary built from this branch**, with `XDG_CONFIG_HOME` pointed at a temp directory so real credentials were never touched:

| Scenario | Result |
|---|---|
| Credentials only in legacy `neonctl/` | found, and reported at that path |
| Present in both | `neon/` wins |
| Several profiles | listed with account, path, and which is active |
| `--profile work` | selects it |
| `NEON_PROFILE=adopted` | selects it |
| `--profile ghost` | `Unknown profile "ghost". Known profiles: DEFAULT, work, adopted. Create it with ...` |
| `remove` an adopted profile | unlinked, file **left on disk**, said so |
| `remove` an owned profile | file deleted, and `profiles.json` deleted once only DEFAULT remained |
| `--config-dir` at an empty dir, legacy populated | `SignedIn: no` — the legacy directory was not consulted |

**And the full interactive flow, against live Neon** (isolated `XDG_CONFIG_HOME`, throwaway profile, cleaned up after):

| Step | Result |
|---|---|
| `neon auth --profile e2e` | browser login completed; `credentials.e2e.json` written `0600` |
| `profiles.json` | created lazily, `DEFAULT` pinned explicitly, new entry carries `label` + `userId` from `/users/me` |
| `neon --profile e2e me` / `orgs list` | reached the right account against the live API |
| `neon profile remove e2e --yes` | **revoked for real** — a saved copy of the token was rejected by the API with 58 minutes of access-token life still on it, so the RFC 7009 cascade works |
| after removal | credentials file deleted, `profiles.json` deleted once only `DEFAULT` remained |

Revocation proved scoped to the single grant: the CLI re-authenticated immediately afterwards with no re-consent, and no other stored credentials were touched.

**Tests:** 4,009 pass across all 10 packages, up 36. 14 new for `@neon/config/paths`, 16 for the profiles module, 6 added to `@neon/env`'s resolver for the new location, XDG, and env-var precedence. The pre-existing `resolve-api-key` tests seed `~/.config/neonctl` and were left untouched — their continuing to pass *is* the backward-compatibility check.

`pnpm build`, `pnpm --filter neon build`, and `pnpm lint:ci` are all clean.

---

## Not in this PR

- **`projects.json`** — the store for project-scoped keys used by claimable projects. Follow-up, by design; this PR is profiles and paths only.
- **Folding `neon-init` into the CLI** — tracked separately. It would remove the last inline copy of the path resolution.
- **`neon-env` has no `--profile`.** It reads `DEFAULT`, since a profile is a CLI-invocation concept and `neon-env` has no flag to carry one. Worth deciding whether it should grow one.

## Flagging

- **The legacy fallback is permanent as written.** One `existsSync` per lookup, and it never expires. I think that's right and a deprecation deadline would buy nothing, but it should be a deliberate choice rather than something that ossifies by accident.
- **`neon profile list` makes no network call**, so `Account` shows `-` for a profile created before this change until its next `neon auth`. Keeping the command offline seemed worth more than a populated column.

