### PR TITLE
Add `neon api-keys`, including project-scoped keys

### DIFF
--- a/.changeset/cli-api-keys.md
+++ b/.changeset/cli-api-keys.md
@@ -1,0 +1,33 @@
+---
+"neon": minor
+"neonctl": minor
+---
+
+Add `neon api-keys`, including project-scoped keys
+
+The CLI exposed no API-key management at all, so the only way to mint one was the console or a hand-rolled `neon api /organizations/{id}/api_keys -X POST`. All six endpoints are now covered:
+
+```bash
+neon api-keys list                                        # your account's keys
+neon api-keys list --org-id org-…                         # an organization's, with scope shown
+
+neon api-keys create --name ci                            # account key
+neon api-keys create --name ci    --org-id org-…          # organization key
+neon api-keys create --name agent --project-id frosty-…   # can access only that project
+
+neon api-keys revoke <id> [--org-id org-…]
+```
+
+**Project-scoped keys are the reason this matters.** A key created with `--project-id` cannot create projects, cannot mint API keys, and cannot see any other project — other projects return "not found" rather than a permission error, so it isn't even an existence oracle. That makes it a credential you can hand to an agent or a CI job without handing over your account:
+
+```bash
+NEON_API_KEY=napi_… neon deploy    # applies neon.ts, and can reach nothing else
+```
+
+`--org-id` and `--project-id` are mutually exclusive: a project-scoped key is already an organization key, and its organization is looked up from the project rather than chosen separately. With neither flag you get an account key.
+
+`api-keys` is deliberately exempt from `.neon` context enrichment. Every other project command fills `--project-id` from the linked directory, which here would mean `api-keys create --name ci` silently producing a key scoped to whatever project is checked out instead of the account key requested. How far a credential reaches comes only from a flag you typed.
+
+`neon api-keys list --org-id` shows which keys are scoped and to what, reading `— all projects —` for keys that aren't narrowed, alongside `last_used_at` and `last_used_from_addr` — the fields you need to spot a key worth revoking.
+
+Also renames the `profiles` command group so the plural is primary and `profile` is the alias, matching `projects`/`project`, `branches`/`branch` and the rest. Both spellings work.

--- a/.changeset/cli-api-keys.md
+++ b/.changeset/cli-api-keys.md
@@ -18,14 +18,15 @@ neon api-keys create --name agent --project-id frosty-…   # can access only th
 neon api-keys revoke <id> [--org-id org-…]
 ```
 
-**Project-scoped keys are the reason this matters.** A key created with `--project-id` cannot create projects, cannot mint API keys, and cannot see any other project — other projects return "not found" rather than a permission error, so it isn't even an existence oracle. It is not read-only — inside that project it can do anything the API allows, including deleting it. What it bounds is reach, which is what lets you hand it to an agent or a CI job without handing over your account:
+**Project-scoped keys are the reason this matters.** A key created with `--project-id` cannot create projects, cannot mint API keys, and cannot see any other project — other projects return "not found" rather than a permission error, so it isn't even an existence oracle. It is not read-only — inside that project it can do anything the API allows, including deleting it. What it bounds is reach, which is what lets you hand it to an agent or a CI job without handing over your account (link the directory as yourself first; a scoped key cannot list projects to pick one):
 
 ```bash
-NEON_API_KEY=napi_… neon deploy    # applies neon.ts, and can reach nothing else
+neon link --project-id frosty-…       # once, as yourself
+NEON_API_KEY=napi_… neon deploy       # then the agent, reaching only that project
 ```
 
 `--org-id` and `--project-id` are mutually exclusive: a project-scoped key is already an organization key, and its organization is looked up from the project rather than chosen separately. With neither flag you get an account key.
 
 `api-keys` is deliberately exempt from `.neon` context enrichment. Every other project command fills `--project-id` from the linked directory, which here would mean `api-keys create --name ci` silently producing a key scoped to whatever project is checked out instead of the account key requested. How far a credential reaches comes only from a flag you typed.
 
-`neon api-keys list --org-id` shows which keys are scoped and to what, reading `— all projects —` for keys that aren't narrowed, alongside `last_used_at` and `last_used_from_addr` — the fields you need to spot a key worth revoking.
+`neon api-keys list --org-id` shows which keys are scoped and to what, reading `(all projects)` for keys that are not narrowed, alongside `last_used_at` and `last_used_from_addr` — the fields you need to spot a key worth revoking.

--- a/.changeset/cli-api-keys.md
+++ b/.changeset/cli-api-keys.md
@@ -18,7 +18,7 @@ neon api-keys create --name agent --project-id frosty-…   # can access only th
 neon api-keys revoke <id> [--org-id org-…]
 ```
 
-**Project-scoped keys are the reason this matters.** A key created with `--project-id` cannot create projects, cannot mint API keys, and cannot see any other project — other projects return "not found" rather than a permission error, so it isn't even an existence oracle. That makes it a credential you can hand to an agent or a CI job without handing over your account:
+**Project-scoped keys are the reason this matters.** A key created with `--project-id` cannot create projects, cannot mint API keys, and cannot see any other project — other projects return "not found" rather than a permission error, so it isn't even an existence oracle. It is not read-only — inside that project it can do anything the API allows, including deleting it. What it bounds is reach, which is what lets you hand it to an agent or a CI job without handing over your account:
 
 ```bash
 NEON_API_KEY=napi_… neon deploy    # applies neon.ts, and can reach nothing else
@@ -29,5 +29,3 @@ NEON_API_KEY=napi_… neon deploy    # applies neon.ts, and can reach nothing el
 `api-keys` is deliberately exempt from `.neon` context enrichment. Every other project command fills `--project-id` from the linked directory, which here would mean `api-keys create --name ci` silently producing a key scoped to whatever project is checked out instead of the account key requested. How far a credential reaches comes only from a flag you typed.
 
 `neon api-keys list --org-id` shows which keys are scoped and to what, reading `— all projects —` for keys that aren't narrowed, alongside `last_used_at` and `last_used_from_addr` — the fields you need to spot a key worth revoking.
-
-Also renames the `profiles` command group so the plural is primary and `profile` is the alias, matching `projects`/`project`, `branches`/`branch` and the rest. Both spellings work.

--- a/.changeset/cli-profiles-plural.md
+++ b/.changeset/cli-profiles-plural.md
@@ -1,0 +1,10 @@
+---
+"neon": patch
+"neonctl": patch
+---
+
+Make `profiles` the primary spelling of the profile command group
+
+`profile` was primary with `profiles` as the alias, which is backwards from every other group — `projects`/`project`, `branches`/`branch`, `databases`/`database`. Both spellings continue to work.
+
+The group first appears in an unreleased version, so nothing depends on the old ordering.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -695,7 +695,21 @@ neon api-keys create --name agent --project-id frosty-…   # can access only th
 neon api-keys revoke <id> [--org-id org-…]
 ```
 
-The key is returned once, on create, and cannot be retrieved again.
+The key is returned once, on create, and cannot be retrieved again. It prints on its own line below the table, so it can be selected in one gesture regardless of terminal width — and `… | tail -1` on stdout yields exactly the key, since both notices go to stderr.
+
+```console
+$ neon api-keys create --name agent --project-id proj-in-org
+API key
+┌─────┬───────┬─────────────┐
+│ Id  │ Name  │ Project     │
+├─────┼───────┼─────────────┤
+│ 303 │ agent │ proj-in-org │
+└─────┴───────┴─────────────┘
+
+napi_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+WARNING: Store this key now: it is not shown again.
+INFO: Limited to proj-in-org: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.
+```
 
 `--org-id` and `--project-id` are mutually exclusive. A project-scoped key *is* an organization key, and its organization is looked up from the project rather than chosen separately. With neither flag you get an account key.
 
@@ -710,6 +724,8 @@ A key created with `--project-id` bounds what it can reach to one project. Verif
 | `neon projects create` | `project-scoped keys are not allowed to create projects` |
 | `neon projects list` | refused |
 | `neon api-keys create` / `list` | refused (true of any organization key, not only scoped ones) |
+| `neon orgs list` | **works** — it can see the id, name and handle of the organization it belongs to |
+| Anything else about that organization (`GET /organizations/{id}`, members) | refused |
 
 It is **not** read-only. Inside its one project it can do everything the API allows, including deleting branches and the project itself — `neon deploy` working at all is proof of that. What it bounds is *reach*, which is what lets you hand it to an agent or a CI job without handing over your account:
 
@@ -725,13 +741,15 @@ NEON_API_KEY=napi_… neon deploy       # then the agent, reaching only that pro
 ### Seeing what is scoped
 
 ```console
-$ neon api-keys list --org-id org-old-flower-82714815
-┌─────────┬───────────────┬────────────────────────┬──────────────────────┬──────────────┐
-│ Id      │ Name          │ Project                │ Created At           │ Last Used At │
-├─────────┼───────────────┼────────────────────────┼──────────────────────┼──────────────┤
-│ 3238954 │ agent         │ divine-credit-28872766 │ 2026-08-03T07:16:04Z │              │
-│ 3196722 │ ci            │ (all projects)         │ 2026-07-16T15:59:25Z │ 2026-07-23…  │
-└─────────┴───────────────┴────────────────────────┴──────────────────────┴──────────────┘
+$ neon api-keys list --org-id org-7
+API keys in org-7
+┌─────┬──────────┬────────────────┬──────────────────────┬──────────────────────┬─────────────────────┐
+│ Id  │ Name     │ Project        │ Created At           │ Last Used At         │ Last Used From Addr │
+├─────┼──────────┼────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
+│ 301 │ scoped   │ proj-in-org    │ 2026-01-02T00:00:00Z │                      │                     │
+├─────┼──────────┼────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
+│ 302 │ org-wide │ (all projects) │ 2026-01-03T00:00:00Z │ 2026-02-03T00:00:00Z │ 203.0.113.9         │
+└─────┴──────────┴────────────────┴──────────────────────┴──────────────────────┴─────────────────────┘
 ```
 
 `last_used_at` and `last_used_from_addr` are how you spot a key worth revoking.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -650,12 +650,12 @@ The CLI holds one Neon account by default. A profile adds another, and is nothin
 
 ```bash
 neon auth --profile work     # create it, or sign in again
-neon profile list
-neon profile remove work
+neon profiles list
+neon profiles remove work
 ```
 
 ```console
-$ neon profile list
+$ neon profiles list
 Profiles
 ┌────────┬─────────┬──────────────────────┬──────────┬──────────────────────────────────────┐
 │ Active │ Name    │ Account              │ SignedIn │ Credentials                          │
@@ -680,14 +680,56 @@ Entries in `profiles.json` are paths, and a path may point anywhere — which is
 }
 ```
 
