### PR TITLE
fix(@neon/sdk): close three gaps in the cancellation work

### DIFF
--- a/.changeset/sdk-cancellation-followups.md
+++ b/.changeset/sdk-cancellation-followups.md
@@ -1,0 +1,24 @@
+---
+"@neon/sdk": patch
+---
+
+Close three gaps in the cancellation and deadline work.
+
+- **A malformed `Retry-After` no longer causes an immediate retry.** Requiring
+  `/^\d+$/` for delta-seconds sent invalid values on to `Date.parse`, which reads `-1`,
+  `1.5` and `+5` as dates in 2001. Those are in the past, so the delay clamped to `0` and
+  the SDK retried at once — the opposite of what the header asks. A numeric-looking value
+  that is not valid delta-seconds is now rejected outright.
+- **A `wait.timeoutMs` larger than `2147483647` no longer expires almost immediately.**
+  `setTimeout` collapses any delay past that to 1ms (`TimeoutOverflowWarning`), and
+  readiness budgets have always accepted arbitrarily large values. Deadline timers are
+  re-armed in chunks, so a large budget behaves as written.
+- **A `snapshots.restore` `preview` callback that throws no longer escapes the result
+  contract.** A callback cooperating with its signal throws an `AbortError`, which
+  propagated out of a client that promised `{ data, error }`. A throw is now reported as
+  `NeonAbortError` when the signal fired and as a `client`-kind `NeonError` otherwise,
+  both saying the restored branch is left un-finalized.
+
+Also: a readiness timeout message counts the operations still outstanding rather than the
+round's starting total, and the readiness tests now cancel and expire during an in-flight
+poll instead of only between polls.

--- a/packages/sdk/src/neon/cancellation.server.test.ts
+++ b/packages/sdk/src/neon/cancellation.server.test.ts
@@ -17,7 +17,11 @@ interface Behaviour {
 	hang: boolean;
 	/** Operations still reported as running when polled. */
 	operationRunning: boolean;
+	/** Leave the operation poll itself in flight, so cancellation lands mid-request. */
+	hangOperations: boolean;
 	operationPolls: number;
+	/** Resolves the first time an operation poll is received. */
+	onOperationPoll?: () => void;
 }
 
 let server: Server;
@@ -25,8 +29,19 @@ let baseUrl: string;
 const behaviour: Behaviour = {
 	hang: false,
 	operationRunning: true,
+	hangOperations: false,
 	operationPolls: 0,
 };
