### PR TITLE
fix(@neon/sdk): make cancellation work, and let a call be bounded

### DIFF
--- a/.changeset/sdk-cancellation-deadlines.md
+++ b/.changeset/sdk-cancellation-deadlines.md
@@ -35,3 +35,10 @@ Cancellation is classified from the SDK's own deadline state rather than by matc
 names, because the generated client reports auth, serialization, interceptor, transport and
 parsing faults through one channel. A transport failure that merely looks like an abort
 stays a `NeonNetworkError`.
+
+**Compile-time note.** `NeonErrorKind` gains `"aborted"`. Widening that union can break a
+consumer whose `switch` over `error.kind` is exhaustive with a `never` check — such code
+stops compiling until the new case is handled. This ships as a minor deliberately: an error
+taxonomy has to be able to grow, and treating every new kind as breaking would either
+freeze it or force a major for each addition. Nothing changes at runtime for existing
+kinds, and no existing kind changes meaning.

--- a/.changeset/sdk-cancellation-deadlines.md
+++ b/.changeset/sdk-cancellation-deadlines.md
@@ -1,0 +1,37 @@
+---
+"@neon/sdk": minor
+---
+
+Make cancellation work, and let a call be bounded.
+
+`CallOptions.signal` was documented on every method but never reached the request: the
+execution core passed only the client into each generated call, so aborting a call let it
+run to completion. The one place a signal did have an effect — interrupting the sleep
+between retries — rejected with a raw `DOMException`, so a client promising
+`{ data, error }` threw, and a `throwOnError` client threw something that was not a
+`NeonError`.
+
+- **`signal` now reaches the request** on all 91 ergonomic call sites, plus paginated
+  `list()`, and the multi-request `postgres.connectionString` resolver.
+- **`requestTimeoutMs`** bounds a request and its retries, on the client or per call.
+  Unset by default, so existing calls stay unbounded; pass `Infinity` on a call to opt out
+  of a client-wide value. It is separate from `wait.timeoutMs`, which budgets readiness
+  polling. Invalid values are rejected at construction rather than silently firing
+  immediately.
+- **New `NeonAbortError`** (`kind: "aborted"`) for caller cancellation, distinct from
+  `NeonTimeoutError` (`kind: "timeout"`) because a timeout is worth retrying and a
+  cancellation is not. Both arrive through the result envelope; neither escapes as a
+  `DOMException`.
+- **Paginated `list()` methods accept per-call options** after their query, so a walk can
+  be cancelled or bounded like any other call. A deadline covers one consumption of the
+  list rather than each page.
+- **`Retry-After` is honoured, not capped.** It previously multiplied straight into a
+  sleep, so `Retry-After: 3600` parked a call for an hour; the HTTP-date form parsed as
+  `NaN` and fell through to generated backoff, retrying far sooner than instructed. The
+  delay is never shortened now — when honouring it would exceed 10s or the remaining
+  deadline, the SDK stops retrying and surfaces the real `423`/`429`/`503`.
+
+Cancellation is classified from the SDK's own deadline state rather than by matching error
+names, because the generated client reports auth, serialization, interceptor, transport and
+parsing faults through one channel. A transport failure that merely looks like an abort
+stays a `NeonNetworkError`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -43,11 +43,12 @@ const { project, connectionString } = data;
 | `waitForReadiness` | `boolean` | `false` | When `true`, mutations block until their provisioning `operations` finish, so the returned resource is ready to use. |
 | `wait` | `{ pollIntervalMs?: number; timeoutMs?: number }` | `1000` / `300000` | Tuning for the readiness poller. |
 | `retries` | `number` | `2` | Automatic retries on always-safe statuses (`423`, `429`, `503`) with backoff. |
+| `requestTimeoutMs` | `number` | — (unbounded) | Deadline for a request **and** its retries. Aborts the request and resolves with a `NeonTimeoutError`. Pass `Infinity` per call to opt out of a client-wide value. Separate from `wait.timeoutMs`. |
 | `orgId` | `string` | — | Default organization, applied to project create/list and as the transfer source org. Overridable per call. |
 | `baseUrl` | `string` | `https://console.neon.tech/api/v2` | Override the API base URL. |
 | `fetch` | `typeof fetch` | global `fetch` | Custom fetch implementation (proxies, tests, non-global runtimes). |
 
-Every option except `apiKey` is also accepted **per call** via the last `options` argument (`{ throwOnError?, waitForReadiness?, signal? }`), overriding the client default.
+Every option except `apiKey` is also accepted **per call** via the last `options` argument (`{ throwOnError?, waitForReadiness?, requestTimeoutMs?, signal? }`), overriding the client default. Paginated `list()` methods take it too, after their query.
 
 ## The result model
 
@@ -82,7 +83,8 @@ The `error` channel carries a typed hierarchy (all `Error` subclasses with a `ki
 | `NeonAuthError` | `"auth"` | (401/403) |
 | `NeonRateLimitError` | `"rate_limit"` | (429, after retries) |
 | `NeonOperationError` | `"operation"` | `operationId`, `status` — an awaited operation failed |
-| `NeonTimeoutError` | `"timeout"` | readiness/wait deadline exceeded |
+| `NeonTimeoutError` | `"timeout"` | a deadline was exceeded — `requestTimeoutMs`, or the readiness/wait budget |
+| `NeonAbortError` | `"aborted"` | the caller's `signal` fired |
 | `NeonNetworkError` | `"network"` | `reason` — transport failure (no response) |
 | `NeonError` | `"client"` | SDK-side errors (e.g. ambiguous connection-string selection) |
 
@@ -112,6 +114,43 @@ responsibility. An empty path parameter builds a URL with an empty segment, whic
 API answers with a redirect rather than a `400`; that can surface as a `"network"` error
 rather than anything that names the argument.
 
+## Cancellation & deadlines
+
+Pass a `signal` to cancel a call, or `requestTimeoutMs` to bound it. Both arrive on the
+`error` channel as typed errors — a cancelled call never rejects with a raw `DOMException`,
+and a `throwOnError` client throws the same `NeonError` subclass it would have returned:
+
+```ts
+const controller = new AbortController();
+const { error } = await neon.projects.list().all();
+
+// cancel in-flight work (a user navigating away, a request handler aborting)
+const result = await neon.projects.get(id, { signal: controller.signal });
+if (result.error?.kind === "aborted") { /* the caller stopped it */ }
+
+// bound a call, on the client or per call
+const neon = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
+const slow = await neon.projects.get(id, { requestTimeoutMs: 5_000 });
+if (slow.error?.kind === "timeout") { /* the deadline was exceeded */ }
+
+// opt a single call back out of a client-wide deadline
+await neon.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
+  requestTimeoutMs: Number.POSITIVE_INFINITY,
+});
+```
+
+`"aborted"` and `"timeout"` are deliberately distinct: a timeout is worth retrying, a
+cancellation is not.
+
+**Calls are unbounded unless you set `requestTimeoutMs`**, which is what they have always
+been. `requestTimeoutMs` covers one request and all of its retries; readiness polling keeps
+its own budget in `wait.timeoutMs`, so setting one does not silently cap the other.
+
+`retries` interacts with it: a `Retry-After` is never shortened, because retrying earlier
+than the server asked is worse than not retrying. If honouring it would take longer than
+10s or than the remaining deadline, the SDK stops retrying and hands you the real
+`423`/`429`/`503` instead of waiting or reporting a timeout that hides the status.
+
 ## Pagination
 
 Cursor-paginated `list()` methods return a lazy `Paginated<T>`:
@@ -120,7 +159,16 @@ Cursor-paginated `list()` methods return a lazy `Paginated<T>`:
 const { data: all } = await neon.projects.list().all();      // every page → { data, error }
 const { data: page } = await neon.projects.list().page();    // one page
 for await (const project of neon.projects.list()) { … }      // stream; throws on a page error
+
+// per-call options come after the query
+const { data } = await neon.projects
+  .list({ search: "prod" }, { signal, requestTimeoutMs: 10_000 })
+  .all();
 ```
+
+A deadline covers **one consumption** — a whole `all()`, or a whole iteration — rather than
+each page, since that is the unit a caller waits on. A `Paginated` is lazy and reusable, so
+consuming it twice gets a fresh deadline each time.
 
 ## Readiness & workflows
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -142,6 +142,17 @@ await neon.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
 `"aborted"` and `"timeout"` are deliberately distinct: a timeout is worth retrying, a
 cancellation is not.
 
+`requestTimeoutMs` must be a positive number of milliseconds up to `2147483647`, or
+`Infinity`. Anything else — `0`, a negative, `NaN`, or a value past that range — is
+rejected with a `client`-kind error when the client is created or the call is made, rather
+than silently becoming an instant timeout or no timeout at all.
+
+Cancellation reaches everything the SDK controls: the request and its retries, readiness
+polling, each page of a paginated walk, and the multi-request `postgres.connectionString`
+resolver. The one thing it cannot interrupt is your own code — a `snapshots.restore`
+`preview` callback receives the signal as its second argument so it can cooperate, and the
+restore is left un-finalized if the call is cancelled around it.
+
 **Calls are unbounded unless you set `requestTimeoutMs`**, which is what they have always
 been. `requestTimeoutMs` covers one request and all of its retries; readiness polling keeps
 its own budget in `wait.timeoutMs`, so setting one does not silently cap the other.
@@ -410,7 +421,9 @@ const { data: snapshot } = await neon.snapshots.create(projectId, branchId, {
 ```ts
 await neon.snapshots.restore(projectId, snapshotId, {
   targetBranchId,
-  preview: async (branch) => (await checks(branch)) === "ok", // true → commit · false → abort
+  // second argument carries the call's signal; the SDK cannot interrupt your callback
+  preview: async (branch, { signal }) =>
+    (await checks(branch, { signal })) === "ok", // true → commit · false → abort
 });
 ```
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -25,6 +25,7 @@ export { createNeonClient } from "./neon/client.js";
 export type { NeonConfig } from "./neon/config.js";
 export type { CallOptions } from "./neon/context.js";
 export {
+	NeonAbortError,
 	NeonApiError,
 	NeonAuthError,
 	NeonError,

--- a/packages/sdk/src/neon/cancellation.server.test.ts
+++ b/packages/sdk/src/neon/cancellation.server.test.ts
@@ -1,0 +1,283 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createNeonClient } from "./client.js";
+
+/**
+ * Cancellation against a real HTTP server, over the runtime's own `fetch`.
+ *
+ * The fetch-stub tests in `cancellation.test.ts` cover mapping, but a stub that honours
+ * `signal` promptly hides two things a real socket does not: work that happens before
+ * `fetch` is reached, and a request that hangs with no response. Both bugs this file
+ * covers were invisible to the stubbed suite.
+ */
+
+interface Behaviour {
+	/** Never respond, leaving the socket open until the client gives up. */
+	hang: boolean;
+	/** Operations still reported as running when polled. */
+	operationRunning: boolean;
+	operationPolls: number;
+}
+
+let server: Server;
+let baseUrl: string;
+const behaviour: Behaviour = {
+	hang: false,
+	operationRunning: true,
+	operationPolls: 0,
+};
+
+function json(body: unknown) {
+	return JSON.stringify(body);
+}
+
+beforeAll(async () => {
+	server = createServer((req, res) => {
+		const url = new URL(req.url ?? "/", "http://localhost");
+
+		if (behaviour.hang) return; // socket stays open, no response ever
+
+		if (url.pathname.includes("/operations/")) {
+			behaviour.operationPolls += 1;
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				json({
+					operation: {
+						id: "op-1",
+						project_id: "p-1",
+						action: "create_timeline",
+						status: behaviour.operationRunning
+							? "running"
+							: "finished",
+					},
+				}),
+			);
+			return;
+		}
+
+		if (req.method === "POST" && url.pathname.endsWith("/projects")) {
+			res.writeHead(200, { "content-type": "application/json" });
+			res.end(
+				json({
+					project: { id: "p-1", name: "test" },
+					operations: [
+						{
+							id: "op-1",
+							project_id: "p-1",
+							action: "create_timeline",
+							status: "running",
+						},
+					],
+					connection_uris: [
+						{
+							connection_uri: "postgresql://u:p@host/db",
+							connection_parameters: {
+								host: "host",
+								pooler_host: "host-pooler",
+							},
+						},
+					],
+				}),
+			);
+			return;
+		}
+
+		res.writeHead(200, { "content-type": "application/json" });
+		res.end(json({ projects: [{ id: "p-1" }], pagination: {} }));
+	});
+
+	await new Promise<void>((resolve) =>
+		server.listen(0, "127.0.0.1", resolve),
+	);
+	const { port } = server.address() as AddressInfo;
+	baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+	server.closeAllConnections?.();
+	await new Promise<void>((resolve, reject) =>
+		server.close((error) => (error ? reject(error) : resolve())),
+	);
+});
+
+describe("against a real socket that never responds", () => {
+	it("times out a request", async () => {
+		behaviour.hang = true;
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			requestTimeoutMs: 60,
+		});
+
+		const { error } = await neon.projects.get("p-1");
+		behaviour.hang = false;
+		expect(error?.kind).toBe("timeout");
+	});
+
+	it("reports a caller abort as aborted, not as a network failure", async () => {
+		behaviour.hang = true;
+		const neon = createNeonClient({ apiKey: "k", baseUrl, retries: 0 });
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 40);
+
+		const { error } = await neon.projects.get("p-1", {
+			signal: controller.signal,
+		});
+		behaviour.hang = false;
+		expect(error?.kind).toBe("aborted");
+	});
+
+	it("bounds a paginated walk, whose page fetches sit outside the execution core", async () => {
+		behaviour.hang = true;
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			requestTimeoutMs: 60,
+		});
+
+		const { error } = await neon.projects.list().all();
+		behaviour.hang = false;
+		expect(error?.kind).toBe("timeout");
+	});
+});
+
+describe("work that happens before fetch is reached", () => {
+	/** Resolving the API key is awaited before the request is built. */
+	const slowApiKey = () =>
+		new Promise<string>((resolve) => setTimeout(() => resolve("k"), 2_000));
+
+	it("bounds a single call", async () => {
+		const neon = createNeonClient({
+			apiKey: slowApiKey,
+			baseUrl,
+			retries: 0,
+			requestTimeoutMs: 50,
+		});
+
+		const startedAt = Date.now();
+		const { error } = await neon.projects.get("p-1");
+		expect(error?.kind).toBe("timeout");
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+	});
+
+	it("bounds a paginated walk", async () => {
+		// A signal cannot reach this phase, so pagination has to be raced against its
+		// deadline the same way the execution core races a request. It was not.
+		const neon = createNeonClient({
+			apiKey: slowApiKey,
+			baseUrl,
+			retries: 0,
+			requestTimeoutMs: 50,
+		});
+
+		const startedAt = Date.now();
+		const { error } = await neon.projects.list().all();
+		expect(error?.kind).toBe("timeout");
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+	});
+
+	it("bounds one page and one iteration too", async () => {
+		const neon = createNeonClient({
+			apiKey: slowApiKey,
+			baseUrl,
+			retries: 0,
+			requestTimeoutMs: 50,
+		});
+
+		const page = await neon.projects.list().page();
+		expect(page.error?.kind).toBe("timeout");
+
+		await expect(async () => {
+			for await (const _project of neon.projects.list()) {
+				// unreachable: the first page never arrives
+			}
+		}).rejects.toMatchObject({ kind: "timeout" });
+	});
+});
+
+describe("readiness polling", () => {
+	it("reports a caller abort during a poll as aborted, not as a network failure", async () => {
+		behaviour.operationRunning = true;
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			waitForReadiness: true,
+			wait: { pollIntervalMs: 10, timeoutMs: 60_000 },
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 60);
+
+		const { error } = await neon.projects.create(
+			{ name: "test" },
+			{ signal: controller.signal },
+		);
+		expect(error?.kind).toBe("aborted");
+	});
+
+	it("enforces its own timeout while operations stay pending", async () => {
+		behaviour.operationRunning = true;
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			waitForReadiness: true,
+			wait: { pollIntervalMs: 10, timeoutMs: 80 },
+		});
+
+		const startedAt = Date.now();
+		const { error } = await neon.projects.create({ name: "test" });
+		expect(error?.kind).toBe("timeout");
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+	});
+
+	it("resolves once the operations finish", async () => {
+		behaviour.operationRunning = false;
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			waitForReadiness: true,
+			wait: { pollIntervalMs: 10, timeoutMs: 5_000 },
+		});
+
+		const { data, error } = await neon.projects.create({ name: "test" });
+		expect(error).toBeUndefined();
+		expect(data?.id).toBe("p-1");
+	});
+});
+
+describe("per-call timeout validation", () => {
+	it("refuses a per-call value setTimeout would mistreat", async () => {
+		const neon = createNeonClient({ apiKey: "k", baseUrl, retries: 0 });
+
+		// Not validating per-call left NaN silently meaning "unbounded" and a value past
+		// setTimeout's range silently meaning 1ms.
+		await expect(
+			neon.projects.get("p-1", { requestTimeoutMs: Number.NaN }),
+		).rejects.toMatchObject({ kind: "client" });
+		await expect(
+			neon.projects.get("p-1", { requestTimeoutMs: 2 ** 31 }),
+		).rejects.toMatchObject({ kind: "client" });
+		await expect(
+			neon.projects.get("p-1", { requestTimeoutMs: -1 }),
+		).rejects.toMatchObject({ kind: "client" });
+	});
+
+	it("accepts Infinity as the documented opt-out", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			requestTimeoutMs: 50,
+		});
+
+		const { error } = await neon.projects.get("p-1", {
+			requestTimeoutMs: Number.POSITIVE_INFINITY,
+		});
+		expect(error).toBeUndefined();
+	});
+});