-`neon profile remove` revokes the refresh token at the authorization server, not just locally. It deletes the credentials file only when the CLI created it: an adopted path like the one above is unlinked and left on disk, and the command says so. Removing the last named profile deletes `profiles.json`, returning you to the single-account layout. `neon profile remove DEFAULT` signs you out.
+`neon profiles remove` revokes the refresh token at the authorization server, not just locally. It deletes the credentials file only when the CLI created it: an adopted path like the one above is unlinked and left on disk, and the command says so. Removing the last named profile deletes `profiles.json`, returning you to the single-account layout. `neon profiles remove DEFAULT` signs you out.
+
+## API keys (`api-keys`)
+
+```bash
+neon api-keys list                                        # your account's keys
+neon api-keys list --org-id org-…                         # an organization's, with scope shown
+
+neon api-keys create --name ci                            # account key
+neon api-keys create --name ci    --org-id org-…          # organization key
+neon api-keys create --name agent --project-id frosty-…   # can access only that project
+
+neon api-keys revoke <id> [--org-id org-…]
+```
+
+The key is returned once, on create, and cannot be retrieved again.
+
+`--org-id` and `--project-id` are mutually exclusive. A project-scoped key *is* an organization key, and its organization is looked up from the project rather than chosen separately. With neither flag you get an account key.
+
+### Project-scoped keys
+
+A key created with `--project-id` is a least-privilege credential: it cannot create projects, cannot mint API keys, and cannot see any other project — others report "not found" rather than a permission error. That makes it safe to hand to an agent or a CI job:
+
+```bash
+NEON_API_KEY=napi_… neon deploy    # applies neon.ts, and can reach nothing else
+```
+
+`api-keys` deliberately ignores the `.neon` context file, unlike every other project command. Otherwise `neon api-keys create --name ci` inside a linked directory would silently mint a key scoped to that project instead of the account key you asked for. How far a credential reaches comes only from a flag you typed.
+
+### Seeing what is scoped
+
+```console
+$ neon api-keys list --org-id org-old-flower-82714815
+┌─────────┬───────────────┬────────────────────────┬──────────────────────┬──────────────┐
+│ Id      │ Name          │ Project                │ Created At           │ Last Used At │
+├─────────┼───────────────┼────────────────────────┼──────────────────────┼──────────────┤
+│ 3238954 │ agent         │ divine-credit-28872766 │ 2026-08-03T07:16:04Z │              │
+│ 3196722 │ ci            │ — all projects —       │ 2026-07-16T15:59:25Z │ 2026-07-23…  │
+└─────────┴───────────────┴────────────────────────┴──────────────────────┴──────────────┘
+```
+
+`last_used_at` and `last_used_from_addr` are how you spot a key worth revoking.
 
 ## Commands
 
 | Command                                                                    | Subcommands                                                                                                  | Description                        |
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
 | [auth](https://neon.com/docs/reference/cli-auth)                           |                                                                                                              | Authenticate                       |
-| profile                                                                    | `list`, `remove`                                                                                             | Manage named sets of credentials   |
+| profiles                                                                   | `list`, `remove`                                                                                             | Manage named sets of credentials   |
+| api-keys                                                                   | `list`, `create`, `revoke`                                                                                   | Manage API keys                    |
 | [projects](https://neon.com/docs/reference/cli-projects)                   | `list`, `create`, `update`, `delete`, `get`                                                                  | Manage projects                    |
 | [ip-allow](https://neon.com/docs/reference/cli-ip-allow)                   | `list`, `add`, `remove`, `reset`                                                                             | Manage IP Allow                    |
 | [me](https://neon.com/docs/reference/cli-me)                               |                                                                                                              | Show current user                  |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -701,13 +701,24 @@ The key is returned once, on create, and cannot be retrieved again.
 
 ### Project-scoped keys
 
-A key created with `--project-id` bounds the blast radius to one project: it cannot create projects, cannot mint API keys, and cannot see any other project — others report "not found" rather than a permission error, so it is not even an existence oracle.
+A key created with `--project-id` bounds what it can reach to one project. Verified against a real scoped key:
 
-It is **not** read-only. Inside that one project it can do everything the API allows, including deleting branches and the project itself — `neon deploy` working at all is proof of that. What it buys is a bound on *reach*, which is what lets you hand it to an agent or a CI job without handing over your account:
+| Attempt | Result |
+| --- | --- |
+| Read and write its own project | works |
+| Read any other project | `project not found` — not even an existence oracle |
+| `neon projects create` | `project-scoped keys are not allowed to create projects` |
+| `neon projects list` | refused |
+| `neon api-keys create` / `list` | refused (true of any organization key, not only scoped ones) |
+
+It is **not** read-only. Inside its one project it can do everything the API allows, including deleting branches and the project itself — `neon deploy` working at all is proof of that. What it bounds is *reach*, which is what lets you hand it to an agent or a CI job without handing over your account:
 
 ```bash
-NEON_API_KEY=napi_… neon deploy    # applies neon.ts, and can reach nothing else
+neon link --project-id frosty-…       # once, as yourself — writes .neon
+NEON_API_KEY=napi_… neon deploy       # then the agent, reaching only that project
 ```
+
+`neon link` needs `--project-id` explicitly when using a scoped key: the interactive picker lists your projects, which a scoped key cannot do.
 
 `api-keys` deliberately ignores the `.neon` context file, unlike every other project command. Otherwise `neon api-keys create --name ci` inside a linked directory would silently mint a key scoped to that project instead of the account key you asked for. How far a credential reaches comes only from a flag you typed.
 
@@ -719,7 +730,7 @@ $ neon api-keys list --org-id org-old-flower-82714815
 │ Id      │ Name          │ Project                │ Created At           │ Last Used At │
 ├─────────┼───────────────┼────────────────────────┼──────────────────────┼──────────────┤
 │ 3238954 │ agent         │ divine-credit-28872766 │ 2026-08-03T07:16:04Z │              │
-│ 3196722 │ ci            │ — all projects —       │ 2026-07-16T15:59:25Z │ 2026-07-23…  │
+│ 3196722 │ ci            │ (all projects)         │ 2026-07-16T15:59:25Z │ 2026-07-23…  │
 └─────────┴───────────────┴────────────────────────┴──────────────────────┴──────────────┘
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -701,7 +701,9 @@ The key is returned once, on create, and cannot be retrieved again.
 
 ### Project-scoped keys
 
-A key created with `--project-id` is a least-privilege credential: it cannot create projects, cannot mint API keys, and cannot see any other project — others report "not found" rather than a permission error. That makes it safe to hand to an agent or a CI job:
+A key created with `--project-id` bounds the blast radius to one project: it cannot create projects, cannot mint API keys, and cannot see any other project — others report "not found" rather than a permission error, so it is not even an existence oracle.
+
+It is **not** read-only. Inside that one project it can do everything the API allows, including deleting branches and the project itself — `neon deploy` working at all is proof of that. What it buys is a bound on *reach*, which is what lets you hand it to an agent or a CI job without handing over your account:
 
 ```bash
 NEON_API_KEY=napi_… neon deploy    # applies neon.ts, and can reach nothing else

--- a/packages/cli/mocks/main/api_keys/999/DELETE.json
+++ b/packages/cli/mocks/main/api_keys/999/DELETE.json
@@ -1,0 +1,1 @@
+{ "id": 999, "name": "laptop", "revoked": true, "last_used_at": "2026-02-01T00:00:00Z", "last_used_from_addr": "203.0.113.1" }

--- a/packages/cli/mocks/main/api_keys/GET.json
+++ b/packages/cli/mocks/main/api_keys/GET.json
@@ -1,0 +1,10 @@
+[
+  {
+    "id": 101,
+    "name": "laptop",
+    "created_at": "2026-01-01T00:00:00Z",
+    "created_by": { "id": "u-1", "name": "Test", "image": "" },
+    "last_used_at": "2026-02-01T00:00:00Z",
+    "last_used_from_addr": "203.0.113.1"
+  }
+]

--- a/packages/cli/mocks/main/api_keys/POST.js
+++ b/packages/cli/mocks/main/api_keys/POST.js
@@ -1,0 +1,10 @@
+// Echoes the requested name so a test can assert the request body reached the API.
+export default function (req, res) {
+	res.json({
+		id: 201,
+		key: "napi_account_secret",
+		name: req.body.key_name,
+		created_at: "2026-03-01T00:00:00Z",
+		created_by: "u-1",
+	});
+}

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/401/DELETE.json
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/401/DELETE.json
@@ -1,0 +1,1 @@
+{ "id": 401, "name": "withdrawn", "revoked": true }

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/500/DELETE.js
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/500/DELETE.js
@@ -1,0 +1,4 @@
+// Withdrawal itself fails, so the CLI must not claim the key was revoked.
+export default function (_req, res) {
+	res.status(500).json({ message: "Internal error" });
+}

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/888/DELETE.json
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/888/DELETE.json
@@ -1,0 +1,1 @@
+{ "id": 888, "name": "org-wide", "revoked": true, "last_used_at": "2026-02-03T00:00:00Z", "last_used_from_addr": "203.0.113.9" }

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/GET.json
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/GET.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": 301,
+    "name": "scoped",
+    "project_id": "proj-in-org",
+    "created_at": "2026-01-02T00:00:00Z",
+    "created_by": { "id": "u-1", "name": "Test", "image": "" }
+  },
+  {
+    "id": 302,
+    "name": "org-wide",
+    "created_at": "2026-01-03T00:00:00Z",
+    "created_by": { "id": "u-1", "name": "Test", "image": "" },
+    "last_used_at": "2026-02-03T00:00:00Z",
+    "last_used_from_addr": "203.0.113.9"
+  }
+]

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
@@ -1,11 +1,34 @@
 // Echoes project_id so the scope check in `api-keys create` sees what it asked for.
+// The names below drive the failure branches: a 2xx can still be unusable.
 export default function (req, res) {
-	res.json({
-		id: 303,
-		key: "napi_org_secret",
+	const base = {
 		name: req.body.key_name,
 		created_at: "2026-03-02T00:00:00Z",
 		created_by: "u-1",
-		...(req.body.project_id ? { project_id: req.body.project_id } : {}),
-	});
+	};
+	switch (req.body.key_name) {
+		// Scoped to a different project than requested; withdrawal succeeds.
+		case "mismatch":
+			return res.json({
+				...base,
+				id: 401,
+				key: "napi_wrong_scope",
+				project_id: "some-other-project",
+			});
+		// Scoped to nothing, though a project was requested; withdrawal fails (500 below).
+		case "noscope":
+			return res.json({ ...base, id: 500, key: "napi_no_scope" });
+		// 2xx with no key at all — a live credential the user could never see.
+		case "nokey":
+			return res.json({ ...base, id: 401 });
+		default:
+			return res.json({
+				...base,
+				id: 303,
+				key: "napi_org_secret",
+				...(req.body.project_id
+					? { project_id: req.body.project_id }
+					: {}),
+			});
+	}
 }

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
@@ -19,6 +19,14 @@ export default function (req, res) {
 		case "noscope":
 			return res.json({ ...base, id: 500, key: "napi_no_scope" });
 		// 2xx with no key at all — a live credential the user could never see.
+		// An org-wide request that comes back narrowed — the inverse mistake.
+		case "sneaky":
+			return res.json({
+				...base,
+				id: 401,
+				key: "napi_unexpected_scope",
+				project_id: "some-other-project",
+			});
 		case "nokey":
 			return res.json({ ...base, id: 401 });
 		default:

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
@@ -1,0 +1,11 @@
+// Echoes project_id so the scope check in `api-keys create` sees what it asked for.
+export default function (req, res) {
+	res.json({
+		id: 303,
+		key: "napi_org_secret",
+		name: req.body.key_name,
+		created_at: "2026-03-02T00:00:00Z",
+		created_by: "u-1",
+		...(req.body.project_id ? { project_id: req.body.project_id } : {}),
+	});
+}

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -463,6 +463,33 @@ export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) => {
 		getAuthDetails: () => call(() => raw.getAuthDetails({ client })),
 		getActiveRegions: () => call(() => raw.getActiveRegions({ client })),
 
+		// ─── API keys ────────────────────────────────────────────────────────
+		// Account keys reach everything the account can. Org keys can additionally be
+		// narrowed to a single project via `project_id`, which is the only way to mint a
+		// least-privilege credential — so the org endpoints are not merely the org
+		// equivalent of the account ones.
+		listApiKeys: () => call(() => raw.listApiKeys({ client })),
+		createApiKey: (body: raw.CreateApiKeyData["body"]) =>
+			call(() => raw.createApiKey({ client, body })),
+		revokeApiKey: (keyId: number) =>
+			call(() => raw.revokeApiKey({ client, path: { key_id: keyId } })),
+		listOrgApiKeys: (orgId: string) =>
+			call(() => raw.listOrgApiKeys({ client, path: { org_id: orgId } })),
+		createOrgApiKey: (
+			orgId: string,
+			body: raw.CreateOrgApiKeyData["body"],
+		) =>
+			call(() =>
+				raw.createOrgApiKey({ client, path: { org_id: orgId }, body }),
+			),
+		revokeOrgApiKey: (orgId: string, keyId: number) =>
+			call(() =>
+				raw.revokeOrgApiKey({
+					client,
+					path: { org_id: orgId, key_id: keyId },
+				}),
+			),
+
 		// ─── Projects ────────────────────────────────────────────────────────
 		listProjects: (
 			query: NonNullable<raw.ListProjectsData["query"]> = {},

--- a/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
@@ -44,6 +44,17 @@ exports[`api-keys create > refuses both scope flags together 1`] = `""`;
 
 exports[`api-keys create > refuses scope flags after a -- terminator 1`] = `""`;
 
+exports[`api-keys create > table output puts the secret on its own line 1`] = `
+"API key
+┌─────┬───────┬─────────────┐
+│ Id  │ Name  │ Project     │
+├─────┼───────┼─────────────┤
+│ 303 │ agent │ proj-in-org │
+└─────┴───────┴─────────────┘
+napi_org_secret
+"
+`;
+
 exports[`api-keys create refuses an unusable response > an org-wide create that comes back scoped is refused 1`] = `""`;
 
 exports[`api-keys create refuses an unusable response > explains a project that belongs to no organization 1`] = `""`;
@@ -119,14 +130,14 @@ exports[`api-keys list > org keys carry the project each is scoped to 1`] = `
 `;
 
 exports[`api-keys list > table output names the unscoped rows 1`] = `
-"API keys
-┌─────┬──────────┬──────────────────┬──────────────────────┬──────────────────────┬─────────────────────┐
-│ Id  │ Name     │ Project          │ Created At           │ Last Used At         │ Last Used From Addr │
-├─────┼──────────┼──────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
-│ 301 │ scoped   │ proj-in-org      │ 2026-01-02T00:00:00Z │                      │                     │
-├─────┼──────────┼──────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
-│ 302 │ org-wide │ — all projects — │ 2026-01-03T00:00:00Z │ 2026-02-03T00:00:00Z │ 203.0.113.9         │
-└─────┴──────────┴──────────────────┴──────────────────────┴──────────────────────┴─────────────────────┘
+"API keys in org-7
+┌─────┬──────────┬────────────────┬──────────────────────┬──────────────────────┬─────────────────────┐
+│ Id  │ Name     │ Project        │ Created At           │ Last Used At         │ Last Used From Addr │
+├─────┼──────────┼────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
+│ 301 │ scoped   │ proj-in-org    │ 2026-01-02T00:00:00Z │                      │                     │
+├─────┼──────────┼────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
+│ 302 │ org-wide │ (all projects) │ 2026-01-03T00:00:00Z │ 2026-02-03T00:00:00Z │ 203.0.113.9         │
+└─────┴──────────┴────────────────┴──────────────────────┴──────────────────────┴─────────────────────┘
 "
 `;
 
@@ -147,5 +158,7 @@ last_used_at: 2026-02-03T00:00:00Z
 last_used_from_addr: 203.0.113.9
 "
 `;
+
+exports[`api-keys revoke > refuses a non-numeric id instead of sending NaN 1`] = `""`;
 
 exports[`api-keys revoke > refuses an empty --org-id rather than hitting the account endpoint 1`] = `""`;

--- a/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
@@ -51,6 +51,7 @@ exports[`api-keys create > table output puts the secret on its own line 1`] = `
 ├─────┼───────┼─────────────┤
 │ 303 │ agent │ proj-in-org │
 └─────┴───────┴─────────────┘
+
 napi_org_secret
 "
 `;
@@ -141,6 +142,8 @@ exports[`api-keys list > table output names the unscoped rows 1`] = `
 "
 `;
 
+exports[`api-keys revoke > a 404 on the account path suggests --org-id 1`] = `""`;
+
 exports[`api-keys revoke > account key 1`] = `
 "id: 999
 name: laptop
@@ -149,6 +152,10 @@ last_used_at: 2026-02-01T00:00:00Z
 last_used_from_addr: 203.0.113.1
 "
 `;
+
+exports[`api-keys revoke > and a 404 on the org path suggests dropping it 1`] = `""`;
+
+exports[`api-keys revoke > names the id the user typed, not NaN 1`] = `""`;
 
 exports[`api-keys revoke > org key 1`] = `
 "id: 888

--- a/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
@@ -166,6 +166,10 @@ last_used_from_addr: 203.0.113.9
 "
 `;
 
+exports[`api-keys revoke > refuses a hex or exponent id 1`] = `""`;
+
 exports[`api-keys revoke > refuses a non-numeric id instead of sending NaN 1`] = `""`;
+
+exports[`api-keys revoke > refuses a non-numeric id, naming what was typed 1`] = `""`;
 
 exports[`api-keys revoke > refuses an empty --org-id rather than hitting the account endpoint 1`] = `""`;

--- a/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
@@ -28,6 +28,8 @@ project_id: proj-in-org
 "
 `;
 
+exports[`api-keys create > refuses --no-project-id rather than widening the key 1`] = `""`;
+
 exports[`api-keys create > refuses a misspelled scope flag rather than widening the key 1`] = `""`;
 
 exports[`api-keys create > refuses a repeated scope flag 1`] = `""`;
@@ -40,11 +42,17 @@ exports[`api-keys create > refuses an empty --project-id instead of widening the
 
 exports[`api-keys create > refuses both scope flags together 1`] = `""`;
 
+exports[`api-keys create > refuses scope flags after a -- terminator 1`] = `""`;
+
+exports[`api-keys create refuses an unusable response > an org-wide create that comes back scoped is refused 1`] = `""`;
+
 exports[`api-keys create refuses an unusable response > explains a project that belongs to no organization 1`] = `""`;
 
 exports[`api-keys create refuses an unusable response > no key in the body 1`] = `""`;
 
 exports[`api-keys create refuses an unusable response > not scoped at all, and the withdrawal fails 1`] = `""`;
+
+exports[`api-keys create refuses an unusable response > prints no secret when it refuses 1`] = `""`;
 
 exports[`api-keys create refuses an unusable response > scoped to the wrong project — withdrawn, and says so 1`] = `""`;
 

--- a/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
@@ -1,0 +1,131 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`api-keys create > account key when no scope is given 1`] = `
+"id: 201
+key: napi_account_secret
+name: ci
+created_at: 2026-03-01T00:00:00Z
+created_by: u-1
+"
+`;
+
+exports[`api-keys create > explains a project that belongs to no organization 1`] = `""`;
+
+exports[`api-keys create > org key with --org-id 1`] = `
+"id: 303
+key: napi_org_secret
+name: ci
+created_at: 2026-03-02T00:00:00Z
+created_by: u-1
+"
+`;
+
+exports[`api-keys create > project-scoped key infers the org from the project 1`] = `
+"id: 303
+key: napi_org_secret
+name: agent
+created_at: 2026-03-02T00:00:00Z
+created_by: u-1
+project_id: proj-in-org
+"
+`;
+
+exports[`api-keys create > refuses an empty --org-id 1`] = `""`;
+
+exports[`api-keys create > refuses an empty --project-id instead of widening the key 1`] = `""`;
+
+exports[`api-keys create > refuses both scope flags together 1`] = `""`;
+
+exports[`api-keys list > account keys 1`] = `
+"- id: 101
+  name: laptop
+  created_at: 2026-01-01T00:00:00Z
+  created_by:
+    id: u-1
+    name: Test
+    image: ""
+  last_used_at: 2026-02-01T00:00:00Z
+  last_used_from_addr: 203.0.113.1
+"
+`;
+
+exports[`api-keys list > json output keeps the raw API shape 1`] = `
+"[
+  {
+    "id": 301,
+    "name": "scoped",
+    "project_id": "proj-in-org",
+    "created_at": "2026-01-02T00:00:00Z",
+    "created_by": {
+      "id": "u-1",
+      "name": "Test",
+      "image": ""
+    }
+  },
+  {
+    "id": 302,
+    "name": "org-wide",
+    "created_at": "2026-01-03T00:00:00Z",
+    "created_by": {
+      "id": "u-1",
+      "name": "Test",
+      "image": ""
+    },
+    "last_used_at": "2026-02-03T00:00:00Z",
+    "last_used_from_addr": "203.0.113.9"
+  }
+]"
+`;
+
+exports[`api-keys list > org keys carry the project each is scoped to 1`] = `
+"- id: 301
+  name: scoped
+  project_id: proj-in-org
+  created_at: 2026-01-02T00:00:00Z
+  created_by:
+    id: u-1
+    name: Test
+    image: ""
+- id: 302
+  name: org-wide
+  created_at: 2026-01-03T00:00:00Z
+  created_by:
+    id: u-1
+    name: Test
+    image: ""
+  last_used_at: 2026-02-03T00:00:00Z
+  last_used_from_addr: 203.0.113.9
+"
+`;
+
+exports[`api-keys list > table output names the unscoped rows 1`] = `
+"API keys
+┌─────┬──────────┬──────────────────┬──────────────────────┬──────────────────────┬─────────────────────┐
+│ Id  │ Name     │ Project          │ Created At           │ Last Used At         │ Last Used From Addr │
+├─────┼──────────┼──────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
+│ 301 │ scoped   │ proj-in-org      │ 2026-01-02T00:00:00Z │                      │                     │
+├─────┼──────────┼──────────────────┼──────────────────────┼──────────────────────┼─────────────────────┤
+│ 302 │ org-wide │ — all projects — │ 2026-01-03T00:00:00Z │ 2026-02-03T00:00:00Z │ 203.0.113.9         │
+└─────┴──────────┴──────────────────┴──────────────────────┴──────────────────────┴─────────────────────┘
+"
+`;
+
+exports[`api-keys revoke > account key 1`] = `
+"id: 999
+name: laptop
+revoked: true
+last_used_at: 2026-02-01T00:00:00Z
+last_used_from_addr: 203.0.113.1
+"
+`;
+
+exports[`api-keys revoke > org key 1`] = `
+"id: 888
+name: org-wide
+revoked: true
+last_used_at: 2026-02-03T00:00:00Z
+last_used_from_addr: 203.0.113.9
+"
+`;
+
+exports[`api-keys revoke > refuses an empty --org-id rather than hitting the account endpoint 1`] = `""`;

--- a/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api_keys.test.ts.snap
@@ -9,32 +9,44 @@ created_by: u-1
 "
 `;
 
-exports[`api-keys create > explains a project that belongs to no organization 1`] = `""`;
-
 exports[`api-keys create > org key with --org-id 1`] = `
-"id: 303
-key: napi_org_secret
-name: ci
+"name: ci
 created_at: 2026-03-02T00:00:00Z
 created_by: u-1
+id: 303
+key: napi_org_secret
 "
 `;
 
 exports[`api-keys create > project-scoped key infers the org from the project 1`] = `
-"id: 303
-key: napi_org_secret
-name: agent
+"name: agent
 created_at: 2026-03-02T00:00:00Z
 created_by: u-1
+id: 303
+key: napi_org_secret
 project_id: proj-in-org
 "
 `;
+
+exports[`api-keys create > refuses a misspelled scope flag rather than widening the key 1`] = `""`;
+
+exports[`api-keys create > refuses a repeated scope flag 1`] = `""`;
+
+exports[`api-keys create > refuses an empty --name 1`] = `""`;
 
 exports[`api-keys create > refuses an empty --org-id 1`] = `""`;
 
 exports[`api-keys create > refuses an empty --project-id instead of widening the key 1`] = `""`;
 
 exports[`api-keys create > refuses both scope flags together 1`] = `""`;
+
+exports[`api-keys create refuses an unusable response > explains a project that belongs to no organization 1`] = `""`;
+
+exports[`api-keys create refuses an unusable response > no key in the body 1`] = `""`;
+
+exports[`api-keys create refuses an unusable response > not scoped at all, and the withdrawal fails 1`] = `""`;
+
+exports[`api-keys create refuses an unusable response > scoped to the wrong project — withdrawn, and says so 1`] = `""`;
 
 exports[`api-keys list > account keys 1`] = `
 "- id: 101

--- a/packages/cli/src/commands/api_keys.test.ts
+++ b/packages/cli/src/commands/api_keys.test.ts
@@ -107,6 +107,110 @@ describe("api-keys create", () => {
 		);
 	});
 
+	test("refuses an empty --name", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "create", "--name", ""], {
+			code: 1,
+			stderr: "ERROR: --name was given an empty value. Pass a real value, or omit the flag entirely.",
+		});
+	});
+
+	// A misspelled flag never binds, so the scope check would see it as absent and mint an
+	// account key from a command line that looks like it asked for a scoped one.
+	test("refuses a misspelled scope flag rather than widening the key", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"x",
+				"--project_id",
+				"proj-in-org",
+			],
+			{ code: 1, stderr: "ERROR: Unknown argument: project_id" },
+		);
+	});
+
+	// Passed twice, yargs yields an array — not a string, so the emptiness check would skip
+	// it and the value would reach the API as `a,b`.
+	test("refuses a repeated scope flag", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"x",
+				"--project-id",
+				"proj-in-org",
+				"--project-id",
+				"test",
+			],
+			{
+				code: 1,
+				stderr: "ERROR: --project-id was given more than once. Pass it at most once.",
+			},
+		);
+	});
+});
+
+/**
+ * A 2xx is not proof the key is what was asked for. These drive the mock to return
+ * responses that are individually plausible and collectively unusable, and assert the CLI
+ * withdraws the key and prints no secret.
+ */
+describe("api-keys create refuses an unusable response", () => {
+	test("scoped to the wrong project — withdrawn, and says so", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"mismatch",
+				"--project-id",
+				"proj-in-org",
+			],
+			{
+				code: 1,
+				stderr: "ERROR: Neon returned a key scoped to some-other-project rather than proj-in-org. The key has been revoked; nothing was issued.",
+			},
+		);
+	});
+
+	// The withdrawal itself fails here, so the message must not claim the key is gone.
+	test("not scoped at all, and the withdrawal fails", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"noscope",
+				"--project-id",
+				"proj-in-org",
+			],
+			{
+				code: 1,
+				stderr: expect.stringContaining(
+					"The key could NOT be revoked and may still be live — remove it with `neon api-keys revoke 500 --org-id org-7`",
+				),
+			},
+		);
+	});
+
+	test("no key in the body", async ({ testCliCommand }) => {
+		await testCliCommand(
+			["api-keys", "create", "--name", "nokey", "--org-id", "org-7"],
+			{
+				code: 1,
+				stderr: "ERROR: Neon returned no key. The key has been revoked; nothing was issued.",
+			},
+		);
+	});
+
 	// A project outside an organization cannot have a scoped key at all: the endpoint that
 	// accepts `project_id` is org-only. Fail with that reason, not a bare 404.
 	test("explains a project that belongs to no organization", async ({

--- a/packages/cli/src/commands/api_keys.test.ts
+++ b/packages/cli/src/commands/api_keys.test.ts
@@ -371,21 +371,22 @@ describe("api-keys revoke", () => {
 		);
 	});
 
-	test("names the id the user typed, not NaN", async ({ testCliCommand }) => {
-		await testCliCommand(["api-keys", "revoke", "abc"], {
-			code: 1,
-			stderr: expect.stringContaining("Got `abc`"),
-		});
-	});
-
-	test("refuses a non-numeric id instead of sending NaN", async ({
+	// Rejected locally rather than sent as NaN, and the message names the token the user
+	// typed rather than the coercion artifact.
+	test("refuses a non-numeric id, naming what was typed", async ({
 		testCliCommand,
 	}) => {
 		await testCliCommand(["api-keys", "revoke", "abc"], {
 			code: 1,
-			stderr: expect.stringContaining(
-				"api-keys revoke needs a numeric key id",
-			),
+			stderr: "ERROR: api-keys revoke needs a numeric key id, from `neon api-keys list`. Got `abc`.",
+		});
+	});
+
+	// `Number("0x65")` is 101: accepting it would revoke a key the user never named.
+	test("refuses a hex or exponent id", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "revoke", "0x65"], {
+			code: 1,
+			stderr: expect.stringContaining("Got `0x65`"),
 		});
 	});
 

--- a/packages/cli/src/commands/api_keys.test.ts
+++ b/packages/cli/src/commands/api_keys.test.ts
@@ -1,15 +1,160 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, expect, describe as vitestDescribe } from "vitest";
 import { enrichFromContext, isApiKeysCommand } from "../context.js";
+import { test } from "../test_utils/fixtures";
+
+const describe = vitestDescribe;
+
+describe("api-keys list", () => {
+	test("account keys", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "list"]);
+	});
+
+	test("org keys carry the project each is scoped to", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["api-keys", "list", "--org-id", "org-7"]);
+	});
+
+	// `writeTable` drops columns empty in every row, so the scope column has to be filled
+	// in for the table. Structured output must NOT gain that synthetic field.
+	test("table output names the unscoped rows", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "list", "--org-id", "org-7"], {
+			outputTable: true,
+		});
+	});
+
+	test("json output keeps the raw API shape", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "list", "--org-id", "org-7"], {
+			output: "json",
+		});
+	});
+});
+
+describe("api-keys create", () => {
+	test("account key when no scope is given", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "create", "--name", "ci"]);
+	});
+
+	test("org key with --org-id", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"api-keys",
+			"create",
+			"--name",
+			"ci",
+			"--org-id",
+			"org-7",
+		]);
+	});
+
+	// The org is looked up from the project rather than supplied, so this also covers
+	// `GET /projects/proj-in-org` returning `org_id: org-7`.
+	test("project-scoped key infers the org from the project", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand([
+			"api-keys",
+			"create",
+			"--name",
+			"agent",
+			"--project-id",
+			"proj-in-org",
+		]);
+	});
+
+	test("refuses both scope flags together", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"x",
+				"--org-id",
+				"org-7",
+				"--project-id",
+				"proj-in-org",
+			],
+			{
+				code: 1,
+				stderr: "ERROR: Arguments org-id and project-id are mutually exclusive",
+			},
+		);
+	});
+
+	// `--project-id "$UNSET"` arrives as an empty string, which is falsy — without the
+	// guard this would quietly mint an ACCOUNT key instead of the scoped one asked for.
+	test("refuses an empty --project-id instead of widening the key", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["api-keys", "create", "--name", "x", "--project-id", ""],
+			{
+				code: 1,
+				stderr: "ERROR: --project-id was given an empty value. Pass a real value, or omit the flag entirely.",
+			},
+		);
+	});
+
+	test("refuses an empty --org-id", async ({ testCliCommand }) => {
+		await testCliCommand(
+			["api-keys", "create", "--name", "x", "--org-id", ""],
+			{
+				code: 1,
+				stderr: "ERROR: --org-id was given an empty value. Pass a real value, or omit the flag entirely.",
+			},
+		);
+	});
+
+	// A project outside an organization cannot have a scoped key at all: the endpoint that
+	// accepts `project_id` is org-only. Fail with that reason, not a bare 404.
+	test("explains a project that belongs to no organization", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["api-keys", "create", "--name", "x", "--project-id", "test"],
+			{
+				code: 1,
+				stderr: "ERROR: Project test does not belong to an organization, so it cannot have a project-scoped API key. Create an account key by omitting --project-id.",
+			},
+		);
+	});
+});
+
+describe("api-keys revoke", () => {
+	test("account key", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "revoke", "999"]);
+	});
+
+	test("org key", async ({ testCliCommand }) => {
+		await testCliCommand([
+			"api-keys",
+			"revoke",
+			"888",
+			"--org-id",
+			"org-7",
+		]);
+	});
+
+	test("refuses an empty --org-id rather than hitting the account endpoint", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["api-keys", "revoke", "999", "--org-id", ""], {
+			code: 1,
+			stderr: "ERROR: --org-id was given an empty value. Pass a real value, or omit the flag entirely.",
+		});
+	});
+});
+
+// ── Context isolation ────────────────────────────────────────────────────────
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
 	while (cleanups.length > 0) cleanups.shift()?.();
 });
 