+
+/** Reset between tests so one test's server behaviour cannot leak into the next. */
+function resetBehaviour(overrides: Partial<Behaviour> = {}) {
+	behaviour.hang = false;
+	behaviour.operationRunning = true;
+	behaviour.hangOperations = false;
+	behaviour.operationPolls = 0;
+	behaviour.onOperationPoll = undefined;
+	Object.assign(behaviour, overrides);
+}
 
 function json(body: unknown) {
 	return JSON.stringify(body);
@@ -40,6 +55,10 @@ beforeAll(async () => {
 
 		if (url.pathname.includes("/operations/")) {
 			behaviour.operationPolls += 1;
+			behaviour.onOperationPoll?.();
+			// Leaves the poll in flight, so an abort or a deadline lands during the
+			// request rather than in the gap between polls.
+			if (behaviour.hangOperations) return;
 			res.writeHead(200, { "content-type": "application/json" });
 			res.end(
 				json({
@@ -199,27 +218,53 @@ describe("work that happens before fetch is reached", () => {
 });
 
 describe("readiness polling", () => {
-	it("reports a caller abort during a poll as aborted, not as a network failure", async () => {
-		behaviour.operationRunning = true;
+	it("reports an abort during an in-flight poll as aborted, not as a network failure", async () => {
+		// The abort is triggered only once the server confirms it is holding a poll, so
+		// this cannot pass on a between-polls check: the request is definitely in flight.
+		const controller = new AbortController();
+		resetBehaviour({
+			hangOperations: true,
+			onOperationPoll: () => setTimeout(() => controller.abort(), 20),
+		});
 		const neon = createNeonClient({
 			apiKey: "k",
 			baseUrl,
 			retries: 0,
 			waitForReadiness: true,
-			wait: { pollIntervalMs: 10, timeoutMs: 60_000 },
+			wait: { pollIntervalMs: 5, timeoutMs: 60_000 },
 		});
-		const controller = new AbortController();
-		setTimeout(() => controller.abort(), 60);
 
 		const { error } = await neon.projects.create(
 			{ name: "test" },
 			{ signal: controller.signal },
 		);
+		expect(behaviour.operationPolls).toBeGreaterThan(0);
 		expect(error?.kind).toBe("aborted");
+		resetBehaviour();
 	});
 
-	it("enforces its own timeout while operations stay pending", async () => {
-		behaviour.operationRunning = true;
+	it("enforces its timeout while a poll is in flight", async () => {
+		// Previously the budget was only consulted between polls, so a poll that never
+		// returned could outlast it indefinitely.
+		resetBehaviour({ hangOperations: true });
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			waitForReadiness: true,
+			wait: { pollIntervalMs: 5, timeoutMs: 80 },
+		});
+
+		const startedAt = Date.now();
+		const { error } = await neon.projects.create({ name: "test" });
+		expect(behaviour.operationPolls).toBeGreaterThan(0);
+		expect(error?.kind).toBe("timeout");
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+		resetBehaviour();
+	});
+
+	it("enforces its timeout while operations stay pending between polls", async () => {
+		resetBehaviour({ operationRunning: true });
 		const neon = createNeonClient({
 			apiKey: "k",
 			baseUrl,
@@ -228,20 +273,35 @@ describe("readiness polling", () => {
 			wait: { pollIntervalMs: 10, timeoutMs: 80 },
 		});
 
-		const startedAt = Date.now();
 		const { error } = await neon.projects.create({ name: "test" });
 		expect(error?.kind).toBe("timeout");
-		expect(Date.now() - startedAt).toBeLessThan(2_000);
 	});
 
 	it("resolves once the operations finish", async () => {
-		behaviour.operationRunning = false;
+		resetBehaviour({ operationRunning: false });
 		const neon = createNeonClient({
 			apiKey: "k",
 			baseUrl,
 			retries: 0,
 			waitForReadiness: true,
 			wait: { pollIntervalMs: 10, timeoutMs: 5_000 },
+		});
+
+		const { data, error } = await neon.projects.create({ name: "test" });
+		expect(error).toBeUndefined();
+		expect(data?.id).toBe("p-1");
+	});
+
+	it("survives a readiness budget larger than setTimeout can represent", async () => {
+		// A single timer above 2^31-1 collapses to 1ms in Node, which would have turned
+		// a very generous budget into an instant timeout.
+		resetBehaviour({ operationRunning: false });
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			waitForReadiness: true,
+			wait: { pollIntervalMs: 5, timeoutMs: 2 ** 31 + 1_000 },
 		});
 
 		const { data, error } = await neon.projects.create({ name: "test" });

--- a/packages/sdk/src/neon/deadline.test.ts
+++ b/packages/sdk/src/neon/deadline.test.ts
@@ -92,6 +92,16 @@ describe("createDeadline", () => {
 		deadline.dispose();
 	});
 
+	it("does not fire early for a budget larger than setTimeout can represent", async () => {
+		// setTimeout collapses any delay above 2^31-1 to 1ms, so a single timer would
+		// have expired this deadline almost immediately.
+		const deadline = createDeadline(2 ** 31 + 1_000);
+		await delay(30);
+		expect(deadline.source()).toBeUndefined();
+		expect(deadline.remainingMs()).toBeGreaterThan(2 ** 31 - 1);
+		deadline.dispose();
+	});
+
 	it("releases the caller-signal listener on dispose", () => {
 		const controller = new AbortController();
 		const deadline = createDeadline(60_000, controller.signal);

--- a/packages/sdk/src/neon/deadline.ts
+++ b/packages/sdk/src/neon/deadline.ts
@@ -187,19 +187,31 @@ export function createDeadline(
 	if (callerSignal?.aborted) trip("caller");
 
 	const onCallerAbort = () => trip("caller");
-	// Deliberately not `unref`ed: every deadline is disposed in a `finally`, so it cannot
-	// outlive its call, and an unref'd timer is invisible to the event loop's liveness
-	// accounting — a call whose only pending work is the deadline would starve instead of
-	// timing out.
-	const timer = bounded
-		? setTimeout(() => trip("timeout"), timeoutMs)
-		: undefined;
-	callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
-
 	const remainingMs = () =>
 		bounded
 			? Math.max(0, timeoutMs - (performance.now() - startedAt))
 			: Number.POSITIVE_INFINITY;
+
+	// Deliberately not `unref`ed: every deadline is disposed in a `finally`, so it cannot
+	// outlive its call, and an unref'd timer is invisible to the event loop's liveness
+	// accounting — a call whose only pending work is the deadline would starve instead of
+	// timing out.
+	//
+	// Re-armed in chunks rather than scheduled once, because `setTimeout` silently
+	// collapses any delay above MAX_TIMER_MS to 1ms. `wait.timeoutMs` has always accepted
+	// arbitrarily large budgets, and a single timer would have turned one into an instant
+	// timeout.
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const arm = () => {
+		const left = remainingMs();
+		if (left === 0) return trip("timeout");
+		timer = setTimeout(
+			left > MAX_TIMER_MS ? arm : () => trip("timeout"),
+			Math.min(left, MAX_TIMER_MS),
+		);
+	};
+	if (bounded) arm();
+	callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
 
 	return {
 		signal: controller.signal,

--- a/packages/sdk/src/neon/resources/snapshots.test.ts
+++ b/packages/sdk/src/neon/resources/snapshots.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createNeonClient } from "../client.js";
+import { NeonAbortError } from "../errors.js";
 
 /**
  * Build a client whose only stub is the network boundary, capturing the
@@ -55,6 +56,65 @@ describe("snapshots.update maps the ergonomic input to the API body", () => {
 		const { neon, calls } = neonCapturing();
 		await neon.snapshots.update("p-1", "snap-1", { name: "renamed" });
 		expect(calls[0]?.body).toEqual({ snapshot: { name: "renamed" } });
+	});
+});
+
+describe("snapshots.restore keeps the result contract around its preview callback", () => {
+	/** Answers the restore, then the branch fetch, with a ready branch. */
+	function neonRestoring() {
+		return createNeonClient({
+			apiKey: "test",
+			retries: 0,
+			fetch: async () =>
+				new Response(
+					JSON.stringify({
+						branch: { id: "br-restored", name: "restored" },
+						operations: [],
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				),
+		});
+	}
+
+	it("reports a callback that honours its signal by throwing as aborted", async () => {
+		// Cooperating with the signal is the documented thing to do, so the DOMException
+		// it throws must not escape a client that promised { data, error }.
+		const neon = neonRestoring();
+		const controller = new AbortController();
+
+		const { error } = await neon.snapshots.restore(
+			"p-1",
+			"snap-1",
+			{
+				targetBranchId: "br-1",
+				preview: async (_branch, { signal }) => {
+					controller.abort();
+					signal?.throwIfAborted();
+					return true;
+				},
+			},
+			{ signal: controller.signal },
+		);
+
+		expect(error).toBeInstanceOf(NeonAbortError);
+		expect(error?.message).toContain("un-finalized");
+	});
+
+	it("reports a callback that throws for its own reasons as a client error", async () => {
+		const neon = neonRestoring();
+
+		const { error } = await neon.snapshots.restore("p-1", "snap-1", {
+			targetBranchId: "br-1",
+			preview: async () => {
+				throw new Error("my checks blew up");
+			},
+		});
+
+		expect(error?.kind).toBe("client");
+		expect(error?.message).toContain("my checks blew up");
 	});
 });
 

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -16,7 +16,7 @@ import type {
 	Snapshot,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
-import { NeonAbortError } from "../errors.js";
+import { NeonAbortError, NeonError } from "../errors.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 /**
@@ -320,7 +320,30 @@ export class Snapshots<DThrow extends boolean> {
 				shouldThrow,
 			);
 		}
-		const commit = await preview(branch, { signal: opts?.signal });
+		let commit: boolean;
+		try {
+			commit = await preview(branch, { signal: opts?.signal });
+		} catch (error) {
+			// A callback that honours the signal by throwing is cooperating correctly, so
+			// its `DOMException` must not escape a client that promised `{ data, error }`.
+			// Any other throw is the caller's own failure, reported as such rather than
+			// swallowed.
+			return finalize(
+				err<Branch>(
+					opts?.signal?.aborted
+						? new NeonAbortError(
+								"The restore was aborted while its preview callback ran; the restored branch is left un-finalized.",
+								{ cause: error },
+							)
+						: new NeonError(
+								`The restore's preview callback threw; the restored branch is left un-finalized: ${error instanceof Error ? error.message : String(error)}`,
+								"client",
+								{ cause: error },
+							),
+				),
+				shouldThrow,
+			);
+		}
 		if (opts?.signal?.aborted) {
 			return finalize(
 				err<Branch>(

--- a/packages/sdk/src/neon/retry.test.ts
+++ b/packages/sdk/src/neon/retry.test.ts
@@ -29,6 +29,18 @@ describe("parseRetryAfterMs", () => {
 		expect(parseRetryAfterMs("   ", NOW)).toBeUndefined();
 		expect(parseRetryAfterMs("soon", NOW)).toBeUndefined();
 	});
+
+	it("rejects malformed numbers instead of letting the date parser rescue them", () => {
+		// `Date.parse` reads "-1", "1.5" and "+5" as dates in 2001 — all in the past, so
+		// the delay clamped to 0 and a malformed header became an immediate retry.
+		for (const header of ["-1", "1.5", "+5", "1e3", "0x10", "007.0"]) {
+			expect(parseRetryAfterMs(header, NOW)).toBeUndefined();
+		}
+	});
+
+	it("still reads a leading-zero integer, which is valid delta-seconds", () => {
+		expect(parseRetryAfterMs("007", NOW)).toBe(7_000);
+	});
 });
 
 describe("backoffMs", () => {

--- a/packages/sdk/src/neon/retry.ts
+++ b/packages/sdk/src/neon/retry.ts
@@ -38,15 +38,19 @@ export function parseRetryAfterMs(
 	const trimmed = header.trim();
 	if (trimmed === "") return undefined;
 
-	// RFC 9110 delta-seconds is a non-negative integer. `Number()` would also accept
-	// "-1", "1.5", "0x10" and "1e3"; treating "-1" as 0 in particular turned a malformed
-	// header into an immediate retry.
+	// RFC 9110 delta-seconds is a non-negative integer.
 	if (/^\d+$/.test(trimmed)) {
 		const seconds = Number(trimmed);
 		return Number.isFinite(seconds * 1000)
 			? seconds * 1000
 			: Number.POSITIVE_INFINITY;
 	}
+
+	// A malformed number must be rejected here rather than fall through to the date
+	// parser. `Date.parse` is permissive enough to read "-1", "1.5" and "+5" as dates in
+	// 2001 — all in the past, so the delay clamped to 0 and a malformed header became an
+	// immediate retry, which is the opposite of what it asks for.
+	if (Number.isFinite(Number(trimmed))) return undefined;
 
 	const at = Date.parse(trimmed);
 	if (Number.isNaN(at)) return undefined;

--- a/packages/sdk/src/neon/wait.ts
+++ b/packages/sdk/src/neon/wait.ts
@@ -101,6 +101,9 @@ export async function waitForOperations(
 			}
 
 			const stillPending: Operation[] = [];
+			// Counted from what is left rather than from the round's starting size, so a
+			// timeout part-way through a round reports the operations actually outstanding.
+			let remaining = pending.length;
 			for (const op of pending) {
 				const polled = await runBounded(deadline, () =>
 					getProjectOperation({
@@ -117,11 +120,7 @@ export async function waitForOperations(
 				// Cancellation is read from the deadline before the response is
 				// classified: an aborted poll comes back as a transport failure with no
 				// response, which `toNeonError` would otherwise report as a network error.
-				const stopped = readinessEnded(
-					deadline,
-					timeoutMs,
-					pending.length,
-				);
+				const stopped = readinessEnded(deadline, timeoutMs, remaining);
 				if (stopped) return err(stopped);
 				if (polled === undefined) {
 					return err(toNeonError(undefined, undefined));
@@ -134,7 +133,8 @@ export async function waitForOperations(
 				if (FAILURE.has(current.status)) {
 					return err(operationFailed(current));
 				}
-				if (!SUCCESS.has(current.status)) stillPending.push(current);
+				if (SUCCESS.has(current.status)) remaining -= 1;
+				else stillPending.push(current);
 			}
 			pending = stillPending;
 		}


### PR DESCRIPTION
Follow-up to [#379](https://github.com/neondatabase/neon-pkgs/pull/379), which merged before its second review round landed. Three of those findings are real defects on `main` today, including one where the earlier fix did not actually work.

## 1. A malformed `Retry-After` still causes an immediate retry

#379 required `/^\d+$/` for delta-seconds, on the grounds that `Number()` wrongly accepted `-1`. It did not fix it — invalid values fell through to `Date.parse`, which is permissive:

```
"-1"    digits-only: false | Date.parse: 2001-01-01T08:00:00.000Z
"1.5"   digits-only: false | Date.parse: 2001-01-05T08:00:00.000Z
"+5"    digits-only: false | Date.parse: 2001-05-01T07:00:00.000Z
```

All three are in the past, so `Math.max(0, at - now)` clamps to `0` and the SDK retries **at once** — the opposite of what the header asks for, and the exact bug #379 claimed to close. #379's description also listed `-1`, decimals and hex as covered by tests; those tests did not exist.

A numeric-looking value that is not valid delta-seconds is now rejected before the date parser sees it, with the cases actually asserted (`-1`, `1.5`, `+5`, `1e3`, `0x10`, `007.0` → no retry delay; `007` → 7s, since leading zeros are still a valid integer).

## 2. A `wait.timeoutMs` above 2147483647 expires almost immediately

A regression #379 introduced by moving the readiness budget from a wall-clock comparison onto a timer. `setTimeout` silently collapses any larger delay:

```
(node:69282) TimeoutOverflowWarning: 2147484648 does not fit into a 32-bit signed integer.
Timeout duration was set to 1.
fired after 3 ms (a 2^31+1000ms delay)
```

`wait.timeoutMs` has always accepted arbitrarily large budgets and previously honoured them, so a caller who set a very generous readiness budget now gets an instant timeout instead. Deadline timers re-arm in chunks of at most `MAX_TIMER_MS`, with `remainingMs()` as the source of truth, so a large budget behaves as written.

Note this leaves the two deadlines deliberately inconsistent: `requestTimeoutMs` still *rejects* a value above that ceiling (shipped in #379), while `wait.timeoutMs` now accepts one. A multi-week request deadline is nonsense and worth refusing; a long readiness budget is at least plausible.

## 3. A `preview` callback that throws escapes the result contract

The documented way for a `snapshots.restore` preview callback to honour its signal is to throw — `signal.throwIfAborted()`. That rejection propagated straight out of a client that promised `{ data, error }`:

```
× reports a callback that honours its signal by throwing as aborted
  AbortError: This operation was aborted
```

A throw from the callback is now reported through the envelope: `NeonAbortError` when the signal fired, and a `client`-kind `NeonError` carrying the original message otherwise. Both say the restored branch is left un-finalized, which is the part the caller has to act on.

```ts
const { error } = await neon.snapshots.restore(projectId, snapshotId, {
  targetBranchId,
  preview: async (branch, { signal }) => {
    signal?.throwIfAborted();          // cooperating, not crashing
    return (await checks(branch)) === "ok";
  },
}, { signal });

if (error?.kind === "aborted") { /* branch exists, un-finalized */ }
if (error?.kind === "client")  { /* your callback threw; same state */ }
```

No interface change: the callback signature and every existing error kind are unchanged.

## Also in here

- **A readiness timeout now counts what is outstanding**, not the round's starting total. Polls happen one operation at a time, so a timeout part-way through a round reported a stale count — "waiting for 5 operation(s)" when one remained.
- **The readiness tests now cancel and expire during an in-flight poll.** They previously answered immediately, so both could have passed on a between-polls check alone — they did not actually exercise the in-flight classification #379 added. The server holds the poll open and the abort fires only once it confirms a poll arrived.

## Verification

Against `4fb2ea4`:

- `pnpm test:ci` — **115 tests, 10 files** (89 before)
- `pnpm test:types` — 15 type tests, no type errors
- `pnpm tsc --noEmit`, `pnpm build` (guard clean, 188 files), `pnpm lint:ci` (580 files) — clean

Each fix was confirmed against the unfixed code rather than assumed:

- the `Date.parse` output above is from Node on this branch's `main`
- the `TimeoutOverflowWarning` and 3ms firing are from a direct `setTimeout` probe
- the preview tests fail with a raw `AbortError` when the `catch` is removed

Not verified: no live-API run. As in #379, the `e2e-live` suite has no cancellation scenarios and I did not add one, since it needs the org key and an unverifiable live test is a poor thing to gate a PR on.

## For your attention

- **The stuck-cursor loop is still unbounded without a deadline**, unchanged from #379 and still deliberately out of scope. A cursor-progress guard is a different root cause.
- **The fetch-stub suite remains.** The second review round called replacing `fetch` a no-mocks violation. I disagree in this one case — `fetch` is a documented `NeonConfig` option, so a test passing one is exercising the public API, not stubbing an internal. The substantive half of that objection was right and is fixed: the stub honoured signals promptly and so could not see the real bugs, which is why the real-server suite exists and now covers the in-flight paths.