### PR TITLE
chore: release neon@2.40.0, neonctl@2.40.0

### DIFF
--- a/.changeset/config-init-services.md
+++ b/.changeset/config-init-services.md
@@ -1,7 +1,0 @@
----
-"neon": minor
----
-
-`neon config init` now asks which Neon services the scaffolded `neon.ts` should declare — Managed Better Auth, AI Gateway, Functions, Object Storage — and writes them into the policy. Selecting Functions also scaffolds the `hello.ts` handler the declared function points at.
-
-`--services auth,ai-gateway,functions,storage` picks them without a prompt, `--services none` scaffolds the bare starter policy, and a run with no TTY (CI, an agent) keeps writing exactly the file it wrote before.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neon
 
+## 2.40.0
+
+### Minor Changes
+
+- a47cf06: `neon config init` now asks which Neon services the scaffolded `neon.ts` should declare — Managed Better Auth, Functions, Object Storage, AI Gateway — and writes them into the policy. Selecting Functions also scaffolds the `hello.ts` handler the declared function points at.
+
+  `--services auth,functions,storage,ai-gateway` picks them without a prompt, `--services none` scaffolds the bare starter policy, and a run with no TTY (CI, an agent) keeps writing exactly the file it wrote before.
+
 ## 2.39.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neon",
-  "version": "2.39.1",
+  "version": "2.40.0",
   "description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
   "keywords": [
     "neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 2.40.0
+
+### Patch Changes
+
+- Updated dependencies [a47cf06]
+  - neon@2.40.0
+
 ## 2.39.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "2.39.1",
+  "version": "2.40.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
Version bump for the `config init` service picker (#370). Consumes `.changeset/config-init-services.md`.

## Bumped in this run

| Package | Old | New | Why |
|---|---|---|---|
| `neon` | 2.39.1 | 2.40.0 | Minor: the `config init` service picker and `--services` |
| `neonctl` | 2.39.1 | 2.40.0 | Fixed group with `neon`; patch-level dependency cascade |

## Publish backlog after this merges

| Package | npm | main |
|---|---|---|
| `neon` | 2.39.1 | 2.40.0 |
| `neonctl` | 2.39.1 | 2.40.0 |

Every other maintained package is level with npm. Four packages sit ahead of npm — `get-db` and `neondb` at 0.14.2 vs 0.14.0, `vite-plugin-db` and `@neondatabase/vite-plugin-postgres` at 0.8.2 vs 0.8.0 — but all four carry a DEPRECATED banner and predate this release; nothing here changes them.

## Incidental

The changelog line lists the picker's services in shipped order (Managed Better Auth, Functions, Object Storage, AI Gateway) and the matching `--services` example. The changeset text was written before the rows were reordered, so `changeset version` would otherwise have published the old order.

## Verification

`pnpm changeset version` on `a47cf06`, then `pnpm lint:ci`. Post-merge CI on `a47cf06` (the merge of #370) was green across CI, Type Check Distribution, psql conformance, and e2e (live Neon) before this branch was cut.

## Next

This lands versions on `main` only. The npm publish is a separate manual dispatch, once per package, leaf-first: `neon` then `neonctl`.