-/** A `.neon` pinning both an org and a project, the state a linked directory is in. */
+/** A `.neon` pinning both an org and a project — the state a linked directory is in. */
 function contextFile(): string {
 	const dir = mkdtempSync(join(tmpdir(), "neon-apikeys-ctx-"));
 	cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
@@ -42,33 +187,29 @@ describe("isApiKeysCommand", () => {
 });
 
 /**
- * The load-bearing guarantee of this command group: how far a minted credential reaches must
- * come from a flag the user typed, never from whichever project happens to be checked out.
- * Enriched, `api-keys create --name ci` in a linked directory would arrive with `projectId`
- * already set and silently mint a project-scoped key instead of the account key asked for.
- *
- * Paired with a control, so the test fails if enrichment simply stops working everywhere.
+ * How far a minted credential reaches must come from a flag the user typed, never from
+ * whichever project happens to be checked out. Enriched, `api-keys create --name ci` in a
+ * linked directory would arrive with `projectId` already set and silently produce a scoped
+ * key. Paired with a control, so this fails if enrichment stops working everywhere rather
+ * than just here.
  */
 describe("api-keys is exempt from .neon enrichment", () => {
 	test("control: another command IS enriched from the same file", () => {
-		const file = contextFile();
-		const args = argsFor(["projects", "list"], file);
+		const args = argsFor(["projects", "list"], contextFile());
 		enrichFromContext(args);
 		expect(read(args).orgId).toBe("org-pinned-11111111");
 		expect(read(args).projectId).toBe("pinned-project-22222222");
 	});
 
 	test("api-keys sees neither orgId nor projectId", () => {
-		const file = contextFile();
-		const args = argsFor(["api-keys", "create"], file);
+		const args = argsFor(["api-keys", "create"], contextFile());
 		enrichFromContext(args);
 		expect(read(args).orgId).toBeUndefined();
 		expect(read(args).projectId).toBeUndefined();
 	});
 
 	test("the api-key alias is exempt too", () => {
-		const file = contextFile();
-		const args = argsFor(["api-key", "create"], file);
+		const args = argsFor(["api-key", "create"], contextFile());
 		enrichFromContext(args);
 		expect(read(args).orgId).toBeUndefined();
 		expect(read(args).projectId).toBeUndefined();

--- a/packages/cli/src/commands/api_keys.test.ts
+++ b/packages/cli/src/commands/api_keys.test.ts
@@ -64,6 +64,24 @@ describe("api-keys create", () => {
 		]);
 	});
 
+	// Locks the layout: metadata in the table, the secret alone on the line below, where it
+	// can be selected in one gesture no matter how narrow the terminal is.
+	test("table output puts the secret on its own line", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"agent",
+				"--project-id",
+				"proj-in-org",
+			],
+			{ outputTable: true },
+		);
+	});
+
 	test("refuses both scope flags together", async ({ testCliCommand }) => {
 		await testCliCommand(
 			[
@@ -110,7 +128,7 @@ describe("api-keys create", () => {
 	test("refuses an empty --name", async ({ testCliCommand }) => {
 		await testCliCommand(["api-keys", "create", "--name", ""], {
 			code: 1,
-			stderr: "ERROR: --name needs a value. Pass one, or omit the flag entirely.",
+			stderr: "ERROR: --name needs a value.",
 		});
 	});
 
@@ -141,7 +159,7 @@ describe("api-keys create", () => {
 			["api-keys", "create", "--name", "x", "--no-project-id"],
 			{
 				code: 1,
-				stderr: "ERROR: --project-id needs a value. Pass one, or omit the flag entirely.",
+				stderr: "ERROR: --no-project-id is not a valid way to skip --project-id. Omit the flag entirely.",
 			},
 		);
 	});
@@ -312,6 +330,17 @@ describe("api-keys revoke", () => {
 			"--org-id",
 			"org-7",
 		]);
+	});
+
+	test("refuses a non-numeric id instead of sending NaN", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["api-keys", "revoke", "abc"], {
+			code: 1,
+			stderr: expect.stringContaining(
+				"api-keys revoke needs a numeric key id",
+			),
+		});
 	});
 
 	test("refuses an empty --org-id rather than hitting the account endpoint", async ({

--- a/packages/cli/src/commands/api_keys.test.ts
+++ b/packages/cli/src/commands/api_keys.test.ts
@@ -34,19 +34,25 @@ describe("api-keys list", () => {
 });
 
 describe("api-keys create", () => {
+	// The mitigation the PR leans on: an account key is the only one that reaches
+	// everything, so deleting this warning must fail a test.
 	test("account key when no scope is given", async ({ testCliCommand }) => {
-		await testCliCommand(["api-keys", "create", "--name", "ci"]);
+		await testCliCommand(["api-keys", "create", "--name", "ci"], {
+			stderr: expect.stringContaining(
+				"This key reaches everything your account can, in every organization.",
+			),
+		});
 	});
 
 	test("org key with --org-id", async ({ testCliCommand }) => {
-		await testCliCommand([
-			"api-keys",
-			"create",
-			"--name",
-			"ci",
-			"--org-id",
-			"org-7",
-		]);
+		await testCliCommand(
+			["api-keys", "create", "--name", "ci", "--org-id", "org-7"],
+			{
+				stderr: expect.stringContaining(
+					"This key reaches every project in org-7",
+				),
+			},
+		);
 	});
 
 	// The org is looked up from the project rather than supplied, so this also covers
@@ -54,14 +60,21 @@ describe("api-keys create", () => {
 	test("project-scoped key infers the org from the project", async ({
 		testCliCommand,
 	}) => {
-		await testCliCommand([
-			"api-keys",
-			"create",
-			"--name",
-			"agent",
-			"--project-id",
-			"proj-in-org",
-		]);
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"agent",
+				"--project-id",
+				"proj-in-org",
+			],
+			{
+				stderr: expect.stringContaining(
+					"Limited to proj-in-org: it cannot create projects",
+				),
+			},
+		);
 	});
 
 	// Locks the layout: metadata in the table, the secret alone on the line below, where it
@@ -251,7 +264,7 @@ describe("api-keys create refuses an unusable response", () => {
 			{
 				code: 1,
 				stderr: expect.stringContaining(
-					"The key could NOT be revoked and may still be live — remove it with `neon api-keys revoke 500 --org-id org-7`",
+					"The key could NOT be revoked and may still be live. Remove it with `neon api-keys revoke 500 --org-id org-7`",
 				),
 			},
 		);
@@ -330,6 +343,39 @@ describe("api-keys revoke", () => {
 			"--org-id",
 			"org-7",
 		]);
+	});
+
+	// The easy mistake: `list --org-id X` prints ids the account endpoint cannot see.
+	test("a 404 on the account path suggests --org-id", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["api-keys", "revoke", "12345"], {
+			code: 1,
+			stderr: expect.stringContaining(
+				"If it belongs to an organization, pass --org-id",
+			),
+		});
+	});
+
+	test("and a 404 on the org path suggests dropping it", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["api-keys", "revoke", "12345", "--org-id", "org-7"],
+			{
+				code: 1,
+				stderr: expect.stringContaining(
+					"If it is one of your account's own keys, drop --org-id",
+				),
+			},
+		);
+	});
+
+	test("names the id the user typed, not NaN", async ({ testCliCommand }) => {
+		await testCliCommand(["api-keys", "revoke", "abc"], {
+			code: 1,
+			stderr: expect.stringContaining("Got `abc`"),
+		});
 	});
 
 	test("refuses a non-numeric id instead of sending NaN", async ({

--- a/packages/cli/src/commands/api_keys.test.ts
+++ b/packages/cli/src/commands/api_keys.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { enrichFromContext, isApiKeysCommand } from "../context.js";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.shift()?.();
+});
+
+/** A `.neon` pinning both an org and a project, the state a linked directory is in. */
+function contextFile(): string {
+	const dir = mkdtempSync(join(tmpdir(), "neon-apikeys-ctx-"));
+	cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+	const file = resolve(dir, ".neon");
+	writeFileSync(
+		file,
+		JSON.stringify({
+			orgId: "org-pinned-11111111",
+			projectId: "pinned-project-22222222",
+			branch: "main",
+		}),
+	);
+	return file;
+}
+
+const argsFor = (command: string[], file: string) =>
+	({ _: command, contextFile: file }) as never as Parameters<
+		typeof enrichFromContext
+	>[0];
+
+const read = (args: unknown) => args as Record<string, unknown>;
+
+describe("isApiKeysCommand", () => {
+	test("matches both spellings and nothing else", () => {
+		expect(isApiKeysCommand({ _: ["api-keys", "create"] })).toBe(true);
+		expect(isApiKeysCommand({ _: ["api-key", "list"] })).toBe(true);
+		expect(isApiKeysCommand({ _: ["api", "/projects"] })).toBe(false);
+		expect(isApiKeysCommand({ _: ["projects", "list"] })).toBe(false);
+	});
+});
+
+/**
+ * The load-bearing guarantee of this command group: how far a minted credential reaches must
+ * come from a flag the user typed, never from whichever project happens to be checked out.
+ * Enriched, `api-keys create --name ci` in a linked directory would arrive with `projectId`
+ * already set and silently mint a project-scoped key instead of the account key asked for.
+ *
+ * Paired with a control, so the test fails if enrichment simply stops working everywhere.
+ */
+describe("api-keys is exempt from .neon enrichment", () => {
+	test("control: another command IS enriched from the same file", () => {
+		const file = contextFile();
+		const args = argsFor(["projects", "list"], file);
+		enrichFromContext(args);
+		expect(read(args).orgId).toBe("org-pinned-11111111");
+		expect(read(args).projectId).toBe("pinned-project-22222222");
+	});
+
+	test("api-keys sees neither orgId nor projectId", () => {
+		const file = contextFile();
+		const args = argsFor(["api-keys", "create"], file);
+		enrichFromContext(args);
+		expect(read(args).orgId).toBeUndefined();
+		expect(read(args).projectId).toBeUndefined();
+	});
+
+	test("the api-key alias is exempt too", () => {
+		const file = contextFile();
+		const args = argsFor(["api-key", "create"], file);
+		enrichFromContext(args);
+		expect(read(args).orgId).toBeUndefined();
+		expect(read(args).projectId).toBeUndefined();
+	});
+});

--- a/packages/cli/src/commands/api_keys.test.ts
+++ b/packages/cli/src/commands/api_keys.test.ts
@@ -92,7 +92,7 @@ describe("api-keys create", () => {
 			["api-keys", "create", "--name", "x", "--project-id", ""],
 			{
 				code: 1,
-				stderr: "ERROR: --project-id was given an empty value. Pass a real value, or omit the flag entirely.",
+				stderr: "ERROR: --project-id needs a value. Pass one, or omit the flag entirely.",
 			},
 		);
 	});
@@ -102,7 +102,7 @@ describe("api-keys create", () => {
 			["api-keys", "create", "--name", "x", "--org-id", ""],
 			{
 				code: 1,
-				stderr: "ERROR: --org-id was given an empty value. Pass a real value, or omit the flag entirely.",
+				stderr: "ERROR: --org-id needs a value. Pass one, or omit the flag entirely.",
 			},
 		);
 	});
