### PR TITLE
fix(cli): report a request timeout as a timeout, not a broken connection

### DIFF
--- a/.changeset/cli-timeout-classification.md
+++ b/.changeset/cli-timeout-classification.md
@@ -21,4 +21,7 @@ and recognised through the `cause` chain, so it reports `ECONNABORTED` and "Requ
 out" as intended.
 
 `getApiClient` also accepts `requestTimeoutMs`, defaulting to the same 60s, which is what
-makes the behaviour testable against a server that never responds.
+makes the behaviour testable against a server that never responds. It is validated when
+the client is built: without that, `-1`, `NaN`, `Infinity` and fractions throw from inside
+the fetch wrapper and come back as the same misleading connectivity error, while `0` and
+values above `2147483647` are accepted and make every request time out at once.

--- a/.changeset/cli-timeout-classification.md
+++ b/.changeset/cli-timeout-classification.md
@@ -1,0 +1,24 @@
+---
+"neon": patch
+---
+
+Report a request timeout as a timeout, not as a broken internet connection.
+
+When the Neon API accepted a connection and then didn't answer within the 60s request
+timeout, the CLI printed:
+
+> Could not reach the Neon API. Please check your internet connection and try again.
+
+The connection was fine and the request had reached the server, so the one thing the
+message told the user to check was the one thing that was not wrong.
+
+The timeout is raised inside the CLI's own `fetch` wrapper, so by the time it is
+classified `@neon/sdk` has wrapped it as a `NeonNetworkError` — and the check looked only
+at the top-level error's `name`, which is `NeonNetworkError` on every SDK path. The
+timeout therefore fell through to the connectivity branch, whose message pattern matched
+the SDK's own `Network error: …` text. A timeout is now raised as a CLI-owned error type
+and recognised through the `cause` chain, so it reports `ECONNABORTED` and "Request timed
+out" as intended.
+
+`getApiClient` also accepts `requestTimeoutMs`, defaulting to the same 60s, which is what
+makes the behaviour testable against a server that never responds.

--- a/.changeset/cli-timeout-classification.md
+++ b/.changeset/cli-timeout-classification.md
@@ -22,6 +22,7 @@ out" as intended.
 
 `getApiClient` also accepts `requestTimeoutMs`, defaulting to the same 60s, which is what
 makes the behaviour testable against a server that never responds. It is validated when