--- a/packages/sdk/src/neon/cancellation.test.ts
+++ b/packages/sdk/src/neon/cancellation.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "./client.js";
+import { NeonAbortError, NeonError } from "./errors.js";
+
+/**
+ * A fetch that stays in flight until the request's signal aborts it.
+ *
+ * It still settles on its own after a bounded delay. A promise that never settles is not
+ * something a real `fetch` can do, and leaving one pending wedges the rest of the file.
+ */
+const hangingFetch: typeof fetch = (input) =>
+	new Promise((resolve, reject) => {
+		const signal = input instanceof Request ? input.signal : undefined;
+		const fallback = setTimeout(
+			() => resolve(new Response("{}", { status: 504 })),
+			2_000,
+		);
+		signal?.addEventListener(
+			"abort",
+			() => {
+				clearTimeout(fallback);
+				reject(signal.reason ?? new Error("aborted"));
+			},
+			{ once: true },
+		);
+	});
+
+function jsonFetch(status: number, body: unknown, headers: HeadersInit = {}) {
+	let calls = 0;
+	const fetchImpl: typeof fetch = async () => {
+		calls += 1;
+		return new Response(JSON.stringify(body), {
+			status,
+			headers: { "content-type": "application/json", ...headers },
+		});
+	};
+	return { fetch: fetchImpl, calls: () => calls };
+}
+
+describe("a caller's signal reaches the request", () => {
+	it("aborts an in-flight call instead of running it to completion", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			fetch: hangingFetch,
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+
+		const startedAt = Date.now();
+		const { data, error } = await neon.projects.get("p", {
+			signal: controller.signal,
+		});
+
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+		expect(data).toBeUndefined();
+		expect(error?.kind).toBe("aborted");
+	});
+
+	it("reports the abort through the envelope, never as a raw DOMException", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			fetch: hangingFetch,
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+
+		const result = await neon.projects
+			.get("p", { signal: controller.signal })
+			.catch((thrown) => ({ thrown }));
+
+		expect(result).not.toHaveProperty("thrown");
+		expect("error" in result && result.error).toBeInstanceOf(
+			NeonAbortError,
+		);
+	});
+
+	it("throws the typed NeonAbortError on a throwOnError client", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			throwOnError: true,
+			fetch: hangingFetch,
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+
+		await expect(
+			neon.projects.get("p", { signal: controller.signal }),
+		).rejects.toBeInstanceOf(NeonAbortError);
+	});
+
+	it("cancels a paginated walk", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			fetch: hangingFetch,
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+
+		const { error } = await neon.projects
+			.list(undefined, { signal: controller.signal })
+			.all();
+		expect(error?.kind).toBe("aborted");
+	});
+
+	it("cancels the multi-request connection-string resolver", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			fetch: hangingFetch,
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+
+		const { error } = await neon.postgres.connectionString(
+			{ projectId: "p" },
+			{ signal: controller.signal },
+		);
+		expect(error?.kind).toBe("aborted");
+	});
+});
+
+describe("requestTimeoutMs bounds a call", () => {
+	it("times out a request that never responds", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			requestTimeoutMs: 20,
+			fetch: hangingFetch,
+		});
+
+		const startedAt = Date.now();
+		const { error } = await neon.projects.get("p");
+
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+		expect(error?.kind).toBe("timeout");
+	});
+
+	it("bounds a slow auth phase, which the request signal cannot reach", async () => {
+		let fetched = false;
+		const neon = createNeonClient({
+			// Resolving the key is awaited before the request is built, so a signal
+			// handed to fetch cannot bound this phase at all.
+			apiKey: () =>
+				new Promise<string>((resolve) =>
+					setTimeout(() => resolve("k"), 2_000),
+				),
+			retries: 0,
+			requestTimeoutMs: 20,
+			fetch: async () => {
+				fetched = true;
+				return new Response("{}", { status: 200 });
+			},
+		});
+
+		const startedAt = Date.now();
+		const { error } = await neon.projects.get("p");
+
+		expect(error?.kind).toBe("timeout");
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+		expect(fetched).toBe(false);
+	});
+
+	it("bounds a whole paginated walk rather than each page, so a stuck cursor cannot spin forever", async () => {
+		let pages = 0;
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			requestTimeoutMs: 50,
+			fetch: async () => {
+				pages += 1;
+				return new Response(
+					JSON.stringify({
+						projects: [{ id: `p${pages}` }],
+						pagination: { cursor: "cursor-that-never-advances" },
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			},
+		});
+
+		const { error } = await neon.projects.list().all();
+		expect(error?.kind).toBe("timeout");
+	});
+
+	it("is unset by default, leaving calls unbounded as before", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			fetch: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 60));
+				return new Response(JSON.stringify({ project: { id: "p" } }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			},
+		});
+
+		const { data, error } = await neon.projects.get("p");
+		expect(error).toBeUndefined();
+		expect(data?.id).toBe("p");
+	});
+
+	it("lets a single call opt out of a client-wide deadline with Infinity", async () => {
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 0,
+			requestTimeoutMs: 20,
+			fetch: async () => {
+				await new Promise((resolve) => setTimeout(resolve, 60));
+				return new Response(JSON.stringify({ project: { id: "p" } }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				});
+			},
+		});
+
+		const { error } = await neon.projects.get("p", {
+			requestTimeoutMs: Number.POSITIVE_INFINITY,
+		});
+		expect(error).toBeUndefined();
+	});
+
+	it("refuses a timeout setTimeout would mistreat, at construction", () => {
+		expect(() =>
+			createNeonClient({ apiKey: "k", requestTimeoutMs: 0 }),
+		).toThrow(NeonError);
+		expect(() =>
+			createNeonClient({ apiKey: "k", requestTimeoutMs: -5 }),
+		).toThrow(/positive number/);
+		expect(() =>
+			createNeonClient({ apiKey: "k", requestTimeoutMs: Number.NaN }),
+		).toThrow(/positive number/);
+	});
+});
+
+describe("retry scheduling", () => {
+	it("aborts during the backoff sleep through the envelope, not as a DOMException", async () => {
+		// The one path where a signal already had an effect before this change: it
+		// interrupted the sleep by rejecting, escaping the result contract entirely.
+		const rateLimited = jsonFetch(429, { message: "slow down" });
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 8,
+			fetch: rateLimited.fetch,
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+
+		const result = await neon.projects
+			.get("p", { signal: controller.signal })
+			.catch((thrown) => ({ thrown }));
+
+		expect(result).not.toHaveProperty("thrown");
+		expect("error" in result && result.error?.kind).toBe("aborted");
+	});
+
+	it("throws NeonAbortError rather than a DOMException when backoff is aborted", async () => {
+		const rateLimited = jsonFetch(429, { message: "slow down" });
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 8,
+			throwOnError: true,
+			fetch: rateLimited.fetch,
+		});
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 20);
+
+		await expect(
+			neon.projects.get("p", { signal: controller.signal }),
+		).rejects.toBeInstanceOf(NeonAbortError);
+	});
+
+	it("stops retrying rather than waiting out an hour-long Retry-After", async () => {
+		const rateLimited = jsonFetch(
+			429,
+			{ message: "slow down" },
+			{ "retry-after": "3600" },
+		);
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 3,
+			fetch: rateLimited.fetch,
+		});
+
+		const startedAt = Date.now();
+		const { error } = await neon.projects.get("p");
+
+		// The real 429 is surfaced instead of being hidden behind a long sleep or a
+		// timeout, and the header is never shortened into an early retry.
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+		expect(error?.kind).toBe("rate_limit");
+		expect(rateLimited.calls()).toBe(1);
+	});
+
+	it("still retries a short Retry-After", async () => {
+		const rateLimited = jsonFetch(
+			429,
+			{ message: "slow down" },
+			{ "retry-after": "0" },
+		);
+		const neon = createNeonClient({
+			apiKey: "k",
+			retries: 2,
+			fetch: rateLimited.fetch,
+		});
+
+		await neon.projects.get("p");
+		expect(rateLimited.calls()).toBe(3);
+	});
+});

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -4,7 +4,9 @@ import type {
 	Endpoint,
 	NeonAuthIntegration,
 	NeonAuthOauthProvider,
+	Operation,
 	Project,
+	ProjectListItem,
 	ProjectPermission,
 	Snapshot,
 } from "../client/types.gen.js";