@@ -110,7 +110,7 @@ describe("api-keys create", () => {
 	test("refuses an empty --name", async ({ testCliCommand }) => {
 		await testCliCommand(["api-keys", "create", "--name", ""], {
 			code: 1,
-			stderr: "ERROR: --name was given an empty value. Pass a real value, or omit the flag entirely.",
+			stderr: "ERROR: --name needs a value. Pass one, or omit the flag entirely.",
 		});
 	});
 
@@ -129,6 +129,44 @@ describe("api-keys create", () => {
 				"proj-in-org",
 			],
 			{ code: 1, stderr: "ERROR: Unknown argument: project_id" },
+		);
+	});
+
+	// yargs turns `--no-x` into `false`, which is falsy — so without the guard this reads as
+	// "no project given" and mints an account key from a command line that names the flag.
+	test("refuses --no-project-id rather than widening the key", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["api-keys", "create", "--name", "x", "--no-project-id"],
+			{
+				code: 1,
+				stderr: "ERROR: --project-id needs a value. Pass one, or omit the flag entirely.",
+			},
+		);
+	});
+
+	// After `--` the rest is positional, not options — so the scope flag would be ignored.
+	// These subcommands take no passthrough, so the extra arguments are an error.
+	test("refuses scope flags after a -- terminator", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"x",
+				"--",
+				"--project-id",
+				"proj-in-org",
+			],
+			{
+				code: 1,
+				stderr: expect.stringContaining(
+					"api-keys takes no arguments after `--`",
+				),
+			},
 		);
 	});
 
@@ -201,6 +239,41 @@ describe("api-keys create refuses an unusable response", () => {
 		);
 	});
 
+	// The whole point of refusing is that the secret never reaches the user, so assert its
+	// absence directly rather than inferring it from the error text.
+	test("prints no secret when it refuses", async ({ testCliCommand }) => {
+		await testCliCommand(
+			[
+				"api-keys",
+				"create",
+				"--name",
+				"noscope",
+				"--project-id",
+				"proj-in-org",
+			],
+			{
+				code: 1,
+				stderr: expect.not.stringContaining("napi_no_scope"),
+			},
+		);
+	});
+
+	// A narrower key than asked for is still the wrong key: reporting it as reaching the
+	// whole organization would overstate what the caller can do with it.
+	test("an org-wide create that comes back scoped is refused", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			["api-keys", "create", "--name", "sneaky", "--org-id", "org-7"],
+			{
+				code: 1,
+				stderr: expect.stringContaining(
+					"Neon returned a key scoped to some-other-project rather than the whole organization",
+				),
+			},
+		);
+	});
+
 	test("no key in the body", async ({ testCliCommand }) => {
 		await testCliCommand(
 			["api-keys", "create", "--name", "nokey", "--org-id", "org-7"],
@@ -246,7 +319,7 @@ describe("api-keys revoke", () => {
 	}) => {
 		await testCliCommand(["api-keys", "revoke", "999", "--org-id", ""], {
 			code: 1,
-			stderr: "ERROR: --org-id was given an empty value. Pass a real value, or omit the flag entirely.",
+			stderr: "ERROR: --org-id needs a value. Pass one, or omit the flag entirely.",
 		});
 	});
 });

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -55,21 +55,6 @@ const NO_PROJECT = Symbol("no-project");
 type ExpectedScope = string | typeof NO_PROJECT;
 
 /**
- * Reject a scope flag that is present but unusable.
- *
- * Every failure mode here ends the same way — the flag reads as absent, the scope check
- * falls through, and an **account** key is minted instead of the narrow one asked for.
- * Widening a credential because of a shell accident is the worst thing this command could
- * do, so each case is an error rather than a fallback:
- *
- * - `--project-id "$PROJECT"` with `PROJECT` unset arrives as an empty string, which is falsy.
- * - The same flag passed twice arrives as an array, which is not a string and would reach
- *   the API as `a,b`.
- *
- * A *misspelled* flag is the third case and cannot be caught here, because yargs never binds
- * it — `.strictOptions()` on each subcommand rejects it instead.
- */
-/**
  * A flag is either absent, or exactly one non-empty string. Anything else is an error.
  *
  * Every rejected shape otherwise ends the same way: the flag reads as falsy, the scope check
@@ -96,7 +81,9 @@ const single =
 		// the user their value was empty when they never gave one.
 		if (value === false) {
 			throw new Error(
-				`--no-${name} is not a valid way to skip --${name}. Omit the flag entirely.`,
+				required
+					? `--no-${name} is not valid: --${name} is required.`
+					: `--no-${name} is not a valid way to skip --${name}. Omit the flag entirely.`,
 			);
 		}
 		if (typeof value !== "string" || value.trim() === "") {
@@ -191,21 +178,27 @@ export const builder = (argv: yargs.Argv) =>
 				yargs
 					.positional("id", {
 						describe: "The API key id, from `api-keys list`",
-						type: "number",
+						// Deliberately not `type: "number"`. That coerces before `coerce`
+						// runs, so an unparseable id arrives as NaN and the error can only
+						// echo `NaN` — a JavaScript artifact the user never typed. Taking
+						// the raw string lets the message name what they actually passed,
+						// and stops NaN reaching the API, which answers "not found" and
+						// blames the key rather than the input.
+						type: "string",
 						demandOption: true,
-						// Without this an unparseable id becomes NaN and is sent to the API,
-						// which answers "not found" — blaming the key rather than the input.
 						coerce: (value: unknown) => {
+							const id = Number(value);
 							if (
-								typeof value !== "number" ||
-								!Number.isSafeInteger(value) ||
-								value <= 0
+								typeof value !== "string" ||
+								value.trim() === "" ||
+								!Number.isSafeInteger(id) ||
+								id <= 0
 							) {
 								throw new Error(
 									`api-keys revoke needs a numeric key id, from \`neon api-keys list\`. Got \`${String(value)}\`.`,
 								);
 							}
-							return value;
+							return id;
 						},
 					})
 					.options({
@@ -277,7 +270,7 @@ const list = async (props: ListProps) => {
 	// would claim to be everything while showing only half.
 	if (props.output === "table") {
 		log.info(
-			"Organization keys are listed separately: neon api-keys list --org-id <org>",
+			"Organization keys are listed separately: neon api-keys list --org-id <org> (see `neon orgs list`).",
 		);
 	}
 };
@@ -306,8 +299,8 @@ const create = async (props: CreateProps) => {
 		});
 		await assertUsable(props, data, { orgId, expect: NO_PROJECT });
 		report(props, data, CREATE_FIELDS, CREATE_TABLE_FIELDS);
-		log.info(
-			"Reaches every project in %s. Pass --project-id instead to restrict it to one.",
+		log.warning(
+			"This key reaches every project in %s, including ones created later. Pass --project-id instead to restrict it to one.",
 			orgId,
 		);
 		return;
@@ -368,12 +361,14 @@ const report = (
 			title: "API key",
 		});
 		out.end();
-		out.text(`${data.key}\n`);
+		// Blank line so the key is visually detached from the table border, and so
+		// `| tail -1` on stdout yields exactly the key (both notices go to stderr).
+		out.text(`\n${data.key}\n`);
 	} else {
 		out.write(data as never, { fields: fields as never, title: "API key" });
 		out.end();
 	}
-	log.warning("Store this key now — it is not shown again.");
+	log.warning("Store this key now: it is not shown again.");
 };
 
 /**
@@ -413,7 +408,7 @@ const assertUsable = async (
 				: `The key could NOT be revoked and may still be live${
 						data.id === undefined
 							? ""
-							: ` — remove it with \`neon api-keys revoke ${data.id}${
+							: `. Remove it with \`neon api-keys revoke ${data.id}${
 									scope.orgId
 										? ` --org-id ${scope.orgId}`
 										: ""
@@ -437,9 +432,11 @@ const revokeOrExplain = async (props: RevokeProps) => {
 			? await props.apiClient.revokeOrgApiKey(props.orgId, props.id)
 			: await props.apiClient.revokeApiKey(props.id);
 	} catch (err) {
-		if (isNeonApiError(err) && err.status === 404 && !props.orgId) {
+		if (isNeonApiError(err) && err.status === 404) {
 			throw new Error(
-				`No account API key with id ${props.id}. If it belongs to an organization, pass --org-id — organization keys are not visible to your account.`,
+				props.orgId
+					? `No API key with id ${props.id} in ${props.orgId}. If it is one of your account's own keys, drop --org-id.`
+					: `No account API key with id ${props.id}. If it belongs to an organization, pass --org-id. Organization keys are not visible to your account.`,
 			);
 		}
 		throw err;
@@ -499,7 +496,7 @@ const orgIdForProject = async (
 		if (isNeonApiError(err) && err.status === 404) {
 			throw new Error(
 				projectId.startsWith("org-")
-					? `Project ${projectId} not found — that looks like an organization id. Pass it as --org-id instead.`
+					? `Project ${projectId} not found. That looks like an organization id: Pass it as --org-id instead.`
 					: `Project ${projectId} not found. Check the id with \`neon projects list\`.`,
 			);
 		}

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -36,10 +36,13 @@ const ORG_FIELDS = [
 ] as const;
 
 const CREATE_FIELDS = ["id", "name", "key"] as const;
+/** Metadata only: the secret is printed separately so it can be copied cleanly. */
+const CREATE_TABLE_FIELDS = ["id", "name"] as const;
+const CREATE_TABLE_FIELDS_SCOPED = ["id", "name", "project"] as const;
 const CREATE_FIELDS_SCOPED = ["id", "name", "project_id", "key"] as const;
 
 /** Rendered for an org key that was not narrowed to a project. Table output only. */