-the client is built: without that, `-1`, `NaN`, `Infinity` and fractions throw from inside
-the fetch wrapper and come back as the same misleading connectivity error, while `0` and
-values above `2147483647` are accepted and make every request time out at once.
+the client is built: without that, `-1`, `NaN`, `Infinity`, fractions and values above
+`4294967295` throw from inside the fetch wrapper and come back as the same misleading
+connectivity error, while `0` and the band from `2147483648` to `4294967295` are accepted
+and make every request time out at once.

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -41,6 +41,8 @@ if (PROXY_ENV_VARS.some((name) => process.env[name])) {
 export type ApiCallProps = {
 	apiKey: string;
 	apiHost?: string;
+	/** Per-request timeout. Defaults to {@link REQUEST_TIMEOUT_MS}. */
+	requestTimeoutMs?: number;
 };
 
 const DEFAULT_API_HOST = "https://console.neon.tech/api/v2";
@@ -167,11 +169,51 @@ function headersToObject(headers: Headers): Record<string, string> {
 	return out;
 }
 
+/**
+ * Raised by {@link makeTimedFetch} when the CLI's own request timeout fires. Owning the
+ * type is what makes the timeout recognisable further up: `@neon/sdk` reports every
+ * transport failure as a `NeonNetworkError`, so matching on names or codes cannot tell a
+ * timeout from a reset connection.
+ */
+class RequestTimeoutError extends Error {
+	/**
+	 * What `fetch` actually threw. Not passed as an `Error` `cause`, because this package
+	 * compiles against a lib without `ErrorOptions`.
+	 */
+	readonly reason?: unknown;
+
+	constructor(timeoutMs: number, reason?: unknown) {
+		super(`Request timed out after ${timeoutMs}ms`);
+		this.name = "RequestTimeoutError";
+		this.reason = reason;
+	}
+}
+
+/**
+ * Whether a failure was a request timeout rather than a connectivity problem.
+ *
+ * Walks the `cause` chain, because the SDK wraps whatever `fetch` threw. Before this, the
+ * check only looked at the top-level error's `name` — which is `NeonNetworkError` on every
+ * SDK path — so a timeout fell through to the connectivity branch and the user was told to
+ * check an internet connection that was working.
+ */
 function isAbortError(err: unknown): boolean {
-	return (
-		err instanceof Error &&
-		(err.name === "AbortError" || err.name === "TimeoutError")
-	);
+	let current: unknown = err;
+	for (let depth = 0; depth < 6 && current != null; depth++) {
+		if (current instanceof RequestTimeoutError) return true;
+		if (
+			current instanceof Error &&
+			(current.name === "AbortError" || current.name === "TimeoutError")
+		) {
+			return true;
+		}
+		// `@neon/sdk` classifies its own deadlines and cancellations by kind; the CLI
+		// does not set them today, but reading them keeps this correct if it ever does.
+		const kind = (current as { kind?: unknown }).kind;
+		if (kind === "timeout" || kind === "aborted") return true;
+		current = (current as { cause?: unknown }).cause;
+	}
+	return false;
 }
 
 /**
@@ -246,19 +288,33 @@ function networkError(err: unknown): NeonApiError {
  * and lightweight debug logging of the request line + response status — the
  * fetch-native replacement for the old `axios-debug-log` wiring.
  */
-const timedFetch: typeof fetch = async (input, init) => {
-	const timeout = AbortSignal.timeout(REQUEST_TIMEOUT_MS);
-	const signal = init?.signal
-		? AbortSignal.any([init.signal, timeout])
-		: timeout;
-	const method =
-		init?.method ?? (input instanceof Request ? input.method : "GET");
-	const url = input instanceof Request ? input.url : String(input);
-	log.debug("%s %s", method.toUpperCase(), url);
-	const response = await fetch(input, { ...init, signal });
-	log.debug("%d %s", response.status, response.statusText);
-	return response;
-};
+const makeTimedFetch =
+	(requestTimeoutMs: number): typeof fetch =>
+	async (input, init) => {
+		const timeout = AbortSignal.timeout(requestTimeoutMs);
+		const signal = init?.signal
+			? AbortSignal.any([init.signal, timeout])
+			: timeout;
+		const method =
+			init?.method ?? (input instanceof Request ? input.method : "GET");
+		const url = input instanceof Request ? input.url : String(input);
+		log.debug("%s %s", method.toUpperCase(), url);
+		try {
+			const response = await fetch(input, { ...init, signal });
+			log.debug("%d %s", response.status, response.statusText);
+			return response;
+		} catch (err) {
+			// Our own timeout fired, and we are the only code that knows that: by the
+			// time this reaches `networkError` the SDK has wrapped it as a
+			// `NeonNetworkError`, and neither its name nor its `cause` chain carries a
+			// string code to recognise. Raise something we own instead of leaving the
+			// classification to guess.
+			if (timeout.aborted && !init?.signal?.aborted) {
+				throw new RequestTimeoutError(requestTimeoutMs, err);
+			}
+			throw err;
+		}
+	};
 
 const RETRY_COUNT = 5;
 const RETRY_DELAY = 3000;
@@ -341,13 +397,20 @@ export type RequestParams = {
 	headers?: Record<string, string>;
 };
 
-export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) => {
+export const getApiClient = ({
+	apiKey,
+	apiHost,
+	requestTimeoutMs = REQUEST_TIMEOUT_MS,
+}: ApiCallProps) => {
 	const baseUrl = apiHost ?? DEFAULT_API_HOST;
+	// Shared by the generated client and the low-level `request()` escape hatch, so both
+	// paths get the same timeout and the same timeout classification.
+	const fetchWithTimeout = makeTimedFetch(requestTimeoutMs);
 	const client: Client = createClient(
 		createConfig({
 			auth: () => apiKey,
 			baseUrl,
-			fetch: timedFetch,
+			fetch: fetchWithTimeout,
 			headers: { "User-Agent": USER_AGENT },
 		}),
 	);
@@ -417,7 +480,7 @@ export const getApiClient = ({ apiKey, apiHost }: ApiCallProps) => {
 
 		let response: Response;
 		try {
-			response = await timedFetch(url, {
+			response = await fetchWithTimeout(url, {
 				method: params.method,
 				headers,
 				...(payload !== undefined ? { body: payload } : {}),

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -288,6 +288,30 @@ function networkError(err: unknown): NeonApiError {
  * and lightweight debug logging of the request line + response status — the
  * fetch-native replacement for the old `axios-debug-log` wiring.
  */
+/**
+ * The largest delay a timer can represent. Above it Node warns
+ * (`TimeoutOverflowWarning`) and fires after 1ms instead.
+ */
+const MAX_TIMER_MS = 2 ** 31 - 1;
+
+/**
+ * Reject a timeout `AbortSignal.timeout` would refuse or silently mistreat.
+ *
+ * Without this the bad value surfaces as the very failure this classification exists to
+ * prevent: `-1`, `NaN`, `Infinity` and fractions throw `ERR_OUT_OF_RANGE` from inside the
+ * fetch wrapper, which is then wrapped as a `NeonNetworkError` and reported as a broken
+ * internet connection. `0` and anything above {@link MAX_TIMER_MS} are worse still — both
+ * are accepted, and both make every request time out immediately.
+ */
+function validateRequestTimeout(ms: number): number {
+	if (!Number.isInteger(ms) || ms < 1 || ms > MAX_TIMER_MS) {
+		throw new Error(
+			`requestTimeoutMs must be a whole number of milliseconds between 1 and ${MAX_TIMER_MS}; received ${ms}.`,
+		);
+	}
+	return ms;
+}
+
 const makeTimedFetch =
 	(requestTimeoutMs: number): typeof fetch =>
 	async (input, init) => {
@@ -405,7 +429,9 @@ export const getApiClient = ({
 	const baseUrl = apiHost ?? DEFAULT_API_HOST;
 	// Shared by the generated client and the low-level `request()` escape hatch, so both
 	// paths get the same timeout and the same timeout classification.
-	const fetchWithTimeout = makeTimedFetch(requestTimeoutMs);
+	const fetchWithTimeout = makeTimedFetch(
+		validateRequestTimeout(requestTimeoutMs),
+	);
 	const client: Client = createClient(
 		createConfig({
 			auth: () => apiKey,

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -298,10 +298,13 @@ const MAX_TIMER_MS = 2 ** 31 - 1;
  * Reject a timeout `AbortSignal.timeout` would refuse or silently mistreat.
  *
  * Without this the bad value surfaces as the very failure this classification exists to
- * prevent: `-1`, `NaN`, `Infinity` and fractions throw `ERR_OUT_OF_RANGE` from inside the
- * fetch wrapper, which is then wrapped as a `NeonNetworkError` and reported as a broken
- * internet connection. `0` and anything above {@link MAX_TIMER_MS} are worse still — both
- * are accepted, and both make every request time out immediately.
+ * prevent: `-1`, `NaN`, `Infinity`, fractions and anything above `4294967295` throw
+ * `ERR_OUT_OF_RANGE` from inside the fetch wrapper, which is then wrapped as a
+ * `NeonNetworkError` and reported as a broken internet connection.
+ *
+ * `0`, and the band from {@link MAX_TIMER_MS} + 1 up to `4294967295`, are worse still:
+ * both are accepted, and both make every request time out immediately — `0` by asking for
+ * it, the band because a timer above the signed 32-bit ceiling collapses to 1ms.
  */
 function validateRequestTimeout(ms: number): number {
 	if (!Number.isInteger(ms) || ms < 1 || ms > MAX_TIMER_MS) {

--- a/packages/cli/src/api_timeout.test.ts
+++ b/packages/cli/src/api_timeout.test.ts
@@ -1,0 +1,77 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getApiClient, isNeonApiError } from "./api.js";
+import { isNetworkError } from "./errors.js";
+
+/**
+ * What the user sees when the Neon API accepts a connection and then never answers.
+ *
+ * The CLI installs its own request timeout inside a custom `fetch`, so the failure comes
+ * back through `@neon/sdk`'s wrapper rather than as a bare `DOMException`. That is the
+ * detail the classification has to survive: a timeout must stay a timeout, and must not be
+ * reported as a connectivity problem the user is told to go and check.
+ */
+
+let server: Server;
+let apiHost: string;
+
+beforeAll(async () => {
+	// Accept the connection, then never respond.
+	server = createServer(() => {});
+	await new Promise<void>((resolve) =>
+		server.listen(0, "127.0.0.1", resolve),
+	);
+	const { port } = server.address() as AddressInfo;
+	apiHost = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+	server.closeAllConnections?.();
+	await new Promise<void>((resolve, reject) =>
+		server.close((error) => (error ? reject(error) : resolve())),
+	);
+});
+
+describe("a request that times out", () => {
+	async function timeoutError() {
+		const api = getApiClient({
+			apiKey: "test",
+			apiHost,
+			requestTimeoutMs: 150,
+		});
+		try {
+			await api.listProjects({});
+			throw new Error("expected the request to time out");
+		} catch (err) {
+			return err;
+		}
+	}
+
+	it("is reported as a timeout, not as a connectivity failure", async () => {
+		const err = await timeoutError();
+
+		expect(isNeonApiError(err)).toBe(true);
+		if (!isNeonApiError(err)) return;
+
+		// ECONNABORTED is the CLI's timeout code, deliberately kept out of
+		// NETWORK_ERROR_CODES so a timeout is not reported as "check your connection".
+		expect(err.code).toBe("ECONNABORTED");
+		expect(err.message).toBe("Request timed out");
+	});
+
+	it("is not classified as a network error, so the connectivity advice is not shown", async () => {
+		// The regression: the SDK wraps a transport failure with a message beginning
+		// "Network error: ...", which `isNetworkError`'s message pattern matches. A 60s
+		// timeout was therefore reported as "Could not reach the Neon API. Please check
+		// your internet connection", which is wrong and unactionable — the connection is
+		// fine and the request did reach the server.
+		expect(isNetworkError(await timeoutError())).toBe(false);
+	});
+
+	it("does not carry a status, since no response arrived", async () => {
+		const err = await timeoutError();
+		if (!isNeonApiError(err)) throw new Error("expected a NeonApiError");
+		expect(err.status).toBeUndefined();
+	});
+});

--- a/packages/cli/src/api_timeout.test.ts
+++ b/packages/cli/src/api_timeout.test.ts
@@ -74,4 +74,55 @@ describe("a request that times out", () => {
 		if (!isNeonApiError(err)) throw new Error("expected a NeonApiError");
 		expect(err.status).toBeUndefined();
 	});
+
+	it("classifies the low-level request() escape hatch the same way", async () => {
+		// A different code path from the generated client, sharing one fetch wrapper.
+		const api = getApiClient({
+			apiKey: "test",
+			apiHost,
+			requestTimeoutMs: 150,
+		});
+		try {
+			await api.request({ path: "projects", method: "GET" });
+			throw new Error("expected the request to time out");
+		} catch (err) {
+			if (!isNeonApiError(err)) throw err;
+			expect(err.code).toBe("ECONNABORTED");
+			expect(err.message).toBe("Request timed out");
+		}
+	});
+});
+
+describe("an invalid requestTimeoutMs", () => {
+	it("is refused when the client is built, not surfaced as a connection failure", () => {
+		// Left unvalidated, each of these reaches AbortSignal.timeout inside the fetch
+		// wrapper and comes back as "check your internet connection" — the failure this
+		// whole file exists to prevent. `0` and 2**31 are worse: both are accepted, and
+		// both make every request time out at once.
+		for (const requestTimeoutMs of [
+			-1,
+			0,
+			1.5,
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			2 ** 31,
+		]) {
+			expect(() =>
+				getApiClient({ apiKey: "test", apiHost, requestTimeoutMs }),
+			).toThrow(/requestTimeoutMs must be a whole number/);
+		}
+	});
+
+	it("accepts the boundary values", () => {
+		expect(() =>
+			getApiClient({ apiKey: "test", apiHost, requestTimeoutMs: 1 }),
+		).not.toThrow();
+		expect(() =>
+			getApiClient({
+				apiKey: "test",
+				apiHost,
+				requestTimeoutMs: 2 ** 31 - 1,
+			}),
+		).not.toThrow();
+	});
 });


### PR DESCRIPTION
Found while working on [#379](https://github.com/neondatabase/neon-pkgs/pull/379) and flagged there as out of scope. Pre-existing; not caused by that PR.

## Problem

When the Neon API accepts a connection and then doesn't answer within the CLI's 60s request timeout, the user is told:

> Could not reach the Neon API. Please check your internet connection and try again. If your connection is fine and this keeps happening, check https://neonstatus.com for ongoing incidents.

The connection is fine and the request did reach the server. The one thing the message tells the user to check is the one thing that is not wrong — and after waiting a full minute for it.

The code already intends the correct behaviour. `networkError()` maps a timeout to `ECONNABORTED` with the message "Request timed out", and `errors.ts` deliberately keeps `ECONNABORTED` out of `NETWORK_ERROR_CODES` with the comment *"Deliberately excludes `ECONNABORTED` (axios' timeout), which the CLI already reports as a timeout."* That path is unreachable.

## Diagnosis

The chain, verified by asserting against the unfixed code:

```
expected 'ENETWORK' to be 'ECONNABORTED'     // err.code
expected true to be false                     // isNetworkError(err)
```

1. `timedFetch` installs `AbortSignal.timeout(60_000)`, so on timeout `fetch` rejects with a `DOMException` named `TimeoutError`.
2. That rejection is caught by the generated client and returned on the error channel, where `@neon/sdk` wraps it as a **`NeonNetworkError`** — as it does for every transport failure.
3. `isAbortError()` tested only the top-level error: `err.name === "AbortError" || "TimeoutError"`. The name is now `NeonNetworkError`, so this is `false`.
4. `readSocketCode()` walks the `cause` chain looking for a **string** `code`. The `DOMException` underneath has a `code`, but it is the legacy **numeric** `23`, so nothing matches and the code becomes `ENETWORK`.
5. `isNetworkError()` then matches its `/network error/i` pattern against the SDK's own message, `"Network error: no response received from the Neon API (…)"` — so the timeout is finally classified as a connectivity failure and gets the "check your internet connection" advice.

The load-bearing detail is step 3. The check was written when a timeout arrived as a bare `DOMException`; `@neon/sdk` 1.4.0 began wrapping transport failures in `NeonNetworkError`, and no name-based check can survive that. Nothing failed loudly, because every step produced a plausible-looking error.

## The fix

The CLI installs the timeout, so the CLI is the only code that knows its own signal fired. It now says so with a type it owns instead of leaving the classification to infer it:

```ts
if (timeout.aborted && !init?.signal?.aborted) {
  throw new RequestTimeoutError(requestTimeoutMs, err);
}
```

`isAbortError()` walks the `cause` chain for that type rather than matching names, and additionally reads the `kind` field `@neon/sdk` sets on its own deadlines (`"timeout"` / `"aborted"`), so this stays correct if the CLI ever adopts the SDK's `requestTimeoutMs` instead of its own wrapper. The name checks are kept as a fallback for any path that still surfaces a raw `AbortError`.

Restored behaviour:

```
Request timed out          (code: ECONNABORTED, no status)
```

## The interface

One addition, additive and optional:

```ts
getApiClient({ apiKey, apiHost, requestTimeoutMs: 150 });
//                              ^ defaults to 60_000, unchanged
```

It exists because the bug is otherwise untestable — a regression test would have to wait 60 seconds for the real default. No CLI flag, no user-facing surface, no change to any existing call site.

It is validated when the client is built, because leaving it unchecked reproduced the very failure this PR fixes:

```
-1           -> throws ERR_OUT_OF_RANGE
NaN          -> throws ERR_OUT_OF_RANGE
Infinity     -> throws ERR_OUT_OF_RANGE
1.5          -> throws ERR_OUT_OF_RANGE
0            -> accepted        (every request times out at once)
2147483648   -> accepted        (TimeoutOverflowWarning; collapses to 1ms)
4294967295   -> accepted        (same collapse; this is the last accepted value)
4294967296   -> throws ERR_OUT_OF_RANGE
```

The throwing cases land inside the fetch wrapper, so they are wrapped as `NeonNetworkError` and reported as a broken internet connection. The accepted cases are worse, because nothing is reported at all — every request simply fails immediately: `0` because it asks for that, and everything from `2147483648` to `4294967295` because a timer above the signed 32-bit ceiling collapses to 1ms. `requestTimeoutMs` must now be a whole number between 1 and 2147483647, refused with a direct message otherwise.

## Verification

Against `4fb2ea4`:

- `pnpm build` — clean
- `pnpm vitest run` — **3232 tests, 122 files**, all pass (6 new)
- `pnpm lint:ci` — 581 files, clean

The new test in `src/api_timeout.test.ts` runs a real `node:http` server that accepts the connection and never responds, over the CLI's real client — no mocks:

- the error is a `NeonApiError` with `code: "ECONNABORTED"` and the message "Request timed out"
- `isNetworkError()` is `false`, so the connectivity advice is not shown
- no `status`, since no response arrived

Plus the low-level `request()` escape hatch — a separate code path sharing the same fetch wrapper — and the rejection of each invalid `requestTimeoutMs`, with `1` and `2147483647` accepted as the boundaries.

The first three were run against the unfixed classification first: the two quoted above fail, and the `status` one passes either way, which is why it is not the test that matters.

Not verified: no live run against the production API, which would mean provoking a real 60s timeout. The `e2e-live` job exercises this client against the real API but has no timeout scenario.

## Also in here

- `timedFetch` became `makeTimedFetch(requestTimeoutMs)`, and the resulting function is shared by the generated client and the low-level `request()` escape hatch — previously both used the same module-level constant, and they now stay consistent by construction rather than by coincidence.
- `RequestTimeoutError` carries the original failure on a `reason` field rather than as an `Error` `cause`, because this package compiles against a lib without `ErrorOptions`.

## For your attention

- **`isNetworkError`'s message pattern is still broad.** `/network error/i` matches `@neon/sdk`'s own `"Network error: …"` prefix, which is what turned this misclassification into confident wrong advice. It is correct for genuine transport faults, so I left it — but it means any future SDK error whose message starts that way will be classified as a connectivity problem regardless of what it is. Worth narrowing to the `kind` field now that the SDK exposes one.
- **The 60s default is unchanged.** Whether a minute is the right wait before telling a user their request timed out is a separate product question.

