### PR TITLE
fix(@neon/sdk): make the dist guard reliable and cover it with tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,10 +367,18 @@ does **not** match `client.test-d.ts` — the `test-d` exclusion is separate, wh
 `@neon/config` and `@neon/env` list both.
 
 `pnpm --filter @neon/sdk build` ends in `node scripts/check-dist.mjs`, which fails when
-`dist/` carries bundled dependencies, emitted test files, a non-empty `dependencies`
-map, or a bare runtime import a consumer could not resolve. CI's Build job runs
-`pnpm build`, so a regression fails the PR rather than reaching npm. Don't route around
-it by relaxing the check — fix the entry globs or move the offending file out of them.
+`dist/` carries bundled dependencies, emitted test files, or a non-empty `dependencies`
+map. Those bound both directions: a dependency left *external* rather than bundled can
+only be one tsdown was told to externalize, which means it is declared in
+`dependencies`. The checks live in `scripts/dist-guard.mjs` and are covered by
+`scripts/dist-guard.test.mjs` against real temporary package trees.
+
+CI's Build job runs `pnpm build`, so a regression fails the PR rather than reaching npm.
+Don't route around it by relaxing the check — fix the entry globs or move the offending
+file out of them. Scanning `dist` for bare imports was tried and removed: a regex over
+emitted JavaScript flags imports inside strings and comments and misses multiline ones,
+and a release gate that blocks a good release costs more than the redundant coverage it
+buys.
 
 **Automated spec refresh (`.github/workflows/sdk-spec-refresh.yml`):**
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,18 +367,22 @@ does **not** match `client.test-d.ts` — the `test-d` exclusion is separate, wh
 `@neon/config` and `@neon/env` list both.
 
 `pnpm --filter @neon/sdk build` ends in `node scripts/check-dist.mjs`, which fails when
-`dist/` carries bundled dependencies, emitted test files, or a non-empty `dependencies`
-map. Those bound both directions: a dependency left *external* rather than bundled can
-only be one tsdown was told to externalize, which means it is declared in
-`dependencies`. The checks live in `scripts/dist-guard.mjs` and are covered by
+`dist/` carries bundled dependencies, emitted test files, a runtime dependency in any of
+`dependencies` / `peerDependencies` / `optionalDependencies`, or a bare import a consumer
+would have to install. The checks live in `scripts/dist-guard.mjs` and are covered by
 `scripts/dist-guard.test.mjs` against real temporary package trees.
+
+**Manifest checks alone are not enough**, which is worth knowing before simplifying this.
+tsdown externalizes `dependencies` **∪ `peerDependencies`** (`getPackageDeps` in
+`tsdown/dist/src-XtWW9dvn.mjs`) and honours an explicit `external` option that no manifest
+field records, so a dependency can leave the build as a bare import with nothing in
+`package.json` to reveal it. The emitted code is therefore parsed too — with
+`es-module-lexer`, not a regex: a regex flags imports inside strings and comments, which
+misfired on this package's own `@example` JSDoc, and misses imports spanning lines.
 
 CI's Build job runs `pnpm build`, so a regression fails the PR rather than reaching npm.
 Don't route around it by relaxing the check — fix the entry globs or move the offending
-file out of them. Scanning `dist` for bare imports was tried and removed: a regex over
-emitted JavaScript flags imports inside strings and comments and misses multiline ones,
-and a release gate that blocks a good release costs more than the redundant coverage it
-buys.
+file out of them.
 
 **Automated spec refresh (`.github/workflows/sdk-spec-refresh.yml`):**
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -15,8 +15,8 @@
 
   The globs now match the exclusions `@neon/config` and `@neon/env` already used, and
   `pnpm build` fails if the artifact regresses: `scripts/check-dist.mjs` rejects a
-  `dist/` that carries bundled dependencies, emitted test files, or a non-empty
-  `dependencies` map.
+  `dist/` that carries bundled dependencies, emitted test files, a non-empty
+  `dependencies` map, or a bare runtime import a consumer could not resolve.
 
   No API change.
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -15,8 +15,8 @@
 
   The globs now match the exclusions `@neon/config` and `@neon/env` already used, and
   `pnpm build` fails if the artifact regresses: `scripts/check-dist.mjs` rejects a
-  `dist/` that carries bundled dependencies, emitted test files, a non-empty
-  `dependencies` map, or a bare runtime import a consumer could not resolve.
+  `dist/` that carries bundled dependencies, emitted test files, or a non-empty
+  `dependencies` map.
 
   No API change.
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -62,6 +62,7 @@
 		"@types/node": "catalog:",
 		"@vitest/coverage-v8": "catalog:",
 		"console-fail-test": "catalog:",
+		"es-module-lexer": "2.3.1",
 		"tsdown": "catalog:",
 		"typescript": "catalog:",
 		"vitest": "catalog:"

--- a/packages/sdk/scripts/check-dist.mjs
+++ b/packages/sdk/scripts/check-dist.mjs
@@ -18,5 +18,5 @@ if (problems.length > 0) {
 }
 
 console.log(
-	`${name}: dist/ is clean — ${fileCount} files, no bundled dependencies and no test artifacts.`,
+	`${name}: dist/ is clean — ${fileCount} files, no bundled or external dependencies and no test artifacts.`,
 );

--- a/packages/sdk/scripts/check-dist.mjs
+++ b/packages/sdk/scripts/check-dist.mjs
@@ -1,153 +1,22 @@
 /**
- * Guards the zero-dependency claim in `dist/`, straight after tsdown writes it.
- *
- * tsdown externalizes what `dependencies` lists and inlines everything else, so an
- * import of a devDependency from any file matched by the `entry` globs gets copied
- * into `dist/node_modules/`. That is how 743KB of vitest, chai, expect-type, loupe and
- * tinyrainbow reached the published tarball once: `client.test-d.ts` imports
- * `expectTypeOf`, and the entry globs excluded only `*.test.ts`.
- *
- * Both directions are failures, so both are checked: a bundled dependency (vendored
- * into `dist/node_modules/`) and an externalized one (a bare import left in `dist/`
- * that a consumer cannot resolve).
+ * Fails the build when `dist/` is not publishable. See `dist-guard.mjs` for what is
+ * checked and why.
  */
 