-const ALL_PROJECTS = "— all projects —";
+const ALL_PROJECTS = "(all projects)";
 
 /**
  * "This key should carry no project scope."
@@ -67,33 +70,44 @@ type ExpectedScope = string | typeof NO_PROJECT;
  * it — `.strictOptions()` on each subcommand rejects it instead.
  */
 /**
- * A scope flag is either absent, or exactly one non-empty string. Anything else is an error.
+ * A flag is either absent, or exactly one non-empty string. Anything else is an error.
  *
  * Every rejected shape otherwise ends the same way: the flag reads as falsy, the scope check
- * falls through, and an **account** key is minted instead of the narrow one asked for. That
- * is the worst thing this command can do, so none of them get a lenient reading.
+ * falls through, and an **account** key is minted instead of the narrow one asked for — the
+ * worst thing this command can do, so none of them get a lenient reading.
  *
  * - `--project-id ""` — an unset shell variable; empty string, which is falsy.
  * - `--no-project-id` — yargs boolean negation; `false`, which is falsy.
  * - `--project-id a --project-id b` — an array, which would reach the API as `a,b`.
  *
- * A misspelled flag never binds at all and cannot be seen here; `.strict()` rejects it.
- * Anything after a `--` terminator is handled by {@link noPassthrough}.
+ * A misspelled flag never binds and cannot be seen here; `.strict()` rejects it. Anything
+ * after a `--` terminator is handled by {@link noPassthrough}.
  */
-const single = (name: string) => (value: unknown) => {
-	if (value === undefined) return undefined;
-	if (Array.isArray(value)) {
-		throw new Error(
-			`--${name} was given more than once. Pass it at most once.`,
-		);
-	}
-	if (typeof value !== "string" || value.trim() === "") {
-		throw new Error(
-			`--${name} needs a value. Pass one, or omit the flag entirely.`,
-		);
-	}
-	return value;
-};
+const single =
+	(name: string, { required = false }: { required?: boolean } = {}) =>
+	(value: unknown) => {
+		if (value === undefined) return undefined;
+		if (Array.isArray(value)) {
+			throw new Error(
+				`--${name} was given more than once. Pass it at most once.`,
+			);
+		}
+		// `--no-x` is the negation form and yields `false`, so name it rather than telling
+		// the user their value was empty when they never gave one.
+		if (value === false) {
+			throw new Error(
+				`--no-${name} is not a valid way to skip --${name}. Omit the flag entirely.`,
+			);
+		}
+		if (typeof value !== "string" || value.trim() === "") {
+			throw new Error(
+				required
+					? `--${name} needs a value.`
+					: `--${name} needs a value. Pass one, or omit the flag entirely.`,
+			);
+		}
+		return value;
+	};
 
 /**
  * Refuse arguments after a `--` terminator.
@@ -147,7 +161,7 @@ export const builder = (argv: yargs.Argv) =>
 							describe: "A name to identify the key later",
 							type: "string",
 							demandOption: true,
-							coerce: single("name"),
+							coerce: single("name", { required: true }),
 						},
 						"org-id": {
 							describe:
@@ -179,6 +193,20 @@ export const builder = (argv: yargs.Argv) =>
 						describe: "The API key id, from `api-keys list`",
 						type: "number",
 						demandOption: true,
+						// Without this an unparseable id becomes NaN and is sent to the API,
+						// which answers "not found" — blaming the key rather than the input.
+						coerce: (value: unknown) => {
+							if (
+								typeof value !== "number" ||
+								!Number.isSafeInteger(value) ||
+								value <= 0
+							) {
+								throw new Error(
+									`api-keys revoke needs a numeric key id, from \`neon api-keys list\`. Got \`${String(value)}\`.`,
+								);
+							}
+							return value;
+						},
 					})
 					.options({
 						"org-id": {
@@ -223,14 +251,14 @@ const list = async (props: ListProps) => {
 				})),
 				{
 					fields: ORG_TABLE_FIELDS,
-					title: "API keys",
+					title: `API keys in ${props.orgId}`,
 					emptyMessage: "This organization has no API keys.",
 				},
 			);
 		} else {
 			out.write(data, {
 				fields: ORG_FIELDS,
-				title: "API keys",
+				title: `API keys in ${props.orgId}`,
 				emptyMessage: "This organization has no API keys.",
 			});
 		}
@@ -241,10 +269,17 @@ const list = async (props: ListProps) => {
 	const { data } = await props.apiClient.listApiKeys();
 	out.write(data, {
 		fields: ACCOUNT_FIELDS,
-		title: "API keys",
-		emptyMessage: "You have no API keys.",
+		title: "Account API keys",
+		emptyMessage: "You have no account API keys.",
 	});
 	out.end();
+	// Organization keys live on a different endpoint, so a heading of plain "API keys"
+	// would claim to be everything while showing only half.
+	if (props.output === "table") {
+		log.info(
+			"Organization keys are listed separately: neon api-keys list --org-id <org>",
+		);
+	}
 };
 
 const create = async (props: CreateProps) => {
@@ -256,7 +291,12 @@ const create = async (props: CreateProps) => {
 	if (!projectId && !orgId) {
 		const { data } = await props.apiClient.createApiKey({ key_name: name });
 		await assertUsable(props, data, { orgId: null, expect: NO_PROJECT });
-		report(props, data, CREATE_FIELDS);
+		report(props, data, CREATE_FIELDS, CREATE_TABLE_FIELDS);
+		// The only key here that reaches everything, and the only one that used to say
+		// nothing about its reach.
+		log.warning(
+			"This key reaches everything your account can, in every organization. Pass --org-id or --project-id to narrow it.",
+		);
 		return;
 	}
 
@@ -265,7 +305,7 @@ const create = async (props: CreateProps) => {
 			key_name: name,
 		});
 		await assertUsable(props, data, { orgId, expect: NO_PROJECT });
-		report(props, data, CREATE_FIELDS);
+		report(props, data, CREATE_FIELDS, CREATE_TABLE_FIELDS);
 		log.info(
 			"Reaches every project in %s. Pass --project-id instead to restrict it to one.",
 			orgId,
@@ -292,23 +332,48 @@ const create = async (props: CreateProps) => {
 		expect: scopeTo,
 	});
 
-	report(props, data, CREATE_FIELDS_SCOPED);
+	report(props, data, CREATE_FIELDS_SCOPED, CREATE_TABLE_FIELDS_SCOPED);
 	log.info(
 		"Limited to %s: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.",
 		scopeTo,
 	);
 };
 
-/** Print the issued key and the reminder that it will not be shown again. */
+/**
+ * Print the issued key.
+ *
+ * In a terminal the secret goes on its own line rather than into a table cell: `cli-table`
+ * neither wraps nor truncates, so a 50-odd character key makes the row wider than most
+ * terminals and the wrapped remainder ends up beside box-drawing characters. Since this is
+ * the only time the key is ever shown, it has to be selectable in one gesture. Structured
+ * output keeps the key in the object, where a script expects it.
+ */
 const report = (
 	props: CommonProps,
-	data: unknown,
+	data: { key?: string; [field: string]: unknown },
 	fields: readonly string[],
+	tableFields: readonly string[],
 ) => {
 	const out = writer(props);
-	out.write(data as never, { fields: fields as never, title: "API key" });
-	out.end();
-	log.info("Store this key now — it is not shown again.");
+	if (props.output === "table") {
+		// `project` mirrors the column name `list` uses. Added here rather than by the
+		// caller so structured output keeps the API's own `project_id` and gains no
+		// duplicate under a second name.
+		const row =
+			typeof data.project_id === "string"
+				? { ...data, project: data.project_id }
+				: data;
+		out.write(row as never, {
+			fields: tableFields as never,
+			title: "API key",
+		});
+		out.end();
+		out.text(`${data.key}\n`);
+	} else {
+		out.write(data as never, { fields: fields as never, title: "API key" });
+		out.end();
+	}
+	log.warning("Store this key now — it is not shown again.");
 };
 
 /**
@@ -358,6 +423,29 @@ const assertUsable = async (
 	);
 };
 
+/**
+ * Revoke, turning the most likely mistake into a usable message.
+ *
+ * Account and organization keys live on different endpoints, and `api-keys list --org-id X`
+ * shows ids that the account endpoint cannot see. Copying one and forgetting the flag is the
+ * easy error, and a bare "API key not found" sends the user looking for a deleted key rather
+ * than a missing flag.
+ */
+const revokeOrExplain = async (props: RevokeProps) => {
+	try {
+		return props.orgId
+			? await props.apiClient.revokeOrgApiKey(props.orgId, props.id)
+			: await props.apiClient.revokeApiKey(props.id);
+	} catch (err) {
+		if (isNeonApiError(err) && err.status === 404 && !props.orgId) {
+			throw new Error(
+				`No account API key with id ${props.id}. If it belongs to an organization, pass --org-id — organization keys are not visible to your account.`,
+			);
+		}
+		throw err;
+	}
+};
+
 /** Best-effort withdrawal of a key we are refusing to report. Never throws. */
 const withdraw = async (
 	props: CommonProps,
@@ -384,9 +472,7 @@ const withdraw = async (
 
 const revoke = async (props: RevokeProps) => {
 	const out = writer(props);
-	const { data } = props.orgId
-		? await props.apiClient.revokeOrgApiKey(props.orgId, props.id)
-		: await props.apiClient.revokeApiKey(props.id);
+	const { data } = await revokeOrExplain(props);
 	out.write(data, {
 		fields: ["id", "name", "revoked", "last_used_at"],
 		title: "API key",
@@ -412,7 +498,9 @@ const orgIdForProject = async (
 	} catch (err) {
 		if (isNeonApiError(err) && err.status === 404) {
 			throw new Error(
-				`Project ${projectId} not found. Check the id with \`neon projects list\`.`,
+				projectId.startsWith("org-")
+					? `Project ${projectId} not found — that looks like an organization id. Pass it as --org-id instead.`
+					: `Project ${projectId} not found. Check the id with \`neon projects list\`.`,
 			);
 		}
 		throw err;

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -42,6 +42,16 @@ const CREATE_FIELDS_SCOPED = ["id", "name", "project_id", "key"] as const;
 const ALL_PROJECTS = "— all projects —";
 
 /**
+ * "This key should carry no project scope."
+ *
+ * A symbol rather than a string, because project ids are `^[a-z0-9-]{1,60}$` — any sentinel
+ * spelled as a string is a legal project id, and a project genuinely called that would have
+ * its correctly-scoped key rejected and revoked.
+ */
+const NO_PROJECT = Symbol("no-project");
+type ExpectedScope = string | typeof NO_PROJECT;
+
+/**
  * Reject a scope flag that is present but unusable.
  *
  * Every failure mode here ends the same way — the flag reads as absent, the scope check
@@ -245,7 +255,7 @@ const create = async (props: CreateProps) => {
 	// really did ask for account scope rather than inheriting a checked-out project.
 	if (!projectId && !orgId) {
 		const { data } = await props.apiClient.createApiKey({ key_name: name });
-		await assertUsable(props, data, { orgId: null, expect: "no-project" });
+		await assertUsable(props, data, { orgId: null, expect: NO_PROJECT });
 		report(props, data, CREATE_FIELDS);
 		return;
 	}
@@ -254,7 +264,7 @@ const create = async (props: CreateProps) => {
 		const { data } = await props.apiClient.createOrgApiKey(orgId, {
 			key_name: name,
 		});
-		await assertUsable(props, data, { orgId, expect: "no-project" });
+		await assertUsable(props, data, { orgId, expect: NO_PROJECT });
 		report(props, data, CREATE_FIELDS);
 		log.info(
 			"Reaches every project in %s. Pass --project-id instead to restrict it to one.",
@@ -316,12 +326,12 @@ const report = (
 const assertUsable = async (
 	props: CommonProps,
 	data: { id?: number; key?: string; project_id?: string },
-	scope: { orgId: string | null; expect: string | "no-project" },
+	scope: { orgId: string | null; expect: ExpectedScope },
 ): Promise<void> => {
 	// `expect` is always stated, never inferred from a missing field: "no project" has to be
 	// checked as deliberately as an exact project, or a key that came back narrower than
 	// requested would be reported as reaching the whole organization.
-	const wanted = scope.expect === "no-project" ? undefined : scope.expect;
+	const wanted = scope.expect === NO_PROJECT ? undefined : scope.expect;
 	const problem =
 		typeof data.key !== "string" || data.key.trim() === ""
 			? "Neon returned no key."

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -56,21 +56,51 @@ const ALL_PROJECTS = "— all projects —";
  * A *misspelled* flag is the third case and cannot be caught here, because yargs never binds
  * it — `.strictOptions()` on each subcommand rejects it instead.
  */
+/**
+ * A scope flag is either absent, or exactly one non-empty string. Anything else is an error.
+ *
+ * Every rejected shape otherwise ends the same way: the flag reads as falsy, the scope check
+ * falls through, and an **account** key is minted instead of the narrow one asked for. That
+ * is the worst thing this command can do, so none of them get a lenient reading.
+ *
+ * - `--project-id ""` — an unset shell variable; empty string, which is falsy.
+ * - `--no-project-id` — yargs boolean negation; `false`, which is falsy.
+ * - `--project-id a --project-id b` — an array, which would reach the API as `a,b`.
+ *
+ * A misspelled flag never binds at all and cannot be seen here; `.strict()` rejects it.
+ * Anything after a `--` terminator is handled by {@link noPassthrough}.
+ */
 const single = (name: string) => (value: unknown) => {
-	// Repeated flags arrive as an array. Coerce runs during parsing, before `strictOptions`
-	// reports the array's numeric keys as unknown arguments, so this is what produces the
-	// message the user actually sees.
+	if (value === undefined) return undefined;
 	if (Array.isArray(value)) {
 		throw new Error(
 			`--${name} was given more than once. Pass it at most once.`,
 		);
 	}
-	if (typeof value === "string" && value.trim() === "") {
+	if (typeof value !== "string" || value.trim() === "") {
 		throw new Error(
-			`--${name} was given an empty value. Pass a real value, or omit the flag entirely.`,
+			`--${name} needs a value. Pass one, or omit the flag entirely.`,
 		);
 	}
 	return value;
+};
+
+/**
+ * Refuse arguments after a `--` terminator.
+ *
+ * The CLI sets `populate--`, so everything past `--` lands in `argv["--"]` where `.strict()`
+ * never looks — `create --name x -- --project-id p` would parse cleanly and mint an account
+ * key from a line that names the scope flag. No `api-keys` subcommand takes passthrough
+ * arguments, so their presence is always a mistake.
+ */
+const noPassthrough = (argv: Record<string, unknown>): true => {
+	const rest = argv["--"];
+	if (Array.isArray(rest) && rest.length > 0) {
+		throw new Error(
+			`api-keys takes no arguments after \`--\`, and options placed there are ignored rather than applied. Remove the \`--\`.`,
+		);
+	}
+	return true;
 };
 
 export const command = "api-keys";
@@ -93,7 +123,8 @@ export const builder = (argv: yargs.Argv) =>
 							coerce: single("org-id"),
 						},
 					})
-					.strictOptions(),
+					.strict()
+					.check(noPassthrough),
 			async (args) => await list(args as unknown as ListProps),
 		)
 		.command(
@@ -125,7 +156,8 @@ export const builder = (argv: yargs.Argv) =>
 					// both is contradictory rather than redundant — the org is derived from
 					// the project and cannot be chosen independently.
 					.conflicts("org-id", "project-id")
-					.strictOptions(),
+					.strict()
+					.check(noPassthrough),
 			async (args) => await create(args as unknown as CreateProps),
 		)
 		.command(
@@ -146,7 +178,8 @@ export const builder = (argv: yargs.Argv) =>
 							coerce: single("org-id"),
 						},
 					})
-					.strictOptions(),
+					.strict()
+					.check(noPassthrough),
 			async (args) => await revoke(args as unknown as RevokeProps),
 		)
 		.demandCommand(1, "Run `neon api-keys --help` to see the subcommands.");