@@ -61,6 +63,44 @@ it("branches + workflows carry the envelope and narrow under throwOnError", () =
 	expectTypeOf(
 		throwing.branches.delete("p", "br"),
 	).resolves.toEqualTypeOf<void>();
+});
+
+it("cancellation and deadline options are accepted on the client and per call", () => {
+	const neon = createNeonClient({ apiKey: "x", requestTimeoutMs: 30_000 });
+	const controller = new AbortController();
+
+	expectTypeOf(
+		neon.projects.get("p", {
+			signal: controller.signal,
+			requestTimeoutMs: 5_000,
+		}),
+	).resolves.toEqualTypeOf<NeonResult<Project>>();
+
+	// Paginated lists take the same per-call options as every other method, after their
+	// query, and still erase the response-body type.
+	expectTypeOf(
+		neon.projects.list({ search: "x" }, { signal: controller.signal }),
+	).toEqualTypeOf<Paginated<ProjectListItem>>();
+	expectTypeOf(neon.branches.list("p", undefined, {})).toEqualTypeOf<
+		Paginated<Branch>
+	>();
+	expectTypeOf(
+		neon.operations.list("p", { requestTimeoutMs: 1_000 }),
+	).toEqualTypeOf<Paginated<Operation>>();
+
+	// A per-call throwOnError still narrows when other options ride along.
+	expectTypeOf(
+		neon.projects.get("p", {
+			throwOnError: true,
+			signal: controller.signal,
+		}),
+	).resolves.toEqualTypeOf<Project>();
+
+	createNeonClient({
+		apiKey: "x",
+		// @ts-expect-error — a deadline is a number of milliseconds
+		requestTimeoutMs: "30s",
+	});
 });
 
 it("postgres namespace + tier-2/3 resources are reachable and typed", () => {

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -1,6 +1,6 @@
 import { createClient, createConfig } from "../client/client/index.js";
 import type { ResolvedConfig } from "./context.js";
-import { NeonError } from "./errors.js";
+import { resolveTimeoutMs } from "./deadline.js";
 import type { WaitForOptions } from "./wait.js";
 
 const DEFAULT_BASE_URL = "https://console.neon.tech/api/v2";
@@ -49,22 +49,6 @@ export interface NeonConfig<Throw extends boolean = false> {
 	 * for transfers when not given explicitly; overridable on every call.
 	 */
 	orgId?: string;
-}
-
-/**
- * Reject a timeout that `setTimeout` would silently mistreat — `NaN` and negatives fire
- * immediately, so a typo would turn every call into an instant timeout instead of an
- * obvious configuration error. `Infinity` is the documented way to say "unbounded".
- */
-export function resolveTimeoutMs(value: number | undefined): number {
-	if (value === undefined) return Number.POSITIVE_INFINITY;
-	if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
-		throw new NeonError(
-			`requestTimeoutMs must be a positive number of milliseconds (or Infinity to disable); received ${String(value)}.`,
-			"client",
-		);
-	}
-	return value;
 }
 
 export function resolveConfig(config: NeonConfig<boolean>): ResolvedConfig {

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -1,5 +1,6 @@
 import { createClient, createConfig } from "../client/client/index.js";
 import type { ResolvedConfig } from "./context.js";
+import { NeonError } from "./errors.js";
 import type { WaitForOptions } from "./wait.js";
 
 const DEFAULT_BASE_URL = "https://console.neon.tech/api/v2";
@@ -26,6 +27,19 @@ export interface NeonConfig<Throw extends boolean = false> {
 	wait?: WaitForOptions;
 	/** Number of automatic retries on always-safe statuses (423/429/503). Default 2. */
 	retries?: number;
+	/**
+	 * Deadline in milliseconds for a single request **and** its retries, after which the
+	 * call resolves with a `NeonTimeoutError` and the request is aborted. Overridable per
+	 * call.
+	 *
+	 * Unset by default: calls are unbounded, as they have always been. Set it to bound
+	 * them, and pass `Infinity` on a call that needs to opt back out of a client-wide
+	 * value — a large `storage.objects.get` download or a `functions.deploy` upload, say.
+	 *
+	 * Separate from `wait.timeoutMs`, which budgets readiness polling rather than a
+	 * request.
+	 */
+	requestTimeoutMs?: number;
 	/** Override the API base URL. Defaults to `https://console.neon.tech/api/v2`. */
 	baseUrl?: string;
 	/** Custom `fetch` implementation (e.g. for proxies, tests, or non-global runtimes). */
@@ -35,6 +49,22 @@ export interface NeonConfig<Throw extends boolean = false> {
 	 * for transfers when not given explicitly; overridable on every call.
 	 */
 	orgId?: string;
+}
+
+/**
+ * Reject a timeout that `setTimeout` would silently mistreat — `NaN` and negatives fire
+ * immediately, so a typo would turn every call into an instant timeout instead of an
+ * obvious configuration error. `Infinity` is the documented way to say "unbounded".
+ */
+export function resolveTimeoutMs(value: number | undefined): number {
+	if (value === undefined) return Number.POSITIVE_INFINITY;
+	if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
+		throw new NeonError(
+			`requestTimeoutMs must be a positive number of milliseconds (or Infinity to disable); received ${String(value)}.`,
+			"client",
+		);
+	}
+	return value;
 }
 
 export function resolveConfig(config: NeonConfig<boolean>): ResolvedConfig {
@@ -53,6 +83,7 @@ export function resolveConfig(config: NeonConfig<boolean>): ResolvedConfig {
 		client,
 		throwOnError: config.throwOnError ?? false,
 		retries: config.retries ?? 2,
+		requestTimeoutMs: resolveTimeoutMs(config.requestTimeoutMs),
 		waitForReadiness: config.waitForReadiness ?? false,
 		waitOptions: config.wait ?? {},
 		orgId: config.orgId,

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -1,5 +1,11 @@
 import type { Client } from "../client/client/index.js";
-import { toNeonError } from "./errors.js";
+import {
+	cancelled,
+	createDeadline,
+	type Deadline,
+	runBounded,
+} from "./deadline.js";
+import { type NeonError, toNeonError } from "./errors.js";
 import { err, finalize, type NeonResult, ok } from "./result.js";
 import { withRetries } from "./retry.js";
 import {
@@ -13,6 +19,8 @@ export interface ResolvedConfig {
 	client: Client;
 	throwOnError: boolean;
 	retries: number;
+	/** `Infinity` when calls are unbounded, which is the default. */
+	requestTimeoutMs: number;
 	waitForReadiness: boolean;
 	waitOptions: WaitForOptions;
 	orgId?: string;
@@ -24,6 +32,12 @@ export interface CallOptions<Throw extends boolean = boolean> {
 	throwOnError?: Throw;
 	/** Override the client's `waitForReadiness` for this call (mutations only). */
 	waitForReadiness?: boolean;
+	/**
+	 * Deadline for this request and its retries. `Infinity` opts out of a client-wide
+	 * value; readiness polling keeps its own `wait` budget either way.
+	 */
+	requestTimeoutMs?: number;
+	/** Cancel the call. Surfaces as a `NeonAbortError` (`kind: "aborted"`). */
 	signal?: AbortSignal;
 }
 
@@ -33,10 +47,22 @@ interface RawResult<D> {
 	response?: Response | undefined;
 }
 
+/** Every generated call the ergonomic layer makes, given the client and the call's signal. */
+type Exec<D> = (
+	client: Client,
+	signal: AbortSignal | undefined,
+) => Promise<RawResult<D>>;
+
+/** The request phase's outcome, before readiness polling is considered. */
+type Requested<D> =
+	| { ok: true; data: D | undefined; response: Response | undefined }
+	| { ok: false; error: NeonError };
+
 /**
- * Shared execution core: runs a raw client call with retries, maps its envelope to the
- * ergonomic resource shape, optionally waits for provisioning operations, and applies the
- * resolved `throwOnError` policy. Returns the bare value (throwing) or a {@link NeonResult}.
+ * Shared execution core: runs a raw client call under a deadline and with retries, maps
+ * its envelope to the ergonomic resource shape, optionally waits for provisioning
+ * operations, and applies the resolved `throwOnError` policy. Returns the bare value
+ * (throwing) or a {@link NeonResult}.
  */
 export class RequestContext {
 	readonly #config: ResolvedConfig;
@@ -53,10 +79,17 @@ export class RequestContext {
 		return this.#config;
 	}
 
+	/** The deadline for one call: the per-call timeout if given, else the client's. */
+	deadlineFor(opts: CallOptions | undefined): Deadline {
+		const timeoutMs =
+			opts?.requestTimeoutMs ?? this.#config.requestTimeoutMs;
+		return createDeadline(timeoutMs, opts?.signal);
+	}
+
 	/** Run a raw call and map its body; applies the resolved `throwOnError` policy. */
 	async run<D, T>(
 		opts: CallOptions | undefined,
-		exec: (client: Client) => Promise<RawResult<D>>,
+		exec: Exec<D>,
 		map: (data: D) => T,
 	): Promise<T | NeonResult<T>> {
 		const shouldThrow = opts?.throwOnError ?? this.#config.throwOnError;
@@ -66,23 +99,16 @@ export class RequestContext {
 	/** Like {@link run} but for endpoints that may return an empty (204) body. */
 	async runVoid<D>(
 		opts: CallOptions | undefined,
-		exec: (client: Client) => Promise<RawResult<D>>,
+		exec: Exec<D>,
 	): Promise<void | NeonResult<void>> {
 		const shouldThrow = opts?.throwOnError ?? this.#config.throwOnError;
-		const raw = await withRetries(
-			() => exec(this.#config.client),
-			this.#config.retries,
-			opts?.signal,
-		);
-		if (raw.error !== undefined) {
-			return finalize(
-				err<void>(toNeonError(raw.error, raw.response)),
-				shouldThrow,
-			);
-		}
-		const readiness = await this.#maybeWait(opts, raw.data);
-		if (readiness?.error)
+		const requested = await this.#request(opts, exec);
+		if (!requested.ok)
+			return finalize(err<void>(requested.error), shouldThrow);
+		const readiness = await this.#maybeWait(opts, requested.data);
+		if (readiness?.error) {
 			return finalize(err<void>(readiness.error), shouldThrow);
+		}
 		return finalize(ok(undefined), shouldThrow);
 	}
 
@@ -92,20 +118,57 @@ export class RequestContext {
 	 */
 	async execute<D, T>(
 		opts: CallOptions | undefined,
-		exec: (client: Client) => Promise<RawResult<D>>,
+		exec: Exec<D>,
 		map: (data: D) => T,
 	): Promise<NeonResult<T>> {
-		const raw = await withRetries(
-			() => exec(this.#config.client),
-			this.#config.retries,
-			opts?.signal,
-		);
-		if (raw.error || raw.data === undefined) {
-			return err(toNeonError(raw.error, raw.response));
+		const requested = await this.#request(opts, exec);
+		if (!requested.ok) return err(requested.error);
+		if (requested.data === undefined) {
+			return err(toNeonError(undefined, requested.response));
 		}
-		const readiness = await this.#maybeWait(opts, raw.data);
+		const readiness = await this.#maybeWait(opts, requested.data);
 		if (readiness?.error) return err(readiness.error);
-		return ok(map(raw.data));
+		return ok(map(requested.data));
+	}
+
+	/**
+	 * The request phase: bounded by the call's deadline, retried, and never allowed to
+	 * reject. The deadline is disposed before readiness polling begins, so a request
+	 * budget cannot cut short the separate `wait` budget.
+	 */
+	async #request<D>(
+		opts: CallOptions | undefined,
+		exec: Exec<D>,
+	): Promise<Requested<D>> {
+		const deadline = this.deadlineFor(opts);
+		try {
+			const raw = await runBounded(deadline, () =>
+				withRetries(
+					() => exec(this.#config.client, deadline.signal),
+					this.#config.retries,
+					deadline,
+				),
+			);
+			const cancellation = cancelled(deadline);
+			if (cancellation) return { ok: false, error: cancellation };
+			if (raw === undefined) {
+				return { ok: false, error: toNeonError(undefined, undefined) };
+			}
+			if (raw.error !== undefined) {
+				return {
+					ok: false,
+					error: toNeonError(raw.error, raw.response),
+				};
+			}
+			return { ok: true, data: raw.data, response: raw.response };
+		} catch (error) {
+			return {
+				ok: false,
+				error: cancelled(deadline) ?? toNeonError(error, undefined),
+			};
+		} finally {
+			deadline.dispose();
+		}
 	}
 
 	/** Poll provisioning operations when `waitForReadiness` is on and the body has any. */

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -3,6 +3,7 @@ import {
 	cancelled,
 	createDeadline,
 	type Deadline,
+	resolveTimeoutMs,
 	runBounded,
 } from "./deadline.js";
 import { type NeonError, toNeonError } from "./errors.js";
@@ -79,10 +80,18 @@ export class RequestContext {
 		return this.#config;
 	}
 
-	/** The deadline for one call: the per-call timeout if given, else the client's. */
+	/**
+	 * The deadline for one call: the per-call timeout if given, else the client's.
+	 *
+	 * A per-call value is validated the same way the client's was. Skipping that left
+	 * `requestTimeoutMs: NaN` meaning *unbounded* and a value past `setTimeout`'s range
+	 * meaning *1ms*, both silently.
+	 */
 	deadlineFor(opts: CallOptions | undefined): Deadline {
 		const timeoutMs =
-			opts?.requestTimeoutMs ?? this.#config.requestTimeoutMs;
+			opts?.requestTimeoutMs === undefined
+				? this.#config.requestTimeoutMs
+				: resolveTimeoutMs(opts.requestTimeoutMs);
 		return createDeadline(timeoutMs, opts?.signal);
 	}
 

--- a/packages/sdk/src/neon/deadline.test.ts
+++ b/packages/sdk/src/neon/deadline.test.ts
@@ -1,0 +1,157 @@
+import { getEventListeners } from "node:events";
+import { describe, expect, it } from "vitest";
+import { cancelled, createDeadline, delay, runBounded } from "./deadline.js";
+
+describe("delay", () => {
+	it("reports elapsed when it runs to completion", async () => {
+		expect(await delay(5)).toBe("elapsed");
+	});
+
+	it("reports cancelled instead of rejecting, so no DOMException escapes", async () => {
+		const controller = new AbortController();
+		setTimeout(() => controller.abort(), 5);
+		expect(await delay(60_000, controller.signal)).toBe("cancelled");
+	});
+
+	it("reports cancelled immediately for an already-aborted signal", async () => {
+		expect(await delay(60_000, AbortSignal.abort())).toBe("cancelled");
+	});
+
+	it("removes its abort listener either way, so repeated waits don't accumulate", async () => {
+		const controller = new AbortController();
+		for (let i = 0; i < 25; i++) await delay(1, controller.signal);
+		// Node warns past 10 listeners on one target; a leak here would be a poller that
+		// degrades the longer it runs.
+		expect(getEventListeners(controller.signal, "abort").length).toBe(0);
+	});
+});
+
+describe("createDeadline", () => {
+	it("is unbounded and allocates no signal when nothing can cancel it", () => {
+		const deadline = createDeadline(Number.POSITIVE_INFINITY);
+		expect(deadline.signal).toBeUndefined();
+		expect(deadline.remainingMs()).toBe(Number.POSITIVE_INFINITY);
+		expect(deadline.source()).toBeUndefined();
+	});
+
+	it("still exposes a signal when unbounded but given a caller signal", () => {
+		const controller = new AbortController();
+		const deadline = createDeadline(
+			Number.POSITIVE_INFINITY,
+			controller.signal,
+		);
+		expect(deadline.signal).toBeDefined();
+		expect(deadline.remainingMs()).toBe(Number.POSITIVE_INFINITY);
+		deadline.dispose();
+	});
+
+	it("names the timeout as the source and aborts its signal", async () => {
+		const deadline = createDeadline(5);
+		await deadline.fired();
+		expect(deadline.source()).toBe("timeout");
+		expect(deadline.signal?.aborted).toBe(true);
+		deadline.dispose();
+	});
+
+	it("names the caller as the source, distinguishing cancellation from a timeout", async () => {
+		const controller = new AbortController();
+		const deadline = createDeadline(60_000, controller.signal);
+		controller.abort();
+		await deadline.fired();
+		expect(deadline.source()).toBe("caller");
+		deadline.dispose();
+	});
+
+	it("trips immediately on a signal that was already aborted", () => {
+		const deadline = createDeadline(60_000, AbortSignal.abort());
+		expect(deadline.source()).toBe("caller");
+		expect(deadline.signal?.aborted).toBe(true);
+		deadline.dispose();
+	});
+
+	it("counts the budget down and floors it at zero", async () => {
+		const deadline = createDeadline(50);
+		expect(deadline.remainingMs()).toBeLessThanOrEqual(50);
+		await delay(70);
+		expect(deadline.remainingMs()).toBe(0);
+		deadline.dispose();
+	});
+
+	it("expires from the clock even when the timer never gets a turn", async () => {
+		const deadline = createDeadline(5);
+		// Awaiting already-resolved promises drains the microtask queue without ever
+		// reaching the timer phase, so a deadline that only trusted its timer would never
+		// fire here and the caller would spin forever.
+		let iterations = 0;
+		while (!deadline.source() && iterations < 1_000_000) {
+			await Promise.resolve();
+			iterations++;
+		}
+		expect(deadline.source()).toBe("timeout");
+		expect(deadline.signal?.aborted).toBe(true);
+		deadline.dispose();
+	});
+
+	it("releases the caller-signal listener on dispose", () => {
+		const controller = new AbortController();
+		const deadline = createDeadline(60_000, controller.signal);
+		expect(
+			getEventListeners(controller.signal, "abort").length,
+		).toBeGreaterThan(0);
+		deadline.dispose();
+		expect(getEventListeners(controller.signal, "abort").length).toBe(0);
+	});
+});
+
+describe("cancelled", () => {
+	it("maps a timeout to a timeout error", async () => {
+		const deadline = createDeadline(1);
+		await deadline.fired();
+		expect(cancelled(deadline)?.kind).toBe("timeout");
+		deadline.dispose();
+	});
+
+	it("maps a caller abort to an abort error", async () => {
+		const deadline = createDeadline(60_000, AbortSignal.abort());
+		expect(cancelled(deadline)?.kind).toBe("aborted");
+		deadline.dispose();
+	});
+
+	it("returns undefined while the deadline has not fired", () => {
+		const deadline = createDeadline(60_000);
+		expect(cancelled(deadline)).toBeUndefined();
+		deadline.dispose();
+	});
+});
+
+describe("runBounded", () => {
+	it("returns the value when the work wins", async () => {
+		const deadline = createDeadline(60_000);
+		expect(await runBounded(deadline, async () => "done")).toBe("done");
+		deadline.dispose();
+	});
+
+	it("resolves undefined when the deadline wins, without waiting for the work", async () => {
+		const deadline = createDeadline(5);
+		const startedAt = Date.now();
+		const result = await runBounded(
+			deadline,
+			() => new Promise<string>((resolve) => setTimeout(resolve, 60_000)),
+		);
+		expect(result).toBeUndefined();
+		expect(Date.now() - startedAt).toBeLessThan(1_000);
+		deadline.dispose();
+	});
+
+	it("does not leave an unhandled rejection behind when the deadline wins", async () => {
+		const deadline = createDeadline(5);
+		await runBounded(deadline, async () => {
+			await delay(20);
+			throw new Error("late failure the caller never saw");
+		});
+		// The abandoned work rejects after the race is decided; if that rejection were
+		// unhandled it would surface here as an unhandled-rejection failure.
+		await delay(60);
+		deadline.dispose();
+	});
+});

--- a/packages/sdk/src/neon/deadline.ts
+++ b/packages/sdk/src/neon/deadline.ts
@@ -12,7 +12,14 @@
  * to a caller who was promised `{ data, error }`.
  */
 
-import { NeonAbortError, type NeonError, NeonTimeoutError } from "./errors.js";
+import { NeonAbortError, NeonError, NeonTimeoutError } from "./errors.js";
+
+/**
+ * The largest delay `setTimeout` can represent. Beyond it Node warns
+ * (`TimeoutOverflowWarning`) and fires after 1ms instead, which would turn a deliberately
+ * generous deadline into an instant timeout.
+ */
+const MAX_TIMER_MS = 2 ** 31 - 1;
 
 /** Why a bounded wait ended. */
 export type DelayOutcome = "elapsed" | "cancelled";
@@ -54,6 +61,36 @@ const UNBOUNDED: Deadline = {
 	fired: () => new Promise<void>(() => {}),
 	dispose: () => {},
 };
+
+/**
+ * Normalize a `requestTimeoutMs`, rejecting values `setTimeout` would mistreat.
+ *
+ * Shared by the client config and by per-call overrides — validating only at construction
+ * left `requestTimeoutMs: NaN` on a call silently meaning *unbounded*, and a value past
+ * {@link MAX_TIMER_MS} silently meaning *1ms*. Both are worse than an error, because the
+ * call still returns a plausible-looking result.
+ *
+ * `undefined` and `Infinity` both mean unbounded; `Infinity` is the documented way to opt
+ * a single call out of a client-wide deadline.
+ */
+export function resolveTimeoutMs(value: number | undefined): number {
+	if (value === undefined || value === Number.POSITIVE_INFINITY) {
+		return Number.POSITIVE_INFINITY;
+	}
+	if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
+		throw new NeonError(
+			`requestTimeoutMs must be a positive number of milliseconds, or Infinity to disable; received ${String(value)}.`,
+			"client",
+		);
+	}
+	if (value > MAX_TIMER_MS) {
+		throw new NeonError(
+			`requestTimeoutMs must be at most ${MAX_TIMER_MS}ms (about 24.8 days); received ${value}. Pass Infinity for no deadline.`,
+			"client",
+		);
+	}
+	return value;
+}
 
 /**
  * The typed error for a deadline that has fired, or `undefined` if it has not.
@@ -130,7 +167,9 @@ export function createDeadline(
 	const bounded = Number.isFinite(timeoutMs);
 	if (!bounded && !callerSignal) return UNBOUNDED;
 
-	const startedAt = Date.now();
+	// Monotonic: a wall-clock jump (NTP correction, manual change) would otherwise expire
+	// a deadline early or extend one whose timer is being starved.
+	const startedAt = performance.now();
 	const controller = new AbortController();
 	let source: DeadlineSource | undefined;
 	let notify: (() => void) | undefined;
@@ -159,7 +198,7 @@ export function createDeadline(
 
 	const remainingMs = () =>
 		bounded
-			? Math.max(0, timeoutMs - (Date.now() - startedAt))
+			? Math.max(0, timeoutMs - (performance.now() - startedAt))
 			: Number.POSITIVE_INFINITY;
 
 	return {

--- a/packages/sdk/src/neon/deadline.ts
+++ b/packages/sdk/src/neon/deadline.ts
@@ -1,0 +1,178 @@
+/**
+ * Cancellation and deadline plumbing shared by the ergonomic layer.
+ *
+ * Two facts shape this module. Handing a signal to `fetch` does **not** bound a call: the
+ * generated client awaits authentication and request interceptors before it constructs the
+ * `Request` (see `client/client/client.gen.ts`), and a caller-supplied `fetch` may ignore
+ * the signal entirely. So a deadline both carries a signal *and* offers {@link Deadline.fired}
+ * to race the whole execution against.
+ *
+ * And a cancelled call must still speak the result contract. Anything that waits here
+ * reports cancellation as a value rather than rejecting, so a `DOMException` never escapes
+ * to a caller who was promised `{ data, error }`.
+ */
+
+import { NeonAbortError, type NeonError, NeonTimeoutError } from "./errors.js";
+
+/** Why a bounded wait ended. */
+export type DelayOutcome = "elapsed" | "cancelled";
+
+/** What ended a call: the caller's own signal, or the request-timeout budget. */
+export type DeadlineSource = "caller" | "timeout";
+
+export interface Deadline {
+	/**
+	 * Attach to every request the call makes. `undefined` when the call is unbounded and
+	 * the caller passed no signal, so nothing extra is allocated for the common case.
+	 */
+	readonly signal: AbortSignal | undefined;
+	/** Budget left in milliseconds; `Infinity` when no request timeout applies. */
+	remainingMs(): number;
+	/**
+	 * What ended the call, or `undefined` while it may still proceed.
+	 *
+	 * Reads the clock rather than trusting the timer to have run, and trips the deadline
+	 * itself if the budget is already spent. A loop that only ever awaits
+	 * already-resolved promises — paginating a cursor the API keeps repeating, say —
+	 * yields to the microtask queue but never to the timer phase, so a timer-only
+	 * deadline would never fire and the call would spin forever.
+	 */
+	source(): DeadlineSource | undefined;
+	/**
+	 * Resolves when the deadline fires, and otherwise never settles. Used to bound the
+	 * phases a request signal cannot reach. Never rejects.
+	 */
+	fired(): Promise<void>;
+	/** Release the timer and the caller-signal listener. Safe to call more than once. */
+	dispose(): void;
+}
+
+const UNBOUNDED: Deadline = {
+	signal: undefined,
+	remainingMs: () => Number.POSITIVE_INFINITY,
+	source: () => undefined,
+	fired: () => new Promise<void>(() => {}),
+	dispose: () => {},
+};
+
+/**
+ * The typed error for a deadline that has fired, or `undefined` if it has not.
+ *
+ * Cancellation is classified from the deadline's own state rather than from the shape of
+ * the error that came back. The generated client funnels authentication, serialization,
+ * interceptor, transport and parsing faults through one channel, so an error merely named
+ * `AbortError` is not evidence that the caller cancelled.
+ */
+export function cancelled(deadline: Deadline): NeonError | undefined {
+	const source = deadline.source();
+	if (source === "caller") {
+		return new NeonAbortError("The request was aborted by its signal.");
+	}
+	if (source === "timeout") {
+		return new NeonTimeoutError(
+			"Timed out waiting for the Neon API to respond (requestTimeoutMs).",
+		);
+	}
+	return undefined;
+}
+
+/**
+ * Race `run()` against the deadline, resolving `undefined` when the deadline wins.
+ *
+ * The signal alone does not bound a call. The generated client awaits authentication and
+ * request interceptors before it constructs the `Request`, and a caller-supplied `fetch`
+ * need not honour a signal at all, so an `apiKey` function that never resolves would
+ * otherwise hang forever even with a deadline set.
+ */
+export async function runBounded<T>(
+	deadline: Deadline,
+	run: () => Promise<T>,
+): Promise<T | undefined> {
+	if (!deadline.signal) return run();
+	const execution = run();
+	// The losing arm still settles later. Without a handler, its rejection is reported as
+	// unhandled once the deadline has already answered the caller.
+	execution.catch(() => {});
+	return Promise.race([execution, deadline.fired().then(() => undefined)]);
+}
+
+/**
+ * Wait `ms`, or stop early when `signal` aborts. Resolves either way — an abort is
+ * reported as `"cancelled"` rather than thrown, and the listener is always removed so a
+ * long-lived caller signal doesn't accumulate one per wait.
+ */
+export function delay(ms: number, signal?: AbortSignal): Promise<DelayOutcome> {
+	if (signal?.aborted) return Promise.resolve("cancelled");
+	return new Promise<DelayOutcome>((resolve) => {
+		const onAbort = () => {
+			clearTimeout(timer);
+			resolve("cancelled");
+		};
+		const timer = setTimeout(() => {
+			signal?.removeEventListener("abort", onAbort);
+			resolve("elapsed");
+		}, ms);
+		signal?.addEventListener("abort", onAbort, { once: true });
+	});
+}
+
+/**
+ * Build the deadline for one call.
+ *
+ * `timeoutMs` is `Infinity` when no request timeout applies. With no timeout and no caller
+ * signal there is nothing to cancel, so a shared no-op deadline is returned and no timer
+ * or controller is allocated.
+ */
+export function createDeadline(
+	timeoutMs: number,
+	callerSignal?: AbortSignal,
+): Deadline {
+	const bounded = Number.isFinite(timeoutMs);
+	if (!bounded && !callerSignal) return UNBOUNDED;
+
+	const startedAt = Date.now();
+	const controller = new AbortController();
+	let source: DeadlineSource | undefined;
+	let notify: (() => void) | undefined;
+	const fired = new Promise<void>((resolve) => {
+		notify = resolve;
+	});
+
+	const trip = (reason: DeadlineSource) => {
+		if (source) return;
+		source = reason;
+		controller.abort();
+		notify?.();
+	};
+
+	if (callerSignal?.aborted) trip("caller");
+
+	const onCallerAbort = () => trip("caller");
+	// Deliberately not `unref`ed: every deadline is disposed in a `finally`, so it cannot
+	// outlive its call, and an unref'd timer is invisible to the event loop's liveness
+	// accounting — a call whose only pending work is the deadline would starve instead of
+	// timing out.
+	const timer = bounded
+		? setTimeout(() => trip("timeout"), timeoutMs)
+		: undefined;
+	callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+
+	const remainingMs = () =>
+		bounded
+			? Math.max(0, timeoutMs - (Date.now() - startedAt))
+			: Number.POSITIVE_INFINITY;
+
+	return {
+		signal: controller.signal,
+		remainingMs,
+		source: () => {
+			if (!source && remainingMs() === 0) trip("timeout");
+			return source;
+		},
+		fired: () => fired,
+		dispose: () => {
+			clearTimeout(timer);
+			callerSignal?.removeEventListener("abort", onCallerAbort);
+		},
+	};
+}

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -15,6 +15,7 @@ export type NeonErrorKind =
 	| "rate_limit"
 	| "operation"
 	| "timeout"
+	| "aborted"
 	| "network"
 	| "client";
 
@@ -125,11 +126,32 @@ export class NeonOperationError extends NeonError {
 	}
 }
 
-/** Waiting for operations to finish exceeded the configured timeout. */
+/**
+ * A deadline was exceeded — either `requestTimeoutMs` for a request and its retries, or
+ * the `wait` budget while polling operations for readiness.
+ */
 export class NeonTimeoutError extends NeonError {
 	constructor(message: string) {
 		super(message, "timeout");
 		this.name = "NeonTimeoutError";
+	}
+}
+
+/**
+ * The caller's `AbortSignal` fired. Distinct from {@link NeonTimeoutError} because nothing
+ * went wrong: the caller asked for the work to stop, and the two call for different
+ * handling (retry a timeout, don't retry a cancellation).
+ *
+ * Raised only where the SDK knows the caller cancelled — the call's own deadline, or an
+ * already-aborted `signal` on a raw call. A transport failure that merely looks like an
+ * abort stays a {@link NeonNetworkError}, since the generated client reports auth,
+ * serialization, interceptor and parsing faults through the same channel and an error's
+ * name is not evidence about which one occurred.
+ */
+export class NeonAbortError extends NeonError {
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, "aborted", options);
+		this.name = "NeonAbortError";
 	}
 }
 

--- a/packages/sdk/src/neon/paginate.ts
+++ b/packages/sdk/src/neon/paginate.ts
@@ -1,3 +1,4 @@
+import { cancelled, type Deadline } from "./deadline.js";
 import { toNeonError } from "./errors.js";
 import { err, type NeonResult, ok } from "./result.js";
 
@@ -33,7 +34,7 @@ class PaginatedList<T, D> implements Paginated<T> {
 		signal?: AbortSignal,
 	) => Promise<RawResult<D>>;
 	readonly #mapPage: (data: D) => Page<T>;
-	readonly #signal?: AbortSignal;
+	readonly #newDeadline: () => Deadline;
 
 	constructor(
 		fetchPage: (
@@ -41,42 +42,78 @@ class PaginatedList<T, D> implements Paginated<T> {
 			signal?: AbortSignal,
 		) => Promise<RawResult<D>>,
 		mapPage: (data: D) => Page<T>,
-		signal?: AbortSignal,
+		newDeadline: () => Deadline,
 	) {
 		this.#fetchPage = fetchPage;
 		this.#mapPage = mapPage;
-		this.#signal = signal;
+		this.#newDeadline = newDeadline;
 	}
 
-	async page(cursor?: string): Promise<NeonResult<Page<T>>> {
-		const raw = await this.#fetchPage(cursor, this.#signal);
+	async #page(
+		cursor: string | undefined,
+		deadline: Deadline,
+	): Promise<NeonResult<Page<T>>> {
+		let raw: RawResult<D>;
+		try {
+			raw = await this.#fetchPage(cursor, deadline.signal);
+		} catch (error) {
+			return err(cancelled(deadline) ?? toNeonError(error, undefined));
+		}
+		const cancellation = cancelled(deadline);
+		if (cancellation) return err(cancellation);
 		if (raw.error || raw.data === undefined) {
 			return err(toNeonError(raw.error, raw.response));
 		}
 		return ok(this.#mapPage(raw.data));
 	}
 
-	async all(): Promise<NeonResult<T[]>> {
-		const items: T[] = [];
-		let cursor: string | undefined;
-		while (true) {
-			const result = await this.page(cursor);
-			if (result.error) return err(result.error);
-			items.push(...result.data.items);
-			if (!result.data.cursor || result.data.items.length === 0) break;
-			cursor = result.data.cursor;
+	async page(cursor?: string): Promise<NeonResult<Page<T>>> {
+		const deadline = this.#newDeadline();
+		try {
+			return await this.#page(cursor, deadline);
+		} finally {
+			deadline.dispose();
 		}
-		return ok(items);
+	}
+
+	/**
+	 * One deadline covers the whole walk, not each page: `all()` is a single operation
+	 * from the caller's side, and a per-page budget would leave an unbounded number of
+	 * pages unbounded in total.
+	 */
+	async all(): Promise<NeonResult<T[]>> {
+		const deadline = this.#newDeadline();
+		try {
+			const items: T[] = [];
+			let cursor: string | undefined;
+			while (true) {
+				const result = await this.#page(cursor, deadline);
+				if (result.error) return err(result.error);
+				items.push(...result.data.items);
+				if (!result.data.cursor || result.data.items.length === 0)
+					break;
+				cursor = result.data.cursor;
+			}
+			return ok(items);
+		} finally {
+			deadline.dispose();
+		}
 	}
 
 	async *[Symbol.asyncIterator](): AsyncIterator<T> {
-		let cursor: string | undefined;
-		while (true) {
-			const result = await this.page(cursor);
-			if (result.error) throw result.error;
-			yield* result.data.items;
-			if (!result.data.cursor || result.data.items.length === 0) break;
-			cursor = result.data.cursor;
+		const deadline = this.#newDeadline();
+		try {
+			let cursor: string | undefined;
+			while (true) {
+				const result = await this.#page(cursor, deadline);
+				if (result.error) throw result.error;
+				yield* result.data.items;
+				if (!result.data.cursor || result.data.items.length === 0)
+					break;
+				cursor = result.data.cursor;
+			}
+		} finally {
+			deadline.dispose();
 		}
 	}
 }
@@ -84,6 +121,10 @@ class PaginatedList<T, D> implements Paginated<T> {
 /**
  * Build a {@link Paginated} list from a page fetcher and a page mapper. The response-body
  * type `D` is inferred and erased from the public `Paginated<T>` return.
+ *
+ * `newDeadline` is called once per consumption — each `page()`, each `all()`, each
+ * iteration — because a `Paginated` is lazy and may be consumed more than once, so a
+ * deadline created when the list was built would already be spent.
  */
 export function paginate<T, D>(
 	fetchPage: (
@@ -91,7 +132,7 @@ export function paginate<T, D>(
 		signal?: AbortSignal,
 	) => Promise<RawResult<D>>,
 	mapPage: (data: D) => Page<T>,
-	signal?: AbortSignal,
+	newDeadline: () => Deadline,
 ): Paginated<T> {
-	return new PaginatedList(fetchPage, mapPage, signal);
+	return new PaginatedList(fetchPage, mapPage, newDeadline);
 }

--- a/packages/sdk/src/neon/paginate.ts
+++ b/packages/sdk/src/neon/paginate.ts
@@ -1,4 +1,4 @@
-import { cancelled, type Deadline } from "./deadline.js";
+import { cancelled, type Deadline, runBounded } from "./deadline.js";
 import { toNeonError } from "./errors.js";
 import { err, type NeonResult, ok } from "./result.js";
 
@@ -53,16 +53,21 @@ class PaginatedList<T, D> implements Paginated<T> {
 		cursor: string | undefined,
 		deadline: Deadline,
 	): Promise<NeonResult<Page<T>>> {
-		let raw: RawResult<D>;
+		let raw: RawResult<D> | undefined;
 		try {
-			raw = await this.#fetchPage(cursor, deadline.signal);
+			// Bounded the same way the execution core bounds a request: the signal alone
+			// does not cover the phases before `fetch` is reached, so a slow auth provider
+			// would otherwise outlast the deadline.
+			raw = await runBounded(deadline, () =>
+				this.#fetchPage(cursor, deadline.signal),
+			);
 		} catch (error) {
 			return err(cancelled(deadline) ?? toNeonError(error, undefined));
 		}
 		const cancellation = cancelled(deadline);
 		if (cancellation) return err(cancellation);
-		if (raw.error || raw.data === undefined) {
-			return err(toNeonError(raw.error, raw.response));
+		if (raw === undefined || raw.error || raw.data === undefined) {
+			return err(toNeonError(raw?.error, raw?.response));
 		}
 		return ok(this.#mapPage(raw.data));
 	}

--- a/packages/sdk/src/neon/raw-wrap.ts
+++ b/packages/sdk/src/neon/raw-wrap.ts
@@ -15,7 +15,26 @@
  */
 
 import type { NeonError } from "./errors.js";
-import { toNeonError } from "./errors.js";
+import { NeonAbortError, toNeonError } from "./errors.js";
+
+/**
+ * Did the caller's own signal end this call?
+ *
+ * Read from the signal rather than the error, because the generated client reports
+ * authentication, serialization, interceptor, transport and parsing faults through one
+ * channel — an error named `AbortError` is not evidence about which occurred. A response
+ * having arrived rules cancellation out.
+ *
+ * This deliberately says nothing about a signal the SDK never saw: the Neon CLI installs
+ * its own request timeout inside a custom `fetch` rather than passing `signal`, so its
+ * timeouts keep classifying as {@link NeonNetworkError} exactly as before.
+ */
+function abortedBy(
+	signal: AbortSignal | undefined,
+	response: Response | undefined,
+): boolean {
+	return response === undefined && signal?.aborted === true;
+}
 
 /**
  * Structural shape of any generated raw function: generic over `throwOnError`, resolving to
@@ -93,7 +112,11 @@ export function wrapRaw<F extends AnyRawFn>(fn: F & AnyRawFn) {
 			responseStyle: "fields",
 		});
 		if (raw.error !== undefined && raw.error !== null) {
-			const error = toNeonError(raw.error, raw.response);
+			const error = abortedBy(options.signal, raw.response)
+				? new NeonAbortError("The request was aborted by its signal.", {
+						cause: raw.error,
+					})
+				: toNeonError(raw.error, raw.response);
 			if (shouldThrow) throw error;
 			return {
 				data: undefined,

--- a/packages/sdk/src/neon/resources/account.ts
+++ b/packages/sdk/src/neon/resources/account.ts
@@ -35,7 +35,8 @@ export class User<DThrow extends boolean> {
 	): Promise<CurrentUserInfoResponse | NeonResult<CurrentUserInfoResponse>> {
 		return this.#ctx.run(
 			opts,
-			(client) => getCurrentUserInfo({ client, throwOnError: false }),
+			(client, signal) =>
+				getCurrentUserInfo({ client, throwOnError: false, signal }),
 			(data) => data,
 		);
 	}
@@ -50,8 +51,12 @@ export class User<DThrow extends boolean> {
 	): Promise<Organization[] | NeonResult<Organization[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
-				getCurrentUserOrganizations({ client, throwOnError: false }),
+			(client, signal) =>
+				getCurrentUserOrganizations({
+					client,
+					throwOnError: false,
+					signal,
+				}),
 			(data) => data.organizations,
 		);
 	}
@@ -75,7 +80,8 @@ export class Regions<DThrow extends boolean> {
 	): Promise<RegionResponse[] | NeonResult<RegionResponse[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) => getActiveRegions({ client, throwOnError: false }),
+			(client, signal) =>
+				getActiveRegions({ client, throwOnError: false, signal }),
 			(data) => data.regions,
 		);
 	}
@@ -101,7 +107,8 @@ export class ApiKeys<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) => listApiKeys({ client, throwOnError: false }),
+			(client, signal) =>
+				listApiKeys({ client, throwOnError: false, signal }),
 			(data) => data,
 		);
 	}
@@ -122,11 +129,12 @@ export class ApiKeys<DThrow extends boolean> {
 	): Promise<ApiKeyCreateResponse | NeonResult<ApiKeyCreateResponse>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createApiKey({
 					client,
 					body: { key_name: keyName },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -144,11 +152,12 @@ export class ApiKeys<DThrow extends boolean> {
 	): Promise<ApiKeyRevokeResponse | NeonResult<ApiKeyRevokeResponse>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				revokeApiKey({
 					client,
 					path: { key_id: keyId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);

--- a/packages/sdk/src/neon/resources/ai-gateway.ts
+++ b/packages/sdk/src/neon/resources/ai-gateway.ts
@@ -28,11 +28,12 @@ export class AiGateway<DThrow extends boolean> {
 	): Promise<BranchAiGateway | NeonResult<BranchAiGateway>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchAiGateway({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);

--- a/packages/sdk/src/neon/resources/auth.ts
+++ b/packages/sdk/src/neon/resources/auth.ts
@@ -59,11 +59,12 @@ export class AuthOauthProviders<DThrow extends boolean> {
 	): Promise<NeonAuthOauthProvider[] | NeonResult<NeonAuthOauthProvider[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listBranchNeonAuthOauthProviders({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.providers,
 		);
@@ -89,12 +90,13 @@ export class AuthOauthProviders<DThrow extends boolean> {
 	): Promise<NeonAuthOauthProvider | NeonResult<NeonAuthOauthProvider>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				addBranchNeonAuthOauthProvider({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -123,7 +125,7 @@ export class AuthOauthProviders<DThrow extends boolean> {
 	): Promise<NeonAuthOauthProvider | NeonResult<NeonAuthOauthProvider>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateBranchNeonAuthOauthProvider({
 					client,
 					path: {
@@ -133,6 +135,7 @@ export class AuthOauthProviders<DThrow extends boolean> {
 					},
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -156,7 +159,7 @@ export class AuthOauthProviders<DThrow extends boolean> {
 		providerId: NeonAuthOauthProviderId,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteBranchNeonAuthOauthProvider({
 				client,
 				path: {
@@ -165,6 +168,7 @@ export class AuthOauthProviders<DThrow extends boolean> {
 					oauth_provider_id: providerId,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -198,11 +202,12 @@ export class AuthTrustedDomains<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listBranchNeonAuthTrustedDomains({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.domains,
 		);
@@ -226,12 +231,13 @@ export class AuthTrustedDomains<DThrow extends boolean> {
 		input: NeonAuthAddDomainToRedirectUriWhitelistRequest,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			addBranchNeonAuthTrustedDomain({
 				client,
 				path: { project_id: projectId, branch_id: branchId },
 				body: input,
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -254,12 +260,13 @@ export class AuthTrustedDomains<DThrow extends boolean> {
 		input: NeonAuthDeleteDomainFromRedirectUriWhitelistRequest,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteBranchNeonAuthTrustedDomain({
 				client,
 				path: { project_id: projectId, branch_id: branchId },
 				body: input,
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -296,12 +303,13 @@ export class AuthUsers<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createBranchNeonAuthNewUser({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -325,7 +333,7 @@ export class AuthUsers<DThrow extends boolean> {
 		authUserId: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteBranchNeonAuthUser({
 				client,
 				path: {
@@ -334,6 +342,7 @@ export class AuthUsers<DThrow extends boolean> {
 					auth_user_id: authUserId,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -364,7 +373,7 @@ export class AuthUsers<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateNeonAuthUserRole({
 					client,
 					path: {
@@ -374,6 +383,7 @@ export class AuthUsers<DThrow extends boolean> {
 					},
 					body: { roles },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -415,11 +425,12 @@ export class Auth<DThrow extends boolean> {
 	): Promise<NeonAuthIntegration | NeonResult<NeonAuthIntegration>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getNeonAuth({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -448,12 +459,13 @@ export class Auth<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createNeonAuth({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -477,12 +489,13 @@ export class Auth<DThrow extends boolean> {
 		input?: { deleteData?: boolean },
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			disableNeonAuth({
 				client,
 				path: { project_id: projectId, branch_id: branchId },
 				body: { delete_data: input?.deleteData },
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -507,12 +520,13 @@ export class Auth<DThrow extends boolean> {
 	): Promise<NeonAuthConfigResponse | NeonResult<NeonAuthConfigResponse>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateNeonAuthConfig({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -60,7 +60,11 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches (cursor-paginated) */
-	list(projectId: string, query?: ListQuery): Paginated<Branch> {
+	list(
+		projectId: string,
+		query?: ListQuery,
+		opts?: CallOptions,
+	): Paginated<Branch> {
 		return paginate(
 			(cursor, signal) =>
 				listProjectBranches({
@@ -74,6 +78,7 @@ export class Branches<DThrow extends boolean> {
 				items: data?.branches ?? [],
 				cursor: data?.pagination?.next,
 			}),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 
@@ -91,11 +96,12 @@ export class Branches<DThrow extends boolean> {
 	): Promise<Branch | NeonResult<Branch>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranch({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.branch,
 		);
@@ -118,12 +124,13 @@ export class Branches<DThrow extends boolean> {
 	): Promise<Branch | NeonResult<Branch>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProjectBranch({
 					client,
 					path: { project_id: projectId },
 					body: { branch: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.branch,
 		);
@@ -149,12 +156,13 @@ export class Branches<DThrow extends boolean> {
 	): Promise<Branch | NeonResult<Branch>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateProjectBranch({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: { branch: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.branch,
 		);
@@ -172,11 +180,12 @@ export class Branches<DThrow extends boolean> {
 		branchId: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranch({
 				client,
 				path: { project_id: projectId, branch_id: branchId },
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -205,7 +214,7 @@ export class Branches<DThrow extends boolean> {
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
 			{ ...opts, waitForReadiness: opts?.waitForReadiness ?? true },
-			(client) =>
+			(client, signal) =>
 				createProjectBranch({
 					client,
 					path: { project_id: projectId },
@@ -222,6 +231,7 @@ export class Branches<DThrow extends boolean> {
 						],
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -255,11 +265,12 @@ export class Branches<DThrow extends boolean> {
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectBranches({
 					client,
 					path: { project_id: projectId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.branches,
 		);
@@ -297,11 +308,12 @@ export class Branches<DThrow extends boolean> {
 	): Promise<Branch | NeonResult<Branch>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				setDefaultProjectBranch({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.branch,
 		);
@@ -333,12 +345,13 @@ export class Branches<DThrow extends boolean> {
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				finalizeRestoreBranch({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: { name: input?.name },
 					throwOnError: false,
+					signal,
 				}),
 			() => undefined,
 		);
@@ -365,11 +378,12 @@ export class Branches<DThrow extends boolean> {
 	): Promise<Branch | NeonResult<Branch>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				recoverProjectBranch({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.branch,
 		);

--- a/packages/sdk/src/neon/resources/bucket-objects.ts
+++ b/packages/sdk/src/neon/resources/bucket-objects.ts
@@ -53,7 +53,7 @@ export class BucketObjects<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectBranchBucketObjects({
 					client,
 					path: {
@@ -63,6 +63,7 @@ export class BucketObjects<DThrow extends boolean> {
 					},
 					query,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -91,7 +92,7 @@ export class BucketObjects<DThrow extends boolean> {
 	): Promise<Blob | NeonResult<Blob>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchBucketObject({
 					client,
 					path: {
@@ -101,6 +102,7 @@ export class BucketObjects<DThrow extends boolean> {
 						object_key: objectKey,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -127,7 +129,7 @@ export class BucketObjects<DThrow extends boolean> {
 		objectKey: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchBucketObject({
 				client,
 				path: {
@@ -137,6 +139,7 @@ export class BucketObjects<DThrow extends boolean> {
 					object_key: objectKey,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -167,7 +170,7 @@ export class BucketObjects<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				deleteProjectBranchBucketObjectsByPrefix({
 					client,
 					path: {
@@ -177,6 +180,7 @@ export class BucketObjects<DThrow extends boolean> {
 					},
 					query: { prefix },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -208,7 +212,7 @@ export class BucketObjects<DThrow extends boolean> {
 	): Promise<PresignResponse | NeonResult<PresignResponse>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				presignProjectBranchBucketObject({
 					client,
 					path: {
@@ -219,6 +223,7 @@ export class BucketObjects<DThrow extends boolean> {
 					},
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);

--- a/packages/sdk/src/neon/resources/buckets.ts
+++ b/packages/sdk/src/neon/resources/buckets.ts
@@ -38,11 +38,12 @@ export class Buckets<DThrow extends boolean> {
 	): Promise<Bucket[] | NeonResult<Bucket[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectBranchBuckets({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.buckets,
 		);
@@ -68,12 +69,13 @@ export class Buckets<DThrow extends boolean> {
 	): Promise<Bucket | NeonResult<Bucket>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProjectBranchBucket({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.bucket,
 		);
@@ -97,7 +99,7 @@ export class Buckets<DThrow extends boolean> {
 		bucketName: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchBucket({
 				client,
 				path: {
@@ -106,6 +108,7 @@ export class Buckets<DThrow extends boolean> {
 					bucket_name: bucketName,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}

--- a/packages/sdk/src/neon/resources/consumption.ts
+++ b/packages/sdk/src/neon/resources/consumption.ts
@@ -11,7 +11,7 @@ import type {
 	GetConsumptionHistoryPerProjectData,
 	GetConsumptionHistoryPerProjectV2Data,
 } from "../../client/types.gen.js";
-import type { RequestContext } from "../context.js";
+import type { CallOptions, RequestContext } from "../context.js";
 import { type Paginated, paginate } from "../paginate.js";
 
 type PerProjectQuery = Omit<
@@ -38,6 +38,7 @@ export class Consumption {
 	/** @apiCall GET /consumption_history/projects */
 	perProject(
 		query: PerProjectQuery,
+		opts?: CallOptions,
 	): Paginated<ConsumptionHistoryPerProject> {
 		return paginate(
 			(cursor, signal) =>
@@ -51,12 +52,14 @@ export class Consumption {
 				items: data?.projects ?? [],
 				cursor: data?.pagination?.cursor,
 			}),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 
 	/** @apiCall GET /consumption_history/v2/projects */
 	perProjectV2(
 		query: PerProjectV2Query,
+		opts?: CallOptions,
 	): Paginated<ConsumptionHistoryPerProjectV2> {
 		return paginate(
 			(cursor, signal) =>
@@ -70,12 +73,14 @@ export class Consumption {
 				items: data?.projects ?? [],
 				cursor: data?.pagination?.cursor,
 			}),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 
 	/** @apiCall GET /consumption_history/v2/branches */
 	perBranchV2(
 		query: PerBranchV2Query,
+		opts?: CallOptions,
 	): Paginated<ConsumptionHistoryPerBranchV2> {
 		return paginate(
 			(cursor, signal) =>
@@ -89,6 +94,7 @@ export class Consumption {
 				items: data?.branches ?? [],
 				cursor: data?.pagination?.cursor,
 			}),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 }

--- a/packages/sdk/src/neon/resources/credentials.ts
+++ b/packages/sdk/src/neon/resources/credentials.ts
@@ -38,11 +38,12 @@ export class Credentials<DThrow extends boolean> {
 	): Promise<CredentialMeta[] | NeonResult<CredentialMeta[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listCredentials({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.credentials,
 		);
@@ -70,12 +71,13 @@ export class Credentials<DThrow extends boolean> {
 	> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createCredential({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -99,7 +101,7 @@ export class Credentials<DThrow extends boolean> {
 		tokenId: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			revokeCredential({
 				client,
 				path: {
@@ -108,6 +110,7 @@ export class Credentials<DThrow extends boolean> {
 					token_id: tokenId,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}

--- a/packages/sdk/src/neon/resources/dataapi.ts
+++ b/packages/sdk/src/neon/resources/dataapi.ts
@@ -41,7 +41,7 @@ export class DataApi<DThrow extends boolean> {
 	): Promise<DataApiReponse | NeonResult<DataApiReponse>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchDataApi({
 					client,
 					path: {
@@ -50,6 +50,7 @@ export class DataApi<DThrow extends boolean> {
 						database_name: databaseName,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -78,7 +79,7 @@ export class DataApi<DThrow extends boolean> {
 	): Promise<DataApiCreateResponse | NeonResult<DataApiCreateResponse>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProjectBranchDataApi({
 					client,
 					path: {
@@ -88,6 +89,7 @@ export class DataApi<DThrow extends boolean> {
 					},
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -116,7 +118,7 @@ export class DataApi<DThrow extends boolean> {
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateProjectBranchDataApi({
 					client,
 					path: {
@@ -126,6 +128,7 @@ export class DataApi<DThrow extends boolean> {
 					},
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			() => undefined,
 		);
@@ -151,7 +154,7 @@ export class DataApi<DThrow extends boolean> {
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				deleteProjectBranchDataApi({
 					client,
 					path: {
@@ -160,6 +163,7 @@ export class DataApi<DThrow extends boolean> {
 						database_name: databaseName,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			() => undefined,
 		);

--- a/packages/sdk/src/neon/resources/databases.ts
+++ b/packages/sdk/src/neon/resources/databases.ts
@@ -41,11 +41,12 @@ export class Databases<DThrow extends boolean> {
 	): Promise<Database[] | NeonResult<Database[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectBranchDatabases({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.databases,
 		);
@@ -71,7 +72,7 @@ export class Databases<DThrow extends boolean> {
 	): Promise<Database | NeonResult<Database>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchDatabase({
 					client,
 					path: {
@@ -80,6 +81,7 @@ export class Databases<DThrow extends boolean> {
 						database_name: name,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.database,
 		);
@@ -105,12 +107,13 @@ export class Databases<DThrow extends boolean> {
 	): Promise<Database | NeonResult<Database>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProjectBranchDatabase({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: { database: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.database,
 		);
@@ -139,7 +142,7 @@ export class Databases<DThrow extends boolean> {
 	): Promise<Database | NeonResult<Database>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateProjectBranchDatabase({
 					client,
 					path: {
@@ -149,6 +152,7 @@ export class Databases<DThrow extends boolean> {
 					},
 					body: { database: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.database,
 		);
@@ -172,7 +176,7 @@ export class Databases<DThrow extends boolean> {
 		name: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchDatabase({
 				client,
 				path: {
@@ -181,6 +185,7 @@ export class Databases<DThrow extends boolean> {
 					database_name: name,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}

--- a/packages/sdk/src/neon/resources/endpoints.ts
+++ b/packages/sdk/src/neon/resources/endpoints.ts
@@ -40,11 +40,12 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint[] | NeonResult<Endpoint[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectEndpoints({
 					client,
 					path: { project_id: projectId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoints,
 		);
@@ -67,11 +68,12 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint[] | NeonResult<Endpoint[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectBranchEndpoints({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoints,
 		);
@@ -94,11 +96,12 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectEndpoint({
 					client,
 					path: { project_id: projectId, endpoint_id: endpointId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoint,
 		);
@@ -121,12 +124,13 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProjectEndpoint({
 					client,
 					path: { project_id: projectId },
 					body: { endpoint: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoint,
 		);
@@ -152,12 +156,13 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateProjectEndpoint({
 					client,
 					path: { project_id: projectId, endpoint_id: endpointId },
 					body: { endpoint: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoint,
 		);
@@ -178,11 +183,12 @@ export class Endpoints<DThrow extends boolean> {
 		endpointId: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectEndpoint({
 				client,
 				path: { project_id: projectId, endpoint_id: endpointId },
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -204,11 +210,12 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				startProjectEndpoint({
 					client,
 					path: { project_id: projectId, endpoint_id: endpointId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoint,
 		);
@@ -231,11 +238,12 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				suspendProjectEndpoint({
 					client,
 					path: { project_id: projectId, endpoint_id: endpointId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoint,
 		);
@@ -258,11 +266,12 @@ export class Endpoints<DThrow extends boolean> {
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				restartProjectEndpoint({
 					client,
 					path: { project_id: projectId, endpoint_id: endpointId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.endpoint,
 		);

--- a/packages/sdk/src/neon/resources/functions.ts
+++ b/packages/sdk/src/neon/resources/functions.ts
@@ -35,6 +35,7 @@ export class Functions<DThrow extends boolean> {
 		projectId: string,
 		branchId: string,
 		query?: ListQuery,
+		opts?: CallOptions,
 	): Paginated<NeonFunction> {
 		return paginate(
 			(cursor, signal) =>
@@ -49,6 +50,7 @@ export class Functions<DThrow extends boolean> {
 				items: data?.functions ?? [],
 				cursor: data?.pagination?.next,
 			}),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 
@@ -72,7 +74,7 @@ export class Functions<DThrow extends boolean> {
 	): Promise<NeonFunction | NeonResult<NeonFunction>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchFunction({
 					client,
 					path: {
@@ -81,6 +83,7 @@ export class Functions<DThrow extends boolean> {
 						slug,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.function,
 		);
@@ -109,7 +112,7 @@ export class Functions<DThrow extends boolean> {
 	): Promise<NeonFunction | NeonResult<NeonFunction>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateProjectBranchFunction({
 					client,
 					path: {
@@ -119,6 +122,7 @@ export class Functions<DThrow extends boolean> {
 					},
 					body: input,
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.function,
 		);
@@ -142,7 +146,7 @@ export class Functions<DThrow extends boolean> {
 		slug: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchFunction({
 				client,
 				path: {
@@ -151,6 +155,7 @@ export class Functions<DThrow extends boolean> {
 					slug,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -178,7 +183,7 @@ export class Functions<DThrow extends boolean> {
 	): Promise<NeonFunctionDeployment | NeonResult<NeonFunctionDeployment>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProjectBranchFunctionDeployment({
 					client,
 					path: {
@@ -188,6 +193,7 @@ export class Functions<DThrow extends boolean> {
 					},
 					body: input ?? {},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.deployment,
 		);

--- a/packages/sdk/src/neon/resources/operations.ts
+++ b/packages/sdk/src/neon/resources/operations.ts
@@ -8,6 +8,16 @@ import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 import { type WaitForOptions, waitForOperations } from "../wait.js";
 
+/**
+ * Options for {@link Operations.waitFor}.
+ *
+ * `requestTimeoutMs` and `waitForReadiness` are deliberately excluded. Readiness is
+ * budgeted by `timeoutMs`, and waiting *is* the readiness step — accepting either would
+ * offer a knob that silently did nothing.
+ */
+export type WaitForForOptions<Throw extends boolean> = WaitForOptions &
+	Omit<CallOptions<Throw>, "requestTimeoutMs" | "waitForReadiness">;
+
 /** Operation resource — read operations and wait for them to finish. */
 export class Operations<DThrow extends boolean> {
 	readonly #ctx: RequestContext;
@@ -71,11 +81,11 @@ export class Operations<DThrow extends boolean> {
 	waitFor(operations: readonly Operation[]): Promise<Outcome<void, DThrow>>;
 	waitFor<Throw extends boolean = DThrow>(
 		operations: readonly Operation[],
-		opts: WaitForOptions & CallOptions<Throw>,
+		opts: WaitForForOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	async waitFor(
 		operations: readonly Operation[],
-		opts?: WaitForOptions & CallOptions,
+		opts?: WaitForForOptions<boolean>,
 	): Promise<void | NeonResult<void>> {
 		const defaults = this.#ctx.defaults;
 		const shouldThrow = opts?.throwOnError ?? defaults.throwOnError;

--- a/packages/sdk/src/neon/resources/operations.ts
+++ b/packages/sdk/src/neon/resources/operations.ts
@@ -17,7 +17,7 @@ export class Operations<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/operations (cursor-paginated) */
-	list(projectId: string): Paginated<Operation> {
+	list(projectId: string, opts?: CallOptions): Paginated<Operation> {
 		return paginate(
 			(cursor, signal) =>
 				listProjectOperations({
@@ -31,6 +31,7 @@ export class Operations<DThrow extends boolean> {
 				items: data?.operations ?? [],
 				cursor: data?.pagination?.cursor,
 			}),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 
@@ -51,11 +52,12 @@ export class Operations<DThrow extends boolean> {
 	): Promise<Operation | NeonResult<Operation>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectOperation({
 					client,
 					path: { project_id: projectId, operation_id: operationId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.operation,
 		);

--- a/packages/sdk/src/neon/resources/postgres.ts
+++ b/packages/sdk/src/neon/resources/postgres.ts
@@ -5,6 +5,7 @@ import {
 	listProjectBranchRoles,
 } from "../../client/sdk.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { cancelled, runBounded } from "../deadline.js";
 import { NeonError, toNeonError } from "../errors.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 import { DataApi } from "./dataapi.js";
@@ -65,7 +66,30 @@ export class Postgres<DThrow extends boolean> {
 	): Promise<string | NeonResult<string>> {
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
-		return finalize(await this.#resolve(params, opts?.signal), shouldThrow);
+		// This resolver makes up to four sequential requests without going through
+		// RequestContext, so it owns the deadline covering all of them.
+		const deadline = this.#ctx.deadlineFor(opts);
+		try {
+			const resolved = await runBounded(deadline, () =>
+				this.#resolve(params, deadline.signal),
+			);
+			const cancellation = cancelled(deadline);
+			// `runBounded` resolves undefined only when the deadline won the race, which
+			// `cancelled` then reports, so the fallback is unreachable by construction.
+			const result: NeonResult<string> =
+				cancellation !== undefined
+					? err(cancellation)
+					: (resolved ??
+						err(
+							new NeonError(
+								"The connection-string resolver ended without a result.",
+								"client",
+							),
+						));
+			return finalize(result, shouldThrow);
+		} finally {
+			deadline.dispose();
+		}
 	}
 
 	async #resolve(

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -70,11 +70,12 @@ export class Permissions<DThrow extends boolean> {
 	): Promise<ProjectPermission[] | NeonResult<ProjectPermission[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectPermissions({
 					client,
 					path: { project_id: projectId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.project_permissions,
 		);
@@ -97,12 +98,13 @@ export class Permissions<DThrow extends boolean> {
 	): Promise<ProjectPermission | NeonResult<ProjectPermission>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				grantPermissionToProject({
 					client,
 					path: { project_id: projectId },
 					body: { email },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -125,7 +127,7 @@ export class Permissions<DThrow extends boolean> {
 	): Promise<ProjectPermission | NeonResult<ProjectPermission>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				revokePermissionFromProject({
 					client,
 					path: {
@@ -133,6 +135,7 @@ export class Permissions<DThrow extends boolean> {
 						permission_id: permissionId,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -156,7 +159,7 @@ export class Projects<DThrow extends boolean> {
 	 *
 	 * @apiCall GET /projects
 	 */
-	list(query?: ListQuery): Paginated<ProjectListItem> {
+	list(query?: ListQuery, opts?: CallOptions): Paginated<ProjectListItem> {
 		return paginate(
 			(cursor, signal) =>
 				listProjects({
@@ -173,6 +176,7 @@ export class Projects<DThrow extends boolean> {
 				items: data?.projects ?? [],
 				cursor: data?.pagination?.cursor,
 			}),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 
@@ -188,11 +192,12 @@ export class Projects<DThrow extends boolean> {
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProject({
 					client,
 					path: { project_id: id },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.project,
 		);
@@ -210,7 +215,7 @@ export class Projects<DThrow extends boolean> {
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProject({
 					client,
 					body: {
@@ -222,6 +227,7 @@ export class Projects<DThrow extends boolean> {
 						},
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.project,
 		);
@@ -249,7 +255,7 @@ export class Projects<DThrow extends boolean> {
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
 			{ ...opts, waitForReadiness: opts?.waitForReadiness ?? true },
-			(client) =>
+			(client, signal) =>
 				createProject({
 					client,
 					body: {
@@ -261,6 +267,7 @@ export class Projects<DThrow extends boolean> {
 						},
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -290,12 +297,13 @@ export class Projects<DThrow extends boolean> {
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateProject({
 					client,
 					path: { project_id: id },
 					body: { project: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.project,
 		);
@@ -313,11 +321,12 @@ export class Projects<DThrow extends boolean> {
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				deleteProject({
 					client,
 					path: { project_id: id },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.project,
 		);
@@ -340,11 +349,12 @@ export class Projects<DThrow extends boolean> {
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				recoverProject({
 					client,
 					path: { project_id: id },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.project,
 		);
@@ -381,7 +391,7 @@ export class Projects<DThrow extends boolean> {
 		}
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				transferProjectsFromOrgToOrg({
 					client,
 					path: { source_org_id: fromOrgId },
@@ -390,6 +400,7 @@ export class Projects<DThrow extends boolean> {
 						project_ids: input.projectIds,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			() => undefined,
 		);
@@ -414,7 +425,7 @@ export class Projects<DThrow extends boolean> {
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				transferProjectsFromUserToOrg({
 					client,
 					body: {
@@ -422,6 +433,7 @@ export class Projects<DThrow extends boolean> {
 						project_ids: input.projectIds,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			() => undefined,
 		);

--- a/packages/sdk/src/neon/resources/roles.ts
+++ b/packages/sdk/src/neon/resources/roles.ts
@@ -34,11 +34,12 @@ export class Roles<DThrow extends boolean> {
 	): Promise<Role[] | NeonResult<Role[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listProjectBranchRoles({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.roles,
 		);
@@ -64,7 +65,7 @@ export class Roles<DThrow extends boolean> {
 	): Promise<Role | NeonResult<Role>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchRole({
 					client,
 					path: {
@@ -73,6 +74,7 @@ export class Roles<DThrow extends boolean> {
 						role_name: name,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.role,
 		);
@@ -98,12 +100,13 @@ export class Roles<DThrow extends boolean> {
 	): Promise<Role | NeonResult<Role>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createProjectBranchRole({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: { role: input },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.role,
 		);
@@ -127,7 +130,7 @@ export class Roles<DThrow extends boolean> {
 		name: string,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
-		return this.#ctx.runVoid(opts, (client) =>
+		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchRole({
 				client,
 				path: {
@@ -136,6 +139,7 @@ export class Roles<DThrow extends boolean> {
 					role_name: name,
 				},
 				throwOnError: false,
+				signal,
 			}),
 		);
 	}
@@ -164,7 +168,7 @@ export class Roles<DThrow extends boolean> {
 	): Promise<string | NeonResult<string>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchRolePassword({
 					client,
 					path: {
@@ -173,6 +177,7 @@ export class Roles<DThrow extends boolean> {
 						role_name: name,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.password,
 		);
@@ -202,7 +207,7 @@ export class Roles<DThrow extends boolean> {
 	): Promise<Role | NeonResult<Role>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				resetProjectBranchRolePassword({
 					client,
 					path: {
@@ -211,6 +216,7 @@ export class Roles<DThrow extends boolean> {
 						role_name: name,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.role,
 		);

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -16,13 +16,24 @@ import type {
 	Snapshot,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { NeonAbortError } from "../errors.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 /**
  * Inspect a freshly restored (not-yet-finalized) branch and decide whether to commit.
  * Return `true` to finalize the restore, `false` to abort it.
  */
-export type RestorePreview = (branch: Branch) => boolean | Promise<boolean>;
+/**
+ * Inspect a restored-but-un-finalized branch and decide whether to commit it.
+ *
+ * The second argument carries the call's `signal`. The SDK cannot interrupt this callback
+ * — it is the caller's own code — so long-running checks should honour the signal
+ * themselves; the restore is left un-finalized if the call is cancelled around it.
+ */
+export type RestorePreview = (
+	branch: Branch,
+	context: { signal?: AbortSignal },
+) => boolean | Promise<boolean>;
 
 /** Options for {@link Snapshots.create} (point-in-time + naming). */
 export interface CreateSnapshotInput {
@@ -295,7 +306,31 @@ export class Snapshots<DThrow extends boolean> {
 		}
 
 		const branch = restored.data;
-		const commit = await preview(branch);
+		// The callback is the caller's own code, so the SDK cannot bound it — a callback
+		// that never settles leaves the restore un-finalized however the signal is set.
+		// It gets the signal so it can cooperate, and the abort is honoured either side
+		// of it rather than pretending to interrupt it.
+		if (opts?.signal?.aborted) {
+			return finalize(
+				err<Branch>(
+					new NeonAbortError(
+						"The restore was aborted before its preview callback ran; the restored branch is left un-finalized.",
+					),
+				),
+				shouldThrow,
+			);
+		}
+		const commit = await preview(branch, { signal: opts?.signal });
+		if (opts?.signal?.aborted) {
+			return finalize(
+				err<Branch>(
+					new NeonAbortError(
+						"The restore was aborted after its preview callback ran; the restored branch is left un-finalized.",
+					),
+				),
+				shouldThrow,
+			);
+		}
 		const step = commit
 			? await this.#ctx.execute(
 					{ ...opts, waitForReadiness: true },

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -115,11 +115,12 @@ export class Snapshots<DThrow extends boolean> {
 	): Promise<Snapshot[] | NeonResult<Snapshot[]>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				listSnapshots({
 					client,
 					path: { project_id: projectId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.snapshots,
 		);
@@ -145,7 +146,7 @@ export class Snapshots<DThrow extends boolean> {
 	): Promise<Snapshot | NeonResult<Snapshot>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				createSnapshot({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
@@ -156,6 +157,7 @@ export class Snapshots<DThrow extends boolean> {
 						expires_at: input?.expiresAt,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.snapshot,
 		);
@@ -181,7 +183,7 @@ export class Snapshots<DThrow extends boolean> {
 	): Promise<Snapshot | NeonResult<Snapshot>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				updateSnapshot({
 					client,
 					path: { project_id: projectId, snapshot_id: snapshotId },
@@ -195,6 +197,7 @@ export class Snapshots<DThrow extends boolean> {
 						},
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.snapshot,
 		);
@@ -217,11 +220,12 @@ export class Snapshots<DThrow extends boolean> {
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				deleteSnapshot({
 					client,
 					path: { project_id: projectId, snapshot_id: snapshotId },
 					throwOnError: false,
+					signal,
 				}),
 			() => undefined,
 		);
@@ -272,7 +276,7 @@ export class Snapshots<DThrow extends boolean> {
 				...opts,
 				waitForReadiness: preview ? true : opts?.waitForReadiness,
 			},
-			(client) =>
+			(client, signal) =>
 				restoreSnapshot({
 					client,
 					path: { project_id: projectId, snapshot_id: snapshotId },
@@ -282,6 +286,7 @@ export class Snapshots<DThrow extends boolean> {
 						finalize_restore: finalizeNow,
 					},
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data.branch,
 		);
@@ -294,7 +299,7 @@ export class Snapshots<DThrow extends boolean> {
 		const step = commit
 			? await this.#ctx.execute(
 					{ ...opts, waitForReadiness: true },
-					(client) =>
+					(client, signal) =>
 						finalizeRestoreBranch({
 							client,
 							path: {
@@ -302,6 +307,7 @@ export class Snapshots<DThrow extends boolean> {
 								branch_id: branch.id,
 							},
 							throwOnError: false,
+							signal,
 						}),
 					() => undefined,
 				)
@@ -309,7 +315,7 @@ export class Snapshots<DThrow extends boolean> {
 				? ok(undefined)
 				: await this.#ctx.execute(
 						{ ...opts, waitForReadiness: true },
-						(client) =>
+						(client, signal) =>
 							deleteProjectBranch({
 								client,
 								path: {
@@ -317,6 +323,7 @@ export class Snapshots<DThrow extends boolean> {
 									branch_id: branch.id,
 								},
 								throwOnError: false,
+								signal,
 							}),
 						() => undefined,
 					);
@@ -342,11 +349,12 @@ export class Snapshots<DThrow extends boolean> {
 	): Promise<BackupSchedule | NeonResult<BackupSchedule>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getSnapshotSchedule({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);
@@ -382,12 +390,13 @@ export class Snapshots<DThrow extends boolean> {
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				setSnapshotSchedule({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					body: schedule,
 					throwOnError: false,
+					signal,
 				}),
 			() => undefined,
 		);

--- a/packages/sdk/src/neon/resources/storage.ts
+++ b/packages/sdk/src/neon/resources/storage.ts
@@ -37,11 +37,12 @@ export class Storage<DThrow extends boolean> {
 	): Promise<BranchStorage | NeonResult<BranchStorage>> {
 		return this.#ctx.run(
 			opts,
-			(client) =>
+			(client, signal) =>
 				getProjectBranchStorage({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
+					signal,
 				}),
 			(data) => data,
 		);

--- a/packages/sdk/src/neon/retry.test.ts
+++ b/packages/sdk/src/neon/retry.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+	backoffMs,
+	MAX_RETRY_WAIT_MS,
+	nextRetryDelayMs,
+	parseRetryAfterMs,
+} from "./retry.js";
+
+const NOW = Date.parse("2026-08-03T00:00:00Z");
+
+describe("parseRetryAfterMs", () => {
+	it("reads the delay-seconds form", () => {
+		expect(parseRetryAfterMs("120", NOW)).toBe(120_000);
+	});
+
+	it("reads the HTTP-date form, which the numeric parse alone leaves as NaN", () => {
+		const header = new Date(NOW + 90_000).toUTCString();
+		expect(parseRetryAfterMs(header, NOW)).toBe(90_000);
+	});
+
+	it("clamps a date already in the past to zero rather than going negative", () => {
+		const header = new Date(NOW - 60_000).toUTCString();
+		expect(parseRetryAfterMs(header, NOW)).toBe(0);
+	});
+
+	it("returns undefined for an absent, blank, or unparseable header", () => {
+		expect(parseRetryAfterMs(null, NOW)).toBeUndefined();
+		expect(parseRetryAfterMs(undefined, NOW)).toBeUndefined();
+		expect(parseRetryAfterMs("   ", NOW)).toBeUndefined();
+		expect(parseRetryAfterMs("soon", NOW)).toBeUndefined();
+	});
+});
+
+describe("backoffMs", () => {
+	it("grows exponentially from a 250ms base", () => {
+		expect(backoffMs(0, () => 1)).toBe(250);
+		expect(backoffMs(1, () => 1)).toBe(500);
+		expect(backoffMs(2, () => 1)).toBe(1000);
+	});
+
+	it("never exceeds the ceiling however many attempts have passed", () => {
+		expect(backoffMs(50, () => 1)).toBe(MAX_RETRY_WAIT_MS);
+	});
+
+	it("jitters across the full range below the ceiling", () => {
+		expect(backoffMs(3, () => 0)).toBe(0);
+		expect(backoffMs(3, () => 0.5)).toBe(1000);
+	});
+});
+
+describe("nextRetryDelayMs", () => {
+	it("honours Retry-After exactly rather than shortening it", () => {
+		// Retrying earlier than the server asked is worse than not retrying, so a
+		// server-supplied delay is never replaced by a smaller generated one.
+		expect(nextRetryDelayMs(0, 5_000, Number.POSITIVE_INFINITY)).toBe(
+			5_000,
+		);
+	});
+
+	it("declines to retry when Retry-After exceeds the ceiling", () => {
+		expect(
+			nextRetryDelayMs(0, 3_600_000, Number.POSITIVE_INFINITY),
+		).toBeUndefined();
+	});
+
+	it("declines to retry when the wait would outlast the remaining budget", () => {
+		expect(nextRetryDelayMs(0, 5_000, 1_000)).toBeUndefined();
+	});
+
+	it("falls back to generated backoff when no header is present", () => {
+		expect(
+			nextRetryDelayMs(0, undefined, Number.POSITIVE_INFINITY, () => 1),
+		).toBe(250);
+	});
+
+	it("declines when even generated backoff would outlast the budget", () => {
+		expect(nextRetryDelayMs(4, undefined, 10, () => 1)).toBeUndefined();
+	});
+});

--- a/packages/sdk/src/neon/retry.ts
+++ b/packages/sdk/src/neon/retry.ts
@@ -1,7 +1,14 @@
 /**
- * Minimal retry-with-backoff for idempotent reads and 429s. The raw layer does no
- * retries; the ergonomic client opts in via `retries` config.
+ * Retry-with-backoff for the statuses Neon documents as always safe to replay. The raw
+ * layer does no retries; the ergonomic client opts in via `retries`.
+ *
+ * The scheduling decisions are pure functions so they can be tested directly, without
+ * fake timers or a stopwatch: {@link parseRetryAfterMs} reads the header,
+ * {@link backoffMs} picks a delay, and {@link nextRetryDelayMs} decides whether a retry
+ * is worth waiting for at all.
  */
+
+import { type Deadline, delay } from "./deadline.js";
 
 export interface RawOutcome {
 	error?: unknown;
@@ -9,43 +16,72 @@ export interface RawOutcome {
 }
 
 // Only statuses Neon documents as always-safe to retry (no work performed / locked /
-// rate limited) — safe for non-idempotent methods too. 5xx is intentionally excluded
-// from the default since a mutating request may have partially applied.
+// rate limited) — safe for non-idempotent methods too. 5xx other than 503 is
+// intentionally excluded, since a mutating request may have partially applied.
 const RETRYABLE_STATUS = new Set([423, 429, 503]);
 
-function backoffMs(attempt: number, response: Response | undefined): number {
-	const retryAfter = response?.headers.get("retry-after");
-	if (retryAfter) {
-		const seconds = Number(retryAfter);
-		if (Number.isFinite(seconds)) return seconds * 1000;
-	}
-	// exponential backoff with full jitter: base 250ms, capped at 10s
-	const ceiling = Math.min(10_000, 250 * 2 ** attempt);
-	return Math.random() * ceiling;
-}
-
-const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
-	new Promise((resolve, reject) => {
-		if (signal?.aborted) return reject(signal.reason);
-		const id = setTimeout(resolve, ms);
-		signal?.addEventListener(
-			"abort",
-			() => {
-				clearTimeout(id);
-				reject(signal.reason);
-			},
-			{ once: true },
-		);
-	});
+/** Ceiling on generated backoff, and on how long a `Retry-After` is worth honouring. */
+export const MAX_RETRY_WAIT_MS = 10_000;
 
 /**
- * Run `exec` up to `retries + 1` times, retrying only on retryable HTTP statuses
- * (`423`, `429`, `5xx`). Non-retryable errors and successes return immediately.
+ * `Retry-After` in milliseconds, or `undefined` when absent or unparseable.
+ *
+ * The header comes in two forms and only one of them is a number. Reading just the
+ * numeric form leaves an HTTP-date parsing as `NaN`, which silently falls through to
+ * generated backoff — retrying far sooner than the server asked.
+ */
+export function parseRetryAfterMs(
+	header: string | null | undefined,
+	now: number,
+): number | undefined {
+	if (!header) return undefined;
+	const trimmed = header.trim();
+	if (trimmed === "") return undefined;
+
+	const seconds = Number(trimmed);
+	if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+	const at = Date.parse(trimmed);
+	if (Number.isNaN(at)) return undefined;
+	return Math.max(0, at - now);
+}
+
+/** Exponential backoff with full jitter: base 250ms, capped at {@link MAX_RETRY_WAIT_MS}. */
+export function backoffMs(attempt: number, random = Math.random): number {
+	const ceiling = Math.min(MAX_RETRY_WAIT_MS, 250 * 2 ** attempt);
+	return random() * ceiling;
+}
+
+/**
+ * How long to wait before the next attempt, or `undefined` to stop retrying.
+ *
+ * `Retry-After` is the server's requested **minimum** delay, so it is never shortened —
+ * retrying earlier than instructed is worse than not retrying at all. When honouring it
+ * would cost more than {@link MAX_RETRY_WAIT_MS}, or more budget than the call has left,
+ * the answer is to stop and let the caller see the real `423`/`429`/`503` rather than to
+ * wait for minutes or to report a timeout that hides the status.
+ */
+export function nextRetryDelayMs(
+	attempt: number,
+	retryAfterMs: number | undefined,
+	remainingMs: number,
+	random?: () => number,
+): number | undefined {
+	const wait = retryAfterMs ?? backoffMs(attempt, random);
+	if (wait > MAX_RETRY_WAIT_MS) return undefined;
+	if (wait >= remainingMs) return undefined;
+	return wait;
+}
+
+/**
+ * Run `exec` up to `retries + 1` times, retrying only on `423`, `429` and `503`.
+ * Non-retryable errors and successes return immediately, as does a cancelled deadline —
+ * the caller inspects {@link Deadline.source} to tell cancellation from the last result.
  */
 export async function withRetries<T extends RawOutcome>(
 	exec: () => Promise<T>,
 	retries: number,
-	signal?: AbortSignal,
+	deadline: Deadline,
 ): Promise<T> {
 	let attempt = 0;
 	for (;;) {
@@ -53,7 +89,19 @@ export async function withRetries<T extends RawOutcome>(
 		const status = result.response?.status;
 		const retryable = status !== undefined && RETRYABLE_STATUS.has(status);
 		if (!result.error || !retryable || attempt >= retries) return result;
-		await sleep(backoffMs(attempt, result.response), signal);
+		if (deadline.source()) return result;
+
+		const wait = nextRetryDelayMs(
+			attempt,
+			parseRetryAfterMs(
+				result.response?.headers.get("retry-after"),
+				Date.now(),
+			),
+			deadline.remainingMs(),
+		);
+		if (wait === undefined) return result;
+
+		if ((await delay(wait, deadline.signal)) === "cancelled") return result;
 		attempt += 1;
 	}
 }

--- a/packages/sdk/src/neon/retry.ts
+++ b/packages/sdk/src/neon/retry.ts
@@ -38,8 +38,15 @@ export function parseRetryAfterMs(
 	const trimmed = header.trim();
 	if (trimmed === "") return undefined;
 
-	const seconds = Number(trimmed);
-	if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+	// RFC 9110 delta-seconds is a non-negative integer. `Number()` would also accept
+	// "-1", "1.5", "0x10" and "1e3"; treating "-1" as 0 in particular turned a malformed
+	// header into an immediate retry.
+	if (/^\d+$/.test(trimmed)) {
+		const seconds = Number(trimmed);
+		return Number.isFinite(seconds * 1000)
+			? seconds * 1000
+			: Number.POSITIVE_INFINITY;
+	}
 
 	const at = Date.parse(trimmed);
 	if (Number.isNaN(at)) return undefined;

--- a/packages/sdk/src/neon/wait.ts
+++ b/packages/sdk/src/neon/wait.ts
@@ -1,9 +1,15 @@
 import type { Client } from "../client/client/index.js";
 import { getProjectOperation } from "../client/sdk.gen.js";
 import type { Operation, OperationStatus } from "../client/types.gen.js";
-import { delay } from "./deadline.js";
+import {
+	createDeadline,
+	type Deadline,
+	delay,
+	runBounded,
+} from "./deadline.js";
 import {
 	NeonAbortError,
+	type NeonError,
 	NeonOperationError,
 	NeonTimeoutError,
 	toNeonError,
@@ -26,10 +32,38 @@ export interface WaitForOptions {
 }
 
 /**
+ * Why waiting stopped, with a message about readiness rather than about a request.
+ * Returns `undefined` while the wait may continue.
+ */
+function readinessEnded(
+	deadline: Deadline,
+	timeoutMs: number,
+	pending: number,
+): NeonError | undefined {
+	const source = deadline.source();
+	if (source === "caller") {
+		return new NeonAbortError(
+			"Waiting for operations was aborted by its signal.",
+		);
+	}
+	if (source === "timeout") {
+		return new NeonTimeoutError(
+			`Timed out after ${timeoutMs}ms waiting for ${pending} operation(s) to finish.`,
+		);
+	}
+	return undefined;
+}
+
+/**
  * Poll the given operations until each reaches a terminal `finished`/`skipped` state.
  * Returns an error result carrying {@link NeonOperationError} if any operation ends in
  * `failed`/`error`/`cancelled`, {@link NeonTimeoutError} if the deadline is exceeded, or
  * {@link NeonAbortError} if the caller's signal fired.
+ *
+ * `timeoutMs` is a real deadline rather than a check between polls. Each poll runs under
+ * it, so a request that hangs cannot outlast the budget, and the budget is re-examined
+ * after every operation rather than once per round — a round polls each pending operation
+ * in turn, so checking only at the top let a long round overrun the timeout arbitrarily.
  *
  * Composable: usable directly with operations obtained from the raw layer.
  */
@@ -40,51 +74,75 @@ export async function waitForOperations(
 ): Promise<NeonResult<void>> {
 	const pollIntervalMs = options.pollIntervalMs ?? 1000;
 	const timeoutMs = options.timeoutMs ?? 300_000;
-	const deadline = Date.now() + timeoutMs;
+	const deadline = createDeadline(timeoutMs, options.signal);
 
-	// Track only operations that aren't already in a terminal state.
-	let pending = operations.filter((op) => !SUCCESS.has(op.status));
+	try {
+		// Track only operations that aren't already in a terminal state.
+		let pending = operations.filter((op) => !SUCCESS.has(op.status));
 
-	for (const op of pending) {
-		if (FAILURE.has(op.status)) return err(operationFailed(op));
-	}
-	pending = pending.filter((op) => !FAILURE.has(op.status));
-
-	while (pending.length > 0) {
-		if (Date.now() > deadline) {
-			return err(
-				new NeonTimeoutError(
-					`Timed out after ${timeoutMs}ms waiting for ${pending.length} operation(s) to finish.`,
-				),
-			);
-		}
-		if ((await delay(pollIntervalMs, options.signal)) === "cancelled") {
-			return err(
-				new NeonAbortError(
-					"Waiting for operations was aborted by its signal.",
-				),
-			);
-		}
-
-		const stillPending: Operation[] = [];
 		for (const op of pending) {
-			const { data, error, response } = await getProjectOperation({
-				client,
-				path: { project_id: op.project_id, operation_id: op.id },
-				throwOnError: false,
-				signal: options.signal,
-			});
-			if (error || !data) return err(toNeonError(error, response));
-
-			const current = data.operation;
-			if (FAILURE.has(current.status))
-				return err(operationFailed(current));
-			if (!SUCCESS.has(current.status)) stillPending.push(current);
+			if (FAILURE.has(op.status)) return err(operationFailed(op));
 		}
-		pending = stillPending;
-	}
+		pending = pending.filter((op) => !FAILURE.has(op.status));
 
-	return ok(undefined);
+		while (pending.length > 0) {
+			const ended = readinessEnded(deadline, timeoutMs, pending.length);
+			if (ended) return err(ended);
+
+			if (
+				(await delay(pollIntervalMs, deadline.signal)) === "cancelled"
+			) {
+				return err(
+					readinessEnded(deadline, timeoutMs, pending.length) ??
+						new NeonAbortError(
+							"Waiting for operations was aborted by its signal.",
+						),
+				);
+			}
+
+			const stillPending: Operation[] = [];
+			for (const op of pending) {
+				const polled = await runBounded(deadline, () =>
+					getProjectOperation({
+						client,
+						path: {
+							project_id: op.project_id,
+							operation_id: op.id,
+						},
+						throwOnError: false,
+						signal: deadline.signal,
+					}),
+				);
+
+				// Cancellation is read from the deadline before the response is
+				// classified: an aborted poll comes back as a transport failure with no
+				// response, which `toNeonError` would otherwise report as a network error.
+				const stopped = readinessEnded(
+					deadline,
+					timeoutMs,
+					pending.length,
+				);
+				if (stopped) return err(stopped);
+				if (polled === undefined) {
+					return err(toNeonError(undefined, undefined));
+				}
+
+				const { data, error, response } = polled;
+				if (error || !data) return err(toNeonError(error, response));
+
+				const current = data.operation;
+				if (FAILURE.has(current.status)) {
+					return err(operationFailed(current));
+				}
+				if (!SUCCESS.has(current.status)) stillPending.push(current);
+			}
+			pending = stillPending;
+		}
+
+		return ok(undefined);
+	} finally {
+		deadline.dispose();
+	}
 }
 
 function operationFailed(op: Operation): NeonOperationError {

--- a/packages/sdk/src/neon/wait.ts
+++ b/packages/sdk/src/neon/wait.ts
@@ -1,7 +1,13 @@
 import type { Client } from "../client/client/index.js";
 import { getProjectOperation } from "../client/sdk.gen.js";
 import type { Operation, OperationStatus } from "../client/types.gen.js";
-import { NeonOperationError, NeonTimeoutError, toNeonError } from "./errors.js";
+import { delay } from "./deadline.js";
+import {
+	NeonAbortError,
+	NeonOperationError,
+	NeonTimeoutError,
+	toNeonError,
+} from "./errors.js";
 import { err, type NeonResult, ok } from "./result.js";
 
 const SUCCESS: ReadonlySet<OperationStatus> = new Set(["finished", "skipped"]);
@@ -19,24 +25,11 @@ export interface WaitForOptions {
 	signal?: AbortSignal;
 }
 
-const sleep = (ms: number, signal?: AbortSignal): Promise<void> =>
-	new Promise((resolve, reject) => {
-		if (signal?.aborted) return reject(signal.reason);
-		const id = setTimeout(resolve, ms);
-		signal?.addEventListener(
-			"abort",
-			() => {
-				clearTimeout(id);
-				reject(signal.reason);
-			},
-			{ once: true },
-		);
-	});
-
 /**
  * Poll the given operations until each reaches a terminal `finished`/`skipped` state.
  * Returns an error result carrying {@link NeonOperationError} if any operation ends in
- * `failed`/`error`/`cancelled`, or {@link NeonTimeoutError} if the deadline is exceeded.
+ * `failed`/`error`/`cancelled`, {@link NeonTimeoutError} if the deadline is exceeded, or
+ * {@link NeonAbortError} if the caller's signal fired.
  *
  * Composable: usable directly with operations obtained from the raw layer.
  */
@@ -65,7 +58,13 @@ export async function waitForOperations(
 				),
 			);
 		}
-		await sleep(pollIntervalMs, options.signal);
+		if ((await delay(pollIntervalMs, options.signal)) === "cancelled") {
+			return err(
+				new NeonAbortError(
+					"Waiting for operations was aborted by its signal.",
+				),
+			);
+		}
 
 		const stillPending: Operation[] = [];
 		for (const op of pending) {


### PR DESCRIPTION
## Problem

`CallOptions.signal` is documented on every ergonomic method. It does nothing. Measured against `main` by probing the built `dist/`:

```
abort() at 100ms -> neon.projects.get() settled after 3002ms   (3s fetch ran to completion)
```

`RequestContext.run` / `runVoid` / `execute` pass only the client into each generated call, so no method forwards the signal to the request. Only `postgres.connectionString` and the pagination page-fetchers did.

Three related faults come from the same missing concept — the execution core has no notion of a deadline, or of cancellation as an outcome:

| Probe | Result on `main` |
| --- | --- |
| `fetch` that never settles, `wait.timeoutMs: 50` | still hanging after 1200ms — nothing bounds a request |
| `429` with `Retry-After: 3600`, `retries: 1` | still sleeping at 1500ms; one fetch made — an hour-long park |
| abort during the retry backoff sleep | **rejected** with `DOMException: This operation was aborted` |

That last one is the sharpest: it is the one path where a signal *did* have an effect, and it breaks both core contracts. A default client promising `{ data, error }` throws, and a `throwOnError: true` client throws a `DOMException` rather than a `NeonError`, so `error.kind` — the documented way to branch — is not there to read.

## The interface

```ts
// Cancel in-flight work. Reported on the error channel, never as a DOMException.
const controller = new AbortController();
const { error } = await neon.projects.get(id, { signal: controller.signal });
if (error?.kind === "aborted") { /* the caller stopped it */ }

// Bound a call, on the client or per call. Unset by default.
const neon = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
const slow = await neon.projects.get(id, { requestTimeoutMs: 5_000 });
if (slow.error?.kind === "timeout") { /* deadline exceeded */ }

// Opt one call back out of a client-wide deadline.
await neon.storage.objects.get(pid, bid, "bucket", "big.tar", {
  requestTimeoutMs: Number.POSITIVE_INFINITY,
});

// Paginated lists take the same options, after their query.
const walk = await neon.projects
  .list({ search: "prod" }, { signal: controller.signal, requestTimeoutMs: 10_000 })
  .all();
```

| Added | | |
| --- | --- | --- |
| `requestTimeoutMs` | `NeonConfig` + `CallOptions` | Deadline for a request **and** its retries. Unset = unbounded. `Infinity` opts out per call. |
| `NeonAbortError` | `kind: "aborted"` | The caller's signal fired. |
| `opts?: CallOptions` | every paginated `list()` | Trailing argument, after the query. |

`"aborted"` is separate from `"timeout"` on purpose: a timeout is worth retrying, a cancellation is not, and collapsing them would make that undecidable.

Cancellation reaches everything the SDK controls — the request and its retries, readiness polling, each page of a walk, and the four-request `postgres.connectionString` resolver. It cannot interrupt caller code, so a `snapshots.restore` `preview` callback now receives the signal as a second argument and the un-finalized outcome is documented.

`requestTimeoutMs` accepts a positive number up to `2147483647`, or `Infinity`. `0`, negatives, `NaN` and larger values are rejected with a `client`-kind error at client creation *and* per call.

**Nothing changes for existing callers.** `requestTimeoutMs` is unset by default, so calls stay unbounded exactly as before. The new `list()` argument is optional and trailing, and the `preview` callback's second argument is additive. No existing error class or `kind` changes meaning.

## Why the default is opt-in

A finite default would be better DX, and it is a separate decision. This PR fixes a missing *capability* — calls could not be bounded at all. A default is *policy*, and I have no latency evidence for the surfaces most at risk: `storage.objects.get` returns an arbitrarily large `Blob` and `functions.deploy` uploads a multipart zip, both of which a blind 60s cap would break mid-transfer on a slow link. It is also the irreversible direction — adding a default later is a minor bump, removing one people rely on is breaking — and shipping both together means a wrong policy takes the capability fix down with it.

## Three things a deadline cannot assume

All three were found while building this, and each would have shipped a deadline that does not hold.

**A signal handed to `fetch` does not bound a call.** `client/client/client.gen.ts` awaits `setAuthParams` and the request interceptors *before* constructing the `Request`:

```ts
if (opts.security) { await setAuthParams(opts); }   // no signal in play yet
...
request = new Request(url, requestInit);
```

So an `apiKey` function that resolves slowly is unreachable by the signal. Every bounded path races the whole execution, not just the fetch — including each page of a paginated walk, which awaited its fetch directly in an earlier revision and took 6077ms against a 50ms deadline.

**A timer alone does not fire in a loop that only awaits resolved promises.** Paginating a cursor the API keeps repeating awaits an already-resolved `fetch` each turn, draining the microtask queue without ever reaching the timer phase — so the deadline's `setTimeout` never ran and the walk spun forever. It also stopped Vitest's own `testTimeout` from firing, which is what made it hard to see. Expiry is read from the clock, with the timer as a wake-up rather than the source of truth. That clock is `performance.now()`, so an NTP correction cannot expire a deadline early.

**A budget checked between polls is not a deadline.** Readiness polling checked its timeout once per round and then polled each pending operation in turn with nothing bounding those requests, so one round could overrun the budget arbitrarily. And an abort during a poll arrives as a transport failure with no response, which `toNeonError` reported as `NeonNetworkError` — cancellation is now read from the deadline before the response is classified.

## Retry-After is honoured, not capped

My first fix capped it at 10s. That is wrong: `Retry-After` is the server's requested **minimum**, so shortening it retries *earlier* than instructed — worse than the bug. It now works the other way: the delay is never shortened, and when honouring it would exceed 10s or the remaining deadline, retrying stops and the real `423`/`429`/`503` is surfaced instead of a long sleep or a timeout that hides the status. Delta-seconds must be a non-negative integer per RFC 9110, so `-1` no longer becomes an immediate retry, and the HTTP-date form is parsed rather than falling through to backoff as `NaN`.

## Also in here

- **`waitForOperations` had the same rejecting sleep**, so aborting during readiness also escaped as a `DOMException`. It and the retry loop share one `delay` that reports cancellation as a value.
- **That sleep leaked listeners** — one `abort` listener per poll iteration, none removed on success, so a long poll degraded as it ran. Asserted at zero after 25 waits.
- **`operations.waitFor` no longer accepts options it ignores.** Its type excludes `requestTimeoutMs` and `waitForReadiness`; readiness is budgeted by `timeoutMs`, and waiting *is* the readiness step.
- The raw layer classifies aborts from `options.signal?.aborted`, and `toNeonError` is unchanged. Deliberate: the generated client funnels auth, serialization, interceptor, transport and parsing faults through one channel, so an error named `AbortError` is not evidence the caller cancelled. It also keeps the Neon CLI unaffected — it installs its timeout inside a custom `fetch` and never passes `signal`, so its failures keep classifying as `NeonNetworkError`.
- 91 execution callbacks across 16 resource files changed arity from `(client) =>` to `(client, signal) =>`. Applied by a codemod, then reviewed; 4 single-line calls in `account.ts` it did not match were fixed by hand.

## Verification

Against `98e785e`:

- `pnpm test:ci` — **89 tests, 9 files** (33 before)
- `pnpm test:types` — 15 type tests, no type errors
- `pnpm tsc --noEmit`, `pnpm build`, `pnpm lint:ci` (572 files) — clean

Two suites, deliberately. The stubbed one covers mapping; the **real-server** one (`cancellation.server.test.ts`, a `node:http` server over the runtime's own `fetch`) covers what a stub hides — a socket that never responds, and work before `fetch` is reached. The stubbed suite could not see either blocker above, because a stub that honours the signal promptly masks both.

Behaviours covered:

- a signal aborts an in-flight call; it settles in <1s rather than running the full 3s
- an aborted call returns `kind: "aborted"`, and **throws `NeonAbortError`** rather than a `DOMException` under `throwOnError`
- abort **during the retry backoff sleep** does both — the regression that motivated this PR
- against a real hanging socket: a request times out, an abort is `"aborted"` and not `"network"`, and a paginated walk is bounded
- a slow **auth phase** is bounded for a single call, a `page()`, an `all()`, and an iteration
- readiness: an abort during a poll is `"aborted"` not `"network"`; the `wait.timeoutMs` budget is enforced while operations stay pending; a finished operation still resolves
- a deadline expires from the clock while its timer is starved by a microtask loop
- `Retry-After: 3600` stops retrying and surfaces the `429` after exactly 1 fetch; `Retry-After: 0` still retries; parsing covers seconds, HTTP-date, past dates, `-1`, decimals, hex, blank and unparseable
- `requestTimeoutMs` rejected for `0`, `-1`, `NaN` and `2**31`, at construction *and* per call; `Infinity` accepted as the opt-out
- cleanup: listeners removed after 25 waits, timer released on dispose, no unhandled rejection from the abandoned race arm

Each new test was checked against the unfixed code rather than assumed to be meaningful — reverting the pagination fix makes the slow-auth walk fail at 6077ms, while the hanging-socket case passes either way, which is the discrimination that matters.

Not verified: **no live-API cancellation coverage.** The `e2e-live` suite has no cancellation scenarios, and I did not add one — it needs the org key, which I cannot run locally, and an unverifiable new live test is a poor thing to gate a PR on. An earlier revision of this description claimed the `e2e-live` job would cover cancellation; it does not. Also unverified: Node 20.19, the declared floor. The implementation avoids `AbortSignal.any` and `AbortSignal.timeout`, using only `AbortController`, `setTimeout` and `performance.now()`, but that is reasoning rather than a run.

## For your attention

- **The stuck-cursor loop is only bounded when a deadline is set.** With `requestTimeoutMs` unset — the default — `.all()` over a repeating cursor still loops forever, and because it never yields to the timer phase it starves the event loop rather than merely hanging one call. A cursor-progress guard is the real fix, is a different root cause, and wants its own PR. Worth deciding whether it lands before this ships.
- **`NeonErrorKind` gains `"aborted"`, which can break a consumer's exhaustive `switch`** with a `never` check at compile time. Shipping as a minor is a deliberate policy call, stated in the changeset: an error taxonomy has to be able to grow, and treating each new kind as breaking would freeze it or force a major per addition. Nothing changes at runtime for existing kinds.
- **A `preview` callback that never settles still hangs the restore**, leaving a preview branch behind. The SDK cannot interrupt caller code; it passes the signal and reports the un-finalized state, and that is the whole contract.
- **Pre-existing CLI bug, found next door.** `packages/cli/src/api.ts` maps timeouts to `ECONNABORTED` via `isAbortError`, which matches only `err.name === "AbortError" | "TimeoutError"`. Since 1.4.0 wrapped transport failures as `NeonNetworkError`, that check already never matches, so CLI request timeouts already report `ENETWORK`. Untouched here; worth its own fix.