### PR TITLE
Stage external package files, and report an undeclared native dependency

### DIFF
--- a/.changeset/lucky-rivers-travel.md
+++ b/.changeset/lucky-rivers-travel.md
@@ -1,0 +1,26 @@
+---
+"@neon/config-runtime": minor
+"neon": minor
+---
+
+Stage the real files of a function's `externalPackages` into the deployed archive, so a
+package backed by a native binary works on Functions instead of failing at invoke. Each
+declared package is installed for the runtime target (linux-arm64, glibc) into a throwaway
+directory, traced for the files it actually reaches, and copied under `node_modules/` with
+its directory layout preserved. The user's own `node_modules` is never read for those files
+or modified.
+
+An entry with `includeFiles: false` is externalized and nothing is staged for it, which is
+the pre-existing behaviour. A function whose entries all opt out — or which declares none —
+produces a byte-identical archive to before.
+
+Deploys and `neon dev` now report a package that was bundled in, carries native code, and
+was never declared. The report is advisory and never fails a deploy: the evidence shows the
+package contains compiled code, not that this function reaches it, and a package with a
+working JavaScript fallback looks identical.
+
+Fixes version pinning for packages whose `exports` map does not list `./package.json`.
+`sharp` is one, so the version the user had installed was never read and the registry's
+latest was staged instead. Versions are now read from the package directory rather than
+through the resolver, and a package whose version still cannot be determined is reported
+instead of being staged silently.

--- a/.changeset/tidy-moons-gather.md
+++ b/.changeset/tidy-moons-gather.md
@@ -1,0 +1,9 @@
+---
+"@neon/config": minor
+---
+
+Add `nativePackages` to a `neon.ts` function definition, declaring packages backed by a
+native binary whose real files should ship into the deployed archive alongside the bundle.
+This is the schema and type surface only; the bundler change that acts on the list follows
+separately. A package may not appear in both `nativePackages` and `externalPackages`, and
+entries are package names without a subpath.

--- a/.changeset/tidy-moons-gather.md
+++ b/.changeset/tidy-moons-gather.md
@@ -2,8 +2,31 @@
 "@neon/config": minor
 ---
 
-Add `nativePackages` to a `neon.ts` function definition, declaring packages backed by a
-native binary whose real files should ship into the deployed archive alongside the bundle.
-This is the schema and type surface only; the bundler change that acts on the list follows
-separately. A package may not appear in both `nativePackages` and `externalPackages`, and
-entries are package names without a subpath.
+**Breaking:** `externalPackages` now ships a package's real files into the deployed archive
+by default, instead of externalizing the import and shipping nothing.
+
+A bare string is the common form and produces a function that works:
+
+```ts
+externalPackages: ["sharp"],
+```
+
+The previous behaviour — externalize the import, ship nothing, throw `Cannot find module`
+if the function reaches it — is now the opt-out, for a package that cannot be staged and is
+never actually reached:
+
+```ts
+externalPackages: ["sharp", { name: "canvas", includeFiles: false }],
+```
+
+`ResolvedFunctionConfig.externalPackages` changes from `string[]` to
+`{ name: string; includeFiles: boolean }[]`, which affects anything reading a resolved
+config or implementing a custom `FunctionBundler`. Two pure helpers are exported for that
+case: `packagesToStage` and `externalPackageRoot`.
+
+A function that declares no `externalPackages`, or whose every entry sets
+`includeFiles: false`, deploys exactly the archive it did before.
+
+Validation additionally rejects the same package listed twice, and a bare name and a subpath
+of it that disagree about `includeFiles`. This is the schema and type surface; the bundler
+change that stages the files lands separately.

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -71,9 +71,10 @@ import { autoPullEnvAfterPin } from "./env.js";
  */
 const neonctlBundler: FunctionBundler = async (fn) => {
 	const externalPackages = fn.externalPackages ?? [];
-	const { files, metafile } = await bundleEntry(fn.source, {
+	const { files, metafile, warnings } = await bundleEntry(fn.source, {
 		externalPackages: externalPackages.map((pkg) => pkg.name),
 	});
+	for (const warning of warnings) log.warning(warning);
 
 	// Advisory only — the evidence cannot prove the code path is reached, so a package with a
 	// working JavaScript fallback must not have its deploy blocked. See native-detect.

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -69,7 +69,11 @@ const neonctlBundler: FunctionBundler = async (fn) =>
 	zipBundle(
 		await bundleEntry(fn.source, {
 			...(fn.externalPackages
-				? { externalPackages: fn.externalPackages }
+				? {
+						externalPackages: fn.externalPackages.map(
+							(pkg) => pkg.name,
+						),
+					}
 				: {}),
 		}),
 	);

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -1,12 +1,15 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
-import { resolveConfig } from "@neon/config";
+import { dirname, join } from "node:path";
+import { packagesToStage, resolveConfig } from "@neon/config";
 import {
 	apply,
+	assertZipWithinLimits,
 	type Config,
 	type ConflictReport,
 	createBranch as createBranchFromPolicy,
+	describeNativeFinding,
 	type FunctionBundler,
+	findUndeclaredNativePackages,
 	inspect,
 	isPartialBranchCreateError,
 	loadConfigFromFile,
@@ -14,6 +17,7 @@ import {
 	PushConflictError,
 	type PushResult,
 	plan,
+	traceNativePackages,
 } from "@neon/config-runtime";
 import chalk from "chalk";
 import type yargs from "yargs";
@@ -65,18 +69,41 @@ import { autoPullEnvAfterPin } from "./env.js";
  * out of config-runtime's static module graph — and therefore out of the packaged
  * neonctl snapshot, which resolves esbuild dynamically at deploy time.
  */
-const neonctlBundler: FunctionBundler = async (fn) =>
-	zipBundle(
-		await bundleEntry(fn.source, {
-			...(fn.externalPackages
-				? {
-						externalPackages: fn.externalPackages.map(
-							(pkg) => pkg.name,
-						),
-					}
-				: {}),
-		}),
-	);
+const neonctlBundler: FunctionBundler = async (fn) => {
+	const externalPackages = fn.externalPackages ?? [];
+	const { files, metafile } = await bundleEntry(fn.source, {
+		externalPackages: externalPackages.map((pkg) => pkg.name),
+	});
+
+	// Advisory only — the evidence cannot prove the code path is reached, so a package with a
+	// working JavaScript fallback must not have its deploy blocked. See native-detect.
+	for (const finding of findUndeclaredNativePackages({
+		metafile,
+		declared: externalPackages.map((pkg) => pkg.name),
+		projectDir: dirname(fn.source),
+	})) {
+		log.warning(describeNativeFinding(fn.slug, finding));
+	}
+
+	const staged = packagesToStage(externalPackages);
+	// Nothing to stage is the pre-existing path: zip the esbuild output and nothing else,
+	// producing the archive it always did.
+	if (staged.length === 0) return zipBundle(files);
+
+	// Staged packages are installed for the runtime target, traced, and merged in under their
+	// `node_modules/...` paths. The tree layout is load-bearing — a `.node` addon finds its
+	// sibling shared libraries relative to its own directory.
+	const traced = await traceNativePackages({
+		slug: fn.slug,
+		packages: staged,
+		projectDir: dirname(fn.source),
+	});
+	for (const warning of traced.warnings) log.warning(warning);
+	const entries = { ...files, ...traced.entries };
+	const zip = zipBundle(entries);
+	assertZipWithinLimits(fn.slug, zip, entries);
+	return zip;
+};
 
 const INSPECT_FIELDS = ["project", "branch", "config"] as const;
 

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -8,6 +8,7 @@ import {
 	type ConflictReport,
 	createBranch as createBranchFromPolicy,
 	describeNativeFinding,
+	enforceLimits,
 	type FunctionBundler,
 	findUndeclaredNativePackages,
 	inspect,
@@ -101,6 +102,9 @@ const neonctlBundler: FunctionBundler = async (fn) => {
 	});
 	for (const warning of traced.warnings) log.warning(warning);
 	const entries = { ...files, ...traced.entries };
+	// Re-checked against the final archive: the staged files were measured without the
+	// bundle, so the entry count and uncompressed total are only complete now.
+	enforceLimits(fn.slug, entries);
 	const zip = zipBundle(entries);
 	assertZipWithinLimits(fn.slug, zip, entries);
 	return zip;

--- a/packages/cli/src/commands/dev.test.ts
+++ b/packages/cli/src/commands/dev.test.ts
@@ -1,8 +1,12 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { test } from "../test_utils/fixtures";
 import {
+	devBundleDir,
 	diffUnits,
 	formatEnvSummary,
 	type RunningUnit,
@@ -39,6 +43,67 @@ describe("dev", () => {
 	}) => {
 		const missing = join(process.cwd(), "does-not-exist.ts");
 		await testCliCommand(["dev", "--source", missing], { code: 1 });
+	});
+});
+
+/**
+ * `neon dev` leaves a function's `nativePackages` unbundled and does not copy anything, so
+ * the bundle must sit somewhere Node's resolver can reach the project's real `node_modules`
+ * from. It does today only because the bundle is written *inside* that directory. These pin
+ * the property, because moving the directory would break local dev for native dependencies
+ * with a `Cannot find module` and nothing else would catch it.
+ */
+describe("devBundleDir", () => {
+	it("puts the bundle inside the project's node_modules", () => {
+		expect(devBundleDir("/proj", "resize")).toBe(
+			join("/proj", "node_modules", ".neon-dev", "resize"),
+		);
+		expect(devBundleDir("/proj")).toBe(
+			join("/proj", "node_modules", ".neon-dev"),
+		);
+	});
+
+	it("is a location an unbundled import actually resolves from", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neonctl-dev-resolve-"));
+		try {
+			// A package only reachable by walking up into the project's node_modules — which
+			// is exactly how an unbundled nativePackages entry is reached locally.
+			const pkg = join(cwd, "node_modules", "only-in-project");
+			mkdirSync(pkg, { recursive: true });
+			writeFileSync(
+				join(pkg, "package.json"),
+				JSON.stringify({ name: "only-in-project", version: "1.0.0" }),
+			);
+			writeFileSync(
+				join(pkg, "index.js"),
+				"module.exports = 'resolved';\n",
+			);
+
+			const bundleDir = devBundleDir(cwd, "resize");
+			mkdirSync(bundleDir, { recursive: true });
+			const bundle = join(bundleDir, "index.mjs");
+			writeFileSync(
+				bundle,
+				[
+					"import { createRequire } from 'node:module';",
+					// Both forms a real bundle uses: a bare ESM import, and the createRequire
+					// shim the deploy banner installs (which is how sharp loads its binary).
+					"import viaImport from 'only-in-project';",
+					"const viaRequire = createRequire(import.meta.url)('only-in-project');",
+					"process.stdout.write(viaImport + '/' + viaRequire);",
+				].join("\n"),
+			);
+
+			// From an unrelated cwd, as the dev child is spawned: resolution is relative to the
+			// importing file, not the working directory.
+			const out = execFileSync(process.execPath, [bundle], {
+				cwd: tmpdir(),
+				encoding: "utf8",
+			});
+			expect(out).toBe("resolved/resolved");
+		} finally {
+			rmSync(cwd, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -1,8 +1,12 @@
 import { type ChildProcess, spawn, spawnSync } from "node:child_process";
 import { once } from "node:events";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+	describeNativeFinding,
+	findUndeclaredNativePackages,
+} from "@neon/config-runtime";
 import chalk from "chalk";
 import type yargs from "yargs";
 import { resolveDevEnv } from "../dev/env.js";
@@ -96,7 +100,7 @@ const runSingleSource = async (props: DevProps): Promise<void> => {
 	const unit: ServedUnit = {
 		slug: null,
 		source,
-		bundleDir: join(process.cwd(), "node_modules", ".neon-dev"),
+		bundleDir: devBundleDir(process.cwd()),
 		childEnv: buildChildEnv(neonEnv, portFromProps(props.port)),
 		label: null,
 		envSummary: { neon: Object.keys(neonEnv), fn: [] },
@@ -241,6 +245,21 @@ const portFromProps = (port: number | undefined): PortSpec => {
 };
 
 /**
+ * Where a locally-served function's bundle is written.
+ *
+ * The location inside the project's own `node_modules` is load-bearing, not a tidiness
+ * choice. A function's `externalPackages` are left unbundled, and Node resolves an unbundled
+ * import by walking up from the importing file — so from here it reaches the project's real
+ * `node_modules` and finds them, at the host architecture that can actually run locally.
+ * Moving this directory anywhere outside `node_modules` breaks `neon dev` for those
+ * functions with a `Cannot find module`, so the path is pinned by a test.
+ */
+export const devBundleDir = (cwd: string, slug?: string): string =>
+	slug === undefined
+		? join(cwd, "node_modules", ".neon-dev")
+		: join(cwd, "node_modules", ".neon-dev", slug);
+
+/**
  * Translate a {@link PlannedFunction} into a {@link ServedUnit}. Port rules:
  *   - explicit `dev.port`: bind exactly, fail if taken.
  *   - no `dev.port`: search for a free port (base coordinated by the caller).
@@ -259,7 +278,7 @@ const plannedToUnit = (
 	return {
 		slug: fn.slug,
 		source: fn.source,
-		bundleDir: join(process.cwd(), "node_modules", ".neon-dev", fn.slug),
+		bundleDir: devBundleDir(process.cwd(), fn.slug),
 		childEnv,
 		label: fn.slug,
 		envSummary: { neon: Object.keys(branchEnv), fn: Object.keys(fn.env) },
@@ -685,9 +704,23 @@ const writeBundle = async (
 	bundleDir: string,
 	externalPackages?: readonly string[],
 ): Promise<string> => {
-	const files = await bundleEntry(source, {
+	// Left unbundled only. `bundleDir` sits inside the project's node_modules, so an
+	// externalized package resolves from the real tree at the host architecture — no install
+	// or copy is needed or wanted locally, whatever `includeFiles` says for a deploy.
+	const { files, metafile } = await bundleEntry(source, {
 		...(externalPackages ? { externalPackages } : {}),
 	});
+
+	// Local runs resolve native packages from the real tree, so a missing declaration is
+	// invisible until deploy. Reporting it here is the only signal before then.
+	for (const finding of findUndeclaredNativePackages({
+		metafile,
+		declared: externalPackages ?? [],
+		projectDir: dirname(source),
+	})) {
+		log.warning(describeNativeFinding(basename(source), finding));
+	}
+
 	mkdirSync(bundleDir, { recursive: true });
 	// bundleEntry emits a single `index.mjs` (no source map). The `.mjs` extension makes Node
 	// load it as ESM directly, so no `package.json` `"type": "module"` marker is needed.

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -707,9 +707,10 @@ const writeBundle = async (
 	// Left unbundled only. `bundleDir` sits inside the project's node_modules, so an
 	// externalized package resolves from the real tree at the host architecture — no install
 	// or copy is needed or wanted locally, whatever `includeFiles` says for a deploy.
-	const { files, metafile } = await bundleEntry(source, {
+	const { files, metafile, warnings } = await bundleEntry(source, {
 		...(externalPackages ? { externalPackages } : {}),
 	});
+	for (const warning of warnings) log.warning(warning);
 
 	// Local runs resolve native packages from the real tree, so a missing declaration is
 	// invisible until deploy. Reporting it here is the only signal before then.

--- a/packages/cli/src/commands/functions.ts
+++ b/packages/cli/src/commands/functions.ts
@@ -293,7 +293,7 @@ const deploy = async (props: DeployProps) => {
 	}
 
 	// Bundle before any network round-trip so a bundling failure fails fast.
-	const zip = zipBundle(await bundleEntry(source));
+	const zip = zipBundle((await bundleEntry(source)).files);
 	const branchId = await branchIdFromProps(props);
 
 	// Snapshot the current version before deploy so we can detect the new one

--- a/packages/cli/src/dev/functions.test.ts
+++ b/packages/cli/src/dev/functions.test.ts
@@ -71,6 +71,36 @@ describe("resolveFunctionsFromConfig", () => {
 		expect(bySlug.get("bare")).not.toHaveProperty("externalPackages");
 	});
 
+	// Locally both forms mean the same thing — leave it unbundled — so the plan carries
+	// names only. `includeFiles` governs the deployed archive, which `neon dev` never builds.
+	it("flattens both entry forms to names", async () => {
+		writeWorkspace(
+			cwd,
+			`export default {
+        preview: {
+          functions: {
+            resize: {
+              name: 'Resize',
+              source: './resize.ts',
+              externalPackages: ['sharp', { name: 'canvas', includeFiles: false }],
+            },
+            bare: { name: 'Bare', source: './bare.ts' },
+          },
+        },
+      };\n`,
+			["resize.ts", "bare.ts"],
+		);
+
+		const resolved = await resolveFunctionsFromConfig(cwd);
+		const bySlug = new Map(resolved?.functions.map((f) => [f.slug, f]));
+		expect(bySlug.get("resize")?.externalPackages).toEqual([
+			"sharp",
+			"canvas",
+		]);
+		// Absent, not empty, when the policy does not declare it.
+		expect(bySlug.get("bare")).not.toHaveProperty("externalPackages");
+	});
+
 	it("resolves each function with an absolute source and its dev settings", async () => {
 		writeWorkspace(
 			cwd,

--- a/packages/cli/src/dev/functions.ts
+++ b/packages/cli/src/dev/functions.ts
@@ -79,8 +79,14 @@ export const resolveFunctionsFromConfig = async (
 				? { port: devPort(fn.dev) as number }
 				: {}),
 			env: { ...fn.env },
+			// Names only: locally every entry is simply left unbundled, and `includeFiles`
+			// governs the deployed archive, which `neon dev` does not build.
 			...(fn.externalPackages
-				? { externalPackages: [...fn.externalPackages] }
+				? {
+						externalPackages: fn.externalPackages.map(
+							(pkg) => pkg.name,
+						),
+					}
 				: {}),
 		};
 	});

--- a/packages/cli/src/utils/esbuild.test.ts
+++ b/packages/cli/src/utils/esbuild.test.ts
@@ -69,21 +69,23 @@ afterAll(() => {
 
 describe("bundleEntry", () => {
 	test("inlines local imports and emits no sourcemap", async () => {
-		const out = await bundleEntry(join(dir, "index.ts"), npmDeps);
-		const js = strFromU8(out["index.mjs"]);
+		const { files } = await bundleEntry(join(dir, "index.ts"), npmDeps);
+		const js = strFromU8(files["index.mjs"]);
 		expect(js).toContain("hi from helper");
 		expect(js).not.toContain("./helper");
 		// No source map is generated — the Functions runtime never consumes it, so we neither
 		// emit `index.mjs.map` nor leave a dangling `sourceMappingURL` link in the bundle.
 		expect(js).not.toContain("sourceMappingURL");
-		expect(out["index.mjs.map"]).toBeUndefined();
+		expect(files["index.mjs.map"]).toBeUndefined();
 	});
 
 	// Node built-ins stay external on platform:'node'; the createRequire banner is injected
 	// so bundled CommonJS deps can `require(...)` inside the ESM output.
 	test("keeps node built-ins external and injects a createRequire banner", async () => {
 		const js = strFromU8(
-			(await bundleEntry(join(dir, "index.ts"), npmDeps))["index.mjs"],
+			(await bundleEntry(join(dir, "index.ts"), npmDeps)).files[
+				"index.mjs"
+			],
 		);
 		expect(js).toContain("node:fs");
 		expect(js).toContain("createRequire");
@@ -108,26 +110,81 @@ describe("bundleEntry", () => {
 	});
 
 	test("externalPackages leaves the named package unbundled and still inlines the rest", async () => {
-		const out = await bundleEntry(join(dir, "needs-external.ts"), {
+		const { files } = await bundleEntry(join(dir, "needs-external.ts"), {
 			...npmDeps,
 			externalPackages: ["not-installed-anywhere"],
 		});
-		const js = strFromU8(out["index.mjs"]);
+		const js = strFromU8(files["index.mjs"]);
 		expect(js).toContain("not-installed-anywhere");
 		expect(js).toContain("hi from helper");
 	});
 
 	test("externalPackages reaches the binary path as --external flags", async () => {
 		await withEnv(ESBUILD_BIN, async () => {
-			const out = await bundleEntry(join(dir, "needs-external.ts"), {
-				isPackaged: () => true,
-				loadEsbuild: () =>
-					Promise.reject(new Error("should not be called")),
-				externalPackages: ["not-installed-anywhere"],
-			});
-			const js = strFromU8(out["index.mjs"]);
+			const { files } = await bundleEntry(
+				join(dir, "needs-external.ts"),
+				{
+					isPackaged: () => true,
+					loadEsbuild: () =>
+						Promise.reject(new Error("should not be called")),
+					externalPackages: ["not-installed-anywhere"],
+				},
+			);
+			const js = strFromU8(files["index.mjs"]);
 			expect(js).toContain("not-installed-anywhere");
 			expect(js).toContain("hi from helper");
+		});
+	});
+
+	test("externalizes every declared package", async () => {
+		writeFileSync(
+			join(dir, "needs-both.ts"),
+			[
+				'import { greet } from "./helper";',
+				'import { thing } from "not-installed-anywhere";',
+				'import addon from "also-not-installed";',
+				"export default { greet, thing, addon };",
+				"",
+			].join("\n"),
+		);
+		const { files } = await bundleEntry(join(dir, "needs-both.ts"), {
+			...npmDeps,
+			externalPackages: ["not-installed-anywhere", "also-not-installed"],
+		});
+		const js = strFromU8(files["index.mjs"]);
+		expect(js).toContain("not-installed-anywhere");
+		expect(js).toContain("also-not-installed");
+		expect(js).toContain("hi from helper");
+	});
+
+	// The metafile is what lets a deploy notice an undeclared native dependency. An
+	// externalized package is deliberately absent from it — esbuild never resolved a file
+	// for it — while a bundled one appears under its node_modules path.
+	test("reports the resolved graph in a metafile on the module path", async () => {
+		const { metafile } = await bundleEntry(join(dir, "needs-external.ts"), {
+			...npmDeps,
+			externalPackages: ["not-installed-anywhere"],
+		});
+		const inputs = Object.keys(metafile?.inputs ?? {});
+		expect(inputs.some((i) => i.endsWith("helper.ts"))).toBe(true);
+		expect(inputs.some((i) => i.includes("not-installed-anywhere"))).toBe(
+			false,
+		);
+	});
+
+	test("reports the resolved graph in a metafile on the binary path too", async () => {
+		await withEnv(ESBUILD_BIN, async () => {
+			const { metafile } = await bundleEntry(
+				join(dir, "needs-external.ts"),
+				{
+					isPackaged: () => true,
+					loadEsbuild: () =>
+						Promise.reject(new Error("should not be called")),
+					externalPackages: ["not-installed-anywhere"],
+				},
+			);
+			const inputs = Object.keys(metafile?.inputs ?? {});
+			expect(inputs.some((i) => i.endsWith("helper.ts"))).toBe(true);
 		});
 	});
 
@@ -141,7 +198,9 @@ describe("bundleEntry", () => {
 				loadEsbuild,
 			});
 			expect(loadEsbuild).not.toHaveBeenCalled();
-			expect(strFromU8(out["index.mjs"])).toContain("hi from helper");
+			expect(strFromU8(out.files["index.mjs"])).toContain(
+				"hi from helper",
+			);
 		});
 	});
 
@@ -155,7 +214,9 @@ describe("bundleEntry", () => {
 				loadEsbuild,
 			});
 			expect(loadEsbuild).toHaveBeenCalledOnce();
-			expect(strFromU8(out["index.mjs"])).toContain("hi from helper");
+			expect(strFromU8(out.files["index.mjs"])).toContain(
+				"hi from helper",
+			);
 		});
 	});
 

--- a/packages/cli/src/utils/esbuild.ts
+++ b/packages/cli/src/utils/esbuild.ts
@@ -19,9 +19,12 @@ const ESM_CJS_INTEROP_BANNER =
 
 // esbuild's JS module, narrowed to the one call we use. Typed structurally so
 // we never statically import from 'esbuild' (see bundleViaModule for why).
+type EsbuildMetafile = { inputs?: Record<string, unknown> };
+
 type EsbuildModule = {
 	build: (opts: Record<string, unknown>) => Promise<{
 		outputFiles?: readonly { path: string; contents: Uint8Array }[];
+		metafile?: EsbuildMetafile;
 	}>;
 };
 
@@ -31,14 +34,26 @@ export type BundleDeps = {
 };
 
 /**
- * Bundling knobs a caller may set, alongside the injectable deps. `externalPackages` comes
- * from a function's `neon.ts` `externalPackages` and is handed to esbuild's `external`, so
- * a package esbuild cannot bundle (a native addon, an optional peer on an untaken code
- * path) stops failing the build. It does NOT become resolvable in the deployed archive —
- * see `FunctionDef.externalPackages` in @neon/config.
+ * Bundling knobs a caller may set, alongside the injectable deps. `externalPackages` are the
+ * names from a function's `neon.ts` `externalPackages`, handed to esbuild's `external` so a
+ * package esbuild cannot bundle stops failing the build. Whether such a package's files then
+ * ship into the archive is `includeFiles`, which the deploy bundler acts on — not this
+ * helper's job. See `FunctionDef.externalPackages` in @neon/config.
  */
 export type BundleOptions = Partial<BundleDeps> & {
 	externalPackages?: readonly string[];
+};
+
+/**
+ * The bundle, plus the graph esbuild resolved to produce it.
+ *
+ * The metafile is what lets a deploy notice a native dependency that was bundled in but never
+ * declared. It is absent on the packaged-binary path when esbuild writes no metafile, and
+ * callers treat that as "no findings" rather than an error.
+ */
+export type BundleResult = {
+	files: Record<string, Uint8Array>;
+	metafile?: EsbuildMetafile;
 };
 
 const defaultDeps: BundleDeps = {
@@ -67,7 +82,7 @@ const bundleViaModule = async (
 	source: string,
 	loadEsbuild: BundleDeps["loadEsbuild"],
 	externalPackages: readonly string[],
-): Promise<Record<string, Uint8Array>> => {
+): Promise<BundleResult> => {
 	// esbuild is resolved by a COMPUTED specifier, never the literal string
 	// 'esbuild'. Both rollup (bundle step) and @yao-pkg/pkg (binary step)
 	// statically scan for literal import()/require() calls and would otherwise
@@ -105,6 +120,9 @@ const bundleViaModule = async (
 			banner: { js: ESM_CJS_INTEROP_BANNER },
 			// Only what the policy declared unbundleable; everything else is still inlined.
 			external: [...externalPackages],
+			// Reveals which packages were inlined, so a deploy can report an undeclared
+			// native dependency. Free here — esbuild is already running.
+			metafile: true,
 			logLevel: "silent",
 		})
 		.catch((err: unknown) => {
@@ -121,7 +139,10 @@ const bundleViaModule = async (
 			`Failed to bundle function from ${source}. esbuild produced no output.`,
 		);
 	}
-	return toFilesByBasename(files);
+	return {
+		files: toFilesByBasename(files),
+		...(result.metafile ? { metafile: result.metafile } : {}),
+	};
 };
 
 // Find the esbuild binary at deploy time. An explicit override is authoritative
@@ -163,10 +184,11 @@ const runEsbuild = (
 const bundleViaBinary = async (
 	source: string,
 	externalPackages: readonly string[],
-): Promise<Record<string, Uint8Array>> => {
+): Promise<BundleResult> => {
 	const bin = resolveEsbuild();
 	const outDir = mkdtempSync(join(tmpdir(), "neon-fn-bundle-"));
 	const outfile = join(outDir, "index.mjs");
+	const metafilePath = join(outDir, "meta.json");
 	try {
 		const { code, stderr } = await runEsbuild(bin, [
 			source,
@@ -178,6 +200,9 @@ const bundleViaBinary = async (
 			`--banner:js=${ESM_CJS_INTEROP_BANNER}`,
 			// One flag per package, mirroring the module path's `external` array.
 			...externalPackages.map((pkg) => `--external:${pkg}`),
+			// Written beside the output so a deploy can report an undeclared native
+			// dependency here too, not only on the module path.
+			`--metafile=${metafilePath}`,
 			"--log-level=error",
 		]);
 		if (code !== 0) {
@@ -188,10 +213,28 @@ const bundleViaBinary = async (
 		// No `--sourcemap`: the Functions runtime has no source-map support, so an uploaded
 		// `index.mjs.map` is never consumed — emitting it only inflated the archive.
 		return {
-			"index.mjs": new Uint8Array(readFileSync(outfile)),
+			files: { "index.mjs": new Uint8Array(readFileSync(outfile)) },
+			...(readMetafile(metafilePath) ?? {}),
 		};
 	} finally {
 		rmSync(outDir, { recursive: true, force: true });
+	}
+};
+
+/**
+ * Read the metafile the binary path wrote. Missing or unparseable is not an error: the
+ * metafile only powers an advisory report, and losing it costs a warning rather than a
+ * deploy.
+ */
+const readMetafile = (
+	path: string,
+): { metafile: EsbuildMetafile } | undefined => {
+	try {
+		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+		if (typeof parsed !== "object" || parsed === null) return undefined;
+		return { metafile: parsed as EsbuildMetafile };
+	} catch {
+		return undefined;
 	}
 };
 
@@ -201,16 +244,16 @@ const bundleViaBinary = async (
 export const bundleEntry = async (
 	source: string,
 	options: BundleOptions = {},
-): Promise<Record<string, Uint8Array>> => {
+): Promise<BundleResult> => {
 	const isPackaged = options.isPackaged ?? defaultDeps.isPackaged;
 	const loadEsbuild = options.loadEsbuild ?? defaultDeps.loadEsbuild;
-	const externalPackages = options.externalPackages ?? [];
-	if (isPackaged()) return bundleViaBinary(source, externalPackages);
+	const external = options.externalPackages ?? [];
+	if (isPackaged()) return bundleViaBinary(source, external);
 	try {
-		return await bundleViaModule(source, loadEsbuild, externalPackages);
+		return await bundleViaModule(source, loadEsbuild, external);
 	} catch (err) {
 		if (err instanceof ModuleNotAvailable)
-			return bundleViaBinary(source, externalPackages);
+			return bundleViaBinary(source, external);
 		throw err;
 	}
 };

--- a/packages/cli/src/utils/esbuild.ts
+++ b/packages/cli/src/utils/esbuild.ts
@@ -54,6 +54,11 @@ export type BundleOptions = Partial<BundleDeps> & {
 export type BundleResult = {
 	files: Record<string, Uint8Array>;
 	metafile?: EsbuildMetafile;
+	/**
+	 * Advisory findings from the bundle step. Returned rather than printed so the caller
+	 * decides how to render them — this module has no logger and must not reach for one.
+	 */
+	warnings: string[];
 };
 
 const defaultDeps: BundleDeps = {
@@ -142,6 +147,7 @@ const bundleViaModule = async (
 	return {
 		files: toFilesByBasename(files),
 		...(result.metafile ? { metafile: result.metafile } : {}),
+		warnings: [],
 	};
 };
 
@@ -212,9 +218,11 @@ const bundleViaBinary = async (
 		}
 		// No `--sourcemap`: the Functions runtime has no source-map support, so an uploaded
 		// `index.mjs.map` is never consumed — emitting it only inflated the archive.
+		const metafile = readMetafile(metafilePath);
 		return {
 			files: { "index.mjs": new Uint8Array(readFileSync(outfile)) },
-			...(readMetafile(metafilePath) ?? {}),
+			...(metafile.metafile ? { metafile: metafile.metafile } : {}),
+			warnings: metafile.warnings,
 		};
 	} finally {
 		rmSync(outDir, { recursive: true, force: true });
@@ -222,20 +230,36 @@ const bundleViaBinary = async (
 };
 
 /**
- * Read the metafile the binary path wrote. Missing or unparseable is not an error: the
- * metafile only powers an advisory report, and losing it costs a warning rather than a
- * deploy.
+ * Read the metafile the binary path asked esbuild to write.
+ *
+ * We always pass `--metafile`, so an unreadable one means esbuild did not do what it was
+ * told. That is worth saying rather than swallowing — but not worth failing a deploy over,
+ * because the metafile only powers an advisory report. Reported and skipped.
  */
 const readMetafile = (
 	path: string,
-): { metafile: EsbuildMetafile } | undefined => {
+): { metafile?: EsbuildMetafile; warnings: string[] } => {
+	let parsed: unknown;
 	try {
-		const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-		if (typeof parsed !== "object" || parsed === null) return undefined;
-		return { metafile: parsed as EsbuildMetafile };
-	} catch {
-		return undefined;
+		parsed = JSON.parse(readFileSync(path, "utf8"));
+	} catch (cause) {
+		return {
+			warnings: [
+				`esbuild was asked for a metafile but none could be read (${message(cause)}). ` +
+					`The bundle is unaffected; this deploy cannot check for an undeclared ` +
+					`native dependency.`,
+			],
+		};
 	}
+	if (typeof parsed !== "object" || parsed === null) {
+		return {
+			warnings: [
+				"esbuild wrote a metafile that is not an object. The bundle is unaffected; " +
+					"this deploy cannot check for an undeclared native dependency.",
+			],
+		};
+	}
+	return { metafile: parsed as EsbuildMetafile, warnings: [] };
 };
 
 // Bundle `source` into the files the Functions archive expects, keyed by

--- a/packages/config-runtime/README.md
+++ b/packages/config-runtime/README.md
@@ -17,7 +17,10 @@ npm install @neon/config-runtime
 - `inspect` / `plan` / `apply` — read the current branch state, diff a policy against it, and apply the changes.
 - `pullConfig` / `pushConfig` — lower-level pull/push primitives.
 - `createBranch` — create a branch to target.
-- `buildFunctionBundle` — bundle Neon Functions for deploy. Honours the function's `externalPackages`, passing each entry to esbuild's `external`.
+- `buildFunctionBundle` — bundle Neon Functions for deploy. Honours the function's `externalPackages`: every entry is passed to esbuild's `external`, and unless it sets `includeFiles: false` the package's real files are staged into the archive alongside the bundle. Reports a bundled-in native dependency that was never declared, as a warning.
+- `traceNativePackages` — install the packages a function stages for the runtime target (`RUNTIME_TARGET`: linux-arm64, glibc) into a throwaway directory, trace the files they reach, and return them keyed by archive path with the `node_modules` layout preserved. Called by `buildFunctionBundle`; exported for a CLI that supplies its own bundler.
+- `findUndeclaredNativePackages` / `describeNativeFinding` — advisory detection of a native package that was bundled in without being declared, and the report text for it. Evidence only: it cannot prove the code path is reached, so it must never fail a deploy.
+- `assertZipWithinLimits` — check a finished archive against the build service's size limits (`DEFAULT_ARCHIVE_LIMITS`), with an error naming the largest files.
 
 ```ts
 import { inspect, plan, apply } from "@neon/config-runtime/v1";

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -60,6 +60,7 @@
 	},
 	"dependencies": {
 		"@neon/config": "workspace:*",
+		"@vercel/nft": "^1.10.2",
 		"esbuild": "^0.28.1",
 		"fflate": "^0.8.3"
 	},

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -100,13 +100,18 @@ function fakeNativeDeps(files: Record<string, Uint8Array>): NativeTraceDeps {
 				writeFileSync(absolute, contents);
 			}
 		},
-		trace: async () => Object.keys(files),
+		trace: async () => ({ files: Object.keys(files) }),
 		installedVersion: () => undefined,
 	};
 }
 
-const pkgJson = (name: string): Uint8Array =>
-	new TextEncoder().encode(JSON.stringify({ name, version: "1.0.0" }));
+const pkgJson = (
+	name: string,
+	platform: Record<string, string[]> = {},
+): Uint8Array =>
+	new TextEncoder().encode(
+		JSON.stringify({ name, version: "1.0.0", ...platform }),
+	);
 
 describe("buildFunctionBundle", () => {
 	test("bundles a handler with esbuild and returns a ZIP containing index.mjs (no sourcemap)", async () => {
@@ -267,7 +272,7 @@ describe("buildFunctionBundle staging external package files", () => {
 				},
 				trace: async () => {
 					traced = true;
-					return [];
+					return { files: [] };
 				},
 			},
 		});
@@ -299,7 +304,7 @@ describe("buildFunctionBundle staging external package files", () => {
 					},
 					trace: async () => {
 						traced = true;
-						return [];
+						return { files: [] };
 					},
 				},
 			},
@@ -483,10 +488,28 @@ describe("buildFunctionBundle staging external package files", () => {
 			onWarning: collectWarning,
 			nativeDeps: fakeNativeDeps({
 				"node_modules/fake-addon/package.json": pkgJson("fake-addon"),
+				"node_modules/@scope/fake-addon-linux-arm64/package.json":
+					pkgJson("@scope/fake-addon-linux-arm64", {
+						os: ["linux"],
+						cpu: ["arm64"],
+						libc: ["glibc"],
+					}),
 				"node_modules/@scope/fake-addon-linux-arm64/lib/addon.node":
 					elfHeader(AARCH64),
+				// The wasm fallback declares no platform at all — npm installs it for every
+				// target, so only its name identifies it.
+				"node_modules/@scope/fake-addon-wasm32/package.json": pkgJson(
+					"@scope/fake-addon-wasm32",
+				),
 				"node_modules/@scope/fake-addon-wasm32/lib/addon.node.js":
 					new TextEncoder().encode("// wasm fallback"),
+				// The musl build says so in its own manifest, which is what excludes it.
+				"node_modules/@scope/fake-addon-linuxmusl-arm64/package.json":
+					pkgJson("@scope/fake-addon-linuxmusl-arm64", {
+						os: ["linux"],
+						cpu: ["arm64"],
+						libc: ["musl"],
+					}),
 				"node_modules/@scope/fake-addon-linuxmusl-arm64/lib/addon.node":
 					elfHeader(AARCH64),
 			}),

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -15,7 +15,10 @@ import {
 	expect,
 	test,
 } from "vitest";
-import { buildFunctionBundle } from "./function-bundle.js";
+import {
+	buildFunctionBundle,
+	ESM_CJS_INTEROP_BANNER,
+} from "./function-bundle.js";
 import type { NativeTraceDeps } from "./native-packages.js";
 
 let dir: string;
@@ -217,10 +220,12 @@ describe("buildFunctionBundle", () => {
 });
 
 describe("buildFunctionBundle staging external package files", () => {
-	// The guarantee that lets this ship: a policy that says nothing about native packages
-	// gets the archive it always did, to the byte. Written against the bytes the pre-existing
-	// code path produces (esbuild output, zipped at level 6, one entry keyed by basename)
-	// rather than a recorded constant, so it stays honest if esbuild's output changes.
+	// The guarantee that lets this ship: an undeclared policy gets the archive it always did.
+	//
+	// Checked against an independently built baseline — esbuild run directly with the
+	// pre-existing flags, zipped the way the pre-existing path zipped it. Unzipping the new
+	// archive and re-zipping its own bytes would pass no matter what the code did, including
+	// if the feature were deleted, so it would assert nothing.
 	test("produces a byte-identical archive to the pre-existing path when undeclared", async () => {
 		const source = join(dir, "plain.ts");
 		writeFileSync(
@@ -228,14 +233,25 @@ describe("buildFunctionBundle staging external package files", () => {
 			"export default { fetch(): Response { return new Response('plain'); } };",
 		);
 
-		const bundle = await buildFunctionBundle(fn(source));
-		const entries = unzipSync(bundle);
-		expect(Object.keys(entries)).toEqual(["index.mjs"]);
-
+		const esbuild = await import("esbuild");
+		const baseline = await esbuild.build({
+			entryPoints: [source],
+			bundle: true,
+			write: false,
+			outfile: "index.mjs",
+			minify: true,
+			format: "esm",
+			platform: "node",
+			banner: { js: ESM_CJS_INTEROP_BANNER },
+			logLevel: "silent",
+		});
 		const expected = zipSync(
-			{ "index.mjs": entries["index.mjs"] },
+			{ "index.mjs": baseline.outputFiles[0].contents },
 			{ level: 6 },
 		);
+
+		const bundle = await buildFunctionBundle(fn(source));
+		expect(Object.keys(unzipSync(bundle))).toEqual(["index.mjs"]);
 		expect(sha256(bundle)).toBe(sha256(expected));
 	});
 

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -24,7 +24,14 @@ function fn(
 		source,
 		env: {},
 		runtime: "nodejs24",
-		...(externalPackages ? { externalPackages } : {}),
+		...(externalPackages
+			? {
+					externalPackages: externalPackages.map((name) => ({
+						name,
+						includeFiles: true,
+					})),
+				}
+			: {}),
 	};
 }
 

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -1,10 +1,22 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createHash, randomFillSync } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { ResolvedFunctionConfig } from "@neon/config";
-import { unzipSync } from "fflate";
-import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import type {
+	ResolvedExternalPackage,
+	ResolvedFunctionConfig,
+} from "@neon/config";
+import { unzipSync, zipSync } from "fflate";
+import {
+	afterAll,
+	beforeAll,
+	beforeEach,
+	describe,
+	expect,
+	test,
+} from "vitest";
 import { buildFunctionBundle } from "./function-bundle.js";
+import type { NativeTraceDeps } from "./native-packages.js";
 
 let dir: string;
 beforeAll(() => {
@@ -16,7 +28,7 @@ afterAll(() => {
 
 function fn(
 	source: string,
-	externalPackages?: string[],
+	externalPackages?: (string | ResolvedExternalPackage)[],
 ): ResolvedFunctionConfig {
 	return {
 		slug: "fn1",
@@ -26,14 +38,72 @@ function fn(
 		runtime: "nodejs24",
 		...(externalPackages
 			? {
-					externalPackages: externalPackages.map((name) => ({
-						name,
-						includeFiles: true,
-					})),
+					externalPackages: externalPackages.map((entry) =>
+						typeof entry === "string"
+							? { name: entry, includeFiles: true }
+							: entry,
+					),
 				}
 			: {}),
 	};
 }
+
+/** An entry that is externalized but stages nothing — the `includeFiles: false` escape. */
+const excluded = (name: string): ResolvedExternalPackage => ({
+	name,
+	includeFiles: false,
+});
+
+/**
+ * Warnings are advisory and go to a callback rather than a return value, so a test that does
+ * not pass one lets them reach `console.warn` — which `console-fail-test` turns into a
+ * failure. Collecting them keeps the default honest and makes them assertable.
+ */
+let warnings: string[] = [];
+const collectWarning = (message: string): void => {
+	warnings.push(message);
+};
+beforeEach(() => {
+	warnings = [];
+});
+
+const sha256 = (data: Uint8Array): string =>
+	createHash("sha256").update(data).digest("hex");
+
+/** A 20-byte ELF header claiming the given `e_machine`, padded to a plausible file. */
+function elfHeader(machine: number): Uint8Array {
+	const buf = Buffer.alloc(64);
+	buf.write("\x7fELF", 0, "binary");
+	buf[4] = 2; // 64-bit
+	buf[5] = 1; // little-endian
+	buf.writeUInt16LE(machine, 18);
+	return new Uint8Array(buf);
+}
+
+const AARCH64 = 0xb7;
+const X86_64 = 0x3e;
+
+/**
+ * Stand-ins for the registry and the tracer, so the bundler's own logic is exercised without
+ * a network install. `files` is written into the staging directory the way npm would, and
+ * every path is then reported as traced.
+ */
+function fakeNativeDeps(files: Record<string, Uint8Array>): NativeTraceDeps {
+	return {
+		install: async (cwd) => {
+			for (const [relative, contents] of Object.entries(files)) {
+				const absolute = join(cwd, relative);
+				mkdirSync(join(absolute, ".."), { recursive: true });
+				writeFileSync(absolute, contents);
+			}
+		},
+		trace: async () => Object.keys(files),
+		installedVersion: () => undefined,
+	};
+}
+
+const pkgJson = (name: string): Uint8Array =>
+	new TextEncoder().encode(JSON.stringify({ name, version: "1.0.0" }));
 
 describe("buildFunctionBundle", () => {
 	test("bundles a handler with esbuild and returns a ZIP containing index.mjs (no sourcemap)", async () => {
@@ -94,8 +164,10 @@ describe("buildFunctionBundle", () => {
 	test("leaves a declared external package unbundled instead of failing to resolve it", async () => {
 		const source = join(dir, "needs-external.ts");
 
+		// `includeFiles: false`, because this package does not exist anywhere — the point
+		// here is only that esbuild stops following the import.
 		const bundle = await buildFunctionBundle(
-			fn(source, ["not-installed-anywhere"]),
+			fn(source, [excluded("not-installed-anywhere")]),
 		);
 
 		const files = unzipSync(bundle);
@@ -118,11 +190,323 @@ describe("buildFunctionBundle", () => {
 		);
 
 		const bundle = await buildFunctionBundle(
-			fn(source, ["not-installed-anywhere"]),
+			fn(source, [excluded("not-installed-anywhere")]),
 		);
 
 		const js = new TextDecoder().decode(unzipSync(bundle)["index.mjs"]);
 		expect(js).toContain("inlined by esbuild");
 		expect(js).toContain("not-installed-anywhere");
+	});
+
+	// The flip that this change is about: a bare string means "ship this package's files",
+	// so a name that resolves nowhere fails at deploy rather than silently shipping an
+	// archive whose import cannot resolve at invoke.
+	test("a bare entry stages the package, so an unresolvable name fails the deploy", async () => {
+		const source = join(dir, "needs-external.ts");
+
+		await expect(
+			buildFunctionBundle(fn(source, ["not-installed-anywhere"]), {
+				nativeDeps: {
+					install: async () => {
+						throw new Error("E404 not found");
+					},
+				},
+			}),
+		).rejects.toThrow(/E404 not found/);
+	});
+});
+
+describe("buildFunctionBundle staging external package files", () => {
+	// The guarantee that lets this ship: a policy that says nothing about native packages
+	// gets the archive it always did, to the byte. Written against the bytes the pre-existing
+	// code path produces (esbuild output, zipped at level 6, one entry keyed by basename)
+	// rather than a recorded constant, so it stays honest if esbuild's output changes.
+	test("produces a byte-identical archive to the pre-existing path when undeclared", async () => {
+		const source = join(dir, "plain.ts");
+		writeFileSync(
+			source,
+			"export default { fetch(): Response { return new Response('plain'); } };",
+		);
+
+		const bundle = await buildFunctionBundle(fn(source));
+		const entries = unzipSync(bundle);
+		expect(Object.keys(entries)).toEqual(["index.mjs"]);
+
+		const expected = zipSync(
+			{ "index.mjs": entries["index.mjs"] },
+			{ level: 6 },
+		);
+		expect(sha256(bundle)).toBe(sha256(expected));
+	});
+
+	test("does not install or trace anything when the list is absent", async () => {
+		const source = join(dir, "plain.ts");
+		let installed = false;
+		let traced = false;
+
+		await buildFunctionBundle(fn(source), {
+			nativeDeps: {
+				install: async () => {
+					installed = true;
+				},
+				trace: async () => {
+					traced = true;
+					return [];
+				},
+			},
+		});
+
+		expect(installed).toBe(false);
+		expect(traced).toBe(false);
+	});
+
+	// The escape hatch has to be genuinely free: an entry that opts out must take the same
+	// path as no entry at all, or `includeFiles: false` would still cost an install.
+	test("installs and traces nothing when every entry sets includeFiles: false", async () => {
+		const source = join(dir, "opted-out.ts");
+		writeFileSync(
+			source,
+			[
+				"import addon from 'fake-addon';",
+				"export default { fetch(): Response { return new Response(String(addon)); } };",
+			].join("\n"),
+		);
+		let installed = false;
+		let traced = false;
+
+		const bundle = await buildFunctionBundle(
+			fn(source, [excluded("fake-addon")]),
+			{
+				nativeDeps: {
+					install: async () => {
+						installed = true;
+					},
+					trace: async () => {
+						traced = true;
+						return [];
+					},
+				},
+			},
+		);
+
+		expect(installed).toBe(false);
+		expect(traced).toBe(false);
+		// The import survives into the bundle unresolved, and nothing ships beside it.
+		expect(Object.keys(unzipSync(bundle))).toEqual(["index.mjs"]);
+	});
+
+	// Staging the registry's latest instead of the version the user tested is exactly the
+	// kind of difference that shows up as an unreproducible production bug, so it is said
+	// out loud rather than left to be discovered from a deployed archive.
+	test("warns when a staged package's version cannot be read from the project", async () => {
+		const source = join(dir, "uses-native.ts");
+		writeFileSync(
+			source,
+			[
+				"import addon from 'fake-addon';",
+				"export default { fetch(): Response { return new Response(String(addon)); } };",
+			].join("\n"),
+		);
+
+		await buildFunctionBundle(fn(source, ["fake-addon"]), {
+			onWarning: collectWarning,
+			nativeDeps: fakeNativeDeps({
+				"node_modules/fake-addon/package.json": pkgJson("fake-addon"),
+				"node_modules/fake-addon/index.js": new TextEncoder().encode(
+					"module.exports = 1;",
+				),
+			}),
+		});
+
+		expect(
+			warnings.some(
+				(w) =>
+					w.includes("fake-addon") &&
+					w.includes("registry resolves as latest"),
+			),
+		).toBe(true);
+	});
+
+	test("ships the traced files under their node_modules paths, unflattened", async () => {
+		const source = join(dir, "uses-native.ts");
+		writeFileSync(
+			source,
+			[
+				"import addon from 'fake-addon';",
+				"export default { fetch(): Response { return new Response(String(addon)); } };",
+			].join("\n"),
+		);
+
+		const bundle = await buildFunctionBundle(fn(source, ["fake-addon"]), {
+			onWarning: collectWarning,
+			nativeDeps: fakeNativeDeps({
+				"node_modules/fake-addon/package.json": pkgJson("fake-addon"),
+				"node_modules/fake-addon/index.js": new TextEncoder().encode(
+					"module.exports = 1;",
+				),
+				"node_modules/@scope/fake-addon-linux-arm64/lib/addon.node":
+					elfHeader(AARCH64),
+				"node_modules/@scope/fake-addon-libs/lib/libthing.so.1":
+					elfHeader(AARCH64),
+			}),
+		});
+
+		const names = Object.keys(unzipSync(bundle)).sort();
+		// The nested paths are what a `.node` addon needs: it locates its sibling shared
+		// libraries relative to its own directory, so a flat archive would break loading even
+		// with every file present.
+		expect(names).toEqual([
+			"index.mjs",
+			"node_modules/@scope/fake-addon-libs/lib/libthing.so.1",
+			"node_modules/@scope/fake-addon-linux-arm64/lib/addon.node",
+			"node_modules/fake-addon/index.js",
+			"node_modules/fake-addon/package.json",
+		]);
+		// Nothing collapsed to a basename.
+		expect(names).not.toContain("addon.node");
+		expect(names).not.toContain("package.json");
+	});
+
+	test("leaves the declared package's import in the bundle instead of inlining it", async () => {
+		const source = join(dir, "uses-native.ts");
+
+		const bundle = await buildFunctionBundle(fn(source, ["fake-addon"]), {
+			onWarning: collectWarning,
+			nativeDeps: fakeNativeDeps({
+				"node_modules/fake-addon/package.json": pkgJson("fake-addon"),
+			}),
+		});
+
+		const js = new TextDecoder().decode(unzipSync(bundle)["index.mjs"]);
+		// The import survives and now resolves, because the files are in the archive beside it.
+		expect(js).toContain("fake-addon");
+	});
+
+	test("still inlines everything not named in the list", async () => {
+		const helper = join(dir, "native-helper.ts");
+		writeFileSync(helper, "export const marker = 'still inlined';\n");
+		const source = join(dir, "native-plus-local.ts");
+		writeFileSync(
+			source,
+			[
+				"import { marker } from './native-helper.js';",
+				"import addon from 'fake-addon';",
+				"export default { fetch(): Response { return new Response(marker + addon); } };",
+			].join("\n"),
+		);
+
+		const bundle = await buildFunctionBundle(fn(source, ["fake-addon"]), {
+			onWarning: collectWarning,
+			nativeDeps: fakeNativeDeps({
+				"node_modules/fake-addon/package.json": pkgJson("fake-addon"),
+			}),
+		});
+
+		const js = new TextDecoder().decode(unzipSync(bundle)["index.mjs"]);
+		expect(js).toContain("still inlined");
+		expect(js).toContain("fake-addon");
+	});
+
+	test("fails when a declared package produced no build for the runtime target", async () => {
+		const source = join(dir, "uses-native.ts");
+
+		// npm omits a platform-specific optional dependency silently when none matches, so an
+		// install can "succeed" and leave the package absent.
+		await expect(
+			buildFunctionBundle(fn(source, ["fake-addon"]), {
+				onWarning: collectWarning,
+				nativeDeps: fakeNativeDeps({}),
+			}),
+		).rejects.toThrow(
+			/did not install for the Functions runtime \(linux-arm64/,
+		);
+	});
+
+	test("rejects a binary built for the wrong architecture", async () => {
+		const source = join(dir, "uses-native.ts");
+
+		await expect(
+			buildFunctionBundle(fn(source, ["fake-addon"]), {
+				onWarning: collectWarning,
+				nativeDeps: fakeNativeDeps({
+					"node_modules/fake-addon/package.json":
+						pkgJson("fake-addon"),
+					"node_modules/fake-addon/lib/addon.node": elfHeader(X86_64),
+				}),
+			}),
+		).rejects.toThrow(
+			/built for a different architecture \(ELF machine 0x3e\)/,
+		);
+	});
+
+	test("rejects a binary that is not a Linux binary at all", async () => {
+		const source = join(dir, "uses-native.ts");
+		// A Mach-O magic number, i.e. a binary compiled on the user's own macOS machine.
+		const machO = new Uint8Array(Buffer.alloc(64));
+		Buffer.from(machO.buffer).writeUInt32BE(0xcffaedfe, 0);
+
+		await expect(
+			buildFunctionBundle(fn(source, ["fake-addon"]), {
+				onWarning: collectWarning,
+				nativeDeps: fakeNativeDeps({
+					"node_modules/fake-addon/package.json":
+						pkgJson("fake-addon"),
+					"node_modules/fake-addon/lib/addon.node": machO,
+				}),
+			}),
+		).rejects.toThrow(/is not a Linux binary/);
+	});
+
+	// Sibling platform builds that cannot run on the runtime. Dropping the wasm build is not
+	// only about size: shipping it would let a broken native path succeed quietly on a slower
+	// code path instead of failing loudly.
+	test("drops sibling wasm and musl builds from the archive", async () => {
+		const source = join(dir, "uses-native.ts");
+
+		const bundle = await buildFunctionBundle(fn(source, ["fake-addon"]), {
+			onWarning: collectWarning,
+			nativeDeps: fakeNativeDeps({
+				"node_modules/fake-addon/package.json": pkgJson("fake-addon"),
+				"node_modules/@scope/fake-addon-linux-arm64/lib/addon.node":
+					elfHeader(AARCH64),
+				"node_modules/@scope/fake-addon-wasm32/lib/addon.node.js":
+					new TextEncoder().encode("// wasm fallback"),
+				"node_modules/@scope/fake-addon-linuxmusl-arm64/lib/addon.node":
+					elfHeader(AARCH64),
+			}),
+		});
+
+		const names = Object.keys(unzipSync(bundle));
+		expect(names).toContain(
+			"node_modules/@scope/fake-addon-linux-arm64/lib/addon.node",
+		);
+		expect(names.filter((n) => n.includes("wasm32"))).toEqual([]);
+		expect(names.filter((n) => n.includes("musl"))).toEqual([]);
+	});
+
+	test("fails when the archive exceeds the compressed size limit, naming the largest files", async () => {
+		const source = join(dir, "uses-native.ts");
+		// A real aarch64 header, so the architecture check passes and the size limit is what
+		// this test exercises. Random bytes so the ZIP genuinely exceeds the limit rather than
+		// compressing back under it.
+		const big = new Uint8Array(11 * 1024 * 1024);
+		big.set(elfHeader(AARCH64), 0);
+		for (let offset = 64; offset < big.length; offset += 65536) {
+			randomFillSync(big, offset, Math.min(65536, big.length - offset));
+		}
+
+		const message = await buildFunctionBundle(fn(source, ["fake-addon"]), {
+			onWarning: collectWarning,
+			nativeDeps: fakeNativeDeps({
+				"node_modules/fake-addon/package.json": pkgJson("fake-addon"),
+				"node_modules/fake-addon/lib/huge.so.1": big,
+			}),
+		}).then(
+			() => "unexpectedly succeeded",
+			(e: unknown) => (e as Error).message,
+		);
+
+		expect(message).toMatch(/archive is 1[01]\.\d MiB compressed/);
+		expect(message).toContain("node_modules/fake-addon/lib/huge.so.1");
 	});
 });

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -1,9 +1,19 @@
-import { basename } from "node:path";
+import { basename, dirname } from "node:path";
 import {
 	ErrorCode,
 	PlatformError,
+	packagesToStage,
 	type ResolvedFunctionConfig,
 } from "@neon/config";
+import {
+	describeNativeFinding,
+	findUndeclaredNativePackages,
+} from "./native-detect.js";
+import {
+	assertZipWithinLimits,
+	type NativeTraceDeps,
+	traceNativePackages,
+} from "./native-packages.js";
 
 /**
  * Builds the deployable ZIP bundle for a single function. The default
@@ -52,8 +62,20 @@ const ESM_CJS_INTEROP_BANNER =
  */
 export async function buildFunctionBundle(
 	fn: ResolvedFunctionConfig,
+	options: {
+		nativeDeps?: Partial<NativeTraceDeps>;
+		/**
+		 * Where advisory findings go — currently the undeclared-native-dependency report.
+		 * Defaults to `console.warn` so a consumer that wires up nothing still sees them; a
+		 * dropped warning about a function that will fail at invoke is worse than noise.
+		 */
+		onWarning?: (message: string) => void;
+	} = {},
 ): Promise<Uint8Array> {
 	const esbuild = await loadEsbuild();
+	const externalPackages = fn.externalPackages ?? [];
+	const staged = packagesToStage(externalPackages);
+	const onWarning = options.onWarning ?? ((message) => console.warn(message));
 
 	let result: Awaited<ReturnType<typeof esbuild.build>>;
 	try {
@@ -75,9 +97,12 @@ export async function buildFunctionBundle(
 			// bundled CommonJS deps work inside the ESM output.
 			banner: { js: ESM_CJS_INTEROP_BANNER },
 			// Packages the policy declared unbundleable. Their imports survive into the
-			// bundle; whether they then resolve depends on `includeFiles`, which the deploy
-			// bundler acts on after this build. Both modes are external to esbuild.
-			external: (fn.externalPackages ?? []).map((pkg) => pkg.name),
+			// bundle instead of being followed; whether they then resolve at runtime depends
+			// on `includeFiles`, which is acted on below. Both modes are external here.
+			external: externalPackages.map((pkg) => pkg.name),
+			// Reveals which packages were bundled in, so an undeclared native dependency can
+			// be reported. Costs nothing here — esbuild is already running.
+			metafile: true,
 			logLevel: "silent",
 		});
 	} catch (cause) {
@@ -99,7 +124,38 @@ export async function buildFunctionBundle(
 		entries[basename(file.path)] = file.contents;
 	}
 
-	return zipBundle(entries);
+	// Only reachable on a successful build, which is the point: `sharp` and its kind bundle
+	// cleanly and fail at invoke, so this is exactly the case nothing else catches. A build
+	// that throws has already failed loudly with esbuild's own diagnostic.
+	for (const finding of findUndeclaredNativePackages({
+		metafile: result.metafile,
+		declared: externalPackages.map((pkg) => pkg.name),
+		projectDir: dirname(fn.source),
+	})) {
+		onWarning(describeNativeFinding(fn.slug, finding));
+	}
+
+	// The pre-existing path, byte for byte: no install, no trace, no size check, and an
+	// archive of exactly the esbuild output. A policy that declares nothing to stage — or
+	// sets `includeFiles: false` on everything — deploys the archive it always did.
+	if (staged.length === 0) return zipBundle(entries);
+
+	const traced = await traceNativePackages({
+		slug: fn.slug,
+		packages: staged,
+		// The user's project, located from their entry — where their resolved versions are
+		// read from. Only versions: the files themselves come from the staging install.
+		projectDir: dirname(fn.source),
+		...(options.nativeDeps ? { deps: options.nativeDeps } : {}),
+	});
+	for (const warning of traced.warnings) onWarning(warning);
+	// Keys carry their `node_modules/...` path, so the archive reproduces the tree layout a
+	// `.node` addon needs to find its sibling libraries. Do not flatten these.
+	Object.assign(entries, traced.entries);
+
+	const zip = await zipBundle(entries);
+	assertZipWithinLimits(fn.slug, zip, entries);
+	return zip;
 }
 
 async function zipBundle(

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -34,7 +34,7 @@ export type FunctionBundler = (
  * `Dynamic require of "x" is not supported`. Re-create those globals via `createRequire`
  * so CJS and ESM dependencies coexist in the single `index.mjs`.
  */
-const ESM_CJS_INTEROP_BANNER =
+export const ESM_CJS_INTEROP_BANNER =
 	"import{createRequire as ___cr}from'module';import{fileURLToPath as ___f}from'url';import{dirname as ___d}from'path';const require=___cr(import.meta.url);const __filename=___f(import.meta.url);const __dirname=___d(__filename);";
 
 /**
@@ -65,9 +65,12 @@ export async function buildFunctionBundle(
 	options: {
 		nativeDeps?: Partial<NativeTraceDeps>;
 		/**
-		 * Where advisory findings go — currently the undeclared-native-dependency report.
-		 * Defaults to `console.warn` so a consumer that wires up nothing still sees them; a
-		 * dropped warning about a function that will fail at invoke is worse than noise.
+		 * Where advisory findings go — the undeclared-native-dependency report, and a package
+		 * whose version could not be pinned.
+		 *
+		 * Defaults to discarding them, because a library has no business writing to the
+		 * console. Pass a handler: these are the only signal that a function will fail at
+		 * invoke, and the CLI wires this to its logger for exactly that reason.
 		 */
 		onWarning?: (message: string) => void;
 	} = {},
@@ -75,7 +78,7 @@ export async function buildFunctionBundle(
 	const esbuild = await loadEsbuild();
 	const externalPackages = fn.externalPackages ?? [];
 	const staged = packagesToStage(externalPackages);
-	const onWarning = options.onWarning ?? ((message) => console.warn(message));
+	const onWarning = options.onWarning ?? (() => {});
 
 	let result: Awaited<ReturnType<typeof esbuild.build>>;
 	try {

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -74,11 +74,10 @@ export async function buildFunctionBundle(
 			// `platform: "node"`. The banner re-creates require/__filename/__dirname so
 			// bundled CommonJS deps work inside the ESM output.
 			banner: { js: ESM_CJS_INTEROP_BANNER },
-			// Packages the policy declared unbundleable (native addons, optional peers on
-			// dead code paths). Their imports survive into the bundle and resolve against a
-			// directory with no node_modules, so reaching one at runtime throws — which is
-			// the documented contract of `FunctionDef.externalPackages`, not a bug here.
-			external: [...(fn.externalPackages ?? [])],
+			// Packages the policy declared unbundleable. Their imports survive into the
+			// bundle; whether they then resolve depends on `includeFiles`, which the deploy
+			// bundler acts on after this build. Both modes are external to esbuild.
+			external: (fn.externalPackages ?? []).map((pkg) => pkg.name),
 			logLevel: "silent",
 		});
 	} catch (cause) {

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -11,6 +11,7 @@ import {
 } from "./native-detect.js";
 import {
 	assertZipWithinLimits,
+	enforceLimits,
 	type NativeTraceDeps,
 	traceNativePackages,
 } from "./native-packages.js";
@@ -156,6 +157,9 @@ export async function buildFunctionBundle(
 	// `.node` addon needs to find its sibling libraries. Do not flatten these.
 	Object.assign(entries, traced.entries);
 
+	// Re-checked against the final archive: the staged files were measured without the
+	// bundle, so the entry count and uncompressed total are only complete now.
+	enforceLimits(fn.slug, entries);
 	const zip = await zipBundle(entries);
 	assertZipWithinLimits(fn.slug, zip, entries);
 	return zip;

--- a/packages/config-runtime/src/lib/native-detect.test.ts
+++ b/packages/config-runtime/src/lib/native-detect.test.ts
@@ -54,6 +54,9 @@ const find = (metafile: unknown, declared: string[] = []) =>
 		metafile: metafile as { inputs?: Record<string, unknown> },
 		declared,
 		projectDir: root,
+		// Metafile paths are relative to esbuild's working directory, which for these
+		// fixtures is the temp project rather than the process cwd.
+		cwd: root,
 	});
 
 describe("packageNameFromInput", () => {
@@ -253,6 +256,64 @@ describe("findUndeclaredNativePackages", () => {
 
 	test("ignores a package that is in the graph but not installed", () => {
 		expect(find(metafileFor("never-installed"))).toEqual([]);
+	});
+
+	// pnpm does not link a transitive dependency at the project root at all, so searching for
+	// it by name from there finds nothing. The package directory has to come from the path
+	// esbuild reported.
+	test("inspects a pnpm transitive that is not linked at the project root", () => {
+		const store = join(
+			root,
+			"node_modules",
+			".pnpm",
+			"deep-native@1.0.0",
+			"node_modules",
+			"deep-native",
+		);
+		mkdirSync(join(store, "build"), { recursive: true });
+		writeFileSync(
+			join(store, "package.json"),
+			JSON.stringify({ name: "deep-native", version: "1.0.0" }),
+		);
+		writeFileSync(join(store, "build", "addon.node"), "\x7fELF");
+
+		const findings = find({
+			inputs: {
+				"node_modules/.pnpm/deep-native@1.0.0/node_modules/deep-native/index.js":
+					{},
+			},
+		});
+		expect(findings).toHaveLength(1);
+		expect(findings[0].name).toBe("deep-native");
+	});
+
+	// A manifest is arbitrary third-party JSON. npm accepts `os` as a bare string, and a
+	// malformed value must not take an advisory scan — and with it the deploy — down.
+	test("accepts os declared as a bare string rather than an array", () => {
+		writePackage("string-os", {
+			manifest: { os: "darwin" },
+			files: { "thing.node": "\x7fELF" },
+		});
+		expect(find(metafileFor("string-os"))).toEqual([]);
+	});
+
+	test("does not crash on a malformed os field", () => {
+		writePackage("weird-os", {
+			manifest: { os: { nope: true }, optionalDependencies: [] },
+			files: { "thing.node": "\x7fELF" },
+		});
+		// Unreadable platform metadata is treated as unrestricted, so it is still reported.
+		expect(find(metafileFor("weird-os"))).toHaveLength(1);
+	});
+
+	// A musl-only build cannot load on the glibc runtime, so it is not shippable and
+	// reporting it would be noise — the same reasoning as the darwin-only case.
+	test("ignores a package excluded from the runtime by libc", () => {
+		writePackage("musl-only", {
+			manifest: { libc: ["musl"] },
+			files: { "thing.node": "\x7fELF" },
+		});
+		expect(find(metafileFor("musl-only"))).toEqual([]);
 	});
 });
 

--- a/packages/config-runtime/src/lib/native-detect.test.ts
+++ b/packages/config-runtime/src/lib/native-detect.test.ts
@@ -1,0 +1,293 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+	describeNativeFinding,
+	findUndeclaredNativePackages,
+	packageNameFromInput,
+} from "./native-detect.js";
+
+/**
+ * Fixtures are real directory trees rather than a faked filesystem: the thing under test is
+ * how a package looks on disk, so a stub would be asserting against my own model of npm's
+ * layout instead of npm's.
+ */
+let root: string;
+beforeEach(() => {
+	root = mkdtempSync(join(tmpdir(), "neon-detect-"));
+});
+afterEach(() => {
+	rmSync(root, { recursive: true, force: true });
+});
+
+type PackageSpec = {
+	manifest?: Record<string, unknown>;
+	files?: Record<string, string>;
+};
+
+const writePackage = (name: string, spec: PackageSpec = {}): string => {
+	const dir = join(root, "node_modules", ...name.split("/"));
+	mkdirSync(dir, { recursive: true });
+	writeFileSync(
+		join(dir, "package.json"),
+		JSON.stringify({ name, version: "1.0.0", ...(spec.manifest ?? {}) }),
+	);
+	for (const [relative, contents] of Object.entries(spec.files ?? {})) {
+		const target = join(dir, relative);
+		mkdirSync(join(target, ".."), { recursive: true });
+		writeFileSync(target, contents);
+	}
+	return dir;
+};
+
+/** A metafile naming one bundled file inside each given package. */
+const metafileFor = (...packages: string[]) => ({
+	inputs: Object.fromEntries([
+		["entry.ts", {}],
+		...packages.map((name) => [`node_modules/${name}/index.js`, {}]),
+	]),
+});
+
+const find = (metafile: unknown, declared: string[] = []) =>
+	findUndeclaredNativePackages({
+		metafile: metafile as { inputs?: Record<string, unknown> },
+		declared,
+		projectDir: root,
+	});
+
+describe("packageNameFromInput", () => {
+	test("reads a bare package name", () => {
+		expect(packageNameFromInput("node_modules/sharp/lib/index.js")).toBe(
+			"sharp",
+		);
+	});
+
+	test("reads a scoped package name", () => {
+		expect(packageNameFromInput("node_modules/@img/colour/index.js")).toBe(
+			"@img/colour",
+		);
+	});
+
+	// pnpm's store puts the real package behind a second node_modules, so anchoring on the
+	// first segment would report `.pnpm` for every dependency in a pnpm project.
+	test("reads through pnpm's store layout", () => {
+		expect(
+			packageNameFromInput(
+				"node_modules/.pnpm/sharp@0.35.3/node_modules/sharp/lib/index.js",
+			),
+		).toBe("sharp");
+	});
+
+	test("reads a scoped package through pnpm's store layout", () => {
+		expect(
+			packageNameFromInput(
+				"node_modules/.pnpm/@img+sharp-linux-arm64@0.35.3/node_modules/@img/sharp-linux-arm64/lib/x.js",
+			),
+		).toBe("@img/sharp-linux-arm64");
+	});
+
+	test("handles windows separators", () => {
+		expect(packageNameFromInput("node_modules\\sharp\\lib\\index.js")).toBe(
+			"sharp",
+		);
+	});
+
+	test("returns undefined for the user's own source", () => {
+		expect(packageNameFromInput("src/functions/resize.ts")).toBeUndefined();
+	});
+
+	test("returns undefined for a scope with no package", () => {
+		expect(packageNameFromInput("node_modules/@img/")).toBeUndefined();
+	});
+});
+
+describe("findUndeclaredNativePackages", () => {
+	test("finds nothing when every bundled package is plain JavaScript", () => {
+		writePackage("lodash", {
+			files: { "index.js": "module.exports = {};" },
+		});
+		expect(find(metafileFor("lodash"))).toEqual([]);
+	});
+
+	test("flags a package containing a .node binary", () => {
+		writePackage("better-sqlite3", {
+			files: { "build/Release/better_sqlite3.node": "\x7fELF" },
+		});
+		const findings = find(metafileFor("better-sqlite3"));
+		expect(findings).toHaveLength(1);
+		expect(findings[0].name).toBe("better-sqlite3");
+		expect(findings[0].evidence.kind).toBe("binary");
+	});
+
+	// The shape that matters most: `sharp` itself is pure JavaScript, and the binary lives in
+	// a platform-gated optional dependency. Scanning only the parent finds nothing.
+	test("flags a package whose binary lives in a platform optional dependency", () => {
+		writePackage("sharp", {
+			manifest: {
+				optionalDependencies: { "@img/sharp-darwin-arm64": "0.35.3" },
+			},
+			files: { "lib/index.js": "module.exports = {};" },
+		});
+		writePackage("@img/sharp-darwin-arm64", {
+			manifest: { os: ["darwin"], cpu: ["arm64"] },
+			files: { "lib/sharp-darwin-arm64.node": "\x7fELF" },
+		});
+
+		const findings = find(metafileFor("sharp"));
+		expect(findings).toHaveLength(1);
+		expect(findings[0].name).toBe("sharp");
+		expect(findings[0].evidence).toMatchObject({
+			kind: "platformDependency",
+			dependency: "@img/sharp-darwin-arm64",
+		});
+	});
+
+	test("flags a package that compiles from source at install time", () => {
+		writePackage("some-addon", {
+			manifest: { scripts: { install: "node-gyp rebuild" } },
+			files: { "index.js": "module.exports = {};" },
+		});
+		const findings = find(metafileFor("some-addon"));
+		expect(findings[0]?.evidence.kind).toBe("buildsFromSource");
+	});
+
+	test("flags a node-pre-gyp package by its binary manifest field", () => {
+		writePackage("pre-gyp-thing", {
+			manifest: { binary: { module_name: "thing" } },
+			files: { "index.js": "module.exports = {};" },
+		});
+		expect(find(metafileFor("pre-gyp-thing"))[0]?.evidence.kind).toBe(
+			"prebuiltManifest",
+		);
+	});
+
+	test("says nothing about a package already declared", () => {
+		writePackage("better-sqlite3", {
+			files: { "build/Release/better_sqlite3.node": "\x7fELF" },
+		});
+		expect(find(metafileFor("better-sqlite3"), ["better-sqlite3"])).toEqual(
+			[],
+		);
+	});
+
+	// Externalizing `pkg` externalizes `pkg/sub` with it, so a subpath declaration speaks for
+	// the whole package and must not leave it looking undeclared.
+	test("treats a declared subpath as covering its package", () => {
+		writePackage("better-sqlite3", {
+			files: { "build/Release/better_sqlite3.node": "\x7fELF" },
+		});
+		expect(
+			find(metafileFor("better-sqlite3"), [
+				"better-sqlite3/lib/index.js",
+			]),
+		).toEqual([]);
+	});
+
+	// `fsevents` is darwin-only. It cannot run on the runtime whatever we do, so it is not a
+	// candidate for shipping and reporting it would be pure noise on every macOS project.
+	test("ignores a package that cannot run on the runtime at all", () => {
+		writePackage("fsevents", {
+			manifest: { os: ["darwin"] },
+			files: { "fsevents.node": "\x7fELF" },
+		});
+		expect(find(metafileFor("fsevents"))).toEqual([]);
+	});
+
+	test("ignores a package excluded from the runtime by cpu", () => {
+		writePackage("x64-only", {
+			manifest: { cpu: ["x64"] },
+			files: { "thing.node": "\x7fELF" },
+		});
+		expect(find(metafileFor("x64-only"))).toEqual([]);
+	});
+
+	test("honours a negated os field", () => {
+		writePackage("not-linux", {
+			manifest: { os: ["!linux"] },
+			files: { "thing.node": "\x7fELF" },
+		});
+		expect(find(metafileFor("not-linux"))).toEqual([]);
+	});
+
+	test("does not look inside a nested node_modules", () => {
+		writePackage("outer", {
+			files: { "index.js": "module.exports = {};" },
+		});
+		mkdirSync(
+			join(root, "node_modules", "outer", "node_modules", "inner"),
+			{
+				recursive: true,
+			},
+		);
+		writeFileSync(
+			join(
+				root,
+				"node_modules",
+				"outer",
+				"node_modules",
+				"inner",
+				"thing.node",
+			),
+			"\x7fELF",
+		);
+		expect(find(metafileFor("outer"))).toEqual([]);
+	});
+
+	test("reports a package once however many of its files were bundled", () => {
+		writePackage("better-sqlite3", {
+			files: { "build/Release/better_sqlite3.node": "\x7fELF" },
+		});
+		const metafile = {
+			inputs: {
+				"node_modules/better-sqlite3/index.js": {},
+				"node_modules/better-sqlite3/lib/database.js": {},
+			},
+		};
+		expect(find(metafile)).toHaveLength(1);
+	});
+
+	test("returns nothing when esbuild produced no metafile", () => {
+		expect(find(undefined)).toEqual([]);
+	});
+
+	test("ignores a package that is in the graph but not installed", () => {
+		expect(find(metafileFor("never-installed"))).toEqual([]);
+	});
+});
+
+describe("describeNativeFinding", () => {
+	test("leads with the shipping fix and offers the opt-out second", () => {
+		const message = describeNativeFinding("resize", {
+			name: "sharp",
+			evidence: {
+				kind: "platformDependency",
+				dependency: "@img/sharp-linux-arm64",
+				file: "lib/sharp.node",
+			},
+		});
+
+		expect(message).toContain('Function "resize" bundles "sharp"');
+		expect(message).toContain("@img/sharp-linux-arm64");
+		expect(message).toContain('externalPackages: ["sharp"]');
+		expect(message).toContain(
+			'externalPackages: [{ name: "sharp", includeFiles: false }]',
+		);
+		// The shipping form comes first: it is the one that produces a working function.
+		expect(message.indexOf('externalPackages: ["sharp"]')).toBeLessThan(
+			message.indexOf("includeFiles: false"),
+		);
+	});
+
+	// The evidence proves the package carries native code, never that this function reaches
+	// it, so the failure has to be stated as conditional and the no-change-needed case has
+	// to be named. `ws` with `bufferutil` installed is exactly that case.
+	test("states the failure conditionally and allows for a working fallback", () => {
+		const message = describeNativeFinding("resize", {
+			name: "ws",
+			evidence: { kind: "binary", file: "build/Release/bufferutil.node" },
+		});
+		expect(message).toContain("if this function reaches that code path");
+		expect(message).toContain("the deploy is already correct");
+	});
+});

--- a/packages/config-runtime/src/lib/native-detect.ts
+++ b/packages/config-runtime/src/lib/native-detect.ts
@@ -1,0 +1,230 @@
+import { type Dirent, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { externalPackageRoot } from "@neon/config";
+import { RUNTIME_TARGET } from "./native-packages.js";
+import { findPackageDir, readPackageManifest } from "./resolve-package.js";
+
+/**
+ * Why a package looks like it needs its files shipped. Carried through to the message so the
+ * report states the evidence rather than a prediction about what will happen at invoke.
+ */
+export type NativeEvidence =
+	| { kind: "binary"; file: string }
+	| { kind: "platformDependency"; dependency: string; file: string }
+	| { kind: "buildsFromSource"; script: string }
+	| { kind: "prebuiltManifest" };
+
+export type NativeFinding = {
+	/** The package as it appears in the user's tree. */
+	name: string;
+	evidence: NativeEvidence;
+};
+
+/** Depth of the walk for a `.node`/`.so` inside one package. */
+const SCAN_DEPTH = 4;
+
+const BINARY_PATTERN = /\.(node|so)(\.\d+)*$/;
+
+const GYP_PATTERN = /\b(node-gyp|node-pre-gyp|prebuild-install|cmake-js)\b/;
+
+type Manifest = {
+	os?: string[];
+	cpu?: string[];
+	libc?: string[];
+	binary?: unknown;
+	optionalDependencies?: Record<string, string>;
+	scripts?: Record<string, string>;
+};
+
+/**
+ * The packages a bundle pulled in that carry native code and were not declared in
+ * `externalPackages`.
+ *
+ * **This is evidence, not a verdict.** It proves the package contains or depends on compiled
+ * code, never that this function's code path reaches it — a package with an optional native
+ * accelerator and a working JavaScript fallback (`ws` with `bufferutil`, a Prisma client with
+ * no Rust engine) looks identical from here and deploys fine today. So the caller reports it
+ * and continues; it must not fail a deploy.
+ *
+ * Only reachable after a successful build. A package esbuild could not resolve, or a `.node`
+ * it has no loader for, throws before any metafile exists — those already fail loudly with
+ * esbuild's own diagnostic.
+ */
+export function findUndeclaredNativePackages(options: {
+	metafile: { inputs?: Record<string, unknown> } | undefined;
+	declared: readonly string[];
+	projectDir: string;
+}): NativeFinding[] {
+	const { metafile, declared, projectDir } = options;
+	const inputs = metafile?.inputs;
+	if (!inputs) return [];
+
+	// A declared subpath covers its whole package: esbuild externalizing `pkg` externalizes
+	// `pkg/sub` with it, so the package is spoken for either way.
+	const declaredRoots = new Set(declared.map(externalPackageRoot));
+
+	const findings: NativeFinding[] = [];
+	const seen = new Set<string>();
+	for (const input of Object.keys(inputs)) {
+		const name = packageNameFromInput(input);
+		if (name === undefined) continue;
+		if (declaredRoots.has(name) || seen.has(name)) continue;
+		seen.add(name);
+
+		const evidence = nativeEvidence(projectDir, name);
+		if (evidence !== undefined) findings.push({ name, evidence });
+	}
+	return findings;
+}
+
+/**
+ * The package an esbuild metafile input belongs to, or `undefined` for the user's own source.
+ *
+ * Keyed off the **last** `node_modules/` segment, which is what makes pnpm's
+ * `node_modules/.pnpm/sharp@0.35.3/node_modules/sharp/lib/x.js` resolve to `sharp` rather
+ * than `.pnpm`. Yarn PnP resolves out of zip archives with no `node_modules` segment at all
+ * and yields nothing here, which is the safe direction: a missed package is a missing
+ * warning, not a wrong one.
+ */
+export function packageNameFromInput(input: string): string | undefined {
+	const normalized = input.split("\\").join("/");
+	const marker = "node_modules/";
+	const last = normalized.lastIndexOf(marker);
+	if (last === -1) return undefined;
+
+	const rest = normalized.slice(last + marker.length);
+	const segments = rest.split("/").filter((segment) => segment.length > 0);
+	if (segments.length === 0) return undefined;
+	if (segments[0].startsWith("@")) {
+		return segments.length >= 2
+			? `${segments[0]}/${segments[1]}`
+			: undefined;
+	}
+	return segments[0];
+}
+
+const readManifest = (dir: string): Manifest | undefined =>
+	readPackageManifest(dir) as Manifest | undefined;
+
+/**
+ * Whether a manifest's own `os`/`cpu` fields permit the Functions runtime. A package that
+ * excludes it — `fsevents` is darwin-only — cannot run there whatever we do, so it is not a
+ * candidate for shipping and reporting it would be noise.
+ */
+function runsOnRuntime(manifest: Manifest): boolean {
+	const permits = (
+		field: readonly string[] | undefined,
+		value: string,
+	): boolean => {
+		if (field === undefined || field.length === 0) return true;
+		if (field.some((entry) => entry === `!${value}`)) return false;
+		const positives = field.filter((entry) => !entry.startsWith("!"));
+		return positives.length === 0 || positives.includes(value);
+	};
+	return (
+		permits(manifest.os, RUNTIME_TARGET.os) &&
+		permits(manifest.cpu, RUNTIME_TARGET.cpu)
+	);
+}
+
+/** The first native signal a package shows, or `undefined` if it looks like plain JavaScript. */
+function nativeEvidence(
+	projectDir: string,
+	name: string,
+): NativeEvidence | undefined {
+	const dir = findPackageDir(projectDir, name);
+	if (dir === undefined) return undefined;
+
+	const manifest = readManifest(dir);
+	if (manifest === undefined) return undefined;
+	if (!runsOnRuntime(manifest)) return undefined;
+
+	const own = findBinary(dir, SCAN_DEPTH);
+	if (own !== undefined) return { kind: "binary", file: own };
+
+	// The modern prebuilt pattern: the parent is pure JavaScript and the binary lives in a
+	// platform-gated optional dependency, which is why scanning only the parent misses it.
+	for (const dependency of Object.keys(manifest.optionalDependencies ?? {})) {
+		const dependencyDir = findPackageDir(projectDir, dependency);
+		if (dependencyDir === undefined) continue;
+		const dependencyManifest = readManifest(dependencyDir);
+		if (dependencyManifest === undefined) continue;
+		// The sibling built for *this* host is the one installed locally; its os/cpu fields
+		// are what mark the package as platform-gated at all.
+		const platformGated =
+			dependencyManifest.os !== undefined ||
+			dependencyManifest.cpu !== undefined;
+		if (!platformGated) continue;
+		const file = findBinary(dependencyDir, SCAN_DEPTH);
+		if (file !== undefined)
+			return { kind: "platformDependency", dependency, file };
+	}
+
+	const script = manifest.scripts?.install ?? manifest.scripts?.postinstall;
+	if (script !== undefined && GYP_PATTERN.test(script))
+		return { kind: "buildsFromSource", script };
+
+	if (manifest.binary !== undefined) return { kind: "prebuiltManifest" };
+
+	return undefined;
+}
+
+/** First compiled artifact under `dir`, not descending into a nested `node_modules`. */
+function findBinary(dir: string, depth: number): string | undefined {
+	if (depth < 0) return undefined;
+	let listing: Dirent[];
+	try {
+		listing = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return undefined;
+	}
+	for (const entry of listing) {
+		if (entry.isFile() && BINARY_PATTERN.test(entry.name))
+			return entry.name;
+	}
+	for (const entry of listing) {
+		if (!entry.isDirectory() || entry.name === "node_modules") continue;
+		const found = findBinary(join(dir, entry.name), depth - 1);
+		if (found !== undefined) return join(entry.name, found);
+	}
+	return undefined;
+}
+
+/**
+ * The report a user sees. States what was found and both ways to act on it, with the
+ * shipping form first because it is the one that produces a working function.
+ */
+export function describeNativeFinding(
+	slug: string,
+	finding: NativeFinding,
+): string {
+	const { name, evidence } = finding;
+	const because = (() => {
+		switch (evidence.kind) {
+			case "binary":
+				return `it contains a compiled binary (${evidence.file})`;
+			case "platformDependency":
+				return `it loads a compiled binary from ${evidence.dependency} (${evidence.file})`;
+			case "buildsFromSource":
+				return `it compiles a binary at install time (${evidence.script})`;
+			case "prebuiltManifest":
+				return "its manifest declares a prebuilt binary";
+		}
+	})();
+
+	return [
+		`Function "${slug}" bundles "${name}", and ${because}.`,
+		`A compiled binary cannot be bundled, so if this function reaches that code path it`,
+		`will fail at invoke rather than at deploy.`,
+		"",
+		`  Ship its files with the deploy:`,
+		`      externalPackages: ["${name}"]`,
+		"",
+		`  Or, if this function never reaches it, silence this by saying so:`,
+		`      externalPackages: [{ name: "${name}", includeFiles: false }]`,
+		"",
+		`Shipping a package adds its whole file tree to the archive, which increases both`,
+		`archive size and cold start. If "${name}" is only used behind a JavaScript fallback,`,
+		`the deploy is already correct and the second form records that.`,
+	].join("\n");
+}

--- a/packages/config-runtime/src/lib/native-detect.ts
+++ b/packages/config-runtime/src/lib/native-detect.ts
@@ -1,5 +1,5 @@
-import { type Dirent, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { type Dirent, readdirSync, realpathSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 import { externalPackageRoot } from "@neon/config";
 import { RUNTIME_TARGET } from "./native-packages.js";
 import { findPackageDir, readPackageManifest } from "./resolve-package.js";
@@ -27,13 +27,17 @@ const BINARY_PATTERN = /\.(node|so)(\.\d+)*$/;
 
 const GYP_PATTERN = /\b(node-gyp|node-pre-gyp|prebuild-install|cmake-js)\b/;
 
+/**
+ * Third-party manifests are arbitrary JSON, so every field is `unknown` and narrowed at use.
+ * npm accepts `os`/`cpu`/`libc` as a bare string as well as an array.
+ */
 type Manifest = {
-	os?: string[];
-	cpu?: string[];
-	libc?: string[];
+	os?: unknown;
+	cpu?: unknown;
+	libc?: unknown;
 	binary?: unknown;
-	optionalDependencies?: Record<string, string>;
-	scripts?: Record<string, string>;
+	optionalDependencies?: unknown;
+	scripts?: Record<string, unknown>;
 };
 
 /**
@@ -54,8 +58,11 @@ export function findUndeclaredNativePackages(options: {
 	metafile: { inputs?: Record<string, unknown> } | undefined;
 	declared: readonly string[];
 	projectDir: string;
+	/** What metafile input paths are relative to. Defaults to the process working directory. */
+	cwd?: string;
 }): NativeFinding[] {
 	const { metafile, declared, projectDir } = options;
+	const cwd = options.cwd ?? process.cwd();
 	const inputs = metafile?.inputs;
 	if (!inputs) return [];
 
@@ -66,15 +73,57 @@ export function findUndeclaredNativePackages(options: {
 	const findings: NativeFinding[] = [];
 	const seen = new Set<string>();
 	for (const input of Object.keys(inputs)) {
-		const name = packageNameFromInput(input);
-		if (name === undefined) continue;
-		if (declaredRoots.has(name) || seen.has(name)) continue;
-		seen.add(name);
+		const located = packageFromInput(input, cwd);
+		if (located === undefined) continue;
+		const { name } = located;
+		if (declaredRoots.has(name)) continue;
 
-		const evidence = nativeEvidence(projectDir, name);
+		// Keyed by directory, not name: pnpm and nested installs can put two versions of one
+		// package in a graph, and they are genuinely different packages to inspect.
+		const dir = located.dir ?? findPackageDir(projectDir, name);
+		if (dir === undefined || seen.has(dir)) continue;
+		seen.add(dir);
+
+		const evidence = nativeEvidence(dir, projectDir);
 		if (evidence !== undefined) findings.push({ name, evidence });
 	}
 	return findings;
+}
+
+/**
+ * The package an input belongs to, and where that exact copy lives on disk.
+ *
+ * Taking the directory straight from the input path rather than searching for the name is
+ * what makes this correct under pnpm, whose transitive dependencies are not linked at the
+ * project root at all and whose store holds several versions of the same package side by
+ * side. A search from the project root would miss the first and could inspect the wrong copy
+ * in the second.
+ */
+function packageFromInput(
+	input: string,
+	cwd: string,
+): { name: string; dir?: string } | undefined {
+	const name = packageNameFromInput(input);
+	if (name === undefined) return undefined;
+
+	const normalized = input.split("\\").join("/");
+	const marker = "node_modules/";
+	const last = normalized.lastIndexOf(marker);
+	// The path through the end of the package's own segments is its directory.
+	const prefixLength = last + marker.length + name.length;
+	const relativeDir = normalized.slice(0, prefixLength);
+	if (!relativeDir.endsWith(name)) return { name };
+
+	const absolute = isAbsolute(relativeDir)
+		? relativeDir
+		: resolve(cwd, relativeDir);
+	try {
+		// realpath so a pnpm symlink and its store target dedupe to one physical package.
+		return { name, dir: realpathSync(absolute) };
+	} catch {
+		// The path esbuild reported is not readable from here — fall back to a search.
+		return { name };
+	}
 }
 
 /**
@@ -107,15 +156,35 @@ const readManifest = (dir: string): Manifest | undefined =>
 	readPackageManifest(dir) as Manifest | undefined;
 
 /**
- * Whether a manifest's own `os`/`cpu` fields permit the Functions runtime. A package that
- * excludes it — `fsevents` is darwin-only — cannot run there whatever we do, so it is not a
- * candidate for shipping and reporting it would be noise.
+ * A manifest field npm accepts as either a string or an array of strings, narrowed to a list.
+ * Anything else is treated as absent: this is an advisory scan reading arbitrary third-party
+ * manifests, and a malformed field must not take a deploy down.
+ */
+function stringList(value: unknown): string[] | undefined {
+	if (typeof value === "string") return [value];
+	if (!Array.isArray(value)) return undefined;
+	const entries = value.filter(
+		(entry): entry is string => typeof entry === "string",
+	);
+	return entries.length === value.length ? entries : undefined;
+}
+
+function optionalDependencies(manifest: Manifest): Record<string, unknown> {
+	const value = manifest.optionalDependencies;
+	return typeof value === "object" && value !== null && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+/**
+ * Whether a manifest's own `os`/`cpu`/`libc` fields permit the Functions runtime. A package
+ * that excludes it — `fsevents` is darwin-only, a musl-only build cannot load on glibc —
+ * cannot run there whatever we do, so it is not a candidate for shipping and reporting it
+ * would be noise.
  */
 function runsOnRuntime(manifest: Manifest): boolean {
-	const permits = (
-		field: readonly string[] | undefined,
-		value: string,
-	): boolean => {
+	const permits = (raw: unknown, value: string): boolean => {
+		const field = stringList(raw);
 		if (field === undefined || field.length === 0) return true;
 		if (field.some((entry) => entry === `!${value}`)) return false;
 		const positives = field.filter((entry) => !entry.startsWith("!"));
@@ -123,18 +192,16 @@ function runsOnRuntime(manifest: Manifest): boolean {
 	};
 	return (
 		permits(manifest.os, RUNTIME_TARGET.os) &&
-		permits(manifest.cpu, RUNTIME_TARGET.cpu)
+		permits(manifest.cpu, RUNTIME_TARGET.cpu) &&
+		permits(manifest.libc, RUNTIME_TARGET.libc)
 	);
 }
 
 /** The first native signal a package shows, or `undefined` if it looks like plain JavaScript. */
 function nativeEvidence(
+	dir: string,
 	projectDir: string,
-	name: string,
 ): NativeEvidence | undefined {
-	const dir = findPackageDir(projectDir, name);
-	if (dir === undefined) return undefined;
-
 	const manifest = readManifest(dir);
 	if (manifest === undefined) return undefined;
 	if (!runsOnRuntime(manifest)) return undefined;
@@ -144,23 +211,33 @@ function nativeEvidence(
 
 	// The modern prebuilt pattern: the parent is pure JavaScript and the binary lives in a
 	// platform-gated optional dependency, which is why scanning only the parent misses it.
-	for (const dependency of Object.keys(manifest.optionalDependencies ?? {})) {
-		const dependencyDir = findPackageDir(projectDir, dependency);
+	for (const dependency of Object.keys(optionalDependencies(manifest))) {
+		// Search from the package's own directory first so a nested or pnpm-linked copy wins
+		// over an unrelated one at the project root, then fall back to the project.
+		const dependencyDir =
+			findPackageDir(dir, dependency) ??
+			findPackageDir(projectDir, dependency);
 		if (dependencyDir === undefined) continue;
 		const dependencyManifest = readManifest(dependencyDir);
 		if (dependencyManifest === undefined) continue;
 		// The sibling built for *this* host is the one installed locally; its os/cpu fields
 		// are what mark the package as platform-gated at all.
 		const platformGated =
-			dependencyManifest.os !== undefined ||
-			dependencyManifest.cpu !== undefined;
+			stringList(dependencyManifest.os) !== undefined ||
+			stringList(dependencyManifest.cpu) !== undefined;
 		if (!platformGated) continue;
 		const file = findBinary(dependencyDir, SCAN_DEPTH);
 		if (file !== undefined)
 			return { kind: "platformDependency", dependency, file };
 	}
 
-	const script = manifest.scripts?.install ?? manifest.scripts?.postinstall;
+	const scripts = manifest.scripts;
+	const script =
+		typeof scripts?.install === "string"
+			? scripts.install
+			: typeof scripts?.postinstall === "string"
+				? scripts.postinstall
+				: undefined;
 	if (script !== undefined && GYP_PATTERN.test(script))
 		return { kind: "buildsFromSource", script };
 

--- a/packages/config-runtime/src/lib/native-detect.ts
+++ b/packages/config-runtime/src/lib/native-detect.ts
@@ -224,7 +224,8 @@ function nativeEvidence(
 		// are what mark the package as platform-gated at all.
 		const platformGated =
 			stringList(dependencyManifest.os) !== undefined ||
-			stringList(dependencyManifest.cpu) !== undefined;
+			stringList(dependencyManifest.cpu) !== undefined ||
+			stringList(dependencyManifest.libc) !== undefined;
 		if (!platformGated) continue;
 		const file = findBinary(dependencyDir, SCAN_DEPTH);
 		if (file !== undefined)

--- a/packages/config-runtime/src/lib/native-packages.test.ts
+++ b/packages/config-runtime/src/lib/native-packages.test.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
@@ -202,6 +208,108 @@ describe("traceNativePackages", () => {
 		expect(requested).toEqual(["exports-only@0.35.3"]);
 	});
 
+	/**
+	 * A package may export only a subpath — `exports: { "./native": … }` with no `.` — in
+	 * which case importing the root throws `ERR_PACKAGE_PATH_NOT_EXPORTED` and the trace
+	 * finds nothing. The whole package is still what gets installed.
+	 */
+	test("installs the package root but traces the specifier as authored", async () => {
+		let requested: string[] = [];
+		let traceEntry = "";
+
+		await traceNativePackages({
+			slug: "fn1",
+			packages: ["subpath-pkg/native"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd, specs) => {
+					requested = specs;
+					writeFileSync(
+						join(
+							mkdirp(join(cwd, "node_modules", "subpath-pkg")),
+							"package.json",
+						),
+						JSON.stringify({
+							name: "subpath-pkg",
+							version: "1.0.0",
+						}),
+					);
+				},
+				trace: async (base, entry) => {
+					traceEntry = readFileSync(join(base, entry), "utf8");
+					return ["node_modules/subpath-pkg/package.json"];
+				},
+			},
+		});
+
+		// npm is given the package; the trace entry imports what the user wrote.
+		expect(requested).toEqual(["subpath-pkg"]);
+		expect(traceEntry).toContain('import "subpath-pkg/native";');
+	});
+
+	test("installs a package once when named both bare and through a subpath", async () => {
+		let requested: string[] = [];
+		await traceNativePackages({
+			slug: "fn1",
+			packages: ["dual", "dual/sub"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd, specs) => {
+					requested = specs;
+					writeFileSync(
+						join(
+							mkdirp(join(cwd, "node_modules", "dual")),
+							"package.json",
+						),
+						JSON.stringify({ name: "dual", version: "1.0.0" }),
+					);
+				},
+				trace: async () => ["node_modules/dual/package.json"],
+			},
+		});
+		expect(requested).toEqual(["dual"]);
+	});
+
+	// The variant filter matches package directory names. A substring test over the whole
+	// path also deletes an ordinary file that happens to be named like a variant, which
+	// would drop a needed file from the archive and fail at invoke.
+	test("keeps a normal file whose name merely contains musl", async () => {
+		const names = await traceNativePackages({
+			slug: "fn1",
+			packages: ["plain-pkg"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd) => {
+					const pkg = mkdirp(join(cwd, "node_modules", "plain-pkg"));
+					writeFileSync(
+						join(pkg, "package.json"),
+						JSON.stringify({ name: "plain-pkg", version: "1.0.0" }),
+					);
+					writeFileSync(
+						join(mkdirp(join(pkg, "lib")), "musl-helper.js"),
+						"module.exports = 1;",
+					);
+					const musl = mkdirp(
+						join(cwd, "node_modules", "thing-musl-arm64"),
+					);
+					writeFileSync(
+						join(musl, "index.js"),
+						"module.exports = 2;",
+					);
+				},
+				trace: async () => [
+					"node_modules/plain-pkg/package.json",
+					"node_modules/plain-pkg/lib/musl-helper.js",
+					"node_modules/thing-musl-arm64/index.js",
+				],
+			},
+		}).then((r) => Object.keys(r.entries));
+
+		expect(names).toContain("node_modules/plain-pkg/lib/musl-helper.js");
+		// The actual musl variant package is still dropped.
+		expect(names).not.toContain("node_modules/thing-musl-arm64/index.js");
+	});
+
 	test("pins a scoped package the same way", async () => {
 		const pkg = join(dir, "node_modules", "@scope", "dep");
 		writeFileSync(
@@ -282,7 +390,7 @@ describe("traceNativePackages", () => {
 			"from the user's laptop",
 		);
 
-		const { entries } = await traceNativePackages({
+		const message = await traceNativePackages({
 			slug: "fn1",
 			packages: ["host-arch-dep"],
 			projectDir: dir,
@@ -299,18 +407,26 @@ describe("traceNativePackages", () => {
 						}),
 					);
 				},
-				// Report the user's file as traced. It is not in the staging tree, so it must be
-				// skipped rather than read from the project.
+				// Report the user's file as traced. Every traced path is resolved inside the
+				// staging tree, so this one is not found there — and is never fetched from the
+				// project instead.
 				trace: async () => [
 					"node_modules/host-arch-dep/package.json",
 					"node_modules/host-arch-dep/host-only.node",
 				],
 			},
-		});
+		}).then(
+			() => "unexpectedly succeeded",
+			(e: unknown) => (e as Error).message,
+		);
 
-		expect(Object.keys(entries)).toEqual([
-			"node_modules/host-arch-dep/package.json",
-		]);
+		// A traced file that is not in staging is an anomaly, and shipping an archive that is
+		// quietly missing a file fails at invoke — the failure this path exists to prevent.
+		// What matters here is that the host binary was not silently substituted for it.
+		expect(message).toMatch(/host-only\.node" disappeared/);
+		expect(readFileSync(join(userPkg, "host-only.node"), "utf8")).toBe(
+			"from the user's laptop",
+		);
 	});
 
 	/**

--- a/packages/config-runtime/src/lib/native-packages.test.ts
+++ b/packages/config-runtime/src/lib/native-packages.test.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import {
 	assertZipWithinLimits,
+	type NativeTraceDeps,
 	RUNTIME_TARGET,
 	RUNTIME_TARGET_LABEL,
 	traceNativePackages,
@@ -25,6 +26,19 @@ import {
  * reads it — so these reach the mirror the same way `pnpm install` does.
  */
 const liveTest = test;
+
+/** A 64-byte ELF file claiming the given `e_machine`. */
+function elfHeader(machine: number): Uint8Array {
+	const buf = Buffer.alloc(64);
+	buf.write("\x7fELF", 0, "binary");
+	buf[4] = 2; // 64-bit
+	buf[5] = 1; // little-endian
+	buf.writeUInt16LE(machine, 18);
+	return new Uint8Array(buf);
+}
+
+const AARCH64 = 0xb7;
+const X86_64 = 0x3e;
 
 let dir: string;
 beforeAll(() => {
@@ -155,7 +169,9 @@ describe("traceNativePackages", () => {
 						JSON.stringify({ name: "local-dep", version: "2.3.4" }),
 					);
 				},
-				trace: async () => ["node_modules/local-dep/package.json"],
+				trace: async () => ({
+					files: ["node_modules/local-dep/package.json"],
+				}),
 			},
 		});
 
@@ -201,7 +217,9 @@ describe("traceNativePackages", () => {
 						}),
 					);
 				},
-				trace: async () => ["node_modules/exports-only/package.json"],
+				trace: async () => ({
+					files: ["node_modules/exports-only/package.json"],
+				}),
 			},
 		});
 
@@ -237,7 +255,7 @@ describe("traceNativePackages", () => {
 				},
 				trace: async (base, entry) => {
 					traceEntry = readFileSync(join(base, entry), "utf8");
-					return ["node_modules/subpath-pkg/package.json"];
+					return { files: ["node_modules/subpath-pkg/package.json"] };
 				},
 			},
 		});
@@ -264,7 +282,9 @@ describe("traceNativePackages", () => {
 						JSON.stringify({ name: "dual", version: "1.0.0" }),
 					);
 				},
-				trace: async () => ["node_modules/dual/package.json"],
+				trace: async () => ({
+					files: ["node_modules/dual/package.json"],
+				}),
 			},
 		});
 		expect(requested).toEqual(["dual"]);
@@ -293,21 +313,196 @@ describe("traceNativePackages", () => {
 						join(cwd, "node_modules", "thing-musl-arm64"),
 					);
 					writeFileSync(
+						join(musl, "package.json"),
+						JSON.stringify({
+							name: "thing-musl-arm64",
+							version: "1.0.0",
+							libc: ["musl"],
+						}),
+					);
+					writeFileSync(
 						join(musl, "index.js"),
 						"module.exports = 2;",
 					);
 				},
-				trace: async () => [
-					"node_modules/plain-pkg/package.json",
-					"node_modules/plain-pkg/lib/musl-helper.js",
-					"node_modules/thing-musl-arm64/index.js",
-				],
+				trace: async () => ({
+					files: [
+						"node_modules/plain-pkg/package.json",
+						"node_modules/plain-pkg/lib/musl-helper.js",
+						"node_modules/thing-musl-arm64/index.js",
+					],
+				}),
 			},
 		}).then((r) => Object.keys(r.entries));
 
 		expect(names).toContain("node_modules/plain-pkg/lib/musl-helper.js");
 		// The actual musl variant package is still dropped.
 		expect(names).not.toContain("node_modules/thing-musl-arm64/index.js");
+	});
+
+	/**
+	 * The check that stops the whole point of this feature being defeated. A binary built for
+	 * the developer's machine deploys fine and then fails to `dlopen` at invoke, so a
+	 * non-AArch64 file has to be refused before it is archived.
+	 */
+	const stagingWith = (
+		files: Record<string, Uint8Array | string>,
+	): Partial<NativeTraceDeps> => ({
+		install: async (cwd) => {
+			writeFileSync(
+				join(
+					mkdirp(join(cwd, "node_modules", "bin-pkg")),
+					"package.json",
+				),
+				JSON.stringify({ name: "bin-pkg", version: "1.0.0" }),
+			);
+			for (const [relative, contents] of Object.entries(files)) {
+				const target = join(cwd, relative);
+				mkdirp(join(target, ".."));
+				writeFileSync(
+					target,
+					typeof contents === "string"
+						? contents
+						: Buffer.from(contents),
+				);
+			}
+		},
+		trace: async () => ({
+			files: [
+				"node_modules/bin-pkg/package.json",
+				...Object.keys(files).filter(
+					(f) => f !== "node_modules/bin-pkg/package.json",
+				),
+			],
+		}),
+	});
+
+	const stage = (files: Record<string, Uint8Array | string>) =>
+		traceNativePackages({
+			slug: "fn1",
+			packages: ["bin-pkg"],
+			projectDir: dir,
+			deps: stagingWith(files),
+		}).then(
+			() => "unexpectedly succeeded",
+			(e: unknown) => (e as Error).message,
+		);
+
+	test("rejects a binary built for another architecture", async () => {
+		const message = await stage({
+			"node_modules/bin-pkg/addon.node": elfHeader(X86_64),
+		});
+		expect(message).toMatch(/built for a different architecture/);
+		expect(message).toContain(RUNTIME_TARGET_LABEL);
+	});
+
+	test("rejects a binary that is not an ELF at all", async () => {
+		// A Mach-O magic number: what a macOS build of the same addon looks like.
+		const machO = new Uint8Array(64);
+		machO.set([0xcf, 0xfa, 0xed, 0xfe], 0);
+		const message = await stage({
+			"node_modules/bin-pkg/addon.node": machO,
+		});
+		expect(message).toMatch(/not a Linux binary/);
+	});
+
+	test("rejects a binary too short to carry an ELF header", async () => {
+		const message = await stage({
+			"node_modules/bin-pkg/addon.node": new Uint8Array(4),
+		});
+		expect(message).toMatch(/too short to be a valid binary/);
+	});
+
+	test("accepts an aarch64 ELF and archives it", async () => {
+		const { entries } = await traceNativePackages({
+			slug: "fn1",
+			packages: ["bin-pkg"],
+			projectDir: dir,
+			deps: stagingWith({
+				"node_modules/bin-pkg/addon.node": elfHeader(AARCH64),
+			}),
+		});
+		expect(Object.keys(entries)).toContain(
+			"node_modules/bin-pkg/addon.node",
+		);
+	});
+
+	// Identified from the manifest rather than the name, the way npm decides what to
+	// install, so a package that merely reads as a variant keeps its files.
+	test("drops a sibling whose manifest excludes the runtime libc", async () => {
+		const { entries } = await traceNativePackages({
+			slug: "fn1",
+			packages: ["parent-pkg"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd) => {
+					const parent = mkdirp(
+						join(cwd, "node_modules", "parent-pkg"),
+					);
+					writeFileSync(
+						join(parent, "package.json"),
+						JSON.stringify({
+							name: "parent-pkg",
+							version: "1.0.0",
+						}),
+					);
+					const musl = mkdirp(
+						join(cwd, "node_modules", "pkg-linuxmusl-arm64"),
+					);
+					writeFileSync(
+						join(musl, "package.json"),
+						JSON.stringify({
+							name: "pkg-linuxmusl-arm64",
+							version: "1.0.0",
+							os: ["linux"],
+							cpu: ["arm64"],
+							libc: ["musl"],
+						}),
+					);
+					writeFileSync(
+						join(musl, "index.js"),
+						"module.exports = 1;",
+					);
+				},
+				trace: async () => ({
+					files: [
+						"node_modules/parent-pkg/package.json",
+						"node_modules/pkg-linuxmusl-arm64/package.json",
+						"node_modules/pkg-linuxmusl-arm64/index.js",
+					],
+				}),
+			},
+		});
+		expect(Object.keys(entries)).toEqual([
+			"node_modules/parent-pkg/package.json",
+		]);
+	});
+
+	test("reports a dependency the tracer could not follow", async () => {
+		const { warnings } = await traceNativePackages({
+			slug: "fn1",
+			packages: ["parent-pkg"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd) => {
+					writeFileSync(
+						join(
+							mkdirp(join(cwd, "node_modules", "parent-pkg")),
+							"package.json",
+						),
+						JSON.stringify({
+							name: "parent-pkg",
+							version: "1.0.0",
+						}),
+					);
+				},
+				trace: async () => ({
+					files: ["node_modules/parent-pkg/package.json"],
+					warnings: ["Failed to resolve dependency ./missing.node"],
+				}),
+			},
+		});
+		expect(warnings.some((w) => w.includes("./missing.node"))).toBe(true);
 	});
 
 	test("pins a scoped package the same way", async () => {
@@ -336,7 +531,9 @@ describe("traceNativePackages", () => {
 						}),
 					);
 				},
-				trace: async () => ["node_modules/@scope/dep/package.json"],
+				trace: async () => ({
+					files: ["node_modules/@scope/dep/package.json"],
+				}),
 			},
 		});
 
@@ -369,9 +566,9 @@ describe("traceNativePackages", () => {
 						}),
 					);
 				},
-				trace: async () => [
-					"node_modules/not-installed-locally/package.json",
-				],
+				trace: async () => ({
+					files: ["node_modules/not-installed-locally/package.json"],
+				}),
 			},
 		});
 		expect(requested).toEqual(["not-installed-locally"]);
@@ -410,10 +607,12 @@ describe("traceNativePackages", () => {
 				// Report the user's file as traced. Every traced path is resolved inside the
 				// staging tree, so this one is not found there — and is never fetched from the
 				// project instead.
-				trace: async () => [
-					"node_modules/host-arch-dep/package.json",
-					"node_modules/host-arch-dep/host-only.node",
-				],
+				trace: async () => ({
+					files: [
+						"node_modules/host-arch-dep/package.json",
+						"node_modules/host-arch-dep/host-only.node",
+					],
+				}),
 			},
 		}).then(
 			() => "unexpectedly succeeded",

--- a/packages/config-runtime/src/lib/native-packages.test.ts
+++ b/packages/config-runtime/src/lib/native-packages.test.ts
@@ -478,33 +478,6 @@ describe("traceNativePackages", () => {
 		]);
 	});
 
-	test("reports a dependency the tracer could not follow", async () => {
-		const { warnings } = await traceNativePackages({
-			slug: "fn1",
-			packages: ["parent-pkg"],
-			projectDir: dir,
-			deps: {
-				install: async (cwd) => {
-					writeFileSync(
-						join(
-							mkdirp(join(cwd, "node_modules", "parent-pkg")),
-							"package.json",
-						),
-						JSON.stringify({
-							name: "parent-pkg",
-							version: "1.0.0",
-						}),
-					);
-				},
-				trace: async () => ({
-					files: ["node_modules/parent-pkg/package.json"],
-					warnings: ["Failed to resolve dependency ./missing.node"],
-				}),
-			},
-		});
-		expect(warnings.some((w) => w.includes("./missing.node"))).toBe(true);
-	});
-
 	test("pins a scoped package the same way", async () => {
 		const pkg = join(dir, "node_modules", "@scope", "dep");
 		writeFileSync(

--- a/packages/config-runtime/src/lib/native-packages.test.ts
+++ b/packages/config-runtime/src/lib/native-packages.test.ts
@@ -1,0 +1,399 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import {
+	assertZipWithinLimits,
+	RUNTIME_TARGET,
+	RUNTIME_TARGET_LABEL,
+	traceNativePackages,
+} from "./native-packages.js";
+
+/**
+ * These cases shell out to `npm` and reach a registry. They run by default rather than
+ * behind an opt-in flag: the whole feature is "install the right binary for a platform this
+ * machine is not", and a suite that stubs the install cannot tell whether that works.
+ *
+ * The protected runners have no public egress, but CI's `prepare` action writes an `~/.npmrc`
+ * pointing at the Databricks JFrog mirror before anything installs, and a spawned `npm`
+ * reads it — so these reach the mirror the same way `pnpm install` does.
+ */
+const liveTest = test;
+
+let dir: string;
+beforeAll(() => {
+	dir = mkdtempSync(join(tmpdir(), "neon-native-"));
+});
+afterAll(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("runtime target", () => {
+	// The triple that decides which prebuilt binaries are installed. Wrong values here ship
+	// binaries that cannot load, so they are asserted rather than left implicit.
+	test("is linux-arm64 with glibc", () => {
+		expect(RUNTIME_TARGET).toEqual({
+			cpu: "arm64",
+			os: "linux",
+			libc: "glibc",
+		});
+		expect(RUNTIME_TARGET_LABEL).toBe("linux-arm64 (glibc)");
+	});
+});
+
+describe("assertZipWithinLimits", () => {
+	test("accepts an archive at the limit", () => {
+		const zip = new Uint8Array(1024);
+		expect(() =>
+			assertZipWithinLimits(
+				"fn1",
+				zip,
+				{ "index.mjs": zip },
+				{
+					maxZipBytes: 1024,
+					maxTotalBytes: 1024,
+					maxEntries: 10,
+				},
+			),
+		).not.toThrow();
+	});
+
+	test("names the largest contributors when over the limit", () => {
+		const entries = {
+			"index.mjs": new Uint8Array(10),
+			"node_modules/big/lib/thing.so.1": new Uint8Array(4096),
+			"node_modules/small/index.js": new Uint8Array(100),
+		};
+		const zip = new Uint8Array(5000);
+		const error = (() => {
+			try {
+				assertZipWithinLimits("fn1", zip, entries, {
+					maxZipBytes: 1024,
+					maxTotalBytes: 1 << 30,
+					maxEntries: 100,
+				});
+			} catch (e) {
+				return e as Error;
+			}
+			throw new Error("expected a rejection");
+		})();
+
+		expect(error.message).toContain("the limit is 0.0 MiB");
+		// Largest first, so the message points at what to remove.
+		expect(error.message).toContain("node_modules/big/lib/thing.so.1");
+		expect(error.message.indexOf("node_modules/big")).toBeLessThan(
+			error.message.indexOf("node_modules/small"),
+		);
+	});
+
+	// The caller is expected to pass the build service's limits rather than rely on a default
+	// baked in here, so a change on the service side is one argument, not a code edit.
+	test("honours caller-supplied limits", () => {
+		const zip = new Uint8Array(2048);
+		expect(() =>
+			assertZipWithinLimits(
+				"fn1",
+				zip,
+				{ "index.mjs": zip },
+				{
+					maxZipBytes: 4096,
+					maxTotalBytes: 1 << 30,
+					maxEntries: 10,
+				},
+			),
+		).not.toThrow();
+	});
+});
+
+describe("traceNativePackages", () => {
+	// The real installer, with an empty PATH so `npm` cannot be found. The packaged CLI ships
+	// without npm inside it, so this is a reachable state and the message has to say what to
+	// do about it rather than surfacing a bare ENOENT.
+	test("reports an actionable error when npm is not on PATH", async () => {
+		const path = process.env.PATH;
+		process.env.PATH = join(dir, "empty-path");
+		try {
+			await expect(
+				traceNativePackages({
+					slug: "fn1",
+					packages: ["sharp"],
+					projectDir: dir,
+				}),
+			).rejects.toThrow(/requires "npm" on PATH/);
+		} finally {
+			process.env.PATH = path;
+		}
+	});
+
+	test("pins the version resolved in the user's own project", async () => {
+		// A package installed locally, standing in for the user's dependency tree.
+		const pkg = join(dir, "node_modules", "local-dep");
+		writeFileSync(
+			join(mkdirp(pkg), "package.json"),
+			JSON.stringify({ name: "local-dep", version: "2.3.4" }),
+		);
+
+		let requested: string[] = [];
+		await traceNativePackages({
+			slug: "fn1",
+			packages: ["local-dep"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd, specs) => {
+					requested = specs;
+					writeFileSync(
+						join(
+							mkdirp(join(cwd, "node_modules", "local-dep")),
+							"package.json",
+						),
+						JSON.stringify({ name: "local-dep", version: "2.3.4" }),
+					);
+				},
+				trace: async () => ["node_modules/local-dep/package.json"],
+			},
+		});
+
+		// The user's resolution, not the registry's latest — so the deploy stages the version
+		// they tested against without reading the binaries beside it.
+		expect(requested).toEqual(["local-dep@2.3.4"]);
+	});
+
+	/**
+	 * The shape that broke this in practice. `sharp` publishes `exports: { "." : … }` with no
+	 * `./package.json`, so a `require.resolve("sharp/package.json")` lookup throws
+	 * `ERR_PACKAGE_PATH_NOT_EXPORTED` even though the package is installed — and the deploy
+	 * silently staged the registry's latest instead of the user's version. Reading the
+	 * manifest off disk is what makes the canonical package work.
+	 */
+	test("pins a package whose exports map hides its package.json", async () => {
+		const pkg = join(dir, "node_modules", "exports-only");
+		writeFileSync(
+			join(mkdirp(pkg), "package.json"),
+			JSON.stringify({
+				name: "exports-only",
+				version: "0.35.3",
+				exports: { ".": "./index.js" },
+			}),
+		);
+
+		let requested: string[] = [];
+		await traceNativePackages({
+			slug: "fn1",
+			packages: ["exports-only"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd, specs) => {
+					requested = specs;
+					writeFileSync(
+						join(
+							mkdirp(join(cwd, "node_modules", "exports-only")),
+							"package.json",
+						),
+						JSON.stringify({
+							name: "exports-only",
+							version: "0.35.3",
+						}),
+					);
+				},
+				trace: async () => ["node_modules/exports-only/package.json"],
+			},
+		});
+
+		expect(requested).toEqual(["exports-only@0.35.3"]);
+	});
+
+	test("pins a scoped package the same way", async () => {
+		const pkg = join(dir, "node_modules", "@scope", "dep");
+		writeFileSync(
+			join(mkdirp(pkg), "package.json"),
+			JSON.stringify({ name: "@scope/dep", version: "1.2.3" }),
+		);
+
+		let requested: string[] = [];
+		await traceNativePackages({
+			slug: "fn1",
+			packages: ["@scope/dep"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd, specs) => {
+					requested = specs;
+					writeFileSync(
+						join(
+							mkdirp(join(cwd, "node_modules", "@scope", "dep")),
+							"package.json",
+						),
+						JSON.stringify({
+							name: "@scope/dep",
+							version: "1.2.3",
+						}),
+					);
+				},
+				trace: async () => ["node_modules/@scope/dep/package.json"],
+			},
+		});
+
+		expect(requested).toEqual(["@scope/dep@1.2.3"]);
+	});
+
+	test("falls back to an unpinned spec when the package is not installed locally", async () => {
+		let requested: string[] = [];
+		await traceNativePackages({
+			slug: "fn1",
+			packages: ["not-installed-locally"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd, specs) => {
+					requested = specs;
+					writeFileSync(
+						join(
+							mkdirp(
+								join(
+									cwd,
+									"node_modules",
+									"not-installed-locally",
+								),
+							),
+							"package.json",
+						),
+						JSON.stringify({
+							name: "not-installed-locally",
+							version: "1.0.0",
+						}),
+					);
+				},
+				trace: async () => [
+					"node_modules/not-installed-locally/package.json",
+				],
+			},
+		});
+		expect(requested).toEqual(["not-installed-locally"]);
+	});
+
+	test("never reads the user's node_modules for the shipped files", async () => {
+		// A file that exists only in the user's tree. If it reaches the archive, the deploy is
+		// shipping host-architecture binaries — the failure mode this design exists to avoid.
+		const userPkg = join(dir, "node_modules", "host-arch-dep");
+		writeFileSync(
+			join(mkdirp(userPkg), "package.json"),
+			JSON.stringify({ name: "host-arch-dep", version: "1.0.0" }),
+		);
+		writeFileSync(
+			join(userPkg, "host-only.node"),
+			"from the user's laptop",
+		);
+
+		const { entries } = await traceNativePackages({
+			slug: "fn1",
+			packages: ["host-arch-dep"],
+			projectDir: dir,
+			deps: {
+				install: async (cwd) => {
+					writeFileSync(
+						join(
+							mkdirp(join(cwd, "node_modules", "host-arch-dep")),
+							"package.json",
+						),
+						JSON.stringify({
+							name: "host-arch-dep",
+							version: "1.0.0",
+						}),
+					);
+				},
+				// Report the user's file as traced. It is not in the staging tree, so it must be
+				// skipped rather than read from the project.
+				trace: async () => [
+					"node_modules/host-arch-dep/package.json",
+					"node_modules/host-arch-dep/host-only.node",
+				],
+			},
+		});
+
+		expect(Object.keys(entries)).toEqual([
+			"node_modules/host-arch-dep/package.json",
+		]);
+	});
+
+	/**
+	 * The real thing: install `sharp` for the runtime target and check what would ship.
+	 *
+	 * A test that merely imports sharp successfully proves nothing — its loader falls through
+	 * several tiers silently, so on an x64 host it can report success having loaded the
+	 * WebAssembly fallback. These assert the *binary* that would be shipped: the linux-arm64
+	 * package is present, it is an aarch64 ELF, its libvips sibling ships too, and the wasm
+	 * and musl variants are gone.
+	 */
+	liveTest(
+		"installs and traces a real sharp for the runtime target",
+		async () => {
+			const { entries } = await traceNativePackages({
+				slug: "resize",
+				packages: ["sharp"],
+				projectDir: dir,
+				limits: {
+					maxZipBytes: 64 * 1024 * 1024,
+					maxTotalBytes: 256 * 1024 * 1024,
+					maxEntries: 16384,
+				},
+			});
+			const names = Object.keys(entries);
+
+			// The addon for the runtime, and the shared library it loads relative to itself.
+			const addon = names.find((n) =>
+				/@img\/sharp-linux-arm64\/lib\/.*\.node$/.test(n),
+			);
+			expect(addon).toBeDefined();
+			const libvips = names.find((n) =>
+				/@img\/sharp-libvips-linux-arm64\/lib\/libvips-cpp\.so/.test(n),
+			);
+			expect(libvips).toBeDefined();
+
+			// aarch64 ELF, not the host's x64 build.
+			const header = Buffer.from(entries[addon as string]);
+			expect(header.subarray(0, 4).toString("binary")).toBe("\x7fELF");
+			expect(header.readUInt16LE(18)).toBe(0xb7);
+
+			// The tiers sharp would otherwise fall through to, so a broken native path fails
+			// loudly instead of quietly running slower code.
+			expect(names.filter((n) => n.includes("wasm32"))).toEqual([]);
+			expect(names.filter((n) => n.includes("musl"))).toEqual([]);
+
+			// The layout the dynamic linker walks: the addon and its library are siblings under
+			// node_modules/@img, not flattened together.
+			expect(addon).toMatch(
+				/^node_modules\/@img\/sharp-linux-arm64\/lib\//,
+			);
+			expect(libvips).toMatch(
+				/^node_modules\/@img\/sharp-libvips-linux-arm64\/lib\//,
+			);
+		},
+		180_000,
+	);
+
+	// A package that declares a platform the runtime is not. npm rejects it as EBADPLATFORM
+	// with a message comparing against the *host*, which reads as though the wrong thing was
+	// asked for; the deploy has to say what actually happened.
+	liveTest(
+		"fails the deploy when a package has no build for the runtime target",
+		async () => {
+			const message = await traceNativePackages({
+				slug: "fn1",
+				packages: ["@img/sharp-win32-x64"],
+				projectDir: dir,
+			}).then(
+				() => "unexpectedly succeeded",
+				(e: unknown) => (e as Error).message,
+			);
+
+			expect(message).toMatch(
+				/has no build for the Functions runtime \(linux-arm64 \(glibc\)\)/,
+			);
+			expect(message).toContain("sharp does");
+		},
+		180_000,
+	);
+});
+
+function mkdirp(path: string): string {
+	mkdirSync(path, { recursive: true });
+	return path;
+}

--- a/packages/config-runtime/src/lib/native-packages.ts
+++ b/packages/config-runtime/src/lib/native-packages.ts
@@ -8,7 +8,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
-import { ErrorCode, PlatformError } from "@neon/config";
+import { ErrorCode, externalPackageRoot, PlatformError } from "@neon/config";
 import { installedPackageVersion } from "./resolve-package.js";
 
 /**
@@ -48,8 +48,26 @@ const BINARY_PATTERN = /\.(node|so)(\.\d+)*$/;
  * Shipping the wasm build is actively harmful: it would let a broken native path succeed
  * quietly on a slower code path instead of failing loudly.
  */
-const EXCLUDED_VARIANT_PATTERN =
-	/(^|[/\\])(node_modules[/\\])?@?[^/\\]*(wasm32|musl)/;
+
+/**
+ * Whether a traced path belongs to an excluded sibling variant.
+ *
+ * Matched against **package directory names only**, never the whole path: a substring test
+ * over the full path also deletes an ordinary file that happens to be called something like
+ * `musl-helper.js`, which would drop a needed file from the archive and fail at invoke.
+ */
+function isExcludedVariant(path: string): boolean {
+	const segments = path.split(/[/\\]/);
+	return segments.some(
+		(segment, index) =>
+			// Only a segment that names a package: the one directly after a `node_modules`,
+			// or the one after that when the first is a scope.
+			(segments[index - 1] === "node_modules" ||
+				(segments[index - 2] === "node_modules" &&
+					segments[index - 1]?.startsWith("@"))) &&
+			(segment.includes("wasm32") || segment.includes("musl")),
+	);
+}
 
 /** How long the staging install may take before the deploy gives up on it. */
 const INSTALL_TIMEOUT_MS = 120_000;
@@ -139,8 +157,12 @@ export async function traceNativePackages(options: {
 	const limits = options.limits ?? DEFAULT_ARCHIVE_LIMITS;
 	const deps: NativeTraceDeps = { ...defaultDeps, ...options.deps };
 
+	// `packages` are the specifiers as authored, which is what the trace entry must import.
+	// Installing and verifying work on whole packages, so those use the roots.
+	const roots = [...new Set(packages.map(externalPackageRoot))];
+
 	const warnings: string[] = [];
-	const specs = packages.map((pkg) => {
+	const specs = roots.map((pkg) => {
 		const version = deps.installedVersion(projectDir, pkg);
 		// Pin to the user's own resolution when we can see it. Without it we install the
 		// registry's latest, which is a different package than the one they tested — said
@@ -165,9 +187,11 @@ export async function traceNativePackages(options: {
 			`${JSON.stringify({ name: "neon-fn-native-staging", private: true }, null, 2)}\n`,
 		);
 		await deps.install(staging, specs);
-		verifyInstalled(slug, packages, staging);
+		verifyInstalled(slug, roots, staging);
 
-		// One entry importing every declared package, so a single trace covers them all.
+		// One entry importing every declared specifier, so a single trace covers them all.
+		// The authored specifier rather than the root: a package whose `exports` map lists
+		// only a subpath cannot be imported by its root at all.
 		writeFileSync(
 			join(staging, "trace-entry.mjs"),
 			packages.map((pkg) => `import ${JSON.stringify(pkg)};`).join("\n"),
@@ -213,7 +237,7 @@ function verifyInstalled(
 /**
  * Reduce a trace to the files worth archiving: everything under `node_modules`, minus the
  * sibling platform builds that cannot run on the runtime (see
- * {@link EXCLUDED_VARIANT_PATTERN}). The trace entry itself is dropped — the real entry is
+ * {@link isExcludedVariant}). The trace entry itself is dropped — the real entry is
  * the esbuild bundle.
  */
 function selectArchiveFiles(slug: string, traced: readonly string[]): string[] {
@@ -223,7 +247,7 @@ function selectArchiveFiles(slug: string, traced: readonly string[]): string[] {
 				path.startsWith(`node_modules${sep}`) ||
 				path.startsWith("node_modules/"),
 		)
-		.filter((path) => !EXCLUDED_VARIANT_PATTERN.test(path))
+		.filter((path) => !isExcludedVariant(path))
 		.map((path) => path.split(sep).join("/"))
 		.sort();
 
@@ -262,7 +286,15 @@ function readArchiveFiles(
 		// lstat, not stat: stat follows the link and would report the target's type, so a
 		// symlink would pass this check silently.
 		const stat = lstatSync(absolute, { throwIfNoEntry: false });
-		if (stat === undefined) continue;
+		// The tracer said this file is needed and it is not there. Skipping it would ship an
+		// archive that is quietly missing something and fail at invoke, which is the failure
+		// this whole path exists to prevent.
+		if (stat === undefined) {
+			throw invalid(
+				`Function "${slug}": traced file "${relative}" disappeared before it could be ` +
+					`read. This is a bug in the deploy — please report it.`,
+			);
+		}
 		if (stat.isSymbolicLink()) {
 			throw invalid(
 				`Function "${slug}" would ship a symbolic link, which the build does not ` +

--- a/packages/config-runtime/src/lib/native-packages.ts
+++ b/packages/config-runtime/src/lib/native-packages.ts
@@ -1,0 +1,475 @@
+import { spawn } from "node:child_process";
+import {
+	lstatSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { ErrorCode, PlatformError } from "@neon/config";
+import { installedPackageVersion } from "./resolve-package.js";
+
+/**
+ * The architecture, OS and libc a Neon Function runs on. Native packages are installed for
+ * this triple rather than for the machine running the deploy, which is usually a macOS or
+ * linux-x64 laptop.
+ */
+export const RUNTIME_TARGET = {
+	cpu: "arm64",
+	os: "linux",
+	libc: "glibc",
+} as const;
+
+/** Human-readable form of {@link RUNTIME_TARGET}, for error messages. */
+export const RUNTIME_TARGET_LABEL = `${RUNTIME_TARGET.os}-${RUNTIME_TARGET.cpu} (${RUNTIME_TARGET.libc})`;
+
+/**
+ * `e_machine` for AArch64 in an ELF header, and the offsets needed to read it. Used to
+ * verify that a binary about to be shipped really is built for the runtime, so a wrong-arch
+ * file fails the deploy instead of failing `dlopen` at invoke.
+ */
+const ELF = {
+	magic: "\x7fELF",
+	machineOffset: 18,
+	headerBytes: 20,
+	aarch64: 0xb7,
+} as const;
+
+/** Extensions treated as compiled artifacts, whose architecture is worth verifying. */
+const BINARY_PATTERN = /\.(node|so)(\.\d+)*$/;
+
+/**
+ * Sibling platform builds a package may install alongside the one we want. `sharp` ships a
+ * WebAssembly fallback its loader silently drops to when the native binary is missing, and
+ * a musl variant for Alpine. Neither can be reached on the runtime (it is Debian, and the
+ * native build is present), and together they are most of the archive, so they are dropped.
+ * Shipping the wasm build is actively harmful: it would let a broken native path succeed
+ * quietly on a slower code path instead of failing loudly.
+ */
+const EXCLUDED_VARIANT_PATTERN =
+	/(^|[/\\])(node_modules[/\\])?@?[^/\\]*(wasm32|musl)/;
+
+/** How long the staging install may take before the deploy gives up on it. */
+const INSTALL_TIMEOUT_MS = 120_000;
+
+/**
+ * Size ceilings the deploy must respect. The build service rejects an archive over these,
+ * with an error that surfaces long after the CLI has exited, so they are checked here where
+ * the message can name the files responsible.
+ *
+ * These mirror the service's limits rather than defining them. Passing them in lets a caller
+ * track a change on the service side without editing this module.
+ */
+export type ArchiveLimits = {
+	/** Compressed archive bytes — the ZIP that is uploaded. */
+	maxZipBytes: number;
+	/** Total uncompressed bytes across every archive entry. */
+	maxTotalBytes: number;
+	/** Number of archive entries. */
+	maxEntries: number;
+};
+
+export const DEFAULT_ARCHIVE_LIMITS: ArchiveLimits = {
+	maxZipBytes: 10 * 1024 * 1024,
+	maxTotalBytes: 64 * 1024 * 1024,
+	maxEntries: 4096,
+};
+
+/** Injectable side effects, so the tracing logic is testable without a registry or npm. */
+export type NativeTraceDeps = {
+	/** Install `specs` for the runtime target into `cwd`. Resolves on success. */
+	install: (cwd: string, specs: string[]) => Promise<void>;
+	/** Trace `entry` within `base`, returning archive-relative file paths. */
+	trace: (base: string, entry: string) => Promise<string[]>;
+	/** Version of `pkg` as resolved in the user's project, or undefined if not installed. */
+	installedVersion: (projectDir: string, pkg: string) => string | undefined;
+};
+
+/** Files to place in the archive under `node_modules/`, keyed by archive-relative path. */
+export type NativeTraceResult = {
+	entries: Record<string, Uint8Array>;
+	/**
+	 * Advisory findings from the staging run — currently a package whose version could not be
+	 * read from the project, which means the registry's latest was staged instead. The caller
+	 * must surface these; a silently different version than the one tested is exactly the
+	 * kind of thing that shows up as an unreproducible production bug.
+	 */
+	warnings: string[];
+};
+
+const bytes = (n: number): string => `${(n / (1024 * 1024)).toFixed(1)} MiB`;
+
+const invalid = (message: string, cause?: unknown): PlatformError =>
+	new PlatformError(
+		ErrorCode.InvalidConfig,
+		message,
+		cause === undefined ? undefined : { cause },
+	);
+
+/**
+ * Collect the files the declared native packages need, ready to be merged into the archive.
+ *
+ * Three steps, in this order for reasons that are not interchangeable:
+ *
+ * 1. **Install for the runtime target into a throwaway directory.** The user's own
+ *    `node_modules` is never read for these files. Its binaries are built for their machine,
+ *    and a cross-platform install is not sticky — a later plain `npm install` re-resolves
+ *    optional dependencies for the host and replaces the target's packages with the host's.
+ *    Only the resolved *version* is taken from the user's tree, so the deploy honours their
+ *    lockfile without trusting the binaries next to it.
+ * 2. **Trace the installed tree.** The file set cannot be discovered by asking Node:
+ *    `@img/sharp-linux-arm64` exports only `./sharp.node` and `./package`, with no `.` and no
+ *    wildcard, so its directory is unreachable through the resolver. A tracer that follows
+ *    `createRequire` is required — which is also why esbuild cannot see these files, and why
+ *    `sharp` bundles cleanly today and then fails at invoke.
+ * 3. **Copy the traced files, preserving the `node_modules` layout.** A `.node` addon locates
+ *    its sibling shared libraries by a path relative to its own directory, so flattening the
+ *    tree breaks loading even though every file is present.
+ */
+export async function traceNativePackages(options: {
+	slug: string;
+	packages: readonly string[];
+	projectDir: string;
+	limits?: ArchiveLimits;
+	deps?: Partial<NativeTraceDeps>;
+}): Promise<NativeTraceResult> {
+	const { slug, packages, projectDir } = options;
+	const limits = options.limits ?? DEFAULT_ARCHIVE_LIMITS;
+	const deps: NativeTraceDeps = { ...defaultDeps, ...options.deps };
+
+	const warnings: string[] = [];
+	const specs = packages.map((pkg) => {
+		const version = deps.installedVersion(projectDir, pkg);
+		// Pin to the user's own resolution when we can see it. Without it we install the
+		// registry's latest, which is a different package than the one they tested — said
+		// out loud rather than left to be discovered from a deployed archive.
+		if (version === undefined) {
+			warnings.push(
+				`Could not read an installed version of "${pkg}" from this project, so the ` +
+					`deploy staged whatever the registry resolves as latest. That may not be the ` +
+					`version you tested against. Install "${pkg}" locally to pin it.`,
+			);
+			return pkg;
+		}
+		return `${pkg}@${version}`;
+	});
+
+	const staging = mkdtempSync(join(tmpdir(), "neon-fn-native-"));
+	try {
+		// A manifest whose name matches no dependency, and no lockfile, so npm treats the
+		// directory as a fresh project and resolves the declared specs on their own.
+		writeFileSync(
+			join(staging, "package.json"),
+			`${JSON.stringify({ name: "neon-fn-native-staging", private: true }, null, 2)}\n`,
+		);
+		await deps.install(staging, specs);
+		verifyInstalled(slug, packages, staging);
+
+		// One entry importing every declared package, so a single trace covers them all.
+		writeFileSync(
+			join(staging, "trace-entry.mjs"),
+			packages.map((pkg) => `import ${JSON.stringify(pkg)};`).join("\n"),
+		);
+
+		const traced = await deps.trace(staging, "trace-entry.mjs");
+		const files = selectArchiveFiles(slug, traced);
+		const entries = readArchiveFiles(slug, staging, files);
+		enforceLimits(slug, entries, limits);
+		return { entries, warnings };
+	} finally {
+		rmSync(staging, { recursive: true, force: true });
+	}
+}
+
+/**
+ * Fail when a declared package produced no build for the runtime target. npm omits a
+ * platform-specific optional dependency silently when none matches, so "installed" does not
+ * imply "usable here" — without this check the archive would ship a package whose binary is
+ * simply absent, and the failure would surface at invoke.
+ */
+function verifyInstalled(
+	slug: string,
+	packages: readonly string[],
+	staging: string,
+): void {
+	for (const pkg of packages) {
+		const manifest = join(staging, "node_modules", pkg, "package.json");
+		if (lstatSync(manifest, { throwIfNoEntry: false }) === undefined) {
+			throw invalid(
+				`Function "${slug}" declares "${pkg}" in externalPackages, but it did not ` +
+					`install for the Functions runtime (${RUNTIME_TARGET_LABEL}). Either the ` +
+					`package does not publish a build for that platform, or it compiles from ` +
+					`source at install time, which the deploy cannot do. Check that it lists a ` +
+					`${RUNTIME_TARGET.os}-${RUNTIME_TARGET.cpu} build among its optional ` +
+					`dependencies. If this function never reaches "${pkg}", exclude it instead: ` +
+					`{ name: "${pkg}", includeFiles: false }.`,
+			);
+		}
+	}
+}
+
+/**
+ * Reduce a trace to the files worth archiving: everything under `node_modules`, minus the
+ * sibling platform builds that cannot run on the runtime (see
+ * {@link EXCLUDED_VARIANT_PATTERN}). The trace entry itself is dropped — the real entry is
+ * the esbuild bundle.
+ */
+function selectArchiveFiles(slug: string, traced: readonly string[]): string[] {
+	const files = traced
+		.filter(
+			(path) =>
+				path.startsWith(`node_modules${sep}`) ||
+				path.startsWith("node_modules/"),
+		)
+		.filter((path) => !EXCLUDED_VARIANT_PATTERN.test(path))
+		.map((path) => path.split(sep).join("/"))
+		.sort();
+
+	if (files.length === 0) {
+		throw invalid(
+			`Function "${slug}" stages external packages, but tracing the installed packages ` +
+				`found no files to ship. This is a bug in the deploy — please report it.`,
+		);
+	}
+	return files;
+}
+
+/**
+ * Read the traced files, checking each one is shippable as it goes.
+ *
+ * Two rejections here, both cheaper to hit now than after upload. A symlink cannot be
+ * represented in the archive at all, and a compiled binary built for the wrong architecture
+ * would deploy fine and then fail to load — which is the exact failure this whole option
+ * exists to prevent, so it must not be reintroduced by a stale or hand-patched tree.
+ */
+function readArchiveFiles(
+	slug: string,
+	staging: string,
+	files: readonly string[],
+): Record<string, Uint8Array> {
+	const entries: Record<string, Uint8Array> = {};
+	for (const relative of files) {
+		const absolute = resolve(staging, relative);
+		// Defence in depth: a traced path must stay inside the staging tree.
+		if (!absolute.startsWith(`${resolve(staging)}${sep}`)) {
+			throw invalid(
+				`Function "${slug}": traced file "${relative}" resolves outside the staging ` +
+					`directory. This is a bug in the deploy — please report it.`,
+			);
+		}
+		// lstat, not stat: stat follows the link and would report the target's type, so a
+		// symlink would pass this check silently.
+		const stat = lstatSync(absolute, { throwIfNoEntry: false });
+		if (stat === undefined) continue;
+		if (stat.isSymbolicLink()) {
+			throw invalid(
+				`Function "${slug}" would ship a symbolic link, which the build does not ` +
+					`support: ${relative}. This is a bug in the deploy — please report it.`,
+			);
+		}
+		if (!stat.isFile()) continue;
+
+		const contents = readFileSync(absolute);
+		if (BINARY_PATTERN.test(relative))
+			verifyArchitecture(slug, relative, contents);
+		entries[relative] = new Uint8Array(contents);
+	}
+	return entries;
+}
+
+/**
+ * Reject a compiled artifact that is not built for the runtime. Only ELF AArch64 can load
+ * there, so anything else — a Mach-O from the user's laptop, an x64 ELF from a stale
+ * install — is a deploy-time error rather than an invoke-time one.
+ */
+function verifyArchitecture(
+	slug: string,
+	relative: string,
+	contents: Buffer,
+): void {
+	if (contents.length < ELF.headerBytes) return;
+	const isElf = contents.subarray(0, 4).toString("binary") === ELF.magic;
+	if (!isElf) {
+		throw invalid(
+			`Function "${slug}" would ship "${relative}", which is not a Linux binary. ` +
+				`The Functions runtime is ${RUNTIME_TARGET_LABEL}, so a binary built for ` +
+				`another platform cannot load there. A package that compiles from source at ` +
+				`install time produces a binary for the machine that installed it and cannot ` +
+				`be cross-installed by the deploy.`,
+		);
+	}
+	const machine = contents.readUInt16LE(ELF.machineOffset);
+	if (machine !== ELF.aarch64) {
+		throw invalid(
+			`Function "${slug}" would ship "${relative}", which is built for a different ` +
+				`architecture (ELF machine 0x${machine.toString(16)}). The Functions runtime is ` +
+				`${RUNTIME_TARGET_LABEL}.`,
+		);
+	}
+}
+
+/**
+ * Check the archive against the build service's limits, naming the largest contributors. The
+ * compressed size is not known until the archive is zipped, so only the counts and
+ * uncompressed total are checked here; {@link assertZipWithinLimits} covers the rest.
+ */
+function enforceLimits(
+	slug: string,
+	entries: Record<string, Uint8Array>,
+	limits: ArchiveLimits,
+): void {
+	const names = Object.keys(entries);
+	// +1 for index.mjs, which the caller adds after this runs.
+	const count = names.length + 1;
+	if (count > limits.maxEntries) {
+		throw invalid(
+			`Function "${slug}" archive has ${count} files; the limit is ${limits.maxEntries}. ` +
+				`Native packages bring their whole file tree — ship fewer of them, or split the ` +
+				`work across functions.`,
+		);
+	}
+	const total = names.reduce((sum, name) => sum + entries[name].length, 0);
+	if (total > limits.maxTotalBytes) {
+		throw invalid(
+			`Function "${slug}" archive is ${bytes(total)} uncompressed; the limit is ` +
+				`${bytes(limits.maxTotalBytes)}.\n\n${describeLargest(entries)}`,
+		);
+	}
+}
+
+/**
+ * Check the compressed archive, which is only measurable once it exists. Separate from
+ * {@link enforceLimits} for that reason, and exported so the bundler can call it on the
+ * finished ZIP.
+ */
+export function assertZipWithinLimits(
+	slug: string,
+	zip: Uint8Array,
+	entries: Record<string, Uint8Array>,
+	limits: ArchiveLimits = DEFAULT_ARCHIVE_LIMITS,
+): void {
+	if (zip.length <= limits.maxZipBytes) return;
+	throw invalid(
+		`Function "${slug}" archive is ${bytes(zip.length)} compressed; the limit is ` +
+			`${bytes(limits.maxZipBytes)}.\n\n${describeLargest(entries)}`,
+	);
+}
+
+/** The handful of files worth naming when an archive is too big. */
+function describeLargest(entries: Record<string, Uint8Array>): string {
+	const largest = Object.entries(entries)
+		.sort(([, a], [, b]) => b.length - a.length)
+		.slice(0, 4)
+		.map(([name, data]) => `  ${bytes(data.length).padStart(9)}  ${name}`);
+	return `Largest contributors:\n${largest.join("\n")}\n\nNative binaries are large. Ship fewer of them, or split the work across functions.`;
+}
+
+const defaultDeps: NativeTraceDeps = {
+	install: (cwd, specs) => runNpmInstall(cwd, specs),
+	trace: async (base, entry) => {
+		const { nodeFileTrace } = await loadNft();
+		// The entry is passed absolute: nft resolves a relative one against the process cwd,
+		// not against `base`. `fileList` still comes back relative to `base`, which is what
+		// the archive keys need.
+		const result = await nodeFileTrace([join(base, entry)], { base });
+		return [...result.fileList];
+	},
+	installedVersion: (projectDir, pkg) =>
+		installedPackageVersion(projectDir, pkg),
+};
+
+/**
+ * Install into the staging directory by shelling out to whatever `npm` is on `PATH`, rather
+ * than importing it. The CLI also ships as a standalone binary with no npm and no
+ * `node_modules` inside it, so a `require()` would be unresolvable there; a subprocess works
+ * in both forms.
+ *
+ * `--cpu/--os/--libc` are what select the runtime's builds instead of the host's.
+ * `--ignore-scripts` matters for more than speed: an install script would compile for the
+ * host architecture and overwrite the prebuilt binary we are here to collect.
+ */
+async function runNpmInstall(cwd: string, specs: string[]): Promise<void> {
+	const args = [
+		"install",
+		...specs,
+		`--cpu=${RUNTIME_TARGET.cpu}`,
+		`--os=${RUNTIME_TARGET.os}`,
+		`--libc=${RUNTIME_TARGET.libc}`,
+		"--ignore-scripts",
+		"--no-audit",
+		"--no-fund",
+		"--no-package-lock",
+		"--loglevel=error",
+	];
+
+	const { code, stderr, spawnError } = await new Promise<{
+		code: number | null;
+		stderr: string;
+		spawnError?: Error;
+	}>((resolveRun) => {
+		const child = spawn("npm", args, {
+			cwd,
+			stdio: ["ignore", "ignore", "pipe"],
+			timeout: INSTALL_TIMEOUT_MS,
+		});
+		let stderr = "";
+		child.stderr.on("data", (chunk: Buffer) => {
+			stderr += chunk.toString();
+		});
+		child.on("error", (spawnError) =>
+			resolveRun({ code: null, stderr, spawnError }),
+		);
+		child.on("close", (code) => resolveRun({ code, stderr }));
+	});
+
+	if (spawnError !== undefined) {
+		const missing = (spawnError as NodeJS.ErrnoException).code === "ENOENT";
+		throw invalid(
+			missing
+				? `Shipping a function's externalPackages requires "npm" on PATH, to install ` +
+						`them for the Functions runtime (${RUNTIME_TARGET_LABEL}). It could not ` +
+						`be found. Install Node.js with npm, or set includeFiles: false on every ` +
+						`entry so nothing needs staging.`
+				: `Failed to install externalPackages for the Functions runtime: ${spawnError.message}`,
+			spawnError,
+		);
+	}
+	if (code !== 0) {
+		// npm reports a package that declares no build for the target as EBADPLATFORM, whose
+		// own message compares against the *host* platform and so reads as though the wrong
+		// thing was asked for. Say what actually happened instead.
+		if (stderr.includes("EBADPLATFORM")) {
+			throw invalid(
+				`A package in externalPackages has no build for the Functions runtime ` +
+					`(${RUNTIME_TARGET_LABEL}), so its files cannot be staged. Use a package ` +
+					`that publishes a ${RUNTIME_TARGET.os}-${RUNTIME_TARGET.cpu} build (sharp ` +
+					`does). If this function never reaches it, exclude it instead with ` +
+					`includeFiles: false.\n\nnpm reported:\n${stderr.trim()}`,
+			);
+		}
+		throw invalid(
+			`Failed to install externalPackages for the Functions runtime ` +
+				`(${RUNTIME_TARGET_LABEL}). npm exited with code ${code}.\n${stderr.trim()}`,
+		);
+	}
+}
+
+/**
+ * Loaded with a dynamic `import()` for the same reason as esbuild and fflate: nothing in this
+ * package's static graph should name the tracer, so a `neon.ts` that only reads config never
+ * pulls it in. A deploy that declares no native packages never reaches this.
+ */
+async function loadNft(): Promise<typeof import("@vercel/nft")> {
+	try {
+		return await import("@vercel/nft");
+	} catch (cause) {
+		throw invalid(
+			"Staging a function's external packages requires `@vercel/nft`, which could not " +
+				"be loaded. It is a dependency of @neon/config-runtime — reinstall your " +
+				"dependencies (`pnpm install` / `npm install`).",
+			cause,
+		);
+	}
+}

--- a/packages/config-runtime/src/lib/native-packages.ts
+++ b/packages/config-runtime/src/lib/native-packages.ts
@@ -137,10 +137,22 @@ export type NativeTraceDeps = {
 	/** Install `specs` for the runtime target into `cwd`. Resolves on success. */
 	install: (cwd: string, specs: string[]) => Promise<void>;
 	/** Trace `entry` within `base`, returning archive-relative file paths. */
-	trace: (
-		base: string,
-		entry: string,
-	) => Promise<{ files: string[]; warnings?: string[] }>;
+	/**
+	 * Trace `entry` within `base`, returning archive-relative file paths.
+	 *
+	 * The tracer's own warnings are deliberately not surfaced. On a platform-gated package
+	 * they are noise and nothing else: `sharp`'s loader names every platform's binary and
+	 * probes for the one that exists, so tracing a correctly staged `sharp` emits about a
+	 * dozen "could not resolve" warnings — one per platform that was correctly not
+	 * installed, plus several for specifiers built by string concatenation that no tracer
+	 * can follow. None of them indicates a missing file, and a report that is wrong every
+	 * time on the canonical package teaches people to ignore it.
+	 *
+	 * An archive that really is incomplete is caught by what does prove it: a traced file
+	 * that is absent from staging fails the deploy, and a shipped binary that is not an
+	 * AArch64 ELF fails it too.
+	 */
+	trace: (base: string, entry: string) => Promise<{ files: string[] }>;
 	/** Version of `pkg` as resolved in the user's project, or undefined if not installed. */
 	installedVersion: (projectDir: string, pkg: string) => string | undefined;
 };
@@ -239,13 +251,6 @@ export async function traceNativePackages(options: {
 		);
 
 		const traced = await deps.trace(staging, "trace-entry.mjs");
-		for (const warning of traced.warnings ?? []) {
-			warnings.push(
-				`While tracing the files to ship for function "${slug}", a dependency could ` +
-					`not be followed: ${warning}. If that file is reached at runtime it will be ` +
-					`missing from the deployed function.`,
-			);
-		}
 		const files = selectArchiveFiles(slug, traced.files, staging);
 		const entries = readArchiveFiles(slug, staging, files);
 		enforceLimits(slug, entries, limits);

--- a/packages/config-runtime/src/lib/native-packages.ts
+++ b/packages/config-runtime/src/lib/native-packages.ts
@@ -9,7 +9,10 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { ErrorCode, externalPackageRoot, PlatformError } from "@neon/config";
-import { installedPackageVersion } from "./resolve-package.js";
+import {
+	installedPackageVersion,
+	readPackageManifest,
+} from "./resolve-package.js";
 
 /**
  * The architecture, OS and libc a Neon Function runs on. Native packages are installed for
@@ -41,32 +44,66 @@ const ELF = {
 const BINARY_PATTERN = /\.(node|so)(\.\d+)*$/;
 
 /**
- * Sibling platform builds a package may install alongside the one we want. `sharp` ships a
- * WebAssembly fallback its loader silently drops to when the native binary is missing, and
- * a musl variant for Alpine. Neither can be reached on the runtime (it is Debian, and the
- * native build is present), and together they are most of the archive, so they are dropped.
- * Shipping the wasm build is actively harmful: it would let a broken native path succeed
- * quietly on a slower code path instead of failing loudly.
+ * The WebAssembly fallback is the one sibling variant that cannot be identified from its
+ * manifest: `@img/sharp-wasm32` declares no `os`, `cpu`, or `libc` at all, so npm installs it
+ * whatever target is asked for and only the name distinguishes it.
+ *
+ * Matched as a whole dash-delimited token rather than a substring, so an ordinary package
+ * that merely contains the word keeps its files.
  */
+const WASM_VARIANT_TOKEN = "wasm32";
 
 /**
- * Whether a traced path belongs to an excluded sibling variant.
+ * Whether a package in the staging tree can be left out of the archive.
  *
- * Matched against **package directory names only**, never the whole path: a substring test
- * over the full path also deletes an ordinary file that happens to be called something like
- * `musl-helper.js`, which would drop a needed file from the archive and fail at invoke.
+ * Incompatible builds are identified from their own manifest, the same way npm decides what
+ * to install — `@img/sharp-linuxmusl-arm64` declares `libc: ["musl"]`, which a glibc runtime
+ * cannot load. That is a fact about the package rather than a guess from its name, so a
+ * package called `musl-helper` is untouched.
+ *
+ * Dropping the wasm build is not merely a size saving: sharp's loader falls through to it
+ * silently, so a broken native path would succeed on much slower code instead of failing
+ * loudly.
  */
-function isExcludedVariant(path: string): boolean {
-	const segments = path.split(/[/\\]/);
-	return segments.some(
-		(segment, index) =>
-			// Only a segment that names a package: the one directly after a `node_modules`,
-			// or the one after that when the first is a scope.
-			(segments[index - 1] === "node_modules" ||
-				(segments[index - 2] === "node_modules" &&
-					segments[index - 1]?.startsWith("@"))) &&
-			(segment.includes("wasm32") || segment.includes("musl")),
+function isExcludedVariant(packageName: string, staging: string): boolean {
+	if (packageName.split(/[-/]/).includes(WASM_VARIANT_TOKEN)) return true;
+	const manifest = readPackageManifest(
+		join(staging, "node_modules", ...packageName.split("/")),
 	);
+	return manifest !== undefined && !manifestRunsOnRuntime(manifest);
+}
+
+/** Whether a manifest's `os`/`cpu`/`libc` permit {@link RUNTIME_TARGET}. */
+function manifestRunsOnRuntime(manifest: Record<string, unknown>): boolean {
+	const permits = (raw: unknown, value: string): boolean => {
+		const field =
+			typeof raw === "string"
+				? [raw]
+				: Array.isArray(raw)
+					? raw.filter(
+							(entry): entry is string =>
+								typeof entry === "string",
+						)
+					: undefined;
+		if (field === undefined || field.length === 0) return true;
+		if (field.includes(`!${value}`)) return false;
+		const positives = field.filter((entry) => !entry.startsWith("!"));
+		return positives.length === 0 || positives.includes(value);
+	};
+	return (
+		permits(manifest.os, RUNTIME_TARGET.os) &&
+		permits(manifest.cpu, RUNTIME_TARGET.cpu) &&
+		permits(manifest.libc, RUNTIME_TARGET.libc)
+	);
+}
+
+/** The package a `node_modules/...` archive path belongs to. */
+function packageOfArchivePath(path: string): string | undefined {
+	const segments = path.split("/");
+	if (segments[0] !== "node_modules" || segments.length < 2) return undefined;
+	return segments[1].startsWith("@") && segments.length >= 3
+		? `${segments[1]}/${segments[2]}`
+		: segments[1];
 }
 
 /** How long the staging install may take before the deploy gives up on it. */
@@ -100,7 +137,10 @@ export type NativeTraceDeps = {
 	/** Install `specs` for the runtime target into `cwd`. Resolves on success. */
 	install: (cwd: string, specs: string[]) => Promise<void>;
 	/** Trace `entry` within `base`, returning archive-relative file paths. */
-	trace: (base: string, entry: string) => Promise<string[]>;
+	trace: (
+		base: string,
+		entry: string,
+	) => Promise<{ files: string[]; warnings?: string[] }>;
 	/** Version of `pkg` as resolved in the user's project, or undefined if not installed. */
 	installedVersion: (projectDir: string, pkg: string) => string | undefined;
 };
@@ -135,8 +175,9 @@ const invalid = (message: string, cause?: unknown): PlatformError =>
  *    `node_modules` is never read for these files. Its binaries are built for their machine,
  *    and a cross-platform install is not sticky — a later plain `npm install` re-resolves
  *    optional dependencies for the host and replaces the target's packages with the host's.
- *    Only the resolved *version* is taken from the user's tree, so the deploy honours their
- *    lockfile without trusting the binaries next to it.
+ *    Only the resolved *version* of the declared package is taken from the user's tree. That
+ *    is not the same as honouring their lockfile: transitive pins, overrides, patches, and
+ *    aliases are not carried across, so the staged graph can differ below the root.
  * 2. **Trace the installed tree.** The file set cannot be discovered by asking Node:
  *    `@img/sharp-linux-arm64` exports only `./sharp.node` and `./package`, with no `.` and no
  *    wildcard, so its directory is unreachable through the resolver. A tracer that follows
@@ -198,7 +239,14 @@ export async function traceNativePackages(options: {
 		);
 
 		const traced = await deps.trace(staging, "trace-entry.mjs");
-		const files = selectArchiveFiles(slug, traced);
+		for (const warning of traced.warnings ?? []) {
+			warnings.push(
+				`While tracing the files to ship for function "${slug}", a dependency could ` +
+					`not be followed: ${warning}. If that file is reached at runtime it will be ` +
+					`missing from the deployed function.`,
+			);
+		}
+		const files = selectArchiveFiles(slug, traced.files, staging);
 		const entries = readArchiveFiles(slug, staging, files);
 		enforceLimits(slug, entries, limits);
 		return { entries, warnings };
@@ -240,15 +288,32 @@ function verifyInstalled(
  * {@link isExcludedVariant}). The trace entry itself is dropped — the real entry is
  * the esbuild bundle.
  */
-function selectArchiveFiles(slug: string, traced: readonly string[]): string[] {
+function selectArchiveFiles(
+	slug: string,
+	traced: readonly string[],
+	staging: string,
+): string[] {
+	// Decided once per package rather than per file: the exclusion is a property of the
+	// package, and its manifest would otherwise be re-read for every file it contributes.
+	const excluded = new Map<string, boolean>();
+	const dropped = (path: string): boolean => {
+		const pkg = packageOfArchivePath(path);
+		if (pkg === undefined) return false;
+		const known = excluded.get(pkg);
+		if (known !== undefined) return known;
+		const decision = isExcludedVariant(pkg, staging);
+		excluded.set(pkg, decision);
+		return decision;
+	};
+
 	const files = traced
 		.filter(
 			(path) =>
 				path.startsWith(`node_modules${sep}`) ||
 				path.startsWith("node_modules/"),
 		)
-		.filter((path) => !isExcludedVariant(path))
 		.map((path) => path.split(sep).join("/"))
+		.filter((path) => !dropped(path))
 		.sort();
 
 	if (files.length === 0) {
@@ -321,7 +386,16 @@ function verifyArchitecture(
 	relative: string,
 	contents: Buffer,
 ): void {
-	if (contents.length < ELF.headerBytes) return;
+	// Too short to carry an ELF header at all. Returning here would let a truncated or
+	// placeholder binary through the one check that exists to stop a wrong-architecture file
+	// reaching the runtime.
+	if (contents.length < ELF.headerBytes) {
+		throw invalid(
+			`Function "${slug}" would ship "${relative}", which is ${contents.length} bytes — ` +
+				`too short to be a valid binary. The Functions runtime is ` +
+				`${RUNTIME_TARGET_LABEL}.`,
+		);
+	}
 	const isElf = contents.subarray(0, 4).toString("binary") === ELF.magic;
 	if (!isElf) {
 		throw invalid(
@@ -346,15 +420,17 @@ function verifyArchitecture(
  * Check the archive against the build service's limits, naming the largest contributors. The
  * compressed size is not known until the archive is zipped, so only the counts and
  * uncompressed total are checked here; {@link assertZipWithinLimits} covers the rest.
+ *
+ * Exported so the caller can re-check the **final** archive: these entries are the staged
+ * files alone, and the bundle is merged in afterwards.
  */
-function enforceLimits(
+export function enforceLimits(
 	slug: string,
 	entries: Record<string, Uint8Array>,
-	limits: ArchiveLimits,
+	limits: ArchiveLimits = DEFAULT_ARCHIVE_LIMITS,
 ): void {
 	const names = Object.keys(entries);
-	// +1 for index.mjs, which the caller adds after this runs.
-	const count = names.length + 1;
+	const count = names.length;
 	if (count > limits.maxEntries) {
 		throw invalid(
 			`Function "${slug}" archive has ${count} files; the limit is ${limits.maxEntries}. ` +
@@ -406,7 +482,13 @@ const defaultDeps: NativeTraceDeps = {
 		// not against `base`. `fileList` still comes back relative to `base`, which is what
 		// the archive keys need.
 		const result = await nodeFileTrace([join(base, entry)], { base });
-		return [...result.fileList];
+		return {
+			files: [...result.fileList],
+			// A specifier the tracer could not follow is a file that will be missing from the
+			// archive and only noticed at invoke. Not fatal — nft warns about plenty that is
+			// genuinely optional — but never silent.
+			warnings: [...result.warnings].map((warning) => warning.message),
+		};
 	},
 	installedVersion: (projectDir, pkg) =>
 		installedPackageVersion(projectDir, pkg),

--- a/packages/config-runtime/src/lib/push-config.test.ts
+++ b/packages/config-runtime/src/lib/push-config.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { defineConfig, ErrorCode, PushConflictError } from "@neon/config";
@@ -649,5 +649,78 @@ describe("pushConfig", () => {
 		expect(api.history.some((h) => h.method === "updateBranch")).toBe(
 			false,
 		);
+	});
+	/**
+	 * The SDK path has to report a native dependency too, not just the CLI. A warning that
+	 * only reaches `neon config apply` leaves anyone deploying through `pushConfig` with a
+	 * function that fails at invoke and no signal at all.
+	 */
+	test("returns a warning when a function bundles an undeclared native dependency", async () => {
+		const { api, projectId } = seededFake();
+
+		// A real package with a real native binary beside the entry, so the detection runs
+		// against an actual node_modules layout rather than a described one.
+		const pkgDir = join(fnTmpDir, "node_modules", "native-ish");
+		mkdirSync(join(pkgDir, "build"), { recursive: true });
+		writeFileSync(
+			join(pkgDir, "package.json"),
+			JSON.stringify({
+				name: "native-ish",
+				version: "1.0.0",
+				main: "index.js",
+			}),
+		);
+		writeFileSync(join(pkgDir, "index.js"), "module.exports = 1;\n");
+		writeFileSync(join(pkgDir, "build", "addon.node"), "\x7fELF");
+
+		const nativeSource = join(fnTmpDir, "uses-native.ts");
+		writeFileSync(
+			nativeSource,
+			[
+				"import addon from 'native-ish';",
+				"export default { fetch(): Response { return new Response(String(addon)); } };",
+				"",
+			].join("\n"),
+		);
+
+		const config = defineConfig({
+			preview: {
+				functions: {
+					resize: { name: "Resize", source: nativeSource },
+				},
+			},
+		});
+
+		const result = await pushConfig(config, {
+			api,
+			projectId,
+			branchId: "br-main",
+			updateExisting: true,
+		});
+
+		expect(
+			result.warnings.some(
+				(w) =>
+					w.includes("native-ish") && w.includes("externalPackages"),
+			),
+		).toBe(true);
+	});
+
+	test("returns no warnings for a function with nothing native in its graph", async () => {
+		const { api, projectId } = seededFake();
+		const config = defineConfig({
+			preview: {
+				functions: { hello: { name: "Hello", source: fnSource } },
+			},
+		});
+
+		const result = await pushConfig(config, {
+			api,
+			projectId,
+			branchId: "br-main",
+			updateExisting: true,
+		});
+
+		expect(result.warnings).toEqual([]);
 	});
 });

--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -27,12 +27,12 @@ import type { FunctionBundler } from "./function-bundle.js";
  * injects its own bundler never triggers this import, so esbuild can be dropped
  * from their build entirely.
  */
-const defaultBundleFunction: FunctionBundler = async (
-	fn: ResolvedFunctionConfig,
-): Promise<Uint8Array> => {
-	const { buildFunctionBundle } = await import("./function-bundle.js");
-	return buildFunctionBundle(fn);
-};
+const makeDefaultBundleFunction =
+	(onWarning: (message: string) => void): FunctionBundler =>
+	async (fn: ResolvedFunctionConfig): Promise<Uint8Array> => {
+		const { buildFunctionBundle } = await import("./function-bundle.js");
+		return buildFunctionBundle(fn, { onWarning });
+	};
 
 export interface PushConfigOptions {
 	/**
@@ -159,6 +159,10 @@ export async function pushConfig(
 	const api = options.api ?? createApiFromOptions(options);
 	const projectId = options.projectId;
 
+	// Collected from the built-in bundler and returned on the result. A caller that injects
+	// its own `bundleFunction` reports for itself, so this stays empty for them.
+	const warnings: string[] = [];
+
 	const dryRun = options.dryRun === true;
 	const updateExisting = options.updateExisting === true;
 	const allowProtectedBranch = options.allowProtectedBranch === true;
@@ -261,7 +265,10 @@ export async function pushConfig(
 					branchById,
 					branchByName,
 					bundleFunction:
-						options.bundleFunction ?? defaultBundleFunction,
+						options.bundleFunction ??
+						makeDefaultBundleFunction((message) => {
+							warnings.push(message);
+						}),
 				});
 		applied.push(change);
 	}
@@ -285,6 +292,7 @@ export async function pushConfig(
 		dryRun,
 		applied,
 		conflicts: diff.conflicts,
+		warnings,
 	};
 	if (remoteProject.orgId) result.orgId = remoteProject.orgId;
 	return result;

--- a/packages/config-runtime/src/lib/resolve-package.ts
+++ b/packages/config-runtime/src/lib/resolve-package.ts
@@ -10,6 +10,11 @@ import { join, resolve } from "node:path";
  * "/package.json")` throw `ERR_PACKAGE_PATH_NOT_EXPORTED` even though the package is right
  * there on disk. `sharp` is one of them, so a resolver-based lookup fails on exactly the
  * package this whole feature exists for.
+ *
+ * `throwIfNoEntry: false` rather than a `try`/`catch`: a missing directory is the expected
+ * signal to keep walking, but a permission or loop error is a real fault and must propagate
+ * instead of being read as "not here" — that silently returns an ancestor's copy of the
+ * package, which is a different version than the one being deployed.
  */
 export function findPackageDir(
 	fromDir: string,
@@ -18,11 +23,8 @@ export function findPackageDir(
 	let current = resolve(fromDir);
 	for (;;) {
 		const candidate = join(current, "node_modules", ...name.split("/"));
-		try {
-			if (statSync(candidate).isDirectory()) return candidate;
-		} catch {
-			// Not at this level; keep walking up.
-		}
+		const stat = statSync(candidate, { throwIfNoEntry: false });
+		if (stat?.isDirectory()) return candidate;
 		const parent = resolve(current, "..");
 		if (parent === current) return undefined;
 		current = parent;

--- a/packages/config-runtime/src/lib/resolve-package.ts
+++ b/packages/config-runtime/src/lib/resolve-package.ts
@@ -1,0 +1,61 @@
+import { readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/**
+ * Locate an installed package by walking `node_modules` up from `fromDir`, the way Node
+ * resolves.
+ *
+ * Deliberately not `require.resolve`. These packages routinely ship an `exports` map that
+ * lists only `.`, which makes both `require.resolve(pkg)` and `require.resolve(pkg +
+ * "/package.json")` throw `ERR_PACKAGE_PATH_NOT_EXPORTED` even though the package is right
+ * there on disk. `sharp` is one of them, so a resolver-based lookup fails on exactly the
+ * package this whole feature exists for.
+ */
+export function findPackageDir(
+	fromDir: string,
+	name: string,
+): string | undefined {
+	let current = resolve(fromDir);
+	for (;;) {
+		const candidate = join(current, "node_modules", ...name.split("/"));
+		try {
+			if (statSync(candidate).isDirectory()) return candidate;
+		} catch {
+			// Not at this level; keep walking up.
+		}
+		const parent = resolve(current, "..");
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+/** A package's parsed manifest, or `undefined` when it is absent or unparseable. */
+export function readPackageManifest(
+	dir: string,
+): Record<string, unknown> | undefined {
+	try {
+		const parsed: unknown = JSON.parse(
+			readFileSync(join(dir, "package.json"), "utf8"),
+		);
+		return typeof parsed === "object" && parsed !== null
+			? (parsed as Record<string, unknown>)
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * The version of `name` as installed under `fromDir`, or `undefined` when it is not
+ * installed. Callers treat `undefined` as "cannot pin" and must say so rather than quietly
+ * installing whatever the registry calls latest.
+ */
+export function installedPackageVersion(
+	fromDir: string,
+	name: string,
+): string | undefined {
+	const dir = findPackageDir(fromDir, name);
+	if (dir === undefined) return undefined;
+	const version = readPackageManifest(dir)?.version;
+	return typeof version === "string" ? version : undefined;
+}

--- a/packages/config-runtime/src/v1.ts
+++ b/packages/config-runtime/src/v1.ts
@@ -58,6 +58,24 @@ export {
 export type { FunctionBundler } from "./lib/function-bundle.js";
 // ─── Function bundling (esbuild + zip) ────────────────────────────────────────
 export { buildFunctionBundle } from "./lib/function-bundle.js";
+// ─── Native dependency staging and detection ──────────────────────────────────
+export type { NativeEvidence, NativeFinding } from "./lib/native-detect.js";
+export {
+	describeNativeFinding,
+	findUndeclaredNativePackages,
+} from "./lib/native-detect.js";
+export type {
+	ArchiveLimits,
+	NativeTraceDeps,
+	NativeTraceResult,
+} from "./lib/native-packages.js";
+export {
+	assertZipWithinLimits,
+	DEFAULT_ARCHIVE_LIMITS,
+	RUNTIME_TARGET,
+	RUNTIME_TARGET_LABEL,
+	traceNativePackages,
+} from "./lib/native-packages.js";
 // ─── Operations (intent-revealing entry points) ───────────────────────────────
 export type {
 	ApplyOptions,

--- a/packages/config-runtime/src/v1.ts
+++ b/packages/config-runtime/src/v1.ts
@@ -72,6 +72,7 @@ export type {
 export {
 	assertZipWithinLimits,
 	DEFAULT_ARCHIVE_LIMITS,
+	enforceLimits,
 	RUNTIME_TARGET,
 	RUNTIME_TARGET_LABEL,
 	traceNativePackages,

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -45,38 +45,9 @@ Service toggles accept `true` / `{}` / `{ enabled: true }` (enabled) and `false`
 
 ### Unbundleable dependencies (`externalPackages`)
 
-A function's `source` is bundled with esbuild at deploy time, and some packages cannot be bundled at all: a native `.node` addon has no esbuild loader, and a library may reference an optional peer dependency on a code path the function never takes. Either one fails the deploy with a resolve or loader error naming the package, and neither is fixable from the function's own source.
+A function's `source` is bundled with esbuild at deploy time, and a package backed by a native `.node` binary cannot be bundled by anything: the binary is a compiled object the platform loads from a real path. `sharp` is the common case, and it does not even fail the build — it loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
 
-`externalPackages` is the escape hatch, and the deploy-time counterpart of Next.js's `serverExternalPackages` — every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed:
-
-```ts
-export default defineConfig({
-  preview: {
-    functions: {
-      agent: {
-        name: "Agent",
-        source: "./functions/agent.ts",
-        externalPackages: ["microsandbox", "@mongodb-js/zstd"],
-      },
-    },
-  },
-});
-```
-
-**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. The option unblocks an import that is never evaluated; it does not make a dependency usable.
-
-A dependency the handler actually calls has to be bundled, and whether that is possible depends on what it is:
-
-- **Pure JavaScript** — bundling is the normal case, and a failure is usually something specific and fixable in the entry.
-- **Backed by a native `.node` binary** — cannot be bundled by any bundler; the binary is a compiled object the platform loads from a real path. Such a package needs its files shipped next to the bundle, which is `nativePackages` below. Listing it here does not help, it only moves the error from deploy to invoke.
-
-A native package may also bundle without needing this option at all. `sharp` loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
-
-Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. `neon dev` applies the same list, so a local run bundles like a deploy.
-
-### Native dependencies (`nativePackages`)
-
-`nativePackages` names packages backed by a native binary whose real files should ship into the deployed archive. Where `externalPackages` only stops such a package failing the build, this is the option that makes it work:
+`externalPackages` is the deploy-time counterpart of Next.js's `serverExternalPackages`. Every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed, and the package's own files are shipped into the archive beside the bundle so that import resolves:
 
 ```ts
 export default defineConfig({
@@ -85,16 +56,16 @@ export default defineConfig({
       resize: {
         name: "Resize",
         source: "./functions/resize.ts",
-        nativePackages: ["sharp"],
+        externalPackages: ["sharp"],
       },
     },
   },
 });
 ```
 
-Each entry is kept out of the bundle and then installed for the Functions runtime target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it actually reaches, and copied into the archive under `node_modules/` with its directory layout intact. The layout matters: a `.node` addon finds its sibling shared libraries relative to its own directory, so a flattened tree fails to load.
+Each declared package is installed for the Functions runtime target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it actually reaches, and copied into the archive under `node_modules/` with its directory layout intact. The layout matters: a `.node` addon finds its sibling shared libraries relative to its own directory, so a flattened tree fails to load.
 
-Your own `node_modules` is never read for those files or modified. Its binaries are built for your machine rather than the deploy target, and a cross-platform install does not survive your next plain `npm install`, so the target's packages are resolved fresh on each deploy. The version installed is the one your project already resolved, read from your dependency tree — the deploy honours your lockfile without trusting the binaries beside it.
+Your own `node_modules` is never read for those files or modified. Its binaries are built for your machine rather than the deploy target, and a cross-platform install does not survive your next plain `npm install`, so the target's packages are resolved fresh on each deploy.
 
 Requirements, all checked at deploy time rather than left to fail at invoke:
 
@@ -102,7 +73,17 @@ Requirements, all checked at deploy time rather than left to fail at invoke:
 - `npm` is on `PATH`
 - the archive stays within the deploy size limits — native binaries are large, so a couple of them is the practical ceiling
 
-Entries are package names without a subpath (`sharp`, `@scope/pkg`), since the whole package is installed and traced. A package must not appear in both lists.
+#### Excluding a package's files
+
+`includeFiles: false` externalizes an import without shipping anything for it. That is the escape hatch for a package that cannot be staged — no build for the runtime target, or too large — and that the function never actually reaches:
+
+```ts
+externalPackages: ["sharp", { name: "canvas", includeFiles: false }],
+```
+
+**An excluded package is not resolvable at runtime.** Nothing is shipped for it, so it throws `Cannot find module` if the function reaches it. It unblocks an import that is never evaluated; it does not make a dependency usable.
+
+Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. Files are staged per package, so a subpath narrows what esbuild leaves unresolved without narrowing what ships.
 
 Under `neon dev` the list only keeps the package out of the bundle. Nothing is installed or copied, and it resolves from your own `node_modules` against your host architecture — which is what you want locally.
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -68,11 +68,43 @@ export default defineConfig({
 A dependency the handler actually calls has to be bundled, and whether that is possible depends on what it is:
 
 - **Pure JavaScript** — bundling is the normal case, and a failure is usually something specific and fixable in the entry.
-- **Backed by a native `.node` binary** — cannot be bundled by any bundler; the binary is a compiled object the platform loads from a real path. Such a package cannot work on Functions until the archive can carry files alongside the bundle. Listing it here does not help, it only moves the error from deploy to invoke.
+- **Backed by a native `.node` binary** — cannot be bundled by any bundler; the binary is a compiled object the platform loads from a real path. Such a package needs its files shipped next to the bundle, which is `nativePackages` below. Listing it here does not help, it only moves the error from deploy to invoke.
 
 A native package may also bundle without needing this option at all. `sharp` loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
 
 Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. `neon dev` applies the same list, so a local run bundles like a deploy.
+
+### Native dependencies (`nativePackages`)
+
+`nativePackages` names packages backed by a native binary whose real files should ship into the deployed archive. Where `externalPackages` only stops such a package failing the build, this is the option that makes it work:
+
+```ts
+export default defineConfig({
+  preview: {
+    functions: {
+      resize: {
+        name: "Resize",
+        source: "./functions/resize.ts",
+        nativePackages: ["sharp"],
+      },
+    },
+  },
+});
+```
+
+Each entry is kept out of the bundle and then installed for the Functions runtime target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it actually reaches, and copied into the archive under `node_modules/` with its directory layout intact. The layout matters: a `.node` addon finds its sibling shared libraries relative to its own directory, so a flattened tree fails to load.
+
+Your own `node_modules` is never read for those files or modified. Its binaries are built for your machine rather than the deploy target, and a cross-platform install does not survive your next plain `npm install`, so the target's packages are resolved fresh on each deploy. The version installed is the one your project already resolved, read from your dependency tree — the deploy honours your lockfile without trusting the binaries beside it.
+
+Requirements, all checked at deploy time rather than left to fail at invoke:
+
+- the package publishes a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages do; anything compiled from source at install time does not)
+- `npm` is on `PATH`
+- the archive stays within the deploy size limits — native binaries are large, so a couple of them is the practical ceiling
+
+Entries are package names without a subpath (`sharp`, `@scope/pkg`), since the whole package is installed and traced. A package must not appear in both lists.
+
+Under `neon dev` the list only keeps the package out of the bundle. Nothing is installed or copied, and it resolves from your own `node_modules` against your host architecture — which is what you want locally.
 
 ### Data API
 

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -188,6 +188,85 @@ describe("resolveConfig", () => {
 		]);
 	});
 
+	test("passes nativePackages through to the resolved function", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./functions/hello-world.ts",
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions).toEqual([
+			{
+				slug: "fn1",
+				name: "Hello World",
+				source: "./functions/hello-world.ts",
+				env: {},
+				nativePackages: ["sharp"],
+				runtime: "nodejs24",
+			},
+		]);
+	});
+
+	test("omits nativePackages entirely when the policy does not declare it", () => {
+		const config = defineConfig({
+			preview: {
+				functions: { fn1: { name: "Hello", source: "./hello.ts" } },
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		// Absent rather than `[]`. The bundler keys the ship-native-files path off this
+		// property being present, so an empty array here would change every deploy.
+		expect(resolved.preview?.functions[0]).not.toHaveProperty(
+			"nativePackages",
+		);
+	});
+
+	test("copies nativePackages so mutating the policy array cannot reach the resolved config", () => {
+		const nativePackages = ["sharp"];
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						nativePackages,
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		nativePackages.push("mutated-after-resolve");
+		expect(resolved.preview?.functions[0]?.nativePackages).toEqual([
+			"sharp",
+		]);
+	});
+
+	test("resolves both package lists independently", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						externalPackages: ["microsandbox"],
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions[0]).toMatchObject({
+			externalPackages: ["microsandbox"],
+			nativePackages: ["sharp"],
+		});
+	});
+
 	test("applies per-branch function runtime tuning", () => {
 		const config = defineConfig({
 			preview: {

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -130,14 +130,14 @@ describe("resolveConfig", () => {
 		});
 	});
 
-	test("passes externalPackages through to the resolved function", () => {
+	test("resolves a bare externalPackages string to includeFiles: true", () => {
 		const config = defineConfig({
 			preview: {
 				functions: {
 					fn1: {
 						name: "Hello World",
 						source: "./functions/hello-world.ts",
-						externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+						externalPackages: ["sharp", "@mongodb-js/zstd"],
 					},
 				},
 			},
@@ -149,9 +149,54 @@ describe("resolveConfig", () => {
 				name: "Hello World",
 				source: "./functions/hello-world.ts",
 				env: {},
-				externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+				externalPackages: [
+					{ name: "sharp", includeFiles: true },
+					{ name: "@mongodb-js/zstd", includeFiles: true },
+				],
 				runtime: "nodejs24",
 			},
+		]);
+	});
+
+	test("carries includeFiles: false through from the object form", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						externalPackages: [
+							"sharp",
+							{ name: "canvas", includeFiles: false },
+						],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions[0]?.externalPackages).toEqual([
+			{ name: "sharp", includeFiles: true },
+			{ name: "canvas", includeFiles: false },
+		]);
+	});
+
+	test("treats an explicit includeFiles: true the same as the bare string", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						externalPackages: [
+							{ name: "sharp", includeFiles: true },
+						],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions[0]?.externalPackages).toEqual([
+			{ name: "sharp", includeFiles: true },
 		]);
 	});
 
@@ -162,7 +207,8 @@ describe("resolveConfig", () => {
 			},
 		});
 		const resolved = resolveConfig(config, { name: "main", exists: true });
-		// Absent rather than `[]`, so an existing policy resolves to the shape it always did.
+		// Absent rather than `[]`. The bundler keys the stage-files path off there being a
+		// shipping entry, and an undeclared policy must produce the archive it always did.
 		expect(resolved.preview?.functions[0]).not.toHaveProperty(
 			"externalPackages",
 		);
@@ -184,87 +230,8 @@ describe("resolveConfig", () => {
 		const resolved = resolveConfig(config, { name: "main", exists: true });
 		externalPackages.push("mutated-after-resolve");
 		expect(resolved.preview?.functions[0]?.externalPackages).toEqual([
-			"microsandbox",
+			{ name: "microsandbox", includeFiles: true },
 		]);
-	});
-
-	test("passes nativePackages through to the resolved function", () => {
-		const config = defineConfig({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./functions/hello-world.ts",
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		expect(resolved.preview?.functions).toEqual([
-			{
-				slug: "fn1",
-				name: "Hello World",
-				source: "./functions/hello-world.ts",
-				env: {},
-				nativePackages: ["sharp"],
-				runtime: "nodejs24",
-			},
-		]);
-	});
-
-	test("omits nativePackages entirely when the policy does not declare it", () => {
-		const config = defineConfig({
-			preview: {
-				functions: { fn1: { name: "Hello", source: "./hello.ts" } },
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		// Absent rather than `[]`. The bundler keys the ship-native-files path off this
-		// property being present, so an empty array here would change every deploy.
-		expect(resolved.preview?.functions[0]).not.toHaveProperty(
-			"nativePackages",
-		);
-	});
-
-	test("copies nativePackages so mutating the policy array cannot reach the resolved config", () => {
-		const nativePackages = ["sharp"];
-		const config = defineConfig({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello",
-						source: "./hello.ts",
-						nativePackages,
-					},
-				},
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		nativePackages.push("mutated-after-resolve");
-		expect(resolved.preview?.functions[0]?.nativePackages).toEqual([
-			"sharp",
-		]);
-	});
-
-	test("resolves both package lists independently", () => {
-		const config = defineConfig({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello",
-						source: "./hello.ts",
-						externalPackages: ["microsandbox"],
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		expect(resolved.preview?.functions[0]).toMatchObject({
-			externalPackages: ["microsandbox"],
-			nativePackages: ["sharp"],
-		});
 	});
 
 	test("applies per-branch function runtime tuning", () => {

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -1,5 +1,6 @@
 import { parseBranchTtl } from "./duration.js";
 import { ConfigValidationError } from "./errors.js";
+import { normalizeExternalPackage } from "./external-packages.js";
 import {
 	branchTuningSchema,
 	configInputSchema,
@@ -341,15 +342,15 @@ function resolveFunctionConfig(
 		source: def.source,
 		env: { ...(def.env ?? {}) },
 		runtime: tuning.runtime ?? DEFAULT_FUNCTION_RUNTIME,
-		// Copied only when declared, so a policy without it resolves unchanged. Both
-		// bundlers read it; `neon dev` mirrors it so a local run bundles like a deploy.
+		// Normalized only when declared, so a policy without it resolves unchanged and takes
+		// the pre-existing bundling path. Both bundlers read it; `neon dev` mirrors it so a
+		// local run leaves the same packages unbundled as a deploy.
 		...(def.externalPackages
-			? { externalPackages: [...def.externalPackages] }
-			: {}),
-		// Same discipline: absent when undeclared, so the bundler can key the
-		// ship-native-files path off its presence and leave every other deploy untouched.
-		...(def.nativePackages
-			? { nativePackages: [...def.nativePackages] }
+			? {
+					externalPackages: def.externalPackages.map(
+						normalizeExternalPackage,
+					),
+				}
 			: {}),
 		// Passed through untouched (no defaults); only `neon dev` reads it.
 		...(def.dev ? { dev: def.dev } : {}),

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -346,6 +346,11 @@ function resolveFunctionConfig(
 		...(def.externalPackages
 			? { externalPackages: [...def.externalPackages] }
 			: {}),
+		// Same discipline: absent when undeclared, so the bundler can key the
+		// ship-native-files path off its presence and leave every other deploy untouched.
+		...(def.nativePackages
+			? { nativePackages: [...def.nativePackages] }
+			: {}),
 		// Passed through untouched (no defaults); only `neon dev` reads it.
 		...(def.dev ? { dev: def.dev } : {}),
 	};

--- a/packages/config/src/lib/external-packages.test.ts
+++ b/packages/config/src/lib/external-packages.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+import {
+	externalPackageRoot,
+	normalizeExternalPackage,
+	packagesToStage,
+} from "./external-packages.js";
+
+describe("externalPackageRoot", () => {
+	test("returns a bare name unchanged", () => {
+		expect(externalPackageRoot("sharp")).toBe("sharp");
+	});
+
+	test("keeps both segments of a scoped name", () => {
+		expect(externalPackageRoot("@img/sharp-linux-arm64")).toBe(
+			"@img/sharp-linux-arm64",
+		);
+	});
+
+	test("drops a subpath", () => {
+		expect(externalPackageRoot("sharp/lib/index.js")).toBe("sharp");
+	});
+
+	test("drops a subpath under a scope", () => {
+		expect(externalPackageRoot("@scope/pkg/sub/deep.js")).toBe(
+			"@scope/pkg",
+		);
+	});
+});
+
+describe("normalizeExternalPackage", () => {
+	test("defaults a bare string to shipping its files", () => {
+		expect(normalizeExternalPackage("sharp")).toEqual({
+			name: "sharp",
+			includeFiles: true,
+		});
+	});
+
+	test("defaults the object form to shipping its files", () => {
+		expect(normalizeExternalPackage({ name: "sharp" })).toEqual({
+			name: "sharp",
+			includeFiles: true,
+		});
+	});
+
+	test("carries includeFiles: false through", () => {
+		expect(
+			normalizeExternalPackage({ name: "canvas", includeFiles: false }),
+		).toEqual({ name: "canvas", includeFiles: false });
+	});
+});
+
+describe("packagesToStage", () => {
+	test("returns the packages that ship, in declaration order", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "@napi-rs/canvas", includeFiles: true },
+			]),
+		).toEqual(["sharp", "@napi-rs/canvas"]);
+	});
+
+	test("omits packages that opted out", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "canvas", includeFiles: false },
+			]),
+		).toEqual(["sharp"]);
+	});
+
+	test("is empty when every entry opted out, so nothing is staged", () => {
+		expect(
+			packagesToStage([{ name: "microsandbox", includeFiles: false }]),
+		).toEqual([]);
+	});
+
+	test("collapses a subpath onto its package", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp/lib/index.js", includeFiles: true },
+			]),
+		).toEqual(["sharp"]);
+	});
+
+	test("stages a package once when named both bare and through a subpath", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "sharp/lib/index.js", includeFiles: true },
+			]),
+		).toEqual(["sharp"]);
+	});
+});

--- a/packages/config/src/lib/external-packages.test.ts
+++ b/packages/config/src/lib/external-packages.test.ts
@@ -74,19 +74,32 @@ describe("packagesToStage", () => {
 		).toEqual([]);
 	});
 
-	test("collapses a subpath onto its package", () => {
+	// Specifiers are kept whole rather than reduced to their package. A package may export
+	// only a subpath, in which case importing the root throws and a trace of it finds
+	// nothing — so the trace has to import exactly what was authored. Reducing to the package
+	// is the caller's job, via `externalPackageRoot`, and only to decide what to install.
+	test("keeps a subpath specifier as authored", () => {
 		expect(
 			packagesToStage([
 				{ name: "sharp/lib/index.js", includeFiles: true },
 			]),
-		).toEqual(["sharp"]);
+		).toEqual(["sharp/lib/index.js"]);
 	});
 
-	test("stages a package once when named both bare and through a subpath", () => {
+	test("keeps a bare name and a subpath of it as two specifiers", () => {
 		expect(
 			packagesToStage([
 				{ name: "sharp", includeFiles: true },
 				{ name: "sharp/lib/index.js", includeFiles: true },
+			]),
+		).toEqual(["sharp", "sharp/lib/index.js"]);
+	});
+
+	test("deduplicates an exactly repeated specifier", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "sharp", includeFiles: true },
 			]),
 		).toEqual(["sharp"]);
 	});

--- a/packages/config/src/lib/external-packages.ts
+++ b/packages/config/src/lib/external-packages.ts
@@ -1,0 +1,46 @@
+import type { ExternalPackageEntry, ResolvedExternalPackage } from "./types.js";
+
+/**
+ * The package a specifier belongs to, dropping any subpath: `sharp` from `sharp/lib/x`,
+ * `@scope/pkg` from `@scope/pkg/sub`.
+ *
+ * Files are installed and traced one package at a time, so this is the unit the deploy
+ * stages. A subpath narrows what esbuild leaves unresolved; it does not narrow what ships.
+ */
+export const externalPackageRoot = (specifier: string): string => {
+	const segments = specifier.split("/");
+	const keep = specifier.startsWith("@") ? 2 : 1;
+	return segments.slice(0, keep).join("/");
+};
+
+/**
+ * Normalize one authored entry into the shape every consumer reads.
+ *
+ * `includeFiles` defaults to **true**: the bare-string form is the one users reach for, and
+ * it should produce a function that works. Turning it off is the deliberate gesture.
+ */
+export const normalizeExternalPackage = (
+	entry: ExternalPackageEntry,
+): ResolvedExternalPackage =>
+	typeof entry === "string"
+		? { name: entry, includeFiles: true }
+		: { name: entry.name, includeFiles: entry.includeFiles !== false };
+
+/**
+ * The distinct packages whose files a function ships, in declaration order.
+ *
+ * Subpath entries collapse onto their package root, so declaring both `pkg` and `pkg/sub`
+ * stages `pkg` once. The schema has already rejected any pair that disagrees about
+ * `includeFiles`, so collapsing here cannot silently pick a side.
+ */
+export const packagesToStage = (
+	entries: readonly ResolvedExternalPackage[],
+): string[] => {
+	const roots: string[] = [];
+	for (const entry of entries) {
+		if (!entry.includeFiles) continue;
+		const root = externalPackageRoot(entry.name);
+		if (!roots.includes(root)) roots.push(root);
+	}
+	return roots;
+};

--- a/packages/config/src/lib/external-packages.ts
+++ b/packages/config/src/lib/external-packages.ts
@@ -27,20 +27,21 @@ export const normalizeExternalPackage = (
 		: { name: entry.name, includeFiles: entry.includeFiles !== false };
 
 /**
- * The distinct packages whose files a function ships, in declaration order.
+ * The specifiers whose files a function ships, in declaration order and deduplicated.
  *
- * Subpath entries collapse onto their package root, so declaring both `pkg` and `pkg/sub`
- * stages `pkg` once. The schema has already rejected any pair that disagrees about
- * `includeFiles`, so collapsing here cannot silently pick a side.
+ * These are the specifiers **as authored**, subpath included, because that is what the trace
+ * has to import. A package may export only a subpath — `exports: { "./native": … }` with no
+ * `.` — in which case importing the root throws `ERR_PACKAGE_PATH_NOT_EXPORTED` and the
+ * trace finds nothing. Use {@link externalPackageRoot} on these to get what to *install*,
+ * which is always the whole package.
  */
 export const packagesToStage = (
 	entries: readonly ResolvedExternalPackage[],
 ): string[] => {
-	const roots: string[] = [];
+	const specifiers: string[] = [];
 	for (const entry of entries) {
 		if (!entry.includeFiles) continue;
-		const root = externalPackageRoot(entry.name);
-		if (!roots.includes(root)) roots.push(root);
+		if (!specifiers.includes(entry.name)) specifiers.push(entry.name);
 	}
-	return roots;
+	return specifiers;
 };

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -282,6 +282,33 @@ describe("configInputSchema", () => {
 		).toBe(true);
 	});
 
+	// A staged entry's root is handed to `npm install`, so it has to name one package.
+	// esbuild's `external` also accepts a wildcard and a bare scope, which name a set.
+	test("rejects a wildcard entry that would be staged", () => {
+		const result = withExternalPackages(["@scope/*"]);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(formatZodIssues(result.error).join("\n")).toMatch(
+				/does not name a single installable package/,
+			);
+		}
+	});
+
+	test("accepts a wildcard entry that stages nothing", () => {
+		expect(
+			withExternalPackages([{ name: "@scope/*", includeFiles: false }])
+				.success,
+		).toBe(true);
+	});
+
+	test("rejects a bare scope that would be staged", () => {
+		expect(withExternalPackages(["@scope"]).success).toBe(false);
+	});
+
+	test("rejects a protocol specifier that would be staged", () => {
+		expect(withExternalPackages(["node:fs"]).success).toBe(false);
+	});
+
 	test("accepts two scoped packages sharing a scope", () => {
 		// Same scope, different packages — not the same root, so not a conflict.
 		expect(

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -184,6 +184,161 @@ describe("configInputSchema", () => {
 		expect(result.success).toBe(false);
 	});
 
+	test("accepts nativePackages with bare and scoped names", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["sharp", "@napi-rs/canvas"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts an empty nativePackages list", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: [],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects a relative path in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["./local-addon.node"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(formatZodIssues(result.error).join("\n")).toMatch(
+				/not a relative or absolute path/,
+			);
+		}
+	});
+
+	test("rejects an absolute path in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["/opt/addon.node"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a non-string entry in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: [42],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	// A native package is installed and traced whole, so a subpath names nothing the
+	// option can act on — unlike externalPackages, where esbuild accepts one.
+	test("rejects a subpath in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["sharp/lib/sharp.node"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(formatZodIssues(result.error).join("\n")).toMatch(
+				/without a subpath/,
+			);
+		}
+	});
+
+	test("accepts a scoped nativePackages name, which has one legitimate slash", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["@img/sharp-linux-arm64"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects a package listed in both externalPackages and nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: ["microsandbox", "sharp"],
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issues = formatZodIssues(result.error).join("\n");
+			expect(issues).toMatch(/also in externalPackages/);
+			// Reported against the offending entry, not the whole function.
+			expect(issues).toMatch(/nativePackages\[0\]/);
+		}
+	});
+
+	test("accepts the two lists side by side when they name different packages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: ["microsandbox"],
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
 	test("rejects an unknown key in the function dev block (e.g. removed `portless`)", () => {
 		const result = configInputSchema.safeParse({
 			preview: {

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -309,6 +309,28 @@ describe("configInputSchema", () => {
 		expect(withExternalPackages(["node:fs"]).success).toBe(false);
 	});
 
+	// Whatever passes here becomes an `npm install` argument, so the root is held to npm's
+	// own naming rules rather than merely "not a path".
+	test.each([
+		["a space", "foo bar"],
+		["a leading hash", "#alias"],
+		["an empty path segment", "foo//bar"],
+		["a parent-directory segment", "@scope/pkg/../../escape"],
+		["an uppercase name", "Foo"],
+		["a name starting with a dot", ".hidden"],
+	])("rejects %s in a staged entry", (_label, value) => {
+		expect(withExternalPackages([value]).success).toBe(false);
+	});
+
+	test.each([
+		["a plain name", "sharp"],
+		["a scoped name", "@img/sharp-linux-arm64"],
+		["a name with dots and underscores", "some.pkg_name"],
+		["a subpath", "pkg/sub/deep.js"],
+	])("accepts %s in a staged entry", (_label, value) => {
+		expect(withExternalPackages([value]).success).toBe(true);
+	});
+
 	test("accepts two scoped packages sharing a scope", () => {
 		// Same scope, different packages — not the same root, so not a conflict.
 		expect(

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -184,48 +184,60 @@ describe("configInputSchema", () => {
 		expect(result.success).toBe(false);
 	});
 
-	test("accepts nativePackages with bare and scoped names", () => {
-		const result = configInputSchema.safeParse({
+	const withExternalPackages = (externalPackages: unknown) =>
+		configInputSchema.safeParse({
 			preview: {
 				functions: {
 					fn1: {
 						name: "Hello World",
 						source: "./hello.ts",
-						nativePackages: ["sharp", "@napi-rs/canvas"],
+						externalPackages,
 					},
 				},
 			},
 		});
+
+	test("accepts the object form with includeFiles false", () => {
+		const result = withExternalPackages([
+			"sharp",
+			{ name: "canvas", includeFiles: false },
+		]);
 		expect(result.success).toBe(true);
 	});
 
-	test("accepts an empty nativePackages list", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: [],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(true);
+	test("accepts an explicit includeFiles: true", () => {
+		expect(
+			withExternalPackages([{ name: "sharp", includeFiles: true }])
+				.success,
+		).toBe(true);
 	});
 
-	test("rejects a relative path in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["./local-addon.node"],
-					},
-				},
-			},
-		});
+	test("accepts the object form without includeFiles", () => {
+		expect(withExternalPackages([{ name: "sharp" }]).success).toBe(true);
+	});
+
+	test("rejects an unknown key in the object form", () => {
+		expect(
+			withExternalPackages([{ name: "sharp", includeFile: false }])
+				.success,
+		).toBe(false);
+	});
+
+	test("rejects a non-boolean includeFiles", () => {
+		expect(
+			withExternalPackages([{ name: "sharp", includeFiles: "yes" }])
+				.success,
+		).toBe(false);
+	});
+
+	test("rejects an object entry with no name", () => {
+		expect(withExternalPackages([{ includeFiles: false }]).success).toBe(
+			false,
+		);
+	});
+
+	test("rejects a relative path in the object form too", () => {
+		const result = withExternalPackages([{ name: "./local-addon.node" }]);
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(formatZodIssues(result.error).join("\n")).toMatch(
@@ -234,109 +246,50 @@ describe("configInputSchema", () => {
 		}
 	});
 
-	test("rejects an absolute path in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["/opt/addon.node"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(false);
+	// A subpath is legal: it narrows what esbuild leaves unresolved. Files are staged per
+	// package, so the subpath's package is what ships.
+	test("accepts a subpath entry", () => {
+		expect(withExternalPackages(["pkg/sub"]).success).toBe(true);
 	});
 
-	test("rejects a non-string entry in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: [42],
-					},
-				},
-			},
-		});
+	test("rejects the same package listed twice", () => {
+		const result = withExternalPackages(["sharp", "sharp"]);
 		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issues = formatZodIssues(result.error).join("\n");
+			expect(issues).toMatch(/listed more than once/);
+			// Reported against the offending entry, not the whole function.
+			expect(issues).toMatch(/externalPackages\[1\]/);
+		}
 	});
 
-	// A native package is installed and traced whole, so a subpath names nothing the
-	// option can act on — unlike externalPackages, where esbuild accepts one.
-	test("rejects a subpath in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["sharp/lib/sharp.node"],
-					},
-				},
-			},
-		});
+	test("rejects a bare name and a subpath of it that disagree about includeFiles", () => {
+		const result = withExternalPackages([
+			"sharp",
+			{ name: "sharp/lib/index.js", includeFiles: false },
+		]);
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(formatZodIssues(result.error).join("\n")).toMatch(
-				/without a subpath/,
+				/disagree about includeFiles/,
 			);
 		}
 	});
 
-	test("accepts a scoped nativePackages name, which has one legitimate slash", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["@img/sharp-linux-arm64"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(true);
+	test("accepts a bare name and a subpath of it that agree", () => {
+		expect(
+			withExternalPackages(["sharp", "sharp/lib/index.js"]).success,
+		).toBe(true);
 	});
 
-	test("rejects a package listed in both externalPackages and nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						externalPackages: ["microsandbox", "sharp"],
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			const issues = formatZodIssues(result.error).join("\n");
-			expect(issues).toMatch(/also in externalPackages/);
-			// Reported against the offending entry, not the whole function.
-			expect(issues).toMatch(/nativePackages\[0\]/);
-		}
-	});
-
-	test("accepts the two lists side by side when they name different packages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						externalPackages: ["microsandbox"],
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(true);
+	test("accepts two scoped packages sharing a scope", () => {
+		// Same scope, different packages — not the same root, so not a conflict.
+		expect(
+			withExternalPackages([
+				{ name: "@img/sharp-linux-arm64", includeFiles: false },
+				"@img/colour",
+			]).success,
+		).toBe(true);
 	});
 
 	test("rejects an unknown key in the function dev block (e.g. removed `portless`)", () => {

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -224,13 +224,29 @@ const externalPackageNameSchema = z
  * being installed for them.
  */
 const stageablePackageName = (value: string): boolean => {
-	if (value.includes("*")) return false;
 	// A protocol (`node:fs`, `npm:pkg`) is a specifier, not something to install.
 	if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
-	const root = externalPackageRoot(value);
+	// An empty segment (`foo//bar`) or a traversal is not a subpath the deploy can act on.
+	const segments = value.split("/");
+	if (segments.some((segment) => segment === "" || segment === "..")) {
+		return false;
+	}
+	return isNpmPackageName(externalPackageRoot(value));
+};
+
+/**
+ * npm's own rules for a package name, which is what the deploy hands to `npm install`.
+ * Deliberately strict: whatever slips through here becomes a subprocess argument.
+ */
+const NPM_NAME_SEGMENT = /^[a-z0-9~][a-z0-9._~-]*$/;
+
+const isNpmPackageName = (root: string): boolean => {
+	if (root.length === 0 || root.length > 214) return false;
+	if (!root.startsWith("@")) return NPM_NAME_SEGMENT.test(root);
+	const [scope, name, ...rest] = root.slice(1).split("/");
 	// A bare scope names every package in it, not one package.
-	if (root.startsWith("@")) return /^@[^/]+\/[^/]+$/.test(root);
-	return root.length > 0;
+	if (rest.length > 0 || name === undefined) return false;
+	return NPM_NAME_SEGMENT.test(scope) && NPM_NAME_SEGMENT.test(name);
 };
 
 /**

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -224,20 +224,57 @@ const externalPackageSchema = z
  */
 const functionExternalPackagesSchema = z.array(externalPackageSchema);
 
+/**
+ * A package whose real files ship alongside the bundle. Same specifier grammar as
+ * {@link externalPackageSchema}, minus the subpath: a native package is installed and
+ * traced as a whole, so the unit is the package, not a file inside it.
+ */
+const nativePackageSchema = externalPackageSchema.refine(
+	(value) => value.split("/").length === (value.startsWith("@") ? 2 : 1),
+	{
+		error: 'must be a package name such as "sharp" or "@scope/pkg", without a subpath',
+	},
+);
+
+/**
+ * Per-function list of packages shipped as real files next to the bundle. See
+ * {@link FunctionDef.nativePackages}.
+ */
+const functionNativePackagesSchema = z.array(nativePackageSchema);
+
 const runtimeSchema = z.literal("nodejs24");
 
 /**
  * Static definition of a function (existence). The slug is the record key (validated by
  * {@link functionSlugSchema}), so it is not a field here. Deploy tuning (`runtime`) lives
  * in the `branch` closure, not here.
+ *
+ * `externalPackages` and `nativePackages` are mutually exclusive per package: the first
+ * means "leave the import unresolved", the second "leave it unresolved AND ship the files".
+ * Listing one package in both states two different intents for it, so it is rejected here
+ * rather than silently resolved in favour of one.
  */
-export const functionDefSchema = z.strictObject({
-	name: z.string().min(1).max(255),
-	source: z.string().min(1),
-	env: functionEnvSchema.optional(),
-	externalPackages: functionExternalPackagesSchema.optional(),
-	dev: functionDevConfigSchema.optional(),
-});
+export const functionDefSchema = z
+	.strictObject({
+		name: z.string().min(1).max(255),
+		source: z.string().min(1),
+		env: functionEnvSchema.optional(),
+		externalPackages: functionExternalPackagesSchema.optional(),
+		nativePackages: functionNativePackagesSchema.optional(),
+		dev: functionDevConfigSchema.optional(),
+	})
+	.check((ctx) => {
+		const external = new Set(ctx.value.externalPackages ?? []);
+		(ctx.value.nativePackages ?? []).forEach((pkg, index) => {
+			if (!external.has(pkg)) return;
+			ctx.issues.push({
+				code: "custom",
+				input: pkg,
+				path: ["nativePackages", index],
+				message: `"${pkg}" is also in externalPackages; a package belongs to one list or the other`,
+			});
+		});
+	});
 
 /** Static definition of a bucket (existence). Name is the record key. */
 export const bucketDefSchema = z.strictObject({

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -218,6 +218,22 @@ const externalPackageNameSchema = z
 	});
 
 /**
+ * An entry whose files are staged has to name one installable package, because the deploy
+ * hands its root to `npm install`. esbuild's `external` additionally accepts a `*` wildcard
+ * and a bare scope, which name a set rather than a package — legal only when nothing is
+ * being installed for them.
+ */
+const stageablePackageName = (value: string): boolean => {
+	if (value.includes("*")) return false;
+	// A protocol (`node:fs`, `npm:pkg`) is a specifier, not something to install.
+	if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
+	const root = externalPackageRoot(value);
+	// A bare scope names every package in it, not one package.
+	if (root.startsWith("@")) return /^@[^/]+\/[^/]+$/.test(root);
+	return root.length > 0;
+};
+
+/**
  * One entry of `externalPackages`. A bare string is the common case and ships the package's
  * files; the object form exists only to turn that off. See {@link FunctionDef.externalPackages}.
  */
@@ -276,6 +292,19 @@ export const functionDefSchema = z
 		entries.forEach((entry, index) => {
 			const name = entryName(entry);
 			const includeFiles = entryIncludesFiles(entry);
+
+			if (includeFiles && !stageablePackageName(name)) {
+				ctx.issues.push({
+					code: "custom",
+					input: entry,
+					path: ["externalPackages", index],
+					message:
+						`"${name}" does not name a single installable package, so its files cannot ` +
+						`be staged. Name one package, or set includeFiles: false to leave the ` +
+						`import unresolved without shipping anything for it`,
+				});
+				return;
+			}
 
 			const firstIndex = seenNames.get(name);
 			if (firstIndex !== undefined) {

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { parseBranchTtl, parseSuspendTimeout } from "./duration.js";
+import { externalPackageRoot } from "./external-packages.js";
 import { isWildcardPattern, validatePattern } from "./patterns.js";
 
 /**
@@ -204,12 +205,12 @@ const functionDevConfigSchema = z.strictObject({
 });
 
 /**
- * A package the bundler must leave alone. Accepts what esbuild's `external` accepts for a
- * package — a bare name, a scope, or a subpath — and rejects a relative or absolute path,
- * which names a local module rather than a dependency and is never the right thing to
- * externalize (the bundle would ship an import of a file that isn't deployed).
+ * The name of a package the bundler must leave alone. Accepts what esbuild's `external`
+ * accepts for a package — a bare name, a scope, or a subpath — and rejects a relative or
+ * absolute path, which names a local module rather than a dependency and is never the right
+ * thing to externalize (the bundle would ship an import of a file that isn't deployed).
  */
-const externalPackageSchema = z
+const externalPackageNameSchema = z
 	.string()
 	.min(1)
 	.refine((value) => !value.startsWith(".") && !value.startsWith("/"), {
@@ -217,42 +218,44 @@ const externalPackageSchema = z
 	});
 
 /**
+ * One entry of `externalPackages`. A bare string is the common case and ships the package's
+ * files; the object form exists only to turn that off. See {@link FunctionDef.externalPackages}.
+ */
+const externalPackageEntrySchema = z.union([
+	externalPackageNameSchema,
+	z.strictObject({
+		name: externalPackageNameSchema,
+		includeFiles: z.boolean().optional(),
+	}),
+]);
+
+/**
  * Per-function list of packages esbuild leaves unresolved at deploy time. See
- * {@link FunctionDef.externalPackages} for when this is the right tool — the deployed
- * archive has no `node_modules`, so an externalized package must never be reached at
- * runtime.
+ * {@link FunctionDef.externalPackages}.
  */
-const functionExternalPackagesSchema = z.array(externalPackageSchema);
-
-/**
- * A package whose real files ship alongside the bundle. Same specifier grammar as
- * {@link externalPackageSchema}, minus the subpath: a native package is installed and
- * traced as a whole, so the unit is the package, not a file inside it.
- */
-const nativePackageSchema = externalPackageSchema.refine(
-	(value) => value.split("/").length === (value.startsWith("@") ? 2 : 1),
-	{
-		error: 'must be a package name such as "sharp" or "@scope/pkg", without a subpath',
-	},
-);
-
-/**
- * Per-function list of packages shipped as real files next to the bundle. See
- * {@link FunctionDef.nativePackages}.
- */
-const functionNativePackagesSchema = z.array(nativePackageSchema);
+const functionExternalPackagesSchema = z.array(externalPackageEntrySchema);
 
 const runtimeSchema = z.literal("nodejs24");
+
+/** The declared name of an entry, whichever form it was written in. */
+const entryName = (
+	entry: z.infer<typeof externalPackageEntrySchema>,
+): string => (typeof entry === "string" ? entry : entry.name);
+
+/** Whether an entry ships its files. Absent means yes — see `FunctionDef.externalPackages`. */
+const entryIncludesFiles = (
+	entry: z.infer<typeof externalPackageEntrySchema>,
+): boolean => (typeof entry === "string" ? true : entry.includeFiles !== false);
 
 /**
  * Static definition of a function (existence). The slug is the record key (validated by
  * {@link functionSlugSchema}), so it is not a field here. Deploy tuning (`runtime`) lives
  * in the `branch` closure, not here.
  *
- * `externalPackages` and `nativePackages` are mutually exclusive per package: the first
- * means "leave the import unresolved", the second "leave it unresolved AND ship the files".
- * Listing one package in both states two different intents for it, so it is rejected here
- * rather than silently resolved in favour of one.
+ * `externalPackages` entries are checked for contradictions: the same package named twice,
+ * or named once bare and once through a subpath with a different `includeFiles`. Both state
+ * two intents for one package, and files are staged per package rather than per subpath, so
+ * neither can be honoured as written.
  */
 export const functionDefSchema = z
 	.strictObject({
@@ -260,19 +263,48 @@ export const functionDefSchema = z
 		source: z.string().min(1),
 		env: functionEnvSchema.optional(),
 		externalPackages: functionExternalPackagesSchema.optional(),
-		nativePackages: functionNativePackagesSchema.optional(),
 		dev: functionDevConfigSchema.optional(),
 	})
 	.check((ctx) => {
-		const external = new Set(ctx.value.externalPackages ?? []);
-		(ctx.value.nativePackages ?? []).forEach((pkg, index) => {
-			if (!external.has(pkg)) return;
-			ctx.issues.push({
-				code: "custom",
-				input: pkg,
-				path: ["nativePackages", index],
-				message: `"${pkg}" is also in externalPackages; a package belongs to one list or the other`,
-			});
+		const entries = ctx.value.externalPackages ?? [];
+		const seenNames = new Map<string, number>();
+		const rootIntent = new Map<
+			string,
+			{ includeFiles: boolean; at: string }
+		>();
+
+		entries.forEach((entry, index) => {
+			const name = entryName(entry);
+			const includeFiles = entryIncludesFiles(entry);
+
+			const firstIndex = seenNames.get(name);
+			if (firstIndex !== undefined) {
+				ctx.issues.push({
+					code: "custom",
+					input: entry,
+					path: ["externalPackages", index],
+					message: `"${name}" is listed more than once (first at index ${firstIndex})`,
+				});
+				return;
+			}
+			seenNames.set(name, index);
+
+			// Files are installed and traced per package, so two specifiers that resolve to the
+			// same package cannot disagree about whether that package's files ship.
+			const root = externalPackageRoot(name);
+			const prior = rootIntent.get(root);
+			if (prior !== undefined && prior.includeFiles !== includeFiles) {
+				ctx.issues.push({
+					code: "custom",
+					input: entry,
+					path: ["externalPackages", index],
+					message:
+						`"${name}" and "${prior.at}" are both part of the "${root}" package but disagree ` +
+						`about includeFiles; files ship per package, so the whole package either ships or does not`,
+				});
+				return;
+			}
+			rootIntent.set(root, { includeFiles, at: name });
 		});
 	});
 

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -355,9 +355,9 @@ export interface FunctionDef {
 	 * possible depends on what it is. A pure-JavaScript package can be bundled, and a
 	 * failure to do so is usually something specific and fixable. A package backed by a
 	 * native `.node` binary cannot be bundled by anything — the binary is a compiled
-	 * object the platform loads from a real path — so such a package cannot work on
-	 * Functions until the deployed archive can carry files alongside the bundle. Do not
-	 * reach for `externalPackages` to try: it moves the error from deploy to invoke.
+	 * object the platform loads from a real path — so it needs its files shipped next to
+	 * the bundle instead. That is what {@link FunctionDef.nativePackages} does; reaching
+	 * for `externalPackages` only moves the error from deploy to invoke.
 	 *
 	 * Note that a native package may bundle without ever needing this option. `sharp`, for
 	 * instance, loads its binary through `createRequire`, which esbuild does not follow, so
@@ -370,6 +370,40 @@ export interface FunctionDef {
 	 * @example ["microsandbox", "@mongodb-js/zstd"]
 	 */
 	externalPackages?: string[];
+	/**
+	 * Packages backed by a native binary, whose real files ship into the deployed archive
+	 * alongside the bundle. This is the option that makes a native dependency *work*, where
+	 * {@link FunctionDef.externalPackages} only stops it failing the build.
+	 *
+	 * Each entry is left out of the bundle and then installed for the Functions runtime
+	 * target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it
+	 * actually reaches, and copied into the archive under `node_modules/` with its directory
+	 * layout preserved. That layout is load-bearing, not cosmetic: a `.node` addon locates
+	 * its sibling shared libraries relative to its own directory, so a flattened tree fails
+	 * to load.
+	 *
+	 * Your own `node_modules` is never read for these files or modified. Its binaries are
+	 * built for your machine rather than the deploy target, and a cross-platform install
+	 * does not survive your next plain `npm install`, so the target's packages are resolved
+	 * fresh on each deploy. The version installed is the one your project already resolved,
+	 * read from your dependency tree — the deploy honours your lockfile without trusting the
+	 * binaries sitting next to it.
+	 *
+	 * Requirements and failure modes, all reported at deploy time rather than at invoke: the
+	 * package must publish a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages
+	 * do; anything compiled from source at install time does not), `npm` must be on `PATH`,
+	 * and the archive must stay inside the deploy size limits — native binaries are large.
+	 *
+	 * Entries are package names without a subpath (`sharp`, `@scope/pkg`): the whole package
+	 * is installed and traced, so naming a file inside one means nothing here. A package
+	 * listed here must not also appear in `externalPackages`.
+	 *
+	 * Under `neon dev` the list only keeps the package out of the bundle — nothing is
+	 * installed or copied, and it resolves from your own `node_modules` against your host
+	 * architecture, which is what you want locally.
+	 * @example ["sharp"]
+	 */
+	nativePackages?: string[];
 	/**
 	 * Local-development settings used by `neon dev` when serving every function from
 	 * `neon.ts`. Ignored at deploy time. See {@link FunctionDevConfig}.
@@ -557,6 +591,13 @@ export interface ResolvedFunctionConfig {
 	 * policy that never mentions it resolves to the same shape it always did.
 	 */
 	externalPackages?: string[];
+	/**
+	 * Packages whose real files ship alongside the bundle, passed through from
+	 * {@link FunctionDef.nativePackages}. Absent rather than empty when undeclared: a policy
+	 * that never mentions it takes the pre-existing bundling path and produces the archive
+	 * it always did.
+	 */
+	nativePackages?: string[];
 	runtime: FunctionRuntime;
 	/**
 	 * Local-development settings, passed through untouched from {@link FunctionDef.dev}

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -715,4 +715,17 @@ export interface PushResult {
 	dryRun: boolean;
 	applied: AppliedChange[];
 	conflicts: ConflictReport[];
+	/**
+	 * Advisory findings from the push — a function that bundles a native dependency it never
+	 * declared, or a staged package whose version could not be pinned.
+	 *
+	 * Returned rather than logged, because a library has no business choosing an output
+	 * channel, and returned rather than left to an opt-in callback, because these are the
+	 * only warning that a deployed function will fail at invoke and an unregistered callback
+	 * is easy to never notice. Empty when there is nothing to report.
+	 *
+	 * Only populated by the built-in bundler: a caller that injects its own `bundleFunction`
+	 * owns its own reporting.
+	 */
+	warnings: string[];
 }

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -295,6 +295,40 @@ export interface FunctionDevConfig {
 }
 
 /**
+ * The object form of an {@link FunctionDef.externalPackages} entry, for the one case the
+ * bare string cannot express: externalizing a package without shipping its files.
+ */
+export interface ExternalPackageDef {
+	/** Package name, optionally with a subpath: `sharp`, `@scope/pkg`, `pkg/sub`. */
+	name: string;
+	/**
+	 * Whether the package's real files ship into the deployed archive next to the bundle.
+	 *
+	 * Defaults to `true`, which is the state where the import resolves and the function
+	 * works. Set it to `false` only for a package the function never reaches: nothing is
+	 * shipped for it, so reaching it throws `Cannot find module` at invoke.
+	 */
+	includeFiles?: boolean;
+}
+
+/**
+ * One entry of {@link FunctionDef.externalPackages}. A bare string is the common form and
+ * ships the package's files; {@link ExternalPackageDef} exists to turn that off.
+ */
+export type ExternalPackageEntry = string | ExternalPackageDef;
+
+/**
+ * An {@link ExternalPackageEntry} with its default applied, as every consumer downstream of
+ * `resolveConfig` reads it.
+ */
+export interface ResolvedExternalPackage {
+	/** Package name as declared, subpath included. */
+	name: string;
+	/** Whether this package's files are staged into the archive. */
+	includeFiles: boolean;
+}
+
+/**
  * Static definition of a Neon Function (Preview feature). Declares that the function
  * **exists** on every branch; its branch-unique slug is the **record key** in
  * {@link PreviewInput.functions} (not a field here), so slugs are statically enumerable,
@@ -335,75 +369,64 @@ export interface FunctionDef {
 	 */
 	env?: Record<string, string>;
 	/**
-	 * Packages the bundler must leave alone, by name — the deploy-time equivalent of
-	 * Next.js's `serverExternalPackages`. Every entry is passed to esbuild's `external`,
-	 * so the import survives into the bundle instead of being followed.
+	 * Packages the bundler must leave alone — the deploy-time equivalent of Next.js's
+	 * `serverExternalPackages`. Every entry is passed to esbuild's `external`, so the import
+	 * survives into the bundle instead of being followed, and the package's own files are
+	 * shipped into the deployed archive beside the bundle so that import resolves.
 	 *
 	 * Reach for this when bundling a package is impossible rather than merely undesirable.
-	 * The cases that come up: a native `.node` addon or a `node-gyp` dependency esbuild has
-	 * no loader for, and an optional peer dependency a library references on a code path
-	 * this function never takes. Both fail the deploy at bundle time with a resolve or
-	 * loader error naming the package, and neither is fixable from the function's own
-	 * source.
+	 * The case that comes up is a package backed by a native `.node` binary: the binary is a
+	 * compiled object the platform loads from a real path, so no bundler can inline it.
+	 * `sharp` is the common one, and it does not even fail at build time — it loads its
+	 * binary through `createRequire`, which esbuild does not follow, so it bundles cleanly
+	 * and then fails at invoke with "Could not load the sharp module".
 	 *
-	 * **An external package is not resolvable at runtime.** The deployed archive is a
-	 * single `index.mjs` with no `node_modules` beside it, so anything listed here throws
-	 * `Cannot find module` if the function actually reaches it. This option therefore only
-	 * unblocks an import that is never evaluated; it does not make a dependency usable.
+	 * ```ts
+	 * externalPackages: ["sharp"]
+	 * ```
 	 *
-	 * A dependency the handler actually calls has to be bundled, and whether that is
-	 * possible depends on what it is. A pure-JavaScript package can be bundled, and a
-	 * failure to do so is usually something specific and fixable. A package backed by a
-	 * native `.node` binary cannot be bundled by anything — the binary is a compiled
-	 * object the platform loads from a real path — so it needs its files shipped next to
-	 * the bundle instead. That is what {@link FunctionDef.nativePackages} does; reaching
-	 * for `externalPackages` only moves the error from deploy to invoke.
-	 *
-	 * Note that a native package may bundle without ever needing this option. `sharp`, for
-	 * instance, loads its binary through `createRequire`, which esbuild does not follow, so
-	 * it bundles cleanly and then fails at invoke with "Could not load the sharp module".
-	 *
-	 * Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`,
-	 * `pkg/sub`), matching esbuild. A relative or absolute path is rejected at validation
-	 * time: those are local modules, and a local module that cannot be bundled is a
-	 * different problem.
-	 * @example ["microsandbox", "@mongodb-js/zstd"]
-	 */
-	externalPackages?: string[];
-	/**
-	 * Packages backed by a native binary, whose real files ship into the deployed archive
-	 * alongside the bundle. This is the option that makes a native dependency *work*, where
-	 * {@link FunctionDef.externalPackages} only stops it failing the build.
-	 *
-	 * Each entry is left out of the bundle and then installed for the Functions runtime
-	 * target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it
-	 * actually reaches, and copied into the archive under `node_modules/` with its directory
-	 * layout preserved. That layout is load-bearing, not cosmetic: a `.node` addon locates
-	 * its sibling shared libraries relative to its own directory, so a flattened tree fails
-	 * to load.
+	 * Each declared package is installed for the Functions runtime target — **linux-arm64,
+	 * glibc** — into a throwaway directory, traced for the files it actually reaches, and
+	 * copied into the archive under `node_modules/` with its directory layout preserved. That
+	 * layout is load-bearing rather than cosmetic: a `.node` addon locates its sibling shared
+	 * libraries relative to its own directory, so a flattened tree fails to load.
 	 *
 	 * Your own `node_modules` is never read for these files or modified. Its binaries are
-	 * built for your machine rather than the deploy target, and a cross-platform install
-	 * does not survive your next plain `npm install`, so the target's packages are resolved
-	 * fresh on each deploy. The version installed is the one your project already resolved,
-	 * read from your dependency tree — the deploy honours your lockfile without trusting the
-	 * binaries sitting next to it.
+	 * built for your machine rather than the deploy target, and a cross-platform install does
+	 * not survive your next plain `npm install`, so the target's packages are resolved fresh
+	 * on each deploy.
 	 *
-	 * Requirements and failure modes, all reported at deploy time rather than at invoke: the
-	 * package must publish a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages
-	 * do; anything compiled from source at install time does not), `npm` must be on `PATH`,
-	 * and the archive must stay inside the deploy size limits — native binaries are large.
+	 * Requirements, all reported at deploy time rather than at invoke: the package must
+	 * publish a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages do; anything
+	 * compiled from source at install time does not), `npm` must be on `PATH`, and the
+	 * archive must stay inside the deploy size limits — native binaries are large.
 	 *
-	 * Entries are package names without a subpath (`sharp`, `@scope/pkg`): the whole package
-	 * is installed and traced, so naming a file inside one means nothing here. A package
-	 * listed here must not also appear in `externalPackages`.
+	 * ### Excluding a package's files
+	 *
+	 * `includeFiles: false` externalizes the import without shipping anything, which is the
+	 * escape hatch for a package that cannot be staged — no build for the target, or too
+	 * large — and that the function never actually reaches:
+	 *
+	 * ```ts
+	 * externalPackages: ["sharp", { name: "canvas", includeFiles: false }]
+	 * ```
+	 *
+	 * **An excluded package is not resolvable at runtime.** Nothing is shipped for it, so it
+	 * throws `Cannot find module` if the function reaches it. It unblocks an import that is
+	 * never evaluated; it does not make a dependency usable.
+	 *
+	 * Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`),
+	 * matching esbuild. A relative or absolute path is rejected at validation time: those are
+	 * local modules, and a local module that cannot be bundled is a different problem. Files
+	 * are staged per package, so a subpath narrows what esbuild leaves unresolved without
+	 * narrowing what ships.
 	 *
 	 * Under `neon dev` the list only keeps the package out of the bundle — nothing is
 	 * installed or copied, and it resolves from your own `node_modules` against your host
 	 * architecture, which is what you want locally.
-	 * @example ["sharp"]
+	 * @example ["sharp", { name: "canvas", includeFiles: false }]
 	 */
-	nativePackages?: string[];
+	externalPackages?: ExternalPackageEntry[];
 	/**
 	 * Local-development settings used by `neon dev` when serving every function from
 	 * `neon.ts`. Ignored at deploy time. See {@link FunctionDevConfig}.
@@ -586,18 +609,13 @@ export interface ResolvedFunctionConfig {
 	source: string;
 	env: Record<string, string>;
 	/**
-	 * Packages the bundler leaves unresolved, passed through from
-	 * {@link FunctionDef.externalPackages}. Absent rather than empty when undeclared, so a
-	 * policy that never mentions it resolves to the same shape it always did.
+	 * Packages the bundler leaves unresolved, normalized from
+	 * {@link FunctionDef.externalPackages} with `includeFiles` defaulted.
+	 *
+	 * Absent rather than empty when undeclared, so a policy that never mentions it takes the
+	 * pre-existing bundling path and produces the archive it always did.
 	 */
-	externalPackages?: string[];
-	/**
-	 * Packages whose real files ship alongside the bundle, passed through from
-	 * {@link FunctionDef.nativePackages}. Absent rather than empty when undeclared: a policy
-	 * that never mentions it takes the pre-existing bundling path and produces the archive
-	 * it always did.
-	 */
-	nativePackages?: string[];
+	externalPackages?: ResolvedExternalPackage[];
 	runtime: FunctionRuntime;
 	/**
 	 * Local-development settings, passed through untouched from {@link FunctionDef.dev}

--- a/packages/config/src/v1.test.ts
+++ b/packages/config/src/v1.test.ts
@@ -63,9 +63,11 @@ describe("@neon/config public value surface", () => {
 			  "deriveCredentialScopes",
 			  "diffConfig",
 			  "errors",
+			  "externalPackageRoot",
 			  "isPartialBranchCreateError",
 			  "isPlatformError",
 			  "loadConfigFromFile",
+			  "packagesToStage",
 			  "resolveConfig",
 			  "schemas",
 			]

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -131,6 +131,11 @@ export {
 	PushAbortedError,
 	PushConflictError,
 } from "./lib/errors.js";
+// ─── External packages (pure; also for a custom FunctionBundler) ──────────────
+export {
+	externalPackageRoot,
+	packagesToStage,
+} from "./lib/external-packages.js";
 export type { LoadConfigOptions } from "./lib/loader.js";
 export { loadConfigFromFile } from "./lib/loader.js";
 // ─── NeonApi types (needed by callers implementing their own adapters) ────────
@@ -180,6 +185,8 @@ export type {
 	DataApiSettings,
 	DurationString,
 	DurationUnit,
+	ExternalPackageDef,
+	ExternalPackageEntry,
 	FunctionDef,
 	FunctionDevConfig,
 	FunctionRuntime,
@@ -191,6 +198,7 @@ export type {
 	ResolvedBranchConfig,
 	ResolvedBucketConfig,
 	ResolvedDataApiConfig,
+	ResolvedExternalPackage,
 	ResolvedFunctionConfig,
 	ResolvedPreviewConfig,
 	ServiceEnabled,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       '@neon/config':
         specifier: workspace:*
         version: link:../config
+      '@vercel/nft':
+        specifier: ^1.10.2
+        version: 1.10.2(rollup@4.50.1)
       esbuild:
         specifier: ^0.28.1
         version: 0.28.1
@@ -1398,6 +1401,11 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
@@ -1837,6 +1845,11 @@ packages:
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
 
+  '@vercel/nft@1.10.2':
+    resolution: {integrity: sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
@@ -1894,6 +1907,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1905,6 +1922,11 @@ packages:
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -2013,6 +2035,9 @@ packages:
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
+  async-sema@3.1.1:
+    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
@@ -2029,6 +2054,10 @@ packages:
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   bare-events@2.5.4:
     resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
@@ -2088,6 +2117,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   birpc@2.5.0:
     resolution: {integrity: sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==}
 
@@ -2107,6 +2139,10 @@ packages:
 
   brace-expansion@2.0.1:
     resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2291,6 +2327,10 @@ packages:
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   console-fail-test@0.5.0:
     resolution: {integrity: sha512-nghkQcJ9DJMYtdN1L/ZNu1GvnLMo38DTneWX23+WbIdvjuVkbcshGFxgIG5LbI9j/th4dgwUc0Hiwtq85VWb/Q==}
@@ -2666,6 +2706,9 @@ packages:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -2776,6 +2819,10 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -3266,6 +3313,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@5.1.6:
     resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
     engines: {node: '>=10'}
@@ -3279,6 +3330,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.0.2:
@@ -3348,11 +3403,20 @@ packages:
       encoding:
         optional: true
 
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
   node-pty@1.1.0:
     resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -3499,6 +3563,10 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
@@ -5139,6 +5207,19 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.0.4
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.8.2
+      tar: 7.4.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
     dependencies:
       '@emnapi/core': 1.11.2
@@ -5280,6 +5361,14 @@ snapshots:
       picomatch: 4.0.3
     optionalDependencies:
       rollup: 3.29.4
+
+  '@rollup/pluginutils@5.3.0(rollup@4.50.1)':
+    dependencies:
+      '@types/estree': 1.0.8
+      estree-walker: 2.0.2
+      picomatch: 4.0.3
+    optionalDependencies:
+      rollup: 4.50.1
 
   '@rollup/rollup-android-arm-eabi@4.50.1':
     optional: true
@@ -5507,6 +5596,25 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
+  '@vercel/nft@1.10.2(rollup@4.50.1)':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
+      acorn: 8.15.0
+      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.3
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
   '@vercel/oidc@3.2.0': {}
 
   '@vitest/coverage-v8@3.0.9(vitest@3.0.9(@types/debug@4.1.13)(@types/node@20.19.17)(jiti@2.7.0)(jsdom@26.1.0)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.22.3)(yaml@2.9.0))':
@@ -5613,6 +5721,8 @@ snapshots:
       - react-native-b4a
       - supports-color
 
+  abbrev@3.0.1: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -5627,8 +5737,11 @@ snapshots:
       mime-types: 3.0.1
       negotiator: 1.0.0
 
-  acorn@8.15.0:
-    optional: true
+  acorn-import-attributes@1.9.5(acorn@8.15.0):
+    dependencies:
+      acorn: 8.15.0
+
+  acorn@8.15.0: {}
 
   add-mcp@1.5.1:
     dependencies:
@@ -5645,8 +5758,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  agent-base@7.1.3:
-    optional: true
+  agent-base@7.1.3: {}
 
   ai@6.0.228(zod@4.4.3):
     dependencies:
@@ -5737,6 +5849,8 @@ snapshots:
 
   async-lock@1.4.1: {}
 
+  async-sema@3.1.1: {}
+
   async@3.2.6: {}
 
   b4a@1.6.7: {}
@@ -5745,6 +5859,8 @@ snapshots:
     optional: true
 
   balanced-match@1.0.2: {}
+
+  balanced-match@4.0.4: {}
 
   bare-events@2.5.4:
     optional: true
@@ -5802,6 +5918,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
+
   birpc@2.5.0: {}
 
   bl@4.1.0:
@@ -5846,6 +5966,10 @@ snapshots:
   brace-expansion@2.0.1:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.8:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -6027,6 +6151,8 @@ snapshots:
       readable-stream: 4.7.0
 
   confbox@0.2.4: {}
+
+  consola@3.4.2: {}
 
   console-fail-test@0.5.0: {}
 
@@ -6453,6 +6579,8 @@ snapshots:
     dependencies:
       is-unicode-supported: 2.1.0
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -6584,6 +6712,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.6
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@8.1.0:
     dependencies:
       fs.realpath: 1.0.0
@@ -6668,7 +6802,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   human-id@4.1.1: {}
 
@@ -7035,6 +7168,10 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.8
+
   minimatch@5.1.6:
     dependencies:
       brace-expansion: 2.0.1
@@ -7046,6 +7183,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@3.0.2:
     dependencies:
@@ -7100,11 +7239,17 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-gyp-build@4.8.4: {}
+
   node-int64@0.4.0: {}
 
   node-pty@1.1.0:
     dependencies:
       node-addon-api: 7.1.1
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
 
   normalize-path@3.0.0: {}
 
@@ -7240,6 +7385,11 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
 
   path-to-regexp@0.1.7: {}
 


### PR DESCRIPTION
Depends on #387, which merges `nativePackages` into `externalPackages`. **Merge that first.**

The install / trace / verify pipeline here is Gleb's and is unchanged in substance. This
branch adapts it to the merged option and adds the reporting half.

## The problem

A package backed by a `.node` binary could not work on Functions. The binary is a compiled
object the platform loads from a real path, so no bundler can inline it, and the archive was
a single `index.mjs` with no `node_modules` beside it for an externalized import to resolve
against.

`sharp` is the sharp edge. It loads its binary through `createRequire`, which esbuild does
not follow, so it bundles cleanly at ~40 KB and then dies at invoke:

```
Could not load the "sharp" module using the linux-arm64 runtime
```

**The runtime was never the obstacle.** It imports the entry by absolute path, so Node
resolves `node_modules` next to it — for both `import` and the `createRequire` shim the
bundle's banner already installs — from any working directory. The archive simply never
carried a `node_modules` to resolve against. So this is a bundler and packaging change; no
dataplane change was needed.

## Staging

Three steps, in an order that is not interchangeable.

**1. Install for the runtime target, not the deploy machine.**
`npm install <pkg> --cpu=arm64 --os=linux --libc=glibc` into a throwaway directory.

The user's own `node_modules` is never read for these files. Its binaries are built for their
machine, and — verified — a cross-platform install is **not sticky**: a later plain
`npm install` re-resolves optional dependencies for the host and silently replaces the
target's packages with the host's. `--ignore-scripts` is not only for speed; an install
script would compile for the host and overwrite the prebuilt binary being collected. npm is
spawned rather than imported, because the standalone CLI build contains neither npm nor a
`node_modules`.

**2. Trace the installed tree with `@vercel/nft`.** The file set cannot be discovered by
asking Node. `@img/sharp-linux-arm64` exports only `./sharp.node` and `./package` — no `.`,
no wildcard — so its directory is unreachable through the resolver. A tracer that follows
`createRequire` is the only thing that finds these files, which is the same blindness that
makes esbuild miss them in the first place. Sibling platform builds are then dropped, identified from their own manifests the way npm
decides what to install — `@img/sharp-linuxmusl-arm64` declares `libc: ["musl"]`, which a
glibc runtime cannot load. The WebAssembly fallback is the exception: `@img/sharp-wasm32`
declares no `os`, `cpu`, or `libc` at all, so only its name identifies it, matched as a whole
dash-delimited token. Dropping it is not a size saving — sharp's loader falls through to it
silently, so a broken native path would succeed on much slower code instead of failing
loudly.

**3. Copy the traced files preserving the `node_modules` layout.** A `.node` addon locates
its sibling shared libraries by a path relative to its own directory:

```
$ readelf -d sharp-linux-arm64-0.35.3.node
(NEEDED) libvips-cpp.so.8.18.3
(RPATH)  $ORIGIN/../../sharp-libvips-linux-arm64/lib:...
```

Flattening the tree breaks loading with every file present, so archive keys carry their full
`node_modules/...` path and a test asserts nothing collapses to a basename.

Failures are reported at deploy rather than at invoke: no build for the target; npm's
`EBADPLATFORM`, whose own message compares against the *host* and so reads as though the
wrong thing was asked for; a binary that is not an aarch64 ELF; a symlink, which the archive
cannot represent; and the size and entry limits, whose message names the largest
contributors.

## Reporting an undeclared native dependency

Staging only helps a user who knows the option exists. `sharp` gives no build error to hang
a message off — it bundles cleanly and fails in production — so nothing catches the common
case today.

esbuild's metafile names every package that was bundled in, and the path it reports is also
where that exact copy lives — which is what makes this work under pnpm, whose transitive
dependencies are not linked at the project root and whose store holds several versions of a
package side by side. For each package not already declared, its own metadata is checked for
native code: a `.node`/`.so` in its tree,
a platform-gated optional dependency carrying one (the `sharp` → `@img/sharp-linux-arm64`
shape, which scanning only the parent misses), a node-gyp install script, or a node-pre-gyp
`binary` field. A package whose `os`/`cpu`/`libc` exclude the runtime is skipped — `fsevents` is darwin-only
and a musl build cannot load on glibc, so neither is shippable and reporting them would be
noise on every macOS project. Manifests are read defensively: `os` may be a bare string, and
a malformed value must not take an advisory scan, and with it the deploy, down.

Real output, from a function importing `sharp` with nothing declared:

```
Function "resize" bundles "sharp", and it loads a compiled binary from
@img/sharp-darwin-arm64 (lib/sharp-darwin-arm64-0.35.3.node).
A compiled binary cannot be bundled, so if this function reaches that code path it
will fail at invoke rather than at deploy.

  Ship its files with the deploy:
      externalPackages: ["sharp"]

  Or, if this function never reaches it, silence this by saying so:
      externalPackages: [{ name: "sharp", includeFiles: false }]

Shipping a package adds its whole file tree to the archive, which increases both
archive size and cold start. If "sharp" is only used behind a JavaScript fallback,
the deploy is already correct and the second form records that.
```

Findings are returned, never printed: `pushConfig` puts them on `PushResult.warnings` and
the CLI renders them. A library has no business choosing an output channel, and the repo's
`noConsole` rule agrees.

**It is a warning, never a failure, and that is the central design decision here.** The
evidence proves the package contains compiled code; it cannot prove this function's code path
reaches it. `ws` with `bufferutil` installed, a Prisma client configured with no Rust engine,
and any package with an optional native accelerator behind a working JavaScript fallback all
look identical from here and deploy correctly today. Failing on that evidence would break
working deploys, so the message states the failure conditionally and names the
no-change-needed case.

Two consequences worth knowing:

- **It only runs after a successful bundle.** A package esbuild cannot resolve, or a `.node`
  it has no loader for, throws before any metafile exists — those already fail loudly with
  esbuild's own diagnostic. The case this covers is precisely the one that otherwise reaches
  production.
- **It also runs under `neon dev`**, as a warning. Locally these packages resolve from the
  real `node_modules` at host architecture, so a native dependency works perfectly on your
  laptop and gives no signal at all. Without this the first news is a failed deploy.

## `neon dev`

The declared names are mirrored into esbuild's `external` and nothing else happens: no
install, no copy. The dev bundle is written *inside* the project's own `node_modules`, so an
unbundled package resolves from the real tree at the host architecture. That was previously
incidental to where the bundle directory happened to sit; it is now a named helper with tests
pinning both the path and the resolution behaviour, because moving that directory would break
local dev for native dependencies and nothing else would catch it.

## Also in here

- **Version pinning was broken for the canonical package.** `installedVersion` used
  `require.resolve("<pkg>/package.json")`, which respects the `exports` map. `sharp` publishes
  `exports: { "." : … }` with no `./package.json`, so the lookup threw
  `ERR_PACKAGE_PATH_NOT_EXPORTED` even with `sharp` installed, and the deploy silently staged
  the registry's latest instead of the user's version. Found by the new warning below firing
  on a real project. Versions are now read from the package directory, located by walking
  `node_modules` the way Node does.
- **`NativeTraceResult.warnings` was always `[]`.** It now carries the case where a version
  cannot be determined, and both bundlers surface it, so staging a different version than the
  one you tested is said out loud instead of discovered from a deployed archive.
- **The trace imports the specifier as authored, while the install gets the package root.** A
  package may export only a subpath — `exports: { "./native": … }` with no `.` — in which
  case importing the root throws `ERR_PACKAGE_PATH_NOT_EXPORTED` and the trace finds nothing.
- **A traced file that is not in the staging tree now fails the deploy.** It was skipped,
  which produces an archive that is quietly missing a file and fails at invoke.
- **The `wasm32`/`musl` variant filter matches package directory names**, not the whole path.
  As a substring test it also deleted ordinary files such as `lib/musl-helper.js`.
- **Two deploy messages pointed at `neon function deploy --src`** as the way to ship a
  hand-built binary. That command runs `bundleEntry` and zips only its output — it cannot
  carry extra files, so the advice was false. Replaced with what is actually true.
- **The live install tests no longer skip.** They were gated behind
  `NEON_TEST_NATIVE_INSTALL=1` because the protected runners have no public egress, but CI's
  `prepare` action writes an `~/.npmrc` pointing at the Databricks JFrog mirror before
  anything installs, and a spawned `npm` reads it. They run in ~6s locally and really do
  install `sharp` for linux-arm64 and assert the AArch64 ELF. **If CI disagrees, that is a
  fact I could not check from here and I will re-gate them.**
- `bundleEntry` returns `{ files, metafile }` instead of a bare file map. CLI-internal, three
  call sites.
- `@vercel/nft` is a new dependency of `@neon/config-runtime`, loaded by dynamic `import()`
  like `esbuild` and `fflate` already are, so a `neon.ts` that only reads config never pulls
  it in.

## Verification

`pnpm build`, `pnpm lint:ci`, and `pnpm test:ci` are green across the workspace: 4488 tests.
`@neon/config-runtime` has no skipped tests; the CLI's 6 skips and `ai-sdk-provider`'s 1 are
pre-existing on `main` and untouched here.

Unit coverage runs against stubbed install and trace steps, so it needs no registry: the
unflattened layout, both size limits, the wrong-architecture / non-ELF / too-short-to-be-a-
binary rejections and the accepted aarch64 case, the manifest-driven sibling filter (and that
a package merely named `musl-helper` keeps its files), version pinning (including the
`exports`-map shape that broke it, and a scoped package), the package-root-versus-authored-
specifier split, and the never-read-the-user's-tree property. `pushConfig` is covered against
a real on-disk `node_modules` for both the reported and the nothing-to-report case. Detection is tested against
real `node_modules` trees written to temp directories rather than a faked filesystem, because
the thing under test is how a package looks on disk.

End to end against a real `sharp` install, all three states of the option:

| `externalPackages` | archive | reported |
| --- | --- | --- |
| absent | 1 entry, 0.04 MiB | the warning above |
| `["sharp"]` | 89 entries, 8.05 MiB, both AArch64 binaries present as siblings under `node_modules/@img` | nothing |
| `[{ name: "sharp", includeFiles: false }]` | 1 entry | nothing |

**Not verified: executing the arm64 binary end to end.** That needs a real deploy; this host
is x86_64, where loading it fails as expected. Everything up to and including the bytes that
would ship is verified.

## For your attention

- **The warning will fire on projects that are already correct.** `ws` with `bufferutil`
  installed is the common one. The message says so and `includeFiles: false` records the
  intent, but this is noise added to deploys that do not need changing, and the false-positive
  rate is the thing to push back on if it feels wrong.
- **Archive size.** `sharp` alone is 8.05 MiB compressed, which fits current limits with room
  to spare, but a couple of native packages is the practical ceiling. The size check reads its
  limits from an argument rather than hardcoding them.
- **Cold start** grows for functions that stage anything — 1 file to ~89, read file by file
  when a VM loads. Confined to functions that declare it, but worth measuring before this is
  recommended broadly.
- **Detection cannot see through Yarn PnP**, which resolves out of zip archives with no
  `node_modules` segment, and misses natives with no `.node`/`.so` (a Prisma engine, an
  `ffmpeg` binary) and anything loaded through a computed `require`. A missed package is a
  missing warning rather than a wrong one, which is the safe direction, but it means this is
  a net that catches the common case, not a guarantee.
- **Staging does not reproduce the user's lockfile.** It installs `<name>@<version>` for the
  declared package into a clean directory, so the root version is the one they resolved but
  transitive pins, overrides, patches, and aliases are not carried over. Making this exact
  means reading each package manager's lockfile, which is its own piece of work. A package
  whose version cannot be read at all is now reported rather than silently taking the
  registry's latest, which was the previous behaviour and was hitting `sharp`.
- **A package that is itself platform-gated cannot be staged directly.** Declaring
  `@img/sharp-linux-arm64` rather than `sharp` fails with `EBADPLATFORM`, because npm
  evaluates the root package against the host even when the target flags are passed. Declare
  the parent package instead. The error message names the target rather than explaining this,
  which is a rough edge.
- **`PushResult` gains a required `warnings` field.** Additive for anyone reading a result;
  breaking for anything constructing one.
- **The tracer's own warnings are deliberately not surfaced, and I tried the opposite
  first.** Reporting nft's unresolved-dependency warnings sounds right and measures wrong on
  the canonical package: tracing a correctly staged `sharp` emitted twelve of them, one per
  platform that was correctly not installed plus several for specifiers built by string
  concatenation that no tracer can follow, and none indicated a missing file. A report that
  is wrong every time trains people to ignore it. An archive that really is incomplete is
  caught by the checks that prove it instead — a traced file absent from staging fails the
  deploy, and a shipped binary that is not an AArch64 ELF fails it too.
- **A merged changeset is not a published package** — this needs a release before the option
  works from an installed CLI.