@@ -212,7 +245,7 @@ const create = async (props: CreateProps) => {
 	// really did ask for account scope rather than inheriting a checked-out project.
 	if (!projectId && !orgId) {
 		const { data } = await props.apiClient.createApiKey({ key_name: name });
-		await assertUsable(props, data, { orgId: null });
+		await assertUsable(props, data, { orgId: null, expect: "no-project" });
 		report(props, data, CREATE_FIELDS);
 		return;
 	}
@@ -221,7 +254,7 @@ const create = async (props: CreateProps) => {
 		const { data } = await props.apiClient.createOrgApiKey(orgId, {
 			key_name: name,
 		});
-		await assertUsable(props, data, { orgId });
+		await assertUsable(props, data, { orgId, expect: "no-project" });
 		report(props, data, CREATE_FIELDS);
 		log.info(
 			"Reaches every project in %s. Pass --project-id instead to restrict it to one.",
@@ -246,7 +279,7 @@ const create = async (props: CreateProps) => {
 	// one thing this command must not get wrong.
 	await assertUsable(props, data, {
 		orgId: resolvedOrgId,
-		expectProject: scopeTo,
+		expect: scopeTo,
 	});
 
 	report(props, data, CREATE_FIELDS_SCOPED);
@@ -283,14 +316,17 @@ const report = (
 const assertUsable = async (
 	props: CommonProps,
 	data: { id?: number; key?: string; project_id?: string },
-	scope: { orgId: string | null; expectProject?: string },
+	scope: { orgId: string | null; expect: string | "no-project" },
 ): Promise<void> => {
+	// `expect` is always stated, never inferred from a missing field: "no project" has to be
+	// checked as deliberately as an exact project, or a key that came back narrower than
+	// requested would be reported as reaching the whole organization.
+	const wanted = scope.expect === "no-project" ? undefined : scope.expect;
 	const problem =
 		typeof data.key !== "string" || data.key.trim() === ""
 			? "Neon returned no key."
-			: scope.expectProject !== undefined &&
-					data.project_id !== scope.expectProject
-				? `Neon returned a key scoped to ${data.project_id ?? "nothing"} rather than ${scope.expectProject}.`
+			: data.project_id !== wanted
+				? `Neon returned a key scoped to ${data.project_id ?? "nothing"} rather than ${wanted ?? "the whole organization"}.`
 				: null;
 	if (!problem) return;
 
@@ -318,12 +354,14 @@ const withdraw = async (
 	orgId: string | null,
 	keyId: number | undefined,
 ): Promise<boolean> => {
-	if (keyId === undefined) return false;
+	if (!Number.isSafeInteger(keyId) || (keyId as number) <= 0) return false;
 	try {
 		const { data } = orgId
-			? await props.apiClient.revokeOrgApiKey(orgId, keyId)
-			: await props.apiClient.revokeApiKey(keyId);
-		return data.revoked === true;
+			? await props.apiClient.revokeOrgApiKey(orgId, keyId as number)
+			: await props.apiClient.revokeApiKey(keyId as number);
+		// Check which key the response names: a `revoked: true` for some other id is not
+		// evidence that the one we issued is gone.
+		return data.revoked === true && data.id === keyId;
 	} catch (err) {
 		log.error(
 			"Failed to revoke API key %d: %s",

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -42,27 +42,36 @@ const CREATE_FIELDS_SCOPED = ["id", "name", "project_id", "key"] as const;
 const ALL_PROJECTS = "— all projects —";
 
 /**
- * Reject a flag that was passed with an empty value.
+ * Reject a scope flag that is present but unusable.
  *
- * `--project-id "$PROJECT"` with `PROJECT` unset arrives as an empty string, which is falsy
- * — so without this, asking for a project-scoped key would quietly mint an **account** key
- * instead, and `revoke --org-id ""` would delete from the wrong key class. Silently
- * widening a credential because a shell variable was empty is the worst failure this
- * command could have, so it is an error rather than a fallback.
+ * Every failure mode here ends the same way — the flag reads as absent, the scope check
+ * falls through, and an **account** key is minted instead of the narrow one asked for.
+ * Widening a credential because of a shell accident is the worst thing this command could
+ * do, so each case is an error rather than a fallback:
+ *
+ * - `--project-id "$PROJECT"` with `PROJECT` unset arrives as an empty string, which is falsy.
+ * - The same flag passed twice arrives as an array, which is not a string and would reach
+ *   the API as `a,b`.
+ *
+ * A *misspelled* flag is the third case and cannot be caught here, because yargs never binds
+ * it — `.strictOptions()` on each subcommand rejects it instead.
  */
-const rejectEmptyValues =
-	(...names: string[]) =>
-	(argv: Record<string, unknown>): true => {
-		for (const name of names) {
-			const value = argv[name];
-			if (typeof value === "string" && value.trim() === "") {
-				throw new Error(
-					`--${name} was given an empty value. Pass a real value, or omit the flag entirely.`,
-				);
-			}
-		}
-		return true;
-	};
+const single = (name: string) => (value: unknown) => {
+	// Repeated flags arrive as an array. Coerce runs during parsing, before `strictOptions`
+	// reports the array's numeric keys as unknown arguments, so this is what produces the
+	// message the user actually sees.
+	if (Array.isArray(value)) {
+		throw new Error(
+			`--${name} was given more than once. Pass it at most once.`,
+		);
+	}
+	if (typeof value === "string" && value.trim() === "") {
+		throw new Error(
+			`--${name} was given an empty value. Pass a real value, or omit the flag entirely.`,
+		);
+	}
+	return value;
+};
 
 export const command = "api-keys";
 export const aliases = ["api-key"];
@@ -81,9 +90,10 @@ export const builder = (argv: yargs.Argv) =>
 							describe:
 								"List the organization's keys instead of your account's",
 							type: "string",
+							coerce: single("org-id"),
 						},
 					})
-					.check(rejectEmptyValues("org-id")),
+					.strictOptions(),
 			async (args) => await list(args as unknown as ListProps),
 		)
 		.command(
@@ -96,23 +106,26 @@ export const builder = (argv: yargs.Argv) =>
 							describe: "A name to identify the key later",
 							type: "string",
 							demandOption: true,
+							coerce: single("name"),
 						},
 						"org-id": {
 							describe:
 								"Create a key for this organization instead of your account",
 							type: "string",
+							coerce: single("org-id"),
 						},
 						"project-id": {
 							describe:
 								"Create a key that can access only this project. Its organization is looked up from the project",
 							type: "string",
+							coerce: single("project-id"),
 						},
 					})
 					// A key scoped to a project is already an organization key, so naming
 					// both is contradictory rather than redundant — the org is derived from
 					// the project and cannot be chosen independently.
 					.conflicts("org-id", "project-id")
-					.check(rejectEmptyValues("name", "org-id", "project-id")),
+					.strictOptions(),
 			async (args) => await create(args as unknown as CreateProps),
 		)
 		.command(
@@ -130,9 +143,10 @@ export const builder = (argv: yargs.Argv) =>
 							describe:
 								"Revoke an organization key instead of an account key",
 							type: "string",
+							coerce: single("org-id"),
 						},
 					})
-					.check(rejectEmptyValues("org-id")),
+					.strictOptions(),
 			async (args) => await revoke(args as unknown as RevokeProps),
 		)
 		.demandCommand(1, "Run `neon api-keys --help` to see the subcommands.");