-import { readdir, readFile } from "node:fs/promises";
-import { builtinModules } from "node:module";
-import { dirname, join, relative } from "node:path";
+import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { inspectDist } from "./dist-guard.mjs";
 
 const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
-const distDir = join(packageRoot, "dist");
-
-const BUILTINS = new Set([
-	...builtinModules,
-	...builtinModules.map((name) => `node:${name}`),
-]);
-
-/**
- * `import … from "x"`, a bare `import "x"`, `export … from "x"`, and `import("x")`.
- *
- * Anchored at statement position because the JSDoc in this package contains `@example`
- * blocks that import `@neon/sdk` itself; matching those would block every release.
- */
-const IMPORT_PATTERN =
-	/^\s*(?:import|export)\b[^"';]*?from\s*["']([^"']+)["']|^\s*import\s*["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']/;
-
-/** Drop comment lines so `@example` imports in JSDoc aren't read as real ones. */
-function isCommentLine(line) {
-	const trimmed = line.trimStart();
-	return (
-		trimmed.startsWith("*") ||
-		trimmed.startsWith("//") ||
-		trimmed.startsWith("/*")
-	);
-}
-
-async function listFiles(dir) {
-	const entries = await readdir(dir, {
-		withFileTypes: true,
-		recursive: true,
-	});
-	return entries
-		.filter((entry) => entry.isFile())
-		.map((entry) => join(entry.parentPath ?? entry.path, entry.name));
-}
-
-function isBareSpecifier(specifier) {
-	return !specifier.startsWith(".") && !specifier.startsWith("/");
-}
-
-/** A bare specifier minus any subpath: `@scope/pkg/deep` → `@scope/pkg`. */
-function packageOf(specifier) {
-	const segments = specifier.split("/");
-	return specifier.startsWith("@")
-		? segments.slice(0, 2).join("/")
-		: segments[0];
-}
-
-/**
- * The package a vendored file belongs to. Split on the *last* `node_modules/` so pnpm's
- * nested layout reports `chai` rather than `.pnpm`:
- * `dist/node_modules/.pnpm/chai@5.2.0/node_modules/chai/chai.js`
- */
-function vendoredPackageOf(file) {
-	const marker = "node_modules/";
-	const tail = file.slice(file.lastIndexOf(marker) + marker.length);
-	return packageOf(tail) || "unknown";
-}
-
-function findExternalImports(source) {
-	const found = new Set();
-	for (const line of source.split("\n")) {
-		if (isCommentLine(line)) continue;
-		const match = line.match(IMPORT_PATTERN);
-		if (!match) continue;
-		const specifier = match[1] ?? match[2] ?? match[3];
-		if (!specifier || !isBareSpecifier(specifier)) continue;
-		if (BUILTINS.has(specifier) || BUILTINS.has(packageOf(specifier))) {
-			continue;
-		}
-		found.add(specifier);
-	}
-	return found;
-}
-
-const problems = [];
-
-const manifest = JSON.parse(
-	await readFile(join(packageRoot, "package.json"), "utf8"),
-);
-const runtimeDeps = Object.keys(manifest.dependencies ?? {});
-if (runtimeDeps.length > 0) {
-	problems.push(
-		`package.json declares runtime dependencies, but ${manifest.name} is published as zero-dependency: ${runtimeDeps.join(", ")}`,
-	);
-}
-
-const files = (await listFiles(distDir)).map((file) =>
-	relative(packageRoot, file),
-);
-if (files.length === 0) {
-	problems.push("dist/ is empty — run the build before this check.");
-}
-
-const vendored = files.filter((file) =>
-	file.split("/").includes("node_modules"),
-);
-if (vendored.length > 0) {
-	const packages = new Set(vendored.map(vendoredPackageOf));
-	problems.push(
-		`${vendored.length} file(s) from ${[...packages].sort().join(", ")} were bundled into dist/node_modules/. ` +
-			"A file matched by the tsdown `entry` globs imports a devDependency — exclude it (see tsdown.config.ts).",
-	);
-}
-
-const testArtifacts = files.filter((file) => /\.test(-d)?\./.test(file));
-if (testArtifacts.length > 0) {
-	problems.push(
-		`test files were emitted into dist/: ${testArtifacts.join(", ")}. Widen the \`entry\` exclusions in tsdown.config.ts.`,
-	);
-}
-
-for (const file of files.filter((file) => file.endsWith(".js"))) {
-	const external = findExternalImports(
-		await readFile(join(packageRoot, file), "utf8"),
-	);
-	if (external.size > 0) {
-		problems.push(
-			`${file} imports ${[...external].sort().join(", ")} at runtime, which consumers cannot resolve from a zero-dependency package.`,
-		);
-	}
-}
+const { name, fileCount, problems } = await inspectDist(packageRoot);
 
 if (problems.length > 0) {
-	console.error(`\n${manifest.name}: dist/ is not publishable\n`);
+	console.error(`\n${name}: dist/ is not publishable\n`);
 	for (const problem of problems) console.error(`  • ${problem}`);
 	console.error("");
 	process.exit(1);
 }
 
 console.log(
-	`${manifest.name}: dist/ is clean — ${files.length} files, no bundled or external dependencies.`,
+	`${name}: dist/ is clean — ${fileCount} files, no bundled dependencies and no test artifacts.`,
 );

--- a/packages/sdk/scripts/dist-guard.mjs
+++ b/packages/sdk/scripts/dist-guard.mjs
@@ -1,27 +1,50 @@
 /**
  * The checks behind `scripts/check-dist.mjs`, kept separate so they can be tested.
  *
- * `@neon/sdk` is published zero-dependency. tsdown externalizes what `dependencies`
- * declares and inlines everything else, so an import of a devDependency from any file
- * matched by the `entry` globs is copied into `dist/node_modules/`. That is how 743KB of
- * vitest, chai, expect-type, loupe and tinyrainbow reached the published 1.4.0 tarball:
- * `client.test-d.ts` imports `expectTypeOf`, and the globs excluded only `*.test.ts`.
+ * `@neon/sdk` is published zero-dependency, and a dependency can reach a consumer two
+ * ways. tsdown inlines whatever it was not told to externalize, so an import of a
+ * devDependency from any file matched by the `entry` globs is copied into
+ * `dist/node_modules/` — that is how 743KB of vitest, chai, expect-type, loupe and
+ * tinyrainbow reached the published 1.4.0 tarball, because `client.test-d.ts` imports
+ * `expectTypeOf` and the globs excluded only `*.test.ts`. Or it is externalized and left
+ * as a bare import the consumer has to install.
  *
- * Both directions of that mistake are bounded by the two checks together. A bundled
- * dependency shows up under `dist/node_modules/`. A dependency left external can only be
- * one tsdown was told to externalize, which means it appears in `dependencies` — and a
- * non-empty `dependencies` map fails on its own. Deliberately not attempted: scanning
- * `dist` for bare imports. A regex over emitted JavaScript reports imports inside strings
- * and comments and misses multiline and computed ones, and a release gate that blocks a
- * good release is worse than the redundancy it removes.
+ * Manifest checks alone do not cover the second case. tsdown externalizes
+ * `dependencies` ∪ `peerDependencies` (`tsdown/dist/src-XtWW9dvn.mjs`, `getPackageDeps`)
+ * and also honours an explicit `external` option, which no manifest field records — so
+ * the emitted code is read as well.
+ *
+ * That read uses a real ES module parser rather than a regex. A regex over emitted
+ * JavaScript reports imports inside strings and comments, which already misfired once on
+ * the `@example` blocks in this package's JSDoc, and misses imports spanning lines.
+ * Non-literal dynamic imports (`import(someVariable)`) are out of scope: nothing can
+ * resolve them statically, and tsdown cannot externalize a specifier it never sees.
  */
 
 import { readdir, readFile } from "node:fs/promises";
-import { join, relative, sep } from "node:path";
+import { builtinModules } from "node:module";
+import { join, relative } from "node:path";
+import { init, parse } from "es-module-lexer";
 
-/** Path segments, separator-normalized so the checks behave the same on Windows. */
+const BUILTINS = new Set([
+	...builtinModules,
+	...builtinModules.map((name) => `node:${name}`),
+]);
+
+/** Manifest fields that oblige a consumer to install something at runtime. */
+const RUNTIME_DEPENDENCY_FIELDS = [
+	"dependencies",
+	"peerDependencies",
+	"optionalDependencies",
+];
+
+/**
+ * Path segments, treating both separators as one. `path.relative` yields backslashes on
+ * Windows, where splitting on `/` alone silently matched nothing and let a `dist/` full of
+ * vendored packages pass.
+ */
 export function segmentsOf(path) {
-	return path.split(sep).join("/").split("/");
+	return path.split(/[\\/]+/);
 }
 
 /** True when a file inside `dist` came from a package rather than from `src`. */
@@ -37,7 +60,9 @@ export function isTestArtifact(path) {
 /** A bare specifier minus any subpath: `@scope/pkg/deep` → `@scope/pkg`. */
 export function packageOf(specifier) {
 	const parts = specifier.split("/");
-	return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+	return specifier.startsWith("@")
+		? parts.slice(0, 2).join("/")
+		: (parts[0] ?? "");
 }
 
 /**
@@ -51,35 +76,67 @@ export function vendoredPackageOf(path) {
 	return packageOf(parts.slice(last + 1).join("/")) || "unknown";
 }
 
+/**
+ * Bare, non-builtin specifiers imported by an ES module — the ones a consumer would have
+ * to install. Relative and builtin specifiers are fine, and a specifier the parser reports
+ * as dynamic-but-not-literal is skipped rather than guessed at.
+ */
+export function externalImportsOf(source) {
+	const [imports] = parse(source);
+	const found = new Set();
+	for (const entry of imports) {
+		const specifier = entry.n;
+		if (!specifier) continue;
+		if (specifier.startsWith(".") || specifier.startsWith("/")) continue;
+		if (BUILTINS.has(specifier) || BUILTINS.has(packageOf(specifier))) {
+			continue;
+		}
+		found.add(specifier);
+	}
+	return found;
+}
+
 async function listFiles(dir) {
-	const entries = await readdir(dir, {
-		withFileTypes: true,
-		recursive: true,
-	});
-	return entries
-		.filter((entry) => entry.isFile())
-		.map((entry) => join(entry.parentPath ?? entry.path, entry.name));
+	try {
+		const entries = await readdir(dir, {
+			withFileTypes: true,
+			recursive: true,
+		});
+		return entries
+			.filter((entry) => entry.isFile())
+			.map((entry) => join(entry.parentPath ?? entry.path, entry.name));
+	} catch (error) {
+		// A missing dist is the same finding as an empty one, and reporting it beats an
+		// ENOENT stack trace. Anything else is a real filesystem fault worth surfacing.
+		if (error.code === "ENOENT") return [];
+		throw error;
+	}
 }
 
 /** Everything wrong with a built `dist/`, as messages. Empty means publishable. */
 export async function inspectDist(packageRoot) {
+	await init;
 	const problems = [];
 
 	const manifest = JSON.parse(
 		await readFile(join(packageRoot, "package.json"), "utf8"),
 	);
-	const runtimeDeps = Object.keys(manifest.dependencies ?? {});
-	if (runtimeDeps.length > 0) {
-		problems.push(
-			`package.json declares runtime dependencies, but ${manifest.name} is published as zero-dependency: ${runtimeDeps.join(", ")}. Anything listed here is also left external in dist/, so consumers would have to install it.`,
-		);
+	for (const field of RUNTIME_DEPENDENCY_FIELDS) {
+		const declared = Object.keys(manifest[field] ?? {});
+		if (declared.length > 0) {
+			problems.push(
+				`package.json declares ${field}, but ${manifest.name} is published as zero-dependency: ${declared.join(", ")}.`,
+			);
+		}
 	}
 
 	const files = (await listFiles(join(packageRoot, "dist"))).map((file) =>
 		relative(packageRoot, file),
 	);
 	if (files.length === 0) {
-		problems.push("dist/ is empty — run the build before this check.");
+		problems.push(
+			"dist/ is missing or empty — run the build before this check.",
+		);
 	}
 
 	const vendored = files.filter(isVendored);
@@ -95,6 +152,16 @@ export async function inspectDist(packageRoot) {
 		problems.push(
 			`test files were emitted into dist/: ${testArtifacts.join(", ")}. Widen the \`entry\` exclusions in tsdown.config.ts. Note that \`!src/**/*.test.*\` does not match \`*.test-d.ts\`.`,
 		);
+	}
+
+	for (const file of files.filter((file) => file.endsWith(".js"))) {
+		const source = await readFile(join(packageRoot, file), "utf8");
+		const external = externalImportsOf(source);
+		if (external.size > 0) {
+			problems.push(
+				`${file} imports ${[...external].sort().join(", ")} at runtime, which a consumer of a zero-dependency package cannot resolve. Something was externalized rather than bundled — check \`dependencies\`, \`peerDependencies\`, and any \`external\` option in tsdown.config.ts.`,
+			);
+		}
 	}
 
 	return { name: manifest.name, fileCount: files.length, problems };

--- a/packages/sdk/scripts/dist-guard.mjs
+++ b/packages/sdk/scripts/dist-guard.mjs
@@ -1,0 +1,101 @@
+/**
+ * The checks behind `scripts/check-dist.mjs`, kept separate so they can be tested.
+ *
+ * `@neon/sdk` is published zero-dependency. tsdown externalizes what `dependencies`
+ * declares and inlines everything else, so an import of a devDependency from any file
+ * matched by the `entry` globs is copied into `dist/node_modules/`. That is how 743KB of
+ * vitest, chai, expect-type, loupe and tinyrainbow reached the published 1.4.0 tarball:
+ * `client.test-d.ts` imports `expectTypeOf`, and the globs excluded only `*.test.ts`.
+ *
+ * Both directions of that mistake are bounded by the two checks together. A bundled
+ * dependency shows up under `dist/node_modules/`. A dependency left external can only be
+ * one tsdown was told to externalize, which means it appears in `dependencies` — and a
+ * non-empty `dependencies` map fails on its own. Deliberately not attempted: scanning
+ * `dist` for bare imports. A regex over emitted JavaScript reports imports inside strings
+ * and comments and misses multiline and computed ones, and a release gate that blocks a
+ * good release is worse than the redundancy it removes.
+ */
+
+import { readdir, readFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+
+/** Path segments, separator-normalized so the checks behave the same on Windows. */
+export function segmentsOf(path) {
+	return path.split(sep).join("/").split("/");
+}
+
+/** True when a file inside `dist` came from a package rather than from `src`. */
+export function isVendored(path) {
+	return segmentsOf(path).includes("node_modules");
+}
+
+/** True for an emitted test artifact, covering both `*.test.*` and `*.test-d.*`. */
+export function isTestArtifact(path) {
+	return /\.test(-d)?\./.test(segmentsOf(path).at(-1) ?? "");
+}
+
+/** A bare specifier minus any subpath: `@scope/pkg/deep` → `@scope/pkg`. */
+export function packageOf(specifier) {
+	const parts = specifier.split("/");
+	return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+}
+
+/**
+ * The package a vendored file belongs to. Reads from the *last* `node_modules` segment so
+ * pnpm's nested layout reports `chai` rather than `.pnpm`:
+ * `dist/node_modules/.pnpm/chai@5.2.0/node_modules/chai/chai.js`
+ */
+export function vendoredPackageOf(path) {
+	const parts = segmentsOf(path);
+	const last = parts.lastIndexOf("node_modules");
+	return packageOf(parts.slice(last + 1).join("/")) || "unknown";
+}
+
+async function listFiles(dir) {
+	const entries = await readdir(dir, {
+		withFileTypes: true,
+		recursive: true,
+	});
+	return entries
+		.filter((entry) => entry.isFile())
+		.map((entry) => join(entry.parentPath ?? entry.path, entry.name));
+}
+
+/** Everything wrong with a built `dist/`, as messages. Empty means publishable. */
+export async function inspectDist(packageRoot) {
+	const problems = [];
+
+	const manifest = JSON.parse(
+		await readFile(join(packageRoot, "package.json"), "utf8"),
+	);
+	const runtimeDeps = Object.keys(manifest.dependencies ?? {});
+	if (runtimeDeps.length > 0) {
+		problems.push(
+			`package.json declares runtime dependencies, but ${manifest.name} is published as zero-dependency: ${runtimeDeps.join(", ")}. Anything listed here is also left external in dist/, so consumers would have to install it.`,
+		);
+	}
+
+	const files = (await listFiles(join(packageRoot, "dist"))).map((file) =>
+		relative(packageRoot, file),
+	);
+	if (files.length === 0) {
+		problems.push("dist/ is empty — run the build before this check.");
+	}
+
+	const vendored = files.filter(isVendored);
+	if (vendored.length > 0) {
+		const packages = [...new Set(vendored.map(vendoredPackageOf))].sort();
+		problems.push(
+			`${vendored.length} file(s) from ${packages.join(", ")} were bundled into dist/node_modules/. A file matched by the tsdown \`entry\` globs imports a devDependency — exclude it (see tsdown.config.ts).`,
+		);
+	}
+
+	const testArtifacts = files.filter(isTestArtifact);
+	if (testArtifacts.length > 0) {
+		problems.push(
+			`test files were emitted into dist/: ${testArtifacts.join(", ")}. Widen the \`entry\` exclusions in tsdown.config.ts. Note that \`!src/**/*.test.*\` does not match \`*.test-d.ts\`.`,
+		);
+	}
+
+	return { name: manifest.name, fileCount: files.length, problems };
+}

--- a/packages/sdk/scripts/dist-guard.test.mjs
+++ b/packages/sdk/scripts/dist-guard.test.mjs
@@ -1,8 +1,10 @@
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { init } from "es-module-lexer";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import {
+	externalImportsOf,
 	inspectDist,
 	isTestArtifact,
 	isVendored,
@@ -11,26 +13,42 @@ import {
 	vendoredPackageOf,
 } from "./dist-guard.mjs";
 
+beforeAll(async () => {
+	await init;
+});
+
 describe("path classification", () => {
-	it("splits on the platform separator so Windows paths behave the same", () => {
+	it("treats both separators as one, so Windows paths classify the same", () => {
 		expect(segmentsOf("dist/neon/client.js")).toEqual([
+			"dist",
+			"neon",
+			"client.js",
+		]);
+		expect(segmentsOf("dist\\neon\\client.js")).toEqual([
 			"dist",
 			"neon",
 			"client.js",
 		]);
 	});
 
-	it("recognises a vendored file", () => {
+	it("recognises a vendored file given Windows separators", () => {
+		// `path.relative` returns backslashes on Windows. Splitting on "/" alone matched
+		// nothing there, so the guard passed a dist/ full of vendored packages.
+		expect(isVendored("dist\\node_modules\\chai\\chai.js")).toBe(true);
 		expect(isVendored("dist/node_modules/chai/chai.js")).toBe(true);
 		expect(isVendored("dist/neon/client.js")).toBe(false);
-		// A source file merely named after the directory is not vendored.
 		expect(isVendored("dist/neon/node_modules-helper.js")).toBe(false);
 	});
 
-	it("names the real package behind pnpm's nested layout", () => {
+	it("names the real package behind pnpm's nested layout, on either separator", () => {
 		expect(
 			vendoredPackageOf(
 				"dist/node_modules/.pnpm/chai@5.2.0/node_modules/chai/lib/chai.js",
+			),
+		).toBe("chai");
+		expect(
+			vendoredPackageOf(
+				"dist\\node_modules\\.pnpm\\chai@5.2.0\\node_modules\\chai\\lib\\chai.js",
 			),
 		).toBe("chai");
 		expect(
@@ -40,17 +58,62 @@ describe("path classification", () => {
 		).toBe("@vitest/utils");
 	});
 
-	it("keeps a scope together and drops the subpath", () => {
+	it("keeps a scope together, drops the subpath, and survives an empty specifier", () => {
 		expect(packageOf("@scope/pkg/deep/path")).toBe("@scope/pkg");
 		expect(packageOf("chai")).toBe("chai");
+		expect(packageOf("")).toBe("");
 	});
 
 	it("catches both test-file spellings, which is the bug that shipped", () => {
 		expect(isTestArtifact("dist/neon/client.test-d.js")).toBe(true);
 		expect(isTestArtifact("dist/neon/errors.test.js")).toBe(true);
 		expect(isTestArtifact("dist/neon/client.js")).toBe(false);
-		// `latest.js` contains "test" but is not a test artifact.
 		expect(isTestArtifact("dist/neon/latest.js")).toBe(false);
+	});
+});
+
+describe("externalImportsOf", () => {
+	it("finds bare imports and ignores relative and builtin ones", () => {
+		const source = [
+			'import { readFile } from "node:fs/promises";',
+			'import { local } from "./local.js";',
+			'import { dep } from "undici";',
+			'export * from "@scope/pkg/sub";',
+		].join("\n");
+		expect([...externalImportsOf(source)].sort()).toEqual([
+			"@scope/pkg/sub",
+			"undici",
+		]);
+	});
+
+	it("finds an import split across lines, which the old regex missed", () => {
+		const source = 'import {\n  a,\n  b,\n} from\n  "undici";\n';
+		expect([...externalImportsOf(source)]).toEqual(["undici"]);
+	});
+
+	it("ignores import-like text in comments and strings, which the old regex flagged", () => {
+		// This is not hypothetical: the first version of this guard rejected the package
+		// because its JSDoc @example blocks import @neon/sdk.
+		const source = [
+			"/**",
+			" * @example",
+			' * import { createNeonClient } from "@neon/sdk";',
+			" */",
+			'const docs = \'import { x } from "chai"\';',
+			'// import { y } from "vitest";',
+			"export const a = docs;",
+		].join("\n");
+		expect([...externalImportsOf(source)]).toEqual([]);
+	});
+
+	it("finds a literal dynamic import", () => {
+		expect([...externalImportsOf('await import("undici");')]).toEqual([
+			"undici",
+		]);
+	});
+
+	it("skips a dynamic import nothing could resolve statically", () => {
+		expect([...externalImportsOf("await import(specifier);")]).toEqual([]);
 	});
 });
 
@@ -58,7 +121,10 @@ describe("inspectDist against a real package tree", () => {
 	const roots = [];
 
 	afterEach(async () => {
-		await Promise.all(roots.map((root) => rm(root, { recursive: true })));
+		// Runs even when a test fails, so a failure cannot leave temp trees behind.
+		await Promise.all(
+			roots.map((root) => rm(root, { recursive: true, force: true })),
+		);
 		roots.length = 0;
 	});
 
@@ -78,13 +144,21 @@ describe("inspectDist against a real package tree", () => {
 		return root;
 	}
 
-	it("passes a clean dist", async () => {
+	it("passes a clean dist, including one whose comments mention imports", async () => {
 		const root = await packageRoot({
-			files: { "dist/index.js": "export const a = 1;\n" },
+			files: {
+				"dist/index.js": [
+					"/** @example import { createNeonClient } from \"@neon/sdk\"; */",
+					'import { readFile } from "node:fs/promises";',
+					'import { local } from "./local.js";',
+					"export { readFile, local };",
+				].join("\n"),
+				"dist/local.js": "export const local = 1;\n",
+			},
 		});
 		const { problems, fileCount } = await inspectDist(root);
 		expect(problems).toEqual([]);
-		expect(fileCount).toBe(1);
+		expect(fileCount).toBe(2);
 	});
 
 	it("fails on a bundled dependency and names it", async () => {
@@ -98,7 +172,6 @@ describe("inspectDist against a real package tree", () => {
 		const { problems } = await inspectDist(root);
 		expect(problems).toHaveLength(1);
 		expect(problems[0]).toContain("chai");
-		expect(problems[0]).toContain("dist/node_modules/");
 	});
 
 	it("fails on an emitted type-test artifact", async () => {
@@ -113,14 +186,45 @@ describe("inspectDist against a real package tree", () => {
 		expect(problems[0]).toContain("client.test-d.js");
 	});
 
-	it("fails on a runtime dependency, which is also what would be left external", async () => {
+	it("fails on a declared runtime dependency in any of the three fields", async () => {
+		for (const field of [
+			"dependencies",
+			"peerDependencies",
+			"optionalDependencies",
+		]) {
+			const root = await packageRoot({
+				manifest: { [field]: { undici: "^6.0.0" } },
+				files: { "dist/index.js": "export const a = 1;\n" },
+			});
+			const { problems } = await inspectDist(root);
+			expect(problems).toHaveLength(1);
+			expect(problems[0]).toContain(field);
+			expect(problems[0]).toContain("undici");
+		}
+	});
+
+	it("fails on a peer dependency left as a bare import, which manifest checks alone missed", async () => {
+		// tsdown externalizes dependencies AND peerDependencies, so this combination
+		// emits an import the consumer must install. Checking `dependencies` alone
+		// reported this tree as clean.
 		const root = await packageRoot({
-			manifest: { dependencies: { undici: "^6.0.0" } },
-			files: { "dist/index.js": "export const a = 1;\n" },
+			manifest: { peerDependencies: { undici: "^6.0.0" } },
+			files: { "dist/index.js": 'import "undici";\nexport const a = 1;\n' },
+		});
+		const { problems } = await inspectDist(root);
+		expect(problems).toHaveLength(2);
+		expect(problems.some((p) => p.includes("peerDependencies"))).toBe(true);
+		expect(problems.some((p) => p.includes("at runtime"))).toBe(true);
+	});
+
+	it("fails on a bare import no manifest field records, as an `external` option would produce", async () => {
+		const root = await packageRoot({
+			files: { "dist/index.js": 'import { x } from "undici";\nexport { x };\n' },
 		});
 		const { problems } = await inspectDist(root);
 		expect(problems).toHaveLength(1);
 		expect(problems[0]).toContain("undici");
+		expect(problems[0]).toContain("external");
 	});
 
 	it("reports every problem at once rather than stopping at the first", async () => {
@@ -135,10 +239,17 @@ describe("inspectDist against a real package tree", () => {
 		expect(problems).toHaveLength(3);
 	});
 
-	it("fails when dist is empty, so a missing build cannot look like a pass", async () => {
+	it("reports a missing dist rather than throwing ENOENT", async () => {
+		const root = await packageRoot({ files: {} });
+		const { problems } = await inspectDist(root);
+		expect(problems).toHaveLength(1);
+		expect(problems[0]).toContain("missing or empty");
+	});
+
+	it("reports an empty dist directory the same way", async () => {
 		const root = await packageRoot({ files: { "dist/.keep": "" } });
 		await rm(join(root, "dist/.keep"));
 		const { problems } = await inspectDist(root);
-		expect(problems.some((p) => p.includes("dist/ is empty"))).toBe(true);
+		expect(problems.some((p) => p.includes("missing or empty"))).toBe(true);
 	});
 });

--- a/packages/sdk/scripts/dist-guard.test.mjs
+++ b/packages/sdk/scripts/dist-guard.test.mjs
@@ -1,0 +1,144 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	inspectDist,
+	isTestArtifact,
+	isVendored,
+	packageOf,
+	segmentsOf,
+	vendoredPackageOf,
+} from "./dist-guard.mjs";
+
+describe("path classification", () => {
+	it("splits on the platform separator so Windows paths behave the same", () => {
+		expect(segmentsOf("dist/neon/client.js")).toEqual([
+			"dist",
+			"neon",
+			"client.js",
+		]);
+	});
+
+	it("recognises a vendored file", () => {
+		expect(isVendored("dist/node_modules/chai/chai.js")).toBe(true);
+		expect(isVendored("dist/neon/client.js")).toBe(false);
+		// A source file merely named after the directory is not vendored.
+		expect(isVendored("dist/neon/node_modules-helper.js")).toBe(false);
+	});
+
+	it("names the real package behind pnpm's nested layout", () => {
+		expect(
+			vendoredPackageOf(
+				"dist/node_modules/.pnpm/chai@5.2.0/node_modules/chai/lib/chai.js",
+			),
+		).toBe("chai");
+		expect(
+			vendoredPackageOf(
+				"dist/node_modules/.pnpm/@vitest_utils@3.0.9/node_modules/@vitest/utils/dist/index.js",
+			),
+		).toBe("@vitest/utils");
+	});
+
+	it("keeps a scope together and drops the subpath", () => {
+		expect(packageOf("@scope/pkg/deep/path")).toBe("@scope/pkg");
+		expect(packageOf("chai")).toBe("chai");
+	});
+
+	it("catches both test-file spellings, which is the bug that shipped", () => {
+		expect(isTestArtifact("dist/neon/client.test-d.js")).toBe(true);
+		expect(isTestArtifact("dist/neon/errors.test.js")).toBe(true);
+		expect(isTestArtifact("dist/neon/client.js")).toBe(false);
+		// `latest.js` contains "test" but is not a test artifact.
+		expect(isTestArtifact("dist/neon/latest.js")).toBe(false);
+	});
+});
+
+describe("inspectDist against a real package tree", () => {
+	const roots = [];
+
+	afterEach(async () => {
+		await Promise.all(roots.map((root) => rm(root, { recursive: true })));
+		roots.length = 0;
+	});
+
+	/** Build a throwaway package root on disk; no mocks, real files. */
+	async function packageRoot({ manifest = {}, files = {} }) {
+		const root = await mkdtemp(join(tmpdir(), "dist-guard-"));
+		roots.push(root);
+		await writeFile(
+			join(root, "package.json"),
+			JSON.stringify({ name: "@neon/sdk", ...manifest }),
+		);
+		for (const [path, contents] of Object.entries(files)) {
+			const full = join(root, path);
+			await mkdir(join(full, ".."), { recursive: true });
+			await writeFile(full, contents);
+		}
+		return root;
+	}
+
+	it("passes a clean dist", async () => {
+		const root = await packageRoot({
+			files: { "dist/index.js": "export const a = 1;\n" },
+		});
+		const { problems, fileCount } = await inspectDist(root);
+		expect(problems).toEqual([]);
+		expect(fileCount).toBe(1);
+	});
+
+	it("fails on a bundled dependency and names it", async () => {
+		const root = await packageRoot({
+			files: {
+				"dist/index.js": "export const a = 1;\n",
+				"dist/node_modules/.pnpm/chai@5.2.0/node_modules/chai/chai.js":
+					"module.exports = {};\n",
+			},
+		});
+		const { problems } = await inspectDist(root);
+		expect(problems).toHaveLength(1);
+		expect(problems[0]).toContain("chai");
+		expect(problems[0]).toContain("dist/node_modules/");
+	});
+
+	it("fails on an emitted type-test artifact", async () => {
+		const root = await packageRoot({
+			files: {
+				"dist/index.js": "export const a = 1;\n",
+				"dist/neon/client.test-d.js": "export const t = 1;\n",
+			},
+		});
+		const { problems } = await inspectDist(root);
+		expect(problems).toHaveLength(1);
+		expect(problems[0]).toContain("client.test-d.js");
+	});
+
+	it("fails on a runtime dependency, which is also what would be left external", async () => {
+		const root = await packageRoot({
+			manifest: { dependencies: { undici: "^6.0.0" } },
+			files: { "dist/index.js": "export const a = 1;\n" },
+		});
+		const { problems } = await inspectDist(root);
+		expect(problems).toHaveLength(1);
+		expect(problems[0]).toContain("undici");
+	});
+
+	it("reports every problem at once rather than stopping at the first", async () => {
+		const root = await packageRoot({
+			manifest: { dependencies: { undici: "^6.0.0" } },
+			files: {
+				"dist/neon/client.test-d.js": "export const t = 1;\n",
+				"dist/node_modules/chai/chai.js": "module.exports = {};\n",
+			},
+		});
+		const { problems } = await inspectDist(root);
+		expect(problems).toHaveLength(3);
+	});
+
+	it("fails when dist is empty, so a missing build cannot look like a pass", async () => {
+		const root = await packageRoot({ files: { "dist/.keep": "" } });
+		await rm(join(root, "dist/.keep"));
+		const { problems } = await inspectDist(root);
+		expect(problems.some((p) => p.includes("dist/ is empty"))).toBe(true);
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,6 +571,9 @@ importers:
       console-fail-test:
         specifier: 'catalog:'
         version: 0.5.0
+      es-module-lexer:
+        specifier: 2.3.1
+        version: 2.3.1
       tsdown:
         specifier: 'catalog:'
         version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.9.3)
@@ -2543,6 +2546,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
@@ -6221,6 +6227,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:


### PR DESCRIPTION
Follow-up to [#377](https://github.com/neondatabase/neon-pkgs/pull/377) (shipped in `@neon/sdk@1.4.1`), hardening the release gate it added. The packaging fix itself is unaffected and stays as merged.

## Problem

`scripts/check-dist.mjs` is a release gate — `build` runs it, and CI's Build job runs `build`. A gate with false positives blocks good releases; one with false negatives makes its guarantee dishonest. It had both, plus a platform bug that made one check silently vacuous.

**The bare-import scan was a regex over emitted JavaScript.** It missed imports spanning lines and flagged imports inside strings and comments. That is not hypothetical: the first version of it rejected this very package because `@neon/sdk` and `@neon/sdk/raw` appear in `@example` JSDoc blocks, which would have blocked every release. Filtering comment lines patched the symptom rather than the approach.

**The vendored-file check did nothing on Windows.** `path.relative()` returns backslash-separated paths there, so `file.split("/").includes("node_modules")` never matched — the gate would have reported a clean `dist/` while shipping vitest. `vendoredPackageOf()` shared the assumption.

**No failure branch was tested.** CI only proved that today's clean artifact passes, so both defects above were invisible.

## Diagnosis, including the part I got wrong

My first attempt deleted the import scan rather than fixing it, arguing it was redundant: tsdown externalizes only what `dependencies` declares, and a non-empty `dependencies` map is already its own check, so the two remaining checks would bound both directions.

**That premise is false.** From the installed tsdown 0.14.1:

```js
// tsdown/dist/src-XtWW9dvn.mjs:813 — getPackageDeps
return new Set([...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.peerDependencies || {})]);
```

It externalizes `dependencies` **∪ `peerDependencies`**, and separately honours an explicit `external` option that no manifest field records. So a dependency can leave the build as a bare import with nothing in `package.json` to reveal it. Confirmed against the guard as it stood: a tree declaring `peerDependencies: { undici }` and emitting `import "undici"` was reported as `problems: []`.

The manifest can therefore never be the whole story, and the emitted code has to be read. The regex was the defect, not the idea.

## The fix

**The import check is back, parser-backed.** `es-module-lexer` (pinned exactly — a release gate should not shift under a caret range) replaces the regex. It reports import specifiers from an actual parse, so text in comments and strings is not matched and multiline imports are. Non-literal dynamic imports (`import(someVariable)`) are explicitly out of scope: nothing resolves them statically, and tsdown cannot externalize a specifier it never sees.

**All three runtime-dependency fields are rejected**, not just `dependencies` — `peerDependencies` and `optionalDependencies` are equally runtime obligations for a consumer of a package that claims zero dependencies.

**Paths split on both separators**, so classification is platform-independent rather than accidentally POSIX-only.

**A missing `dist/` reports its finding** instead of throwing `ENOENT` from `readdir`, which honours `inspectDist`'s contract of returning everything wrong as messages. A malformed `package.json` still throws, which is the right fail-fast behaviour.

**The logic moved to `scripts/dist-guard.mjs`** behind `inspectDist(packageRoot)`, with `check-dist.mjs` reduced to a runner. That split is what makes the gate testable, and the argument is why it takes a package root rather than reading `cwd`.

```
@neon/sdk: dist/ is clean — 184 files, no bundled or external dependencies and no test artifacts.
```

| Condition | Catches |
| --- | --- |
| any file under `dist/node_modules/` | a devDependency bundled in — the #377 bug |
| any emitted `*.test*` / `*.test-d*` file | test code reaching the tarball |
| `dependencies` / `peerDependencies` / `optionalDependencies` non-empty | the zero-dependency claim becoming false |
| a bare, non-builtin import in `dist/**/*.js` | anything externalized rather than bundled, including via `external` |

## Verification

Against `55dcf77`:

- `pnpm test:ci` — **52 tests** (33 before; 19 are new guard tests)
- `pnpm build`, `pnpm tsc --noEmit`, `pnpm lint:ci` (575 files) — clean
- reverting the `!src/**/*.test-d.*` exclusion and rebuilding still exits 1 and names all eight leaked packages
- `pnpm-lock.yaml` gained 8 lines and references no proxy host

Tests build throwaway package roots under `os.tmpdir()` against real files, no mocks:

- the bypass this review found: `peerDependencies` plus a matching emitted import now reports both problems
- a bare import with **no** manifest field recording it — the `external`-option case
- each of the three dependency fields rejected, individually
- a bundled dependency named `chai` rather than `.pnpm`, through pnpm's nested layout
- an emitted `client.test-d.js`
- three simultaneous problems all reported rather than stopping at the first
- a genuinely absent `dist/`, and separately an empty one
- **backslash paths** asserted directly (`dist\node_modules\chai\chai.js`), so the test would fail against the old `split("/")` rather than passing on POSIX either way
- parser behaviour: multiline imports found; `@example` JSDoc, comments and string literals **not** flagged; literal `import("undici")` found; `import(variable)` skipped
- near-misses that must not fire: `node_modules-helper.js` is not vendored, `latest.js` is not a test artifact

Not verified: no run on Windows. The separator fix is reasoned from `path.relative`'s documented behaviour and asserted with backslash inputs, but no CI runner covers Windows.

## Also in here

- **`AGENTS.md`** now records *why* manifest checks alone are insufficient, citing `getPackageDeps`, so the next person to simplify this does not repeat my mistake.
- **`es-module-lexer` as a devDependency**, pinned to `2.3.1`. It stays out of `dependencies`, and the guard fails the build if that ever changes, so it cannot reach `dist/` or be installed by a consumer.
- No changeset. There is no consumer-facing runtime or API change: `scripts/` is not in `files`, and the added devDependency is not installed for consumers. The published *manifest* does change, though — `package.json` is in `files`, and npm keeps `devDependencies` in the published copy, so `es-module-lexer: 2.3.1` is visible there. Verified by unpacking a `npm pack` tarball: `dependencies` is `null`, `devDependencies` is present.
- The released 1.4.1 CHANGELOG entry is left exactly as shipped. An earlier revision of this PR "corrected" it to drop the bare-import sentence; that was wrong, because 1.4.1 did ship an import check. Net diff against `main` for that file is empty.

## For your attention

- **A correction to the review report that prompted #377.** I claimed the type tests "never run in CI". That is misleading: CI's `build` runs `tsc --noEmit`, which includes the `*.test-d.ts` files, so `expectTypeOf` mismatches and `@ts-expect-error` violations already fail CI. Only the Vitest runtime harness is unexercised, which makes wiring `test:types` into CI worth much less than I implied.
- **`@neon/functions` and `@neon/ai-sdk-provider` still carry the same incomplete `!src/**/*.test.*`** with no `test-d` counterpart. Neither leaks today only because neither has a `.test-d.ts` file. The guard is now a tested module taking a package root as an argument, so promoting it to a shared one is cheap; not done here to keep this to the review findings.
- **Non-literal dynamic imports remain undetectable**, by this gate or any other static check. If one is ever needed in shipped code, the gate will not see the dependency it pulls in.