@@ -192,16 +206,14 @@ const list = async (props: ListProps) => {
 
 const create = async (props: CreateProps) => {
 	const { name, projectId, orgId } = props;
-	const out = writer(props);
 
 	// Neither flag: an account key, matching `POST /api_keys`. `api-keys` is exempt from
 	// `.neon` enrichment (see `isApiKeysCommand`), so reaching this branch means the user
 	// really did ask for account scope rather than inheriting a checked-out project.
 	if (!projectId && !orgId) {
 		const { data } = await props.apiClient.createApiKey({ key_name: name });
-		out.write(data, { fields: CREATE_FIELDS, title: "API key" });
-		out.end();
-		warnStoreItNow();
+		await assertUsable(props, data, { orgId: null });
+		report(props, data, CREATE_FIELDS);
 		return;
 	}
 
@@ -209,9 +221,8 @@ const create = async (props: CreateProps) => {
 		const { data } = await props.apiClient.createOrgApiKey(orgId, {
 			key_name: name,
 		});
-		out.write(data, { fields: CREATE_FIELDS, title: "API key" });
-		out.end();
-		warnStoreItNow();
+		await assertUsable(props, data, { orgId });
+		report(props, data, CREATE_FIELDS);
 		log.info(
 			"Reaches every project in %s. Pass --project-id instead to restrict it to one.",
 			orgId,
@@ -231,22 +242,96 @@ const create = async (props: CreateProps) => {
 	});
 
 	// `project_id` is optional on the response. Printing a key and calling it scoped
-	// without checking would hand the user a credential whose reach we have not confirmed
-	// — the one thing this command must never get wrong. Revoke and fail instead.
-	if (data.project_id !== scopeTo) {
-		await revokeUnverified(props, resolvedOrgId, data.id);
-		throw new Error(
-			`Neon returned a key scoped to ${data.project_id ?? "nothing"} rather than ${scopeTo}. The key has been revoked; nothing was issued.`,
-		);
-	}
+	// without checking would hand over a credential whose reach we never confirmed — the
+	// one thing this command must not get wrong.
+	await assertUsable(props, data, {
+		orgId: resolvedOrgId,
+		expectProject: scopeTo,
+	});
 
-	out.write(data, { fields: CREATE_FIELDS_SCOPED, title: "API key" });
-	out.end();
-	warnStoreItNow();
+	report(props, data, CREATE_FIELDS_SCOPED);
 	log.info(
 		"Limited to %s: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.",
 		scopeTo,
 	);
+};
+
+/** Print the issued key and the reminder that it will not be shown again. */
+const report = (
+	props: CommonProps,
+	data: unknown,
+	fields: readonly string[],
+) => {
+	const out = writer(props);
+	out.write(data as never, { fields: fields as never, title: "API key" });
+	out.end();
+	log.info("Store this key now — it is not shown again.");
+};
+
+/**
+ * Refuse to report a key that isn't what we asked for, and take it back.
+ *
+ * Two ways a 2xx can still be wrong: no `key` in the body, which leaves a live credential
+ * the user can never see or use; and a `project_id` that doesn't match the requested
+ * project, which would mean announcing a scope the key does not have. Both withdraw the key
+ * before throwing.
+ *
+ * The thrown message states whether the withdrawal actually succeeded. Saying "the key has
+ * been revoked" when the revoke itself failed would be worse than saying nothing — it would
+ * leave an unverified credential live while telling the user it is gone.
+ */
+const assertUsable = async (
+	props: CommonProps,
+	data: { id?: number; key?: string; project_id?: string },
+	scope: { orgId: string | null; expectProject?: string },
+): Promise<void> => {
+	const problem =
+		typeof data.key !== "string" || data.key.trim() === ""
+			? "Neon returned no key."
+			: scope.expectProject !== undefined &&
+					data.project_id !== scope.expectProject
+				? `Neon returned a key scoped to ${data.project_id ?? "nothing"} rather than ${scope.expectProject}.`
+				: null;
+	if (!problem) return;
+
+	const withdrawn = await withdraw(props, scope.orgId, data.id);
+	throw new Error(
+		`${problem} ${
+			withdrawn
+				? "The key has been revoked; nothing was issued."
+				: `The key could NOT be revoked and may still be live${
+						data.id === undefined
+							? ""
+							: ` — remove it with \`neon api-keys revoke ${data.id}${
+									scope.orgId
+										? ` --org-id ${scope.orgId}`
+										: ""
+								}\``
+					}.`
+		}`,
+	);
+};
+
+/** Best-effort withdrawal of a key we are refusing to report. Never throws. */
+const withdraw = async (
+	props: CommonProps,
+	orgId: string | null,
+	keyId: number | undefined,
+): Promise<boolean> => {
+	if (keyId === undefined) return false;
+	try {
+		const { data } = orgId
+			? await props.apiClient.revokeOrgApiKey(orgId, keyId)
+			: await props.apiClient.revokeApiKey(keyId);
+		return data.revoked === true;
+	} catch (err) {
+		log.error(
+			"Failed to revoke API key %d: %s",
+			keyId,
+			err instanceof Error ? err.message : String(err),
+		);
+		return false;
+	}
 };
 
 const revoke = async (props: RevokeProps) => {
@@ -259,29 +344,6 @@ const revoke = async (props: RevokeProps) => {
 		title: "API key",
 	});
 	out.end();
-};
-
-/**
- * Withdraw a key we are about to refuse to report. Best-effort: if the revoke also fails the
- * caller still throws, but the user is told the key exists so they can remove it by hand
- * rather than being left with a live credential they never saw.
- */
-const revokeUnverified = async (
-	props: CommonProps,
-	orgId: string,
-	keyId: number,
-): Promise<void> => {
-	try {
-		await props.apiClient.revokeOrgApiKey(orgId, keyId);
-	} catch (err) {
-		log.error(
-			"Could not revoke API key %d after it failed verification. Revoke it manually with `neon api-keys revoke %d --org-id %s`. Cause: %s",
-			keyId,
-			keyId,
-			orgId,
-			err instanceof Error ? err.message : String(err),
-		);
-	}
 };
 
 /**
@@ -314,6 +376,3 @@ const orgIdForProject = async (
 	}
 	return orgId;
 };
-
-const warnStoreItNow = () =>
-	log.info("Store this key now — it is not shown again.");

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -1,0 +1,235 @@
+import type yargs from "yargs";
+
+import { isNeonApiError } from "../api.js";
+import { log } from "../log.js";
+import type { CommonProps } from "../types.js";
+import { writer } from "../writer.js";
+
+const ACCOUNT_FIELDS = [
+	"id",
+	"name",
+	"created_at",
+	"last_used_at",
+	"last_used_from_addr",
+] as const;
+
+/**
+ * `project` is the field that answers "which of my keys are least-privilege, and to what?",
+ * so it earns a column on the org listing.
+ */
+const ORG_FIELDS = [
+	"id",
+	"name",
+	"project",
+	"created_at",
+	"last_used_at",
+	"last_used_from_addr",
+] as const;
+
+const CREATE_FIELDS = ["id", "name", "key"] as const;
+const CREATE_FIELDS_SCOPED = ["id", "name", "project_id", "key"] as const;
+
+/** Shown for an org key that was not narrowed to a project. */
+const ALL_PROJECTS = "— all projects —";
+
+export const command = "api-keys";
+export const aliases = ["api-key"];
+export const describe = "Manage API keys";
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 api-keys <sub-command> [options]")
+		.command(
+			"list",
+			"List API keys for your account, or for an organization",
+			(yargs) =>
+				yargs.options({
+					"org-id": {
+						describe:
+							"List the organization's keys instead of your account's",
+						type: "string",
+					},
+				}),
+			async (args) => await list(args as unknown as ListProps),
+		)
+		.command(
+			"create",
+			"Create an API key. The key is shown once and cannot be retrieved again",
+			(yargs) =>
+				yargs
+					.options({
+						name: {
+							describe: "A name to identify the key later",
+							type: "string",
+							demandOption: true,
+						},
+						"org-id": {
+							describe:
+								"Create a key for this organization instead of your account",
+							type: "string",
+						},
+						"project-id": {
+							describe:
+								"Create a key that can access only this project. Its organization is looked up from the project",
+							type: "string",
+						},
+					})
+					// A key scoped to a project is already an organization key, so naming
+					// both is contradictory rather than redundant — the org is derived from
+					// the project and cannot be chosen independently.
+					.conflicts("org-id", "project-id"),
+			async (args) => await create(args as unknown as CreateProps),
+		)
+		.command(
+			"revoke <id>",
+			"Revoke an API key. Anything using it stops working immediately",
+			(yargs) =>
+				yargs
+					.positional("id", {
+						describe: "The API key id, from `api-keys list`",
+						type: "number",
+						demandOption: true,
+					})
+					.options({
+						"org-id": {
+							describe:
+								"Revoke an organization key instead of an account key",
+							type: "string",
+						},
+					}),
+			async (args) => await revoke(args as unknown as RevokeProps),
+		)
+		.demandCommand(1, "Run `neon api-keys --help` to see the subcommands.");
+
+export const handler = (args: yargs.Argv) => args;
+
+type ListProps = CommonProps & { orgId?: string };
+type CreateProps = CommonProps & {
+	name: string;
+	orgId?: string;
+	projectId?: string;
+};
+type RevokeProps = CommonProps & { id: number; orgId?: string };
+
+const list = async (props: ListProps) => {
+	const out = writer(props);
+
+	if (props.orgId) {
+		const { data } = await props.apiClient.listOrgApiKeys(props.orgId);
+		// `writeTable` drops any column that is empty in every row, so a `project_id`
+		// that is absent throughout would take the whole column with it — hiding the
+		// answer precisely when it is "none of them are scoped". Fill it in instead.
+		const keys = data.map((key) => ({
+			...key,
+			project: key.project_id ?? ALL_PROJECTS,
+		}));
+		out.write(keys, {
+			fields: ORG_FIELDS,
+			title: "API keys",
+			emptyMessage: "This organization has no API keys.",
+		});
+		out.end();
+		return;
+	}
+
+	const { data } = await props.apiClient.listApiKeys();
+	out.write(data, {
+		fields: ACCOUNT_FIELDS,
+		title: "API keys",
+		emptyMessage: "You have no API keys.",
+	});
+	out.end();
+};
+
+const create = async (props: CreateProps) => {
+	const { name, projectId, orgId } = props;
+	const out = writer(props);
+
+	// Neither flag: an account key, matching `POST /api_keys`. Note that `api-keys` is
+	// exempt from `.neon` enrichment (see `isApiKeysCommand`), so reaching this branch
+	// means the user really did ask for account scope rather than inheriting a project.
+	if (!projectId && !orgId) {
+		const { data } = await props.apiClient.createApiKey({ key_name: name });
+		out.write(data, { fields: CREATE_FIELDS, title: "API key" });
+		out.end();
+		warnStoreItNow();
+		return;
+	}
+
+	if (!projectId && orgId) {
+		const { data } = await props.apiClient.createOrgApiKey(orgId, {
+			key_name: name,
+		});
+		out.write(data, { fields: CREATE_FIELDS, title: "API key" });
+		out.end();
+		warnStoreItNow();
+		log.info(
+			"Reaches every project in %s. Pass --project-id instead to restrict it to one.",
+			orgId,
+		);
+		return;
+	}
+
+	// Project-scoped keys exist only on the organization endpoint, so an org is required.
+	// Resolve it from the project rather than asking for both: `--project-id` alone would
+	// otherwise fail for a reason that isn't visible from the command line.
+	const resolvedOrgId = await orgIdForProject(props, projectId as string);
+	const { data } = await props.apiClient.createOrgApiKey(resolvedOrgId, {
+		key_name: name,
+		project_id: projectId,
+	});
+
+	out.write(data, { fields: CREATE_FIELDS_SCOPED, title: "API key" });
+	out.end();
+	warnStoreItNow();
+	log.info(
+		"Scoped to %s: it cannot create projects, mint API keys, or read any other project.",
+		projectId,
+	);
+};
+
+const revoke = async (props: RevokeProps) => {
+	const out = writer(props);
+	const { data } = props.orgId
+		? await props.apiClient.revokeOrgApiKey(props.orgId, props.id)
+		: await props.apiClient.revokeApiKey(props.id);
+	out.write(data, {
+		fields: ["id", "name", "revoked", "last_used_at"],
+		title: "API key",
+	});
+	out.end();
+};
+
+/**
+ * The organization a project belongs to. A project outside any organization cannot have a
+ * scoped key — the endpoint that accepts `project_id` is org-only — so that case fails here
+ * with the reason, rather than as a 404 from a URL the user never typed.
+ */
+const orgIdForProject = async (
+	props: CommonProps,
+	projectId: string,
+): Promise<string> => {
+	let orgId: string | undefined;
+	try {
+		const {
+			data: { project },
+		} = await props.apiClient.getProject(projectId);
+		orgId = project.org_id;
+	} catch (err) {
+		if (isNeonApiError(err) && err.status === 404) {
+			throw new Error(
+				`Project ${projectId} not found. Check the id with \`neon projects list\`.`,
+			);
+		}
+		throw err;
+	}
+	if (!orgId) {
+		throw new Error(
+			`Project ${projectId} does not belong to an organization, so it cannot have a project-scoped API key. Create an account key by omitting --project-id.`,
+		);
+	}
+	return orgId;
+};
+
+const warnStoreItNow = () =>
+	log.info("Store this key now — it is not shown again.");

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -187,10 +187,13 @@ export const builder = (argv: yargs.Argv) =>
 						type: "string",
 						demandOption: true,
 						coerce: (value: unknown) => {
+							// Digits only, checked before Number(): `Number("0x65")` is 101
+							// and `Number("1e3")` is 1000, so either would revoke a key the
+							// user never named while the message promises "a numeric id".
 							const id = Number(value);
 							if (
 								typeof value !== "string" ||
-								value.trim() === "" ||
+								!/^\d+$/.test(value.trim()) ||
 								!Number.isSafeInteger(id) ||
 								id <= 0
 							) {
@@ -245,14 +248,14 @@ const list = async (props: ListProps) => {
 				{
 					fields: ORG_TABLE_FIELDS,
 					title: `API keys in ${props.orgId}`,
-					emptyMessage: "This organization has no API keys.",
+					emptyMessage: `No API keys in ${props.orgId}.`,
 				},
 			);
 		} else {
 			out.write(data, {
 				fields: ORG_FIELDS,
 				title: `API keys in ${props.orgId}`,
-				emptyMessage: "This organization has no API keys.",
+				emptyMessage: `No API keys in ${props.orgId}.`,
 			});
 		}
 		out.end();
@@ -422,9 +425,13 @@ const assertUsable = async (
  * Revoke, turning the most likely mistake into a usable message.
  *
  * Account and organization keys live on different endpoints, and `api-keys list --org-id X`
- * shows ids that the account endpoint cannot see. Copying one and forgetting the flag is the
- * easy error, and a bare "API key not found" sends the user looking for a deleted key rather
- * than a missing flag.
+ * shows ids that the account endpoint cannot see. Copying one and forgetting the flag — or
+ * leaving it on for an account key — is the easy error, and a bare "API key not found" sends
+ * the user looking for a deleted key rather than a misplaced flag.
+ *
+ * Only the key id is worth second-guessing here: an org id that is wrong or not yours does
+ * not reach this path at all, because the API answers "not an organization member" (verified
+ * against production) rather than a 404.
  */
 const revokeOrExplain = async (props: RevokeProps) => {
 	try {
@@ -496,7 +503,7 @@ const orgIdForProject = async (
 		if (isNeonApiError(err) && err.status === 404) {
 			throw new Error(
 				projectId.startsWith("org-")
-					? `Project ${projectId} not found. That looks like an organization id: Pass it as --org-id instead.`
+					? `Project ${projectId} not found. That looks like an organization id. Pass it as --org-id instead.`
 					: `Project ${projectId} not found. Check the id with \`neon projects list\`.`,
 			);
 		}

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -14,10 +14,10 @@ const ACCOUNT_FIELDS = [
 ] as const;
 
 /**
- * `project` is the field that answers "which of my keys are least-privilege, and to what?",
- * so it earns a column on the org listing.
+ * Table view of an org listing. `project` is the rendered column; the raw `project_id` is
+ * what structured output keeps. See {@link list} for why the two differ.
  */
-const ORG_FIELDS = [
+const ORG_TABLE_FIELDS = [
 	"id",
 	"name",
 	"project",
@@ -26,11 +26,43 @@ const ORG_FIELDS = [
 	"last_used_from_addr",
 ] as const;
 
+const ORG_FIELDS = [
+	"id",
+	"name",
+	"project_id",
+	"created_at",
+	"last_used_at",
+	"last_used_from_addr",
+] as const;
+
 const CREATE_FIELDS = ["id", "name", "key"] as const;
 const CREATE_FIELDS_SCOPED = ["id", "name", "project_id", "key"] as const;
 
-/** Shown for an org key that was not narrowed to a project. */
+/** Rendered for an org key that was not narrowed to a project. Table output only. */
 const ALL_PROJECTS = "— all projects —";
+
+/**
+ * Reject a flag that was passed with an empty value.
+ *
+ * `--project-id "$PROJECT"` with `PROJECT` unset arrives as an empty string, which is falsy
+ * — so without this, asking for a project-scoped key would quietly mint an **account** key
+ * instead, and `revoke --org-id ""` would delete from the wrong key class. Silently
+ * widening a credential because a shell variable was empty is the worst failure this
+ * command could have, so it is an error rather than a fallback.
+ */
+const rejectEmptyValues =
+	(...names: string[]) =>
+	(argv: Record<string, unknown>): true => {
+		for (const name of names) {
+			const value = argv[name];
+			if (typeof value === "string" && value.trim() === "") {
+				throw new Error(
+					`--${name} was given an empty value. Pass a real value, or omit the flag entirely.`,
+				);
+			}
+		}
+		return true;
+	};
 
 export const command = "api-keys";
 export const aliases = ["api-key"];
@@ -43,13 +75,15 @@ export const builder = (argv: yargs.Argv) =>
 			"list",
 			"List API keys for your account, or for an organization",
 			(yargs) =>
-				yargs.options({
-					"org-id": {
-						describe:
-							"List the organization's keys instead of your account's",
-						type: "string",
-					},
-				}),
+				yargs
+					.options({
+						"org-id": {
+							describe:
+								"List the organization's keys instead of your account's",
+							type: "string",
+						},
+					})
+					.check(rejectEmptyValues("org-id")),
 			async (args) => await list(args as unknown as ListProps),
 		)
 		.command(
@@ -77,7 +111,8 @@ export const builder = (argv: yargs.Argv) =>
 					// A key scoped to a project is already an organization key, so naming
 					// both is contradictory rather than redundant — the org is derived from
 					// the project and cannot be chosen independently.
-					.conflicts("org-id", "project-id"),
+					.conflicts("org-id", "project-id")
+					.check(rejectEmptyValues("name", "org-id", "project-id")),
 			async (args) => await create(args as unknown as CreateProps),
 		)
 		.command(
@@ -96,7 +131,8 @@ export const builder = (argv: yargs.Argv) =>
 								"Revoke an organization key instead of an account key",
 							type: "string",
 						},
-					}),
+					})
+					.check(rejectEmptyValues("org-id")),
 			async (args) => await revoke(args as unknown as RevokeProps),
 		)
 		.demandCommand(1, "Run `neon api-keys --help` to see the subcommands.");
@@ -116,18 +152,31 @@ const list = async (props: ListProps) => {
 
 	if (props.orgId) {
 		const { data } = await props.apiClient.listOrgApiKeys(props.orgId);
-		// `writeTable` drops any column that is empty in every row, so a `project_id`
-		// that is absent throughout would take the whole column with it — hiding the
-		// answer precisely when it is "none of them are scoped". Fill it in instead.
-		const keys = data.map((key) => ({
-			...key,
-			project: key.project_id ?? ALL_PROJECTS,
-		}));
-		out.write(keys, {
-			fields: ORG_FIELDS,
-			title: "API keys",
-			emptyMessage: "This organization has no API keys.",
-		});
+
+		// `writeTable` drops any column empty in every row, so an all-absent `project_id`
+		// would take the whole column with it — hiding the answer exactly when it is "none
+		// of them are scoped". Fill it in for the table, but leave structured output alone:
+		// json/yaml serialize the whole object, so a synthetic field there would change the
+		// machine-readable shape and duplicate `project_id` under a second name.
+		if (props.output === "table") {
+			out.write(
+				data.map((key) => ({
+					...key,
+					project: key.project_id ?? ALL_PROJECTS,
+				})),
+				{
+					fields: ORG_TABLE_FIELDS,
+					title: "API keys",
+					emptyMessage: "This organization has no API keys.",
+				},
+			);
+		} else {
+			out.write(data, {
+				fields: ORG_FIELDS,
+				title: "API keys",
+				emptyMessage: "This organization has no API keys.",
+			});
+		}
 		out.end();
 		return;
 	}
@@ -145,9 +194,9 @@ const create = async (props: CreateProps) => {
 	const { name, projectId, orgId } = props;
 	const out = writer(props);
 
-	// Neither flag: an account key, matching `POST /api_keys`. Note that `api-keys` is
-	// exempt from `.neon` enrichment (see `isApiKeysCommand`), so reaching this branch
-	// means the user really did ask for account scope rather than inheriting a project.
+	// Neither flag: an account key, matching `POST /api_keys`. `api-keys` is exempt from
+	// `.neon` enrichment (see `isApiKeysCommand`), so reaching this branch means the user
+	// really did ask for account scope rather than inheriting a checked-out project.
 	if (!projectId && !orgId) {
 		const { data } = await props.apiClient.createApiKey({ key_name: name });
 		out.write(data, { fields: CREATE_FIELDS, title: "API key" });
@@ -170,21 +219,33 @@ const create = async (props: CreateProps) => {
 		return;
 	}
 
+	const scopeTo = projectId as string;
+
 	// Project-scoped keys exist only on the organization endpoint, so an org is required.
 	// Resolve it from the project rather than asking for both: `--project-id` alone would
 	// otherwise fail for a reason that isn't visible from the command line.
-	const resolvedOrgId = await orgIdForProject(props, projectId as string);
+	const resolvedOrgId = await orgIdForProject(props, scopeTo);
 	const { data } = await props.apiClient.createOrgApiKey(resolvedOrgId, {
 		key_name: name,
-		project_id: projectId,
+		project_id: scopeTo,
 	});
+
+	// `project_id` is optional on the response. Printing a key and calling it scoped
+	// without checking would hand the user a credential whose reach we have not confirmed
+	// — the one thing this command must never get wrong. Revoke and fail instead.
+	if (data.project_id !== scopeTo) {
+		await revokeUnverified(props, resolvedOrgId, data.id);
+		throw new Error(
+			`Neon returned a key scoped to ${data.project_id ?? "nothing"} rather than ${scopeTo}. The key has been revoked; nothing was issued.`,
+		);
+	}
 
 	out.write(data, { fields: CREATE_FIELDS_SCOPED, title: "API key" });
 	out.end();
 	warnStoreItNow();
 	log.info(
-		"Scoped to %s: it cannot create projects, mint API keys, or read any other project.",
-		projectId,
+		"Limited to %s: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.",
+		scopeTo,
 	);
 };
 
@@ -198,6 +259,29 @@ const revoke = async (props: RevokeProps) => {
 		title: "API key",
 	});
 	out.end();
+};
+
+/**
+ * Withdraw a key we are about to refuse to report. Best-effort: if the revoke also fails the
+ * caller still throws, but the user is told the key exists so they can remove it by hand
+ * rather than being left with a live credential they never saw.
+ */
+const revokeUnverified = async (
+	props: CommonProps,
+	orgId: string,
+	keyId: number,
+): Promise<void> => {
+	try {
+		await props.apiClient.revokeOrgApiKey(orgId, keyId);
+	} catch (err) {
+		log.error(
+			"Could not revoke API key %d after it failed verification. Revoke it manually with `neon api-keys revoke %d --org-id %s`. Cause: %s",
+			keyId,
+			keyId,
+			orgId,
+			err instanceof Error ? err.message : String(err),
+		);
+	}
 };
 
 /**

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,4 +1,5 @@
 import * as api from "./api.js";
+import * as apiKeys from "./api_keys.js";
 import * as auth from "./auth.js";
 import * as bootstrap from "./bootstrap.js";
 import * as branches from "./branches.js";
@@ -33,6 +34,7 @@ import * as vpcEndpoints from "./vpc_endpoints.js";
 export default [
 	auth,
 	profile,
+	apiKeys,
 	api,
 	users,
 	orgs,

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -26,13 +26,13 @@ type ProfileProps = CommonProps & {
 	allowUnsafeTls?: boolean;
 };
 
-export const command = "profile";
-export const aliases = ["profiles"];
+export const command = "profiles";
+export const aliases = ["profile"];
 export const describe = "Manage named sets of Neon credentials";
 
 export const builder = (argv: yargs.Argv) =>
 	argv
-		.usage("$0 profile <sub-command> [options]")
+		.usage("$0 profiles <sub-command> [options]")
 		.command(
 			"list",
 			"List profiles, the account each holds, and where its credentials live",
@@ -63,7 +63,7 @@ export const builder = (argv: yargs.Argv) =>
 					},
 				),
 		)
-		.demandCommand(1, "Run `neon profile --help` to see the subcommands.");
+		.demandCommand(1, "Run `neon profiles --help` to see the subcommands.");
 
 export const handler = (_args: yargs.Arguments) => {
 	/* subcommands only */

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -71,6 +71,13 @@ export const isConfigInit = (args: { _: (string | number)[] }): boolean =>
 export const isProfileCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "profile" || args._[0] === "profiles";
 
+/**
+ * `neon api-keys …`, under either spelling. Exempts the group from context enrichment: how
+ * far a credential reaches must come from an explicit flag, never from `.neon`.
+ */
+export const isApiKeysCommand = (args: { _: (string | number)[] }): boolean =>
+	args._[0] === "api-keys" || args._[0] === "api-key";
+
 const CONTEXT_FILE = ".neon";
 const GITIGNORE_FILE = ".gitignore";
 
@@ -153,6 +160,13 @@ export const enrichFromContext = (
 	// and must see the raw flags rather than values pre-filled from an existing
 	// `.neon`, so skip enrichment for both.
 	if (args._[0] === "link" || args._[0] === "set-context") {
+		return;
+	}
+	// `api-keys` mints credentials, and how far a credential reaches must be something the
+	// user typed — never something inherited from whichever project happens to be checked
+	// out. Enriched here, `api-keys create --name ci` in a linked directory would quietly
+	// produce a key scoped to that project instead of the account key it asked for.
+	if (isApiKeysCommand(args)) {
 		return;
 	}
 	const context = readContextFile(args.contextFile);


### PR DESCRIPTION
## The problem

The CLI exposes **no API-key management at all** — zero references in `packages/cli/src`. The only way to mint one is the console, or a hand-rolled passthrough:

```bash
neon api /organizations/{org_id}/api_keys -X POST -F key_name=agent -F project_id=frosty-…
```

That matters most for the key type you cannot otherwise discover: **project-scoped keys**. The API has supported them all along —

```ts
export type OrgApiKeyCreateRequest = ApiKeyCreateRequest & {
    /** If set, the API key can access only this project */
    project_id?: string;
};
```

— and they are the only way to mint a least-privilege Neon credential. Nothing surfaced them.

## The surface

All six `api_keys` endpoints, which is the complete set in the spec:

```bash
neon api-keys list                                        # your account's keys
neon api-keys list --org-id org-…                         # an organization's, with scope shown

neon api-keys create --name ci                            # account key
neon api-keys create --name ci    --org-id org-…          # organization key
neon api-keys create --name agent --project-id frosty-…   # can access only that project

neon api-keys revoke <id> [--org-id org-…]
```

Alias `api-key`, matching `projects`/`project`.

```console
$ neon api-keys create --name agent --project-id proj-in-org
API key
┌─────┬───────┬─────────────┐
│ Id  │ Name  │ Project     │
├─────┼───────┼─────────────┤
│ 303 │ agent │ proj-in-org │
└─────┴───────┴─────────────┘

napi_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
WARNING: Store this key now: it is not shown again.
INFO: Limited to proj-in-org: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.

$ neon api-keys create --name ci
API key
┌─────┬──────┐
│ Id  │ Name │
├─────┼──────┤
│ 201 │ ci   │
└─────┴──────┘

napi_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
WARNING: Store this key now: it is not shown again.
WARNING: This key reaches everything your account can, in every organization. Pass --org-id or --project-id to narrow it.
```

The secret prints on its own line rather than in a table cell. `cli-table` neither wraps nor truncates, so a 50-character key makes the row wider than most terminals and the wrapped remainder lands beside box-drawing characters, on the one occasion the key is ever shown. It also means `… | tail -1` on stdout yields exactly the key, since both notices go to stderr. Structured output keeps the key in the object.

## What a project-scoped key can and cannot do

Verified against a real scoped key:

| Attempt | Result |
|---|---|
| Read and write its own project | works |
| Read any other project | `project not found` — not even an existence oracle |
| `neon projects create` | `project-scoped keys are not allowed to create projects` |
| `neon projects list` | refused |
| `neon api-keys create` / `list` | refused (true of any organization key, not only scoped ones) |
| `neon orgs list` | **works** — it can see the id, name and handle of the organization it belongs to |
| `GET /organizations/{id}`, `/members` | refused |
| `neon link --project-id <its project>` | works |

It is **not** read-only. Inside its one project it can do anything the API allows, including deleting it. What it bounds is *reach*:

```bash
neon link --project-id frosty-…       # once, as yourself — writes .neon
NEON_API_KEY=napi_… neon deploy       # then the agent, reaching only that project
```

`link` needs `--project-id` explicitly here: the interactive picker lists your projects, which a scoped key cannot do.

No new credential store and no new resolution tier — a minted key goes into `NEON_API_KEY` or `--api-key` like any other. A `projects.json` that auto-selected a key per directory was considered and rejected: it needed a fifth resolution tier and an allowlist of account-scoped commands to stop `neon me` breaking inside a linked directory, to replace an env var that already works.

## Guarding the scope

**Five ways a scope flag could read as absent, each of which minted an account key instead.** All verified against the real yargs before fixing:

| Input | Before | Now |
|---|---|---|
| `--project-id ""` (unset shell variable) | empty string, falsy → account key | error |
| `--no-project-id` | yargs negation yields `false`, falsy → account key | error naming the negation |
| `--project_id real-project` (typo, valid value) | never binds → account key | `Unknown argument: project_id` |
| `--project-id a --project-id b` | array, reaches the API as `a,b` | `given more than once` |
| `-- --project-id p` | `populate--` puts it where `.strict()` never looks → account key | `takes no arguments after --` |

A scope flag is now either absent or exactly one non-empty string. Silently widening a credential because of a shell accident is the worst thing this command could do, so none of these get a lenient reading.

**A 2xx is not proof the key is usable.** `project_id` is optional on the response, so a success that omitted it would print a secret and call it scoped without that being confirmed; a response with no `key` would leave a live credential the user can neither see nor revoke. Every create path verifies the response, withdraws the key, and reports nothing.

The expected scope is stated rather than inferred — "no project" is checked as deliberately as an exact project, so a key that comes back *narrower* than asked for is refused too. It is a symbol, not a string, because project ids match `^[a-z0-9-]{1,60}$` and any string sentinel is itself a legal id.

**The withdrawal message is honest.** When revoking the unverified key itself fails, the output does not claim the key is gone:

```
ERROR: Neon returned a key scoped to nothing rather than proj-in-org. The key could NOT be
revoked and may still be live. Remove it with `neon api-keys revoke 500 --org-id org-7`.
```

## Two decisions worth review

**`--org-id` and `--project-id` conflict.** A project-scoped key already *is* an organization key, and its organization is derived from the project rather than chosen independently, so naming both is contradictory rather than redundant. `--project-id` alone costs one `getProject` lookup. A project outside any organization fails with the reason, since the endpoint that accepts `project_id` is org-only.

**`api-keys` is exempt from `.neon` context enrichment.** `enrichFromContext` fills `orgId` *and* `projectId` from the context file for every command except `link` and `set-context`:

```ts
if (!args.orgId) { args.orgId = context.orgId; }
if (!args.projectId) { args.projectId = context.projectId; }
```

Left enriched, `neon api-keys create --name ci` inside a linked directory would arrive with both already set — minting a key scoped to whatever project is checked out instead of the account key requested. How far a credential reaches comes only from a flag the user typed. A differential test with a control covers it, so it fails if enrichment breaks everywhere rather than just here.

## Errors point at the next action

The likely mistakes on this surface all have a specific message rather than the API's:

| Mistake | Message |
|---|---|
| `revoke <org key id>` without `--org-id` | names `--org-id`, since `list --org-id` prints ids the account endpoint cannot see |
| `revoke <account key id> --org-id …` | says to drop the flag. A wrong org id never reaches here: the API answers "not an organization member", not a 404 |
| `revoke abc` | rejected locally naming `abc`, rather than sending `NaN` and reporting "not found". Digits only, so `0x65` cannot silently revoke key 101 |
| an org id pasted into `--project-id` | "that looks like an organization id. Pass it as `--org-id`" |
| a project in no organization | says scoped keys need one, and to omit `--project-id` |

## Incidental

**`writeTable` drops all-empty columns**, so the `Project` column vanished from `api-keys list --org-id` exactly when no key was scoped — answering "which of my keys are narrowed?" with a missing column. The data is normalised before writing, for **table output only**; json and yaml serialize the whole object, so a synthetic field there would change the machine-readable shape and duplicate `project_id` under a second name.

```console
$ neon api-keys list --org-id org-7
API keys in org-7
┌─────┬──────────┬────────────────┬──────────────────────┬──────────────────────┐
│ Id  │ Name     │ Project        │ Created At           │ Last Used At         │
├─────┼──────────┼────────────────┼──────────────────────┼──────────────────────┤
│ 301 │ scoped   │ proj-in-org    │ 2026-01-02T00:00:00Z │                      │
│ 302 │ org-wide │ (all projects) │ 2026-01-03T00:00:00Z │ 2026-02-03T00:00:00Z │
└─────┴──────────┴────────────────┴──────────────────────┴──────────────────────┘
```

Both listings name their scope in the title, because "API keys" over half the picture is a claim the command cannot support; the account view points at `--org-id` for the rest. `last_used_at` and `last_used_from_addr` are surfaced because they are how you spot a key worth revoking.

**`profiles` is now the primary spelling**, with `profile` as the alias, matching `projects`/`project` and every other group — it was backwards in #373. Its own changeset, since it is a separate logical change. npm is on 2.39.1 and `profile` first appears in the unreleased 2.41.0, so nothing depends on the old spelling.

## Verification

Every path exercised live against the real API with the binary built from this branch, plus 33 tests against the repo's emocks fixtures — 29 command-level, 4 covering context isolation. They span all six endpoints, both scopes, the flag conflict, all five ways a scope flag can misread, a non-numeric revoke id, the project→org lookup, a project in no organization, and the unusable-response branches: wrong project, no scope with the withdrawal itself failing, a narrower key than requested, and a missing key. Two assert the secret's placement and its absence when a key is refused.

`pnpm test:ci` — 3,966 pass, 53 more than main. `pnpm build`, `pnpm --filter neon build`, `pnpm lint:ci` all clean.

All keys and projects created during testing were revoked or deleted.

## Not verified

- **Behaviour when an organization key is revoked while in use.** The 401 path is unchanged by this PR, but no test covers a key disappearing mid-session.
- **Windows console rendering.** All output this PR adds is ASCII, but there was no run on a Windows codepage.

## Flagging

- **The org endpoints are raw-only in `@neon/sdk`.** `neon.apiKeys` wraps the account variants on the ergonomic client; `listOrgApiKeys` / `createOrgApiKey` / `revokeOrgApiKey` exist only in the raw layer. This PR uses the CLI's own client layer for all six rather than mixing layers. Wrapping the org three is a reasonable follow-up — project scoping is the most interesting thing this API surface can do and is currently the least accessible.
- **`list` has no `--project-id` filter.** The API has no such parameter, so it would be client-side. Left out to keep the surface to what the endpoints offer.
- **`create` defaults to account scope.** Requiring an explicit `--account` so a forgotten flag could not produce a full-access key was considered and rejected for consistency with `POST /api_keys` and the rest of the CLI. The consequence is that the widest credential is the one you get by typing least — mitigated by a warning on that path, not by the API shape.


