### PR TITLE
fix(cli): serve WebSockets under neon dev

### DIFF
--- a/.changeset/tidy-mugs-wander.md
+++ b/.changeset/tidy-mugs-wander.md
@@ -1,0 +1,13 @@
+---
+"neon": minor
+---
+
+Fix WebSockets under `neon dev`. The dev server registered no `'upgrade'` listener, so
+Node handed a WebSocket handshake to the ordinary request handler and answered `200 OK` on
+a connection the client expected to be a `101` — a function's `upgrade` export was never
+called, and the failure looked like success.
+
+The dev server now handles upgrades the way the deployed runtime does: the existing
+`export function upgrade(req, socket, head)` shape works locally for the first time, and
+`upgradeWebSocket()` from `@neon/functions` works too, with the same precedence (a legacy
+`upgrade` export wins) and the same clean `501` for a function that serves no WebSockets.

--- a/packages/cli/src/dev/runtime.test.ts
+++ b/packages/cli/src/dev/runtime.test.ts
@@ -7,6 +7,7 @@ import {
 	type FetchHandler,
 	portSelectionFromEnv,
 	resolveFetchHandler,
+	resolveUpgradeHandler,
 	withErrorBoundary,
 } from "./runtime.js";
 
@@ -39,6 +40,88 @@ describe("resolveFetchHandler", () => {
 		expect(() =>
 			resolveFetchHandler({ handler: () => new Response("named") }),
 		).toThrow(/No request handler found/);
+	});
+});
+
+describe("resolveUpgradeHandler", () => {
+	// Resolution order must match the deployed runtime's: a named export first, then
+	// an `upgrade` method on the default export.
+	const req = {} as Parameters<
+		NonNullable<ReturnType<typeof resolveUpgradeHandler>>
+	>[0];
+	const socket = {} as Parameters<
+		NonNullable<ReturnType<typeof resolveUpgradeHandler>>
+	>[1];
+	const head = Buffer.alloc(0);
+
+	it("picks a named `export function upgrade`", () => {
+		let called = false;
+		const handler = resolveUpgradeHandler({
+			upgrade: () => {
+				called = true;
+			},
+		});
+		handler?.(req, socket, head);
+		expect(called).toBe(true);
+	});
+
+	it("picks an `upgrade` method on the default export", () => {
+		let called = false;
+		const handler = resolveUpgradeHandler({
+			default: {
+				fetch: () => new Response("x"),
+				upgrade: () => {
+					called = true;
+				},
+			},
+		});
+		handler?.(req, socket, head);
+		expect(called).toBe(true);
+	});
+
+	it("prefers the named export over the default-export method", () => {
+		const calls: string[] = [];
+		const handler = resolveUpgradeHandler({
+			upgrade: () => calls.push("named"),
+			default: { upgrade: () => calls.push("default") },
+		});
+		handler?.(req, socket, head);
+		expect(calls).toEqual(["named"]);
+	});
+
+	it("calls the default-export method with `this` bound to the object", () => {
+		// A bundle written as `export default { upgrade() { this.handle(...) } }` must
+		// not lose its receiver.
+		let receiver: unknown = null;
+		const target = {
+			marker: "the-object",
+			upgrade(): void {
+				receiver = this;
+			},
+		};
+		resolveUpgradeHandler({ default: target })?.(req, socket, head);
+		expect(receiver).toBe(target);
+	});
+
+	it("returns undefined when the module has no upgrade export", () => {
+		expect(
+			resolveUpgradeHandler({
+				default: { fetch: () => new Response("x") },
+			}),
+		).toBeUndefined();
+		expect(
+			resolveUpgradeHandler({ default: () => new Response("x") }),
+		).toBeUndefined();
+		expect(resolveUpgradeHandler({})).toBeUndefined();
+	});
+
+	it("ignores a non-function `upgrade`", () => {
+		expect(
+			resolveUpgradeHandler({ upgrade: "not a function" }),
+		).toBeUndefined();
+		expect(
+			resolveUpgradeHandler({ default: { upgrade: 42 } }),
+		).toBeUndefined();
 	});
 });
 

--- a/packages/cli/src/dev/runtime.ts
+++ b/packages/cli/src/dev/runtime.ts
@@ -4,6 +4,12 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { getRequestListener } from "@hono/node-server";
 
+import {
+	createUpgradeListener,
+	installWebSocketBridge,
+	type UpgradeHandler,
+} from "./websocket.js";
+
 /**
  * A WHATWG fetch-style handler: takes a Request, returns a Response. The single
  * shape the local dev server and the deployed Neon Functions runtime both speak.
@@ -47,6 +53,36 @@ export const resolveFetchHandler = (mod: UserModule): FetchHandler => {
 			"  export default { fetch(req) { /* ... */ } }\n" +
 			"  export default function (req) { /* ... */ }",
 	);
+};
+
+const hasUpgradeMethod = (
+	value: unknown,
+): value is { upgrade: UpgradeHandler } =>
+	typeof value === "object" &&
+	value !== null &&
+	"upgrade" in value &&
+	typeof (value as { upgrade: unknown }).upgrade === "function";
+
+/**
+ * Resolve the user's optional WebSocket entrypoint: a named `export function upgrade`,
+ * or an `upgrade` method on the default export. `undefined` when the module has
+ * neither, which is the common case — a function without one either uses
+ * `upgradeWebSocket()` inside `fetch` or serves no WebSockets at all.
+ *
+ * Resolution order matches the deployed runtime exactly (named export first, then the
+ * default-export method), so a module that resolves one way locally cannot resolve the
+ * other way once deployed.
+ */
+export const resolveUpgradeHandler = (
+	mod: UserModule,
+): UpgradeHandler | undefined => {
+	if (typeof mod.upgrade === "function") return mod.upgrade as UpgradeHandler;
+	const defaultExport = mod.default;
+	if (hasUpgradeMethod(defaultExport)) {
+		const target = defaultExport;
+		return (req, socket, head) => target.upgrade(req, socket, head);
+	}
+	return undefined;
 };
 
 /**
@@ -150,12 +186,36 @@ export const startRuntime = async ({
 	const mod = (await import(
 		pathToFileURL(absoluteSource).href
 	)) as UserModule;
-	const handler = withErrorBoundary(resolveFetchHandler(mod));
+	const fetchHandler = resolveFetchHandler(mod);
+	const handler = withErrorBoundary(fetchHandler);
+
+	// Publish the bridge `upgradeWebSocket()` reads before the user module can serve a
+	// request, so the helper resolves locally exactly as it does when deployed.
+	installWebSocketBridge();
 
 	const listener = getRequestListener(handler, { hostname });
 	const server = createServer((incoming, outgoing) => {
 		void listener(incoming, outgoing);
 	});
+
+	// Node emits 'upgrade' rather than 'request' for a WebSocket handshake. Without
+	// this listener Node hands the handshake to the ordinary request handler, which
+	// answers 200 on a connection the client expects to be a 101 — so a function's
+	// WebSocket code silently never ran under `neon dev`.
+	//
+	// The upgrade path takes the RAW handler, not the error-boundary-wrapped one. The
+	// boundary turns a throw into a 500 Response, which on this path is
+	// indistinguishable from a handler that deliberately declined the upgrade — so a
+	// crashing handler would answer 501 ("no WebSocket support") instead of surfacing
+	// the error. The upgrade listener has its own equivalent boundary, and reports a
+	// throw as the 502 the deployed runtime returns.
+	server.on(
+		"upgrade",
+		createUpgradeListener({
+			fetch: fetchHandler,
+			upgrade: resolveUpgradeHandler(mod),
+		}),
+	);
 
 	const boundPort = await bindPort(server, port, hostname);
 	process.stdout.write(`neon-dev:ready ${boundPort}\n`);

--- a/packages/cli/src/dev/websocket.test.ts
+++ b/packages/cli/src/dev/websocket.test.ts
@@ -1,0 +1,761 @@
+import { createServer, type Server } from "node:http";
+import { type AddressInfo, connect, type Socket } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+	acceptKey,
+	createUpgradeListener,
+	installWebSocketBridge,
+	isWebSocketHandshake,
+	type UpgradeHandler,
+	type UpgradeWebSocketOptions,
+	type WebSocketUpgrade,
+} from "./websocket.js";
+
+const WS_BRIDGE_KEY = Symbol.for("neon.websocket.bridge");
+
+/**
+ * Reach the helper the way customer code does — through the bridge global, which is
+ * exactly what `upgradeWebSocket` in `@neon/functions` reads. Calling the export
+ * directly would skip the contract the two packages actually share.
+ */
+const upgradeWebSocket = (
+	request: Request,
+	options?: UpgradeWebSocketOptions,
+): WebSocketUpgrade => {
+	const bridge = (
+		globalThis as unknown as Record<
+			symbol,
+			| {
+					upgrade: (
+						req: Request,
+						opts?: UpgradeWebSocketOptions,
+					) => WebSocketUpgrade;
+			  }
+			| undefined
+		>
+	)[WS_BRIDGE_KEY];
+	if (!bridge) {
+		throw new TypeError(
+			"upgradeWebSocket() is only available inside a Neon Functions invocation",
+		);
+	}
+	return bridge.upgrade(request, options);
+};
+
+type Frame = {
+	fin: boolean;
+	opcode: number;
+	masked: boolean;
+	payload: Buffer;
+};
+
+/**
+ * A WebSocket client that speaks enough of RFC 6455 to verify the server side:
+ * masked client frames, fragmentation, ping/pong and the close handshake.
+ */
+class WsClient {
+	buf = Buffer.alloc(0);
+	frames: Frame[] = [];
+	closed = false;
+	#waiters: {
+		resolve: (frame: Frame) => void;
+		reject: (err: Error) => void;
+	}[] = [];
+
+	constructor(readonly sock: Socket) {
+		sock.on("data", (chunk: Buffer) => this.feed(chunk));
+		sock.on("close", () => {
+			this.closed = true;
+			this.#drain();
+		});
+	}
+
+	feed(chunk: Buffer): void {
+		this.buf = Buffer.concat([this.buf, chunk]);
+		this.#drain();
+	}
+
+	#drain(): void {
+		for (;;) {
+			const frame = this.#decode();
+			if (!frame) break;
+			this.frames.push(frame);
+		}
+		while (this.#waiters.length && this.frames.length) {
+			this.#waiters.shift()?.resolve(this.frames.shift() as Frame);
+		}
+		if (this.closed) {
+			while (this.#waiters.length) {
+				this.#waiters
+					.shift()
+					?.reject(new Error("socket closed before a frame arrived"));
+			}
+		}
+	}
+
+	#decode(): Frame | null {
+		const b = this.buf;
+		if (b.length < 2) return null;
+		const fin = ((b[0] as number) & 0x80) !== 0;
+		const opcode = (b[0] as number) & 0x0f;
+		const masked = ((b[1] as number) & 0x80) !== 0;
+		let len = (b[1] as number) & 0x7f;
+		let off = 2;
+		if (len === 126) {
+			if (b.length < off + 2) return null;
+			len = b.readUInt16BE(off);
+			off += 2;
+		} else if (len === 127) {
+			if (b.length < off + 8) return null;
+			len = Number(b.readBigUInt64BE(off));
+			off += 8;
+		}
+		if (masked) off += 4;
+		if (b.length < off + len) return null;
+		const payload = Buffer.from(b.subarray(off, off + len));
+		this.buf = b.subarray(off + len);
+		return { fin, opcode, masked, payload };
+	}
+
+	next(): Promise<Frame> {
+		const buffered = this.frames.shift();
+		if (buffered) return Promise.resolve(buffered);
+		if (this.closed)
+			return Promise.reject(new Error("socket already closed"));
+		return new Promise<Frame>((resolve, reject) => {
+			this.#waiters.push({ resolve, reject });
+			setTimeout(
+				() => reject(new Error("timed out waiting for a frame")),
+				2000,
+			).unref();
+		});
+	}
+
+	send(payload: string | Buffer, opcode = 0x1, fin = true): void {
+		const body = Buffer.isBuffer(payload)
+			? payload
+			: Buffer.from(payload, "utf8");
+		const mask = Buffer.from([0x12, 0x34, 0x56, 0x78]);
+		let header: Buffer;
+		if (body.length < 126) {
+			header = Buffer.alloc(2);
+			header[1] = 0x80 | body.length;
+		} else {
+			header = Buffer.alloc(4);
+			header[1] = 0x80 | 126;
+			header.writeUInt16BE(body.length, 2);
+		}
+		header[0] = (fin ? 0x80 : 0x00) | opcode;
+		const masked = Buffer.from(body);
+		for (let i = 0; i < masked.length; i++) {
+			masked[i] = (masked[i] as number) ^ (mask[i & 3] as number);
+		}
+		this.sock.write(Buffer.concat([header, mask, masked]));
+	}
+
+	/** An unmasked client frame — a protocol violation the server must reject. */
+	sendUnmasked(payload: string): void {
+		const body = Buffer.from(payload, "utf8");
+		this.sock.write(
+			Buffer.concat([Buffer.from([0x81, body.length]), body]),
+		);
+	}
+
+	sendClose(code = 1000, reason = ""): void {
+		const reasonBuf = Buffer.from(reason, "utf8");
+		const payload = Buffer.alloc(2 + reasonBuf.length);
+		payload.writeUInt16BE(code, 0);
+		reasonBuf.copy(payload, 2);
+		this.send(payload, 0x8);
+	}
+
+	destroy(): void {
+		this.sock.destroy();
+	}
+}
+
+let server: Server | null = null;
+
+/** Start a dev server wired exactly as `startRuntime` wires it. */
+const start = async (mod: {
+	fetch?: (req: Request) => Response | Promise<Response>;
+	upgrade?: UpgradeHandler;
+	log?: (message: string) => void;
+}): Promise<number> => {
+	installWebSocketBridge();
+	// The raw handler, as `startRuntime` passes it: the error boundary would turn a
+	// throw into a 500 Response, which this path cannot tell apart from a handler that
+	// declined the upgrade.
+	const handler = mod.fetch ?? (() => new Response("no fetch handler"));
+	const created = createServer((incoming, outgoing) => {
+		outgoing.writeHead(200, { "content-type": "text/plain" });
+		outgoing.end("ordinary request handler");
+		void incoming;
+	});
+	created.on(
+		"upgrade",
+		createUpgradeListener({
+			fetch: handler,
+			upgrade: mod.upgrade,
+			...(mod.log ? { log: mod.log } : {}),
+		}),
+	);
+	server = created;
+	return new Promise<number>((resolveListen, reject) => {
+		created.once("error", reject);
+		created.listen(0, "127.0.0.1", () => {
+			resolveListen((created.address() as AddressInfo).port);
+		});
+	});
+};
+
+const CLIENT_KEY = "dGhlIHNhbXBsZSBub25jZQ==";
+/** The accept value for CLIENT_KEY, from the RFC's own worked example. */
+const EXPECTED_ACCEPT = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
+const handshakeRequest = (path: string, extraHeaders: string): string =>
+	`GET ${path} HTTP/1.1\r\n` +
+	"host: localhost\r\n" +
+	"connection: Upgrade\r\n" +
+	"upgrade: websocket\r\n" +
+	"sec-websocket-version: 13\r\n" +
+	`sec-websocket-key: ${CLIENT_KEY}\r\n` +
+	extraHeaders +
+	"\r\n";
+
+/** Handshake, then hand back a framing client once the response head is in. */
+const wsHandshake = (
+	port: number,
+	path = "/ws",
+	extraHeaders = "",
+): Promise<{ client: WsClient; raw: string; sock: Socket }> =>
+	new Promise((resolveHandshake, reject) => {
+		const sock = connect(port, "127.0.0.1", () => {
+			sock.write(handshakeRequest(path, extraHeaders));
+		});
+		let head = Buffer.alloc(0);
+		const onData = (chunk: Buffer): void => {
+			head = Buffer.concat([head, chunk]);
+			const end = head.indexOf("\r\n\r\n");
+			if (end === -1) return;
+			sock.off("data", onData);
+			const raw = head.subarray(0, end + 4).toString("utf8");
+			const rest = head.subarray(end + 4);
+			const client = new WsClient(sock);
+			// Frames can share the segment that carried the head.
+			if (rest.length) client.feed(rest);
+			resolveHandshake({ client, raw, sock });
+		};
+		sock.on("data", onData);
+		sock.on("error", reject);
+		sock.setTimeout(2000, () => {
+			sock.destroy();
+			reject(new Error("wsHandshake timeout"));
+		});
+	});
+
+/** Handshake and read the whole response, for the rejection paths. */
+const wsHandshakeFull = (
+	port: number,
+	path = "/ws",
+	extraHeaders = "",
+): Promise<string> =>
+	new Promise((resolveFull, reject) => {
+		const sock = connect(port, "127.0.0.1", () => {
+			sock.write(handshakeRequest(path, extraHeaders));
+		});
+		const chunks: Buffer[] = [];
+		const finish = (): void => {
+			resolveFull(Buffer.concat(chunks).toString("utf8"));
+		};
+		sock.on("data", (c: Buffer) => chunks.push(c));
+		sock.on("end", finish);
+		sock.on("close", finish);
+		sock.on("error", reject);
+		sock.setTimeout(2000, () => {
+			sock.destroy();
+			reject(new Error("wsHandshakeFull timeout"));
+		});
+	});
+
+afterEach(async () => {
+	delete (globalThis as unknown as Record<symbol, unknown>)[WS_BRIDGE_KEY];
+	if (server) {
+		const toClose = server;
+		server = null;
+		await new Promise<void>((resolveClose) => {
+			toClose.close(() => resolveClose());
+		});
+	}
+});
+
+describe("isWebSocketHandshake", () => {
+	it("requires both the upgrade header and a key", () => {
+		const req = (headers: Record<string, string>) =>
+			({ headers }) as unknown as Parameters<
+				typeof isWebSocketHandshake
+			>[0];
+		expect(
+			isWebSocketHandshake(
+				req({ upgrade: "websocket", "sec-websocket-key": CLIENT_KEY }),
+			),
+		).toBe(true);
+		expect(isWebSocketHandshake(req({ upgrade: "websocket" }))).toBe(false);
+		expect(
+			isWebSocketHandshake(
+				req({ upgrade: "h2c", "sec-websocket-key": CLIENT_KEY }),
+			),
+		).toBe(false);
+		expect(isWebSocketHandshake(req({}))).toBe(false);
+	});
+});
+
+describe("acceptKey", () => {
+	it("matches the worked example in RFC 6455", () => {
+		expect(acceptKey(CLIENT_KEY)).toBe(EXPECTED_ACCEPT);
+	});
+});
+
+describe("the legacy upgrade export under neon dev", () => {
+	it("is called with the raw Node triple (previously it never ran at all)", async () => {
+		const seen: { url: string | undefined; hasHead: boolean }[] = [];
+		const port = await start({
+			fetch: () => new Response("fetch-handler-ran"),
+			upgrade: (req, socket, head) => {
+				seen.push({ url: req.url, hasHead: Buffer.isBuffer(head) });
+				socket.write(
+					"HTTP/1.1 101 Switching Protocols\r\n" +
+						"upgrade: websocket\r\nconnection: Upgrade\r\n" +
+						`sec-websocket-accept: ${acceptKey(CLIENT_KEY)}\r\n\r\n`,
+				);
+				socket.end();
+			},
+		});
+
+		const raw = await wsHandshakeFull(port, "/chat?room=1");
+
+		expect(raw.startsWith("HTTP/1.1 101")).toBe(true);
+		expect(seen).toEqual([{ url: "/chat?room=1", hasHead: true }]);
+		// The bug this fixes: the fetch handler answered the handshake with a 200.
+		expect(raw).not.toContain("fetch-handler-ran");
+	});
+
+	it("wins over upgradeWebSocket, matching the deployed precedence", async () => {
+		let legacyRan = false;
+		let fetchRan = false;
+		const port = await start({
+			fetch: (request) => {
+				fetchRan = true;
+				return upgradeWebSocket(request).response;
+			},
+			upgrade: (_req, socket) => {
+				legacyRan = true;
+				socket.end(
+					"HTTP/1.1 101 Switching Protocols\r\nupgrade: websocket\r\nconnection: Upgrade\r\n\r\n",
+				);
+			},
+		});
+
+		const raw = await wsHandshakeFull(port);
+
+		expect(raw.startsWith("HTTP/1.1 101")).toBe(true);
+		expect(legacyRan).toBe(true);
+		expect(fetchRan).toBe(false);
+	});
+
+	it("closes the socket cleanly when it throws, instead of crashing the process", async () => {
+		const logged: string[] = [];
+		const port = await start({
+			fetch: () => new Response("unused"),
+			upgrade: () => {
+				throw new Error("boom from the upgrade handler");
+			},
+			log: (message) => logged.push(message),
+		});
+
+		const raw = await wsHandshakeFull(port);
+
+		expect(raw.startsWith("HTTP/1.1 500")).toBe(true);
+		expect(logged.join("\n")).toContain("boom from the upgrade handler");
+	});
+});
+
+describe("upgradeWebSocket under neon dev", () => {
+	it("completes the 101 and echoes text, binary, and fragmented messages", async () => {
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request);
+				expect(socket.readyState).toBe(0); // CONNECTING until the response returns
+				expect(response.status).toBe(101);
+				expect(response instanceof Response).toBe(true);
+				socket.addEventListener("message", (event) => {
+					socket.send((event as MessageEvent).data);
+				});
+				return response;
+			},
+		});
+
+		const { client, raw } = await wsHandshake(port);
+		expect(raw.startsWith("HTTP/1.1 101 Switching Protocols")).toBe(true);
+		expect(raw.toLowerCase()).toContain(
+			`sec-websocket-accept: ${EXPECTED_ACCEPT.toLowerCase()}`,
+		);
+		expect(raw.toLowerCase()).not.toContain("sec-websocket-extensions");
+
+		client.send("hello");
+		let frame = await client.next();
+		expect(frame.opcode).toBe(0x1);
+		expect(frame.payload.toString("utf8")).toBe("hello");
+		expect(frame.masked).toBe(false); // servers never mask
+
+		client.send(Buffer.from([1, 2, 3, 250]), 0x2);
+		frame = await client.next();
+		expect(frame.opcode).toBe(0x2);
+		expect([...frame.payload]).toEqual([1, 2, 3, 250]);
+
+		client.send("frag", 0x1, false);
+		client.send("mented", 0x0, true);
+		frame = await client.next();
+		expect(frame.payload.toString("utf8")).toBe("fragmented");
+
+		// Crosses the 125-byte boundary into the 16-bit extended length.
+		const big = "x".repeat(1000);
+		client.send(big);
+		frame = await client.next();
+		expect(frame.payload.toString("utf8")).toBe(big);
+
+		client.destroy();
+	});
+
+	it("answers a ping with a pong carrying the same payload", async () => {
+		const port = await start({
+			fetch: (request) => upgradeWebSocket(request).response,
+		});
+
+		const { client } = await wsHandshake(port);
+		client.send(Buffer.from("beat"), 0x9);
+		const frame = await client.next();
+
+		expect(frame.opcode).toBe(0xa);
+		expect(frame.payload.toString("utf8")).toBe("beat");
+		client.destroy();
+	});
+
+	it("sends code and reason on close and walks readyState", async () => {
+		const states: number[] = [];
+		let closeEvent: { code: number; wasClean: boolean } | null = null;
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request);
+				socket.addEventListener("open", () => {
+					states.push(socket.readyState);
+					socket.close(1000, "bye");
+					states.push(socket.readyState);
+				});
+				socket.addEventListener("close", (event) => {
+					const e = event as CloseEvent;
+					closeEvent = { code: e.code, wasClean: e.wasClean };
+				});
+				return response;
+			},
+		});
+
+		const { client } = await wsHandshake(port);
+		const frame = await client.next();
+		expect(frame.opcode).toBe(0x8);
+		expect(frame.payload.readUInt16BE(0)).toBe(1000);
+		expect(frame.payload.subarray(2).toString("utf8")).toBe("bye");
+
+		client.sendClose(1000, "bye");
+		await new Promise((r) => setTimeout(r, 50));
+
+		expect(states).toEqual([1, 2]); // OPEN -> CLOSING
+		expect(closeEvent).toEqual({ code: 1000, wasClean: true });
+		client.destroy();
+	});
+
+	it("mirrors a client-initiated close and reports it to the handler", async () => {
+		let closeEvent: { code: number; reason: string } | null = null;
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request);
+				socket.addEventListener("close", (event) => {
+					const e = event as CloseEvent;
+					closeEvent = { code: e.code, reason: e.reason };
+				});
+				return response;
+			},
+		});
+
+		const { client } = await wsHandshake(port);
+		client.sendClose(4001, "client done");
+		const frame = await client.next();
+
+		expect(frame.opcode).toBe(0x8);
+		expect(frame.payload.readUInt16BE(0)).toBe(4001);
+		await new Promise((r) => setTimeout(r, 50));
+		expect(closeEvent).toEqual({ code: 4001, reason: "client done" });
+		client.destroy();
+	});
+
+	it("fails the connection on an unmasked client frame", async () => {
+		const port = await start({
+			fetch: (request) => upgradeWebSocket(request).response,
+		});
+
+		const { client } = await wsHandshake(port);
+		client.sendUnmasked("unmasked");
+		const frame = await client.next();
+
+		expect(frame.opcode).toBe(0x8);
+		expect(frame.payload.readUInt16BE(0)).toBe(1002);
+		client.destroy();
+	});
+
+	it("echoes a requested-and-offered subprotocol exactly once", async () => {
+		let negotiated: string | null = null;
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request, {
+					protocol: "chat.v2",
+				});
+				negotiated = socket.protocol;
+				return response;
+			},
+		});
+
+		const { client, raw } = await wsHandshake(
+			port,
+			"/ws",
+			"sec-websocket-protocol: chat.v1, chat.v2\r\n",
+		);
+
+		const echoed = raw
+			.split("\r\n")
+			.filter((line) => /^sec-websocket-protocol:/i.test(line));
+		expect(echoed).toHaveLength(1);
+		expect(echoed[0]).toMatch(/chat\.v2$/);
+		expect(negotiated).toBe("chat.v2");
+		client.destroy();
+	});
+
+	it("omits the header and leaves socket.protocol empty when none was selected", async () => {
+		let negotiated: string | null = null;
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request);
+				negotiated = socket.protocol;
+				return response;
+			},
+		});
+
+		const { client, raw } = await wsHandshake(
+			port,
+			"/ws",
+			"sec-websocket-protocol: chat.v1\r\n",
+		);
+
+		expect(raw.toLowerCase()).not.toContain("sec-websocket-protocol");
+		expect(negotiated).toBe("");
+		client.destroy();
+	});
+
+	it("throws when asked for a subprotocol the client never offered", async () => {
+		let thrown: unknown = null;
+		const port = await start({
+			fetch: (request) => {
+				try {
+					return upgradeWebSocket(request, {
+						protocol: "not-offered",
+					}).response;
+				} catch (err) {
+					thrown = err;
+					throw err;
+				}
+			},
+		});
+
+		const raw = await wsHandshakeFull(
+			port,
+			"/ws",
+			"sec-websocket-protocol: chat.v1\r\n",
+		);
+
+		expect(raw.startsWith("HTTP/1.1 502")).toBe(true);
+		expect(thrown).toBeInstanceOf(TypeError);
+		expect((thrown as Error).message).toMatch(
+			/did not offer the subprotocol/,
+		);
+	});
+
+	it("fails loudly on a cloned response, never a silent 200", async () => {
+		const logged: string[] = [];
+		const port = await start({
+			fetch: (request) => upgradeWebSocket(request).response.clone(),
+			log: (message) => logged.push(message),
+		});
+
+		const raw = await wsHandshakeFull(port);
+
+		expect(raw.startsWith("HTTP/1.1 500")).toBe(true);
+		expect(raw).toContain("websocket_upgrade_response_lost");
+		expect(raw).not.toContain("HTTP/1.1 200");
+		expect(logged.join("\n")).toContain("websocket_upgrade_response_lost");
+	});
+
+	it("throws rather than upgrading the same request twice", async () => {
+		let thrown: unknown = null;
+		const port = await start({
+			fetch: (request) => {
+				upgradeWebSocket(request);
+				try {
+					upgradeWebSocket(request);
+				} catch (err) {
+					thrown = err;
+				}
+				return new Response("x");
+			},
+		});
+
+		await wsHandshakeFull(port);
+
+		expect(thrown).toBeInstanceOf(TypeError);
+		expect((thrown as Error).message).toMatch(/already called/);
+	});
+
+	it("returns 501 when the handler ignores the upgrade", async () => {
+		const port = await start({
+			fetch: () => new Response("ordinary body"),
+		});
+
+		const raw = await wsHandshakeFull(port);
+
+		expect(raw.startsWith("HTTP/1.1 501")).toBe(true);
+		expect(raw).not.toContain("ordinary body");
+	});
+
+	it("finds the socket when the handler is handed a rebuilt Request", async () => {
+		// Hono's Node adapter rebuilds the Request, so identity is lost and the
+		// AsyncLocalStorage fallback is what keeps the helper working.
+		const port = await start({
+			fetch: (request) => {
+				const rebuilt = new Request(request.url, {
+					method: request.method,
+					headers: request.headers,
+				});
+				const { socket, response } = upgradeWebSocket(rebuilt);
+				socket.addEventListener("message", (event) => {
+					socket.send((event as MessageEvent).data);
+				});
+				return response;
+			},
+		});
+
+		const { client, raw } = await wsHandshake(port);
+		expect(raw.startsWith("HTTP/1.1 101")).toBe(true);
+		client.send("via-rebuilt-request");
+		const frame = await client.next();
+
+		expect(frame.payload.toString("utf8")).toBe("via-rebuilt-request");
+		client.destroy();
+	});
+
+	it("exposes the WHATWG surface: constants, binaryType, and the state guards", async () => {
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request);
+				expect(() => socket.send("too early")).toThrow(
+					/still CONNECTING/,
+				);
+				expect([
+					socket.CONNECTING,
+					socket.OPEN,
+					socket.CLOSING,
+					socket.CLOSED,
+				]).toEqual([0, 1, 2, 3]);
+				expect(socket.extensions).toBe("");
+				// Server-side default; browsers default to "blob".
+				expect(socket.binaryType).toBe("arraybuffer");
+				expect(socket.url).toBe("ws://localhost/ws");
+				expect(socket.bufferedAmount).toBe(0);
+				socket.binaryType = "blob";
+				expect(socket.binaryType).toBe("blob");
+				socket.binaryType = "arraybuffer";
+				// Only 1000 and 3000-4999 may be sent.
+				expect(() => socket.close(1001)).toThrow(/not allowed/);
+				expect(() => socket.close(1000, "y".repeat(124))).toThrow(
+					/at most 123 bytes/,
+				);
+				socket.onmessage = (event) => {
+					socket.send(`got:${(event as MessageEvent).data}`);
+				};
+				return response;
+			},
+		});
+
+		const { client } = await wsHandshake(port);
+		client.send("prop-style");
+		const frame = await client.next();
+
+		expect(frame.payload.toString("utf8")).toBe("got:prop-style");
+		client.destroy();
+	});
+
+	it("delivers binary as an ArrayBuffer and text as a string", async () => {
+		const seen: (string | undefined)[] = [];
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request);
+				socket.addEventListener("message", (event) => {
+					seen.push((event as MessageEvent).data?.constructor?.name);
+					socket.send("ack");
+				});
+				return response;
+			},
+		});
+
+		const { client } = await wsHandshake(port);
+		client.send(Buffer.from([9, 9]), 0x2);
+		await client.next();
+		client.send("text");
+		await client.next();
+
+		expect(seen).toEqual(["ArrayBuffer", "String"]);
+		client.destroy();
+	});
+
+	it("refuses a non-WebSocket upgrade with 426 rather than hanging", async () => {
+		const port = await start({ fetch: () => new Response("unused") });
+
+		const raw = await new Promise<string>((resolveRaw, reject) => {
+			const sock = connect(port, "127.0.0.1", () => {
+				sock.write(
+					"GET / HTTP/1.1\r\nhost: localhost\r\n" +
+						"connection: Upgrade\r\nupgrade: h2c\r\n\r\n",
+				);
+			});
+			const chunks: Buffer[] = [];
+			sock.on("data", (c: Buffer) => chunks.push(c));
+			sock.on("close", () =>
+				resolveRaw(Buffer.concat(chunks).toString("utf8")),
+			);
+			sock.on("error", reject);
+			sock.setTimeout(2000, () => {
+				sock.destroy();
+				reject(new Error("timeout"));
+			});
+		});
+
+		expect(raw.startsWith("HTTP/1.1 426")).toBe(true);
+	});
+
+	it("throws off-platform, where no bridge is published", () => {
+		delete (globalThis as unknown as Record<symbol, unknown>)[
+			WS_BRIDGE_KEY
+		];
+		expect(() =>
+			upgradeWebSocket(new Request("http://localhost/ws")),
+		).toThrow(/only available inside a Neon Functions invocation/);
+	});
+});

--- a/packages/cli/src/dev/websocket.ts
+++ b/packages/cli/src/dev/websocket.ts
@@ -1,0 +1,1142 @@
+/**
+ * WebSocket support for the `neon dev` server.
+ *
+ * Node's `http.Server` emits `'upgrade'` — not `'request'` — for anything carrying
+ * `Connection: Upgrade`. With no `'upgrade'` listener registered, Node routes the
+ * handshake to the ordinary request handler, which answers `200 OK` on a connection
+ * the client is waiting to see a `101` on. That is why WebSockets did not work under
+ * `neon dev`: a function's `upgrade` export was never called, and the client saw a
+ * nonsense 200 rather than an error.
+ *
+ * This module provides both shapes the deployed runtime supports:
+ *
+ *   1. `export function upgrade(req, socket, head)` — handed the raw Node triple,
+ *      exactly like production. The bundle owns the handshake and framing.
+ *   2. `upgradeWebSocket(request)` from `@neon/functions`, called inside `fetch` —
+ *      reached only when there is no `upgrade` export, matching the runtime's
+ *      precedence rule so local behaviour cannot diverge from deployed behaviour.
+ *
+ * The protocol implementation here mirrors the deployed runtime's. Duplicating it is
+ * deliberate for now: the runtime is a zero-dependency file baked into a microVM image
+ * and cannot import from npm, so sharing a module would mean new vendoring machinery.
+ * The shared contract is the bridge global and the observable behaviour, which the
+ * tests on both sides pin. permessage-deflate is not negotiated on either side.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+
+/** The bridge global `@neon/functions` reads. Must match the deployed runtime. */
+const WS_BRIDGE_KEY = Symbol.for("neon.websocket.bridge");
+
+/** Brand identifying the response the helper produced. Non-enumerable. */
+const UPGRADE_RECORD = Symbol.for("neon.websocket.upgradeRecord");
+
+/** RFC 6455 §1.3. */
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+
+const OP_CONTINUATION = 0x0;
+const OP_TEXT = 0x1;
+const OP_BINARY = 0x2;
+const OP_CLOSE = 0x8;
+const OP_PING = 0x9;
+const OP_PONG = 0xa;
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSING = 2;
+const CLOSED = 3;
+
+/** Reassembly ceiling: a fragmented message buffers until FIN, so it must be bounded. */
+const MAX_MESSAGE_BYTES = 16 * 1024 * 1024;
+/** Control frames carry at most 125 bytes and are never fragmented (§5.5). */
+const MAX_CONTROL_PAYLOAD = 125;
+/** A close reason must fit the 123 bytes left after the 2-byte code. */
+const MAX_CLOSE_REASON_BYTES = 123;
+/** How long to wait for the peer's answering close frame (§7.1.1 leaves this open). */
+const CLOSE_HANDSHAKE_TIMEOUT_MS = 5_000;
+
+const EMPTY = Buffer.alloc(0);
+
+/**
+ * Node has global Event/MessageEvent/CloseEvent but not ErrorEvent, so fall back to a
+ * shim with the same shape (`message` + `error`) when it is missing.
+ */
+type ErrorEventInit = { message?: string; error?: unknown };
+type ErrorEventCtorType = new (type: string, init?: ErrorEventInit) => Event;
+
+class ShimErrorEvent extends Event {
+	readonly message: string;
+	readonly error: unknown;
+	constructor(type: string, init: ErrorEventInit = {}) {
+		super(type);
+		this.message = init.message ?? "";
+		this.error = init.error;
+	}
+}
+
+const ErrorEventCtor: ErrorEventCtorType =
+	typeof (globalThis as { ErrorEvent?: unknown }).ErrorEvent === "function"
+		? ((globalThis as { ErrorEvent?: unknown })
+				.ErrorEvent as ErrorEventCtorType)
+		: ShimErrorEvent;
+
+export type UpgradeWebSocketOptions = {
+	protocol?: string;
+};
+
+export type WebSocketUpgrade = {
+	socket: WebSocket;
+	response: Response;
+};
+
+/** A raw Node upgrade, as the legacy `upgrade` export receives it. */
+export type UpgradeHandler = (
+	req: IncomingMessage,
+	socket: Duplex,
+	head: Buffer,
+) => void | Promise<void>;
+
+type UpgradeRecord = {
+	req: IncomingMessage;
+	socket: Duplex;
+	head: Buffer;
+	claimed: boolean;
+	ws: DevServerWebSocket | null;
+	protocol: string;
+	accept: string;
+};
+
+export const acceptKey = (key: string): string =>
+	createHash("sha1")
+		.update(key + WS_GUID)
+		.digest("base64");
+
+const headerValue = (req: IncomingMessage, name: string): string => {
+	const value = req.headers[name];
+	if (Array.isArray(value)) return value[0] ?? "";
+	return typeof value === "string" ? value : "";
+};
+
+/** Does this request carry a WebSocket handshake (rather than some other upgrade)? */
+export const isWebSocketHandshake = (req: IncomingMessage): boolean =>
+	headerValue(req, "upgrade").toLowerCase() === "websocket" &&
+	headerValue(req, "sec-websocket-key") !== "";
+
+// -- Request <-> socket association -----------------------------------------
+
+/** Primary lookup: the exact Request object the dev server built. */
+const pendingByRequest = new WeakMap<Request, UpgradeRecord>();
+
+/**
+ * Fallback for adapters that rebuild the Request before the handler sees it —
+ * Hono's Node adapter does, so the object identity we keyed on is lost.
+ */
+const upgradeStore = new AsyncLocalStorage<UpgradeRecord>();
+
+const registerUpgrade = (
+	request: Request,
+	parts: { req: IncomingMessage; socket: Duplex; head: Buffer },
+): UpgradeRecord => {
+	const record: UpgradeRecord = {
+		req: parts.req,
+		socket: parts.socket,
+		head: parts.head.length ? Buffer.from(parts.head) : EMPTY,
+		claimed: false,
+		ws: null,
+		protocol: "",
+		accept: "",
+	};
+	pendingByRequest.set(request, record);
+	return record;
+};
+
+const readUpgradeRecord = (value: unknown): UpgradeRecord | null => {
+	if (!value || typeof value !== "object") return null;
+	return (
+		(value as Record<symbol, UpgradeRecord | undefined>)[UPGRADE_RECORD] ??
+		null
+	);
+};
+
+// -- The Response subclass ---------------------------------------------------
+
+/**
+ * `new Response(null, { status: 101 })` throws — the fetch spec restricts constructed
+ * responses to 200-599. A subclass can still report 101 from the getter while being a
+ * genuine `instanceof Response`.
+ *
+ * The lie does not survive `clone()` or `new Response(res.body, res)`; both drop the
+ * brand and the overridden getter. That is detected and failed loudly rather than
+ * silently answering 200 on a socket awaiting a 101.
+ */
+class UpgradeResponse extends Response {
+	constructor(record: UpgradeRecord) {
+		super(null, { status: 200 });
+		Object.defineProperty(this, UPGRADE_RECORD, {
+			value: record,
+			enumerable: false,
+			configurable: false,
+			writable: false,
+		});
+	}
+
+	override get status(): number {
+		return 101;
+	}
+
+	override get statusText(): string {
+		return "Switching Protocols";
+	}
+
+	override get ok(): boolean {
+		return false;
+	}
+}
+
+// -- The public helper -------------------------------------------------------
+
+/** The implementation behind `upgradeWebSocket()` in `@neon/functions`. */
+export const upgradeWebSocket = (
+	request: Request,
+	options: UpgradeWebSocketOptions = {},
+): WebSocketUpgrade => {
+	const record = pendingByRequest.get(request) ?? upgradeStore.getStore();
+	if (!record) {
+		throw new TypeError(
+			"upgradeWebSocket() found no connection to upgrade. It is only usable " +
+				"inside a Neon Functions invocation, on a request carrying a WebSocket " +
+				"handshake.",
+		);
+	}
+	if (record.claimed) {
+		throw new TypeError(
+			"upgradeWebSocket() was already called for this request; a connection " +
+				"can only be upgraded once.",
+		);
+	}
+
+	const req = record.req;
+	const method = (req.method ?? "GET").toUpperCase();
+	if (method !== "GET") {
+		throw new TypeError(
+			`upgradeWebSocket() requires a GET request, got ${method}.`,
+		);
+	}
+	const key = headerValue(req, "sec-websocket-key");
+	if (
+		headerValue(req, "upgrade").toLowerCase() !== "websocket" ||
+		key === ""
+	) {
+		throw new TypeError(
+			"upgradeWebSocket() requires a WebSocket handshake: the request must " +
+				"carry `Upgrade: websocket` and `Sec-WebSocket-Key`.",
+		);
+	}
+	const version = headerValue(req, "sec-websocket-version");
+	if (version !== "" && version !== "13") {
+		throw new TypeError(
+			`unsupported Sec-WebSocket-Version ${version}; only version 13 is supported.`,
+		);
+	}
+
+	// RFC 6455 §4.2.2: echo exactly one protocol, and only one the client offered.
+	// Selecting an un-offered protocol is a server bug that surfaces as an opaque
+	// client-side rejection, so fail here where the cause is obvious.
+	let protocol = "";
+	if (options.protocol != null) {
+		if (typeof options.protocol !== "string") {
+			throw new TypeError("options.protocol must be a string.");
+		}
+		const offered = headerValue(req, "sec-websocket-protocol")
+			.split(",")
+			.map((entry) => entry.trim())
+			.filter((entry) => entry !== "");
+		if (!offered.includes(options.protocol)) {
+			throw new TypeError(
+				`the client did not offer the subprotocol "${options.protocol}" ` +
+					`(offered: ${offered.length ? offered.join(", ") : "none"}).`,
+			);
+		}
+		protocol = options.protocol;
+	}
+
+	record.claimed = true;
+	record.protocol = protocol;
+	record.accept = acceptKey(key);
+	record.ws = new DevServerWebSocket({
+		socket: record.socket,
+		url: socketUrl(req),
+		protocol,
+	});
+	return {
+		socket: record.ws as unknown as WebSocket,
+		response: new UpgradeResponse(record),
+	};
+};
+
+const socketUrl = (req: IncomingMessage): string => {
+	const host = headerValue(req, "host") || "localhost";
+	const target =
+		typeof req.url === "string" && req.url.startsWith("/") ? req.url : "/";
+	return `ws://${host}${target}`;
+};
+
+/** Publish the bridge so `@neon/functions` resolves under `neon dev`. */
+export const installWebSocketBridge = (target: object = globalThis): void => {
+	Object.defineProperty(target, WS_BRIDGE_KEY, {
+		value: { version: 1, upgrade: upgradeWebSocket },
+		enumerable: false,
+		configurable: true,
+		writable: true,
+	});
+};
+
+// -- Handshake completion ----------------------------------------------------
+
+/** Headers the handshake owns; a customer value must not override them. */
+const RESERVED_HANDSHAKE_HEADERS = new Set([
+	"connection",
+	"upgrade",
+	"sec-websocket-accept",
+	"sec-websocket-protocol",
+	"sec-websocket-extensions",
+	"content-length",
+	"content-type",
+	"transfer-encoding",
+]);
+
+const completeUpgrade = (record: UpgradeRecord, response: Response): void => {
+	const socket = record.socket;
+	const ws = record.ws;
+	if (!ws) return;
+	// close() was called before the handler returned: never write the 101.
+	if (ws.readyState === CLOSED) {
+		try {
+			socket.end();
+		} catch {
+			/* already gone */
+		}
+		return;
+	}
+	let head =
+		"HTTP/1.1 101 Switching Protocols\r\n" +
+		"upgrade: websocket\r\n" +
+		"connection: Upgrade\r\n" +
+		`sec-websocket-accept: ${record.accept}\r\n`;
+	if (record.protocol) {
+		head += `sec-websocket-protocol: ${record.protocol}\r\n`;
+	}
+	try {
+		response.headers.forEach((value, name) => {
+			const lower = name.toLowerCase();
+			if (RESERVED_HANDSHAKE_HEADERS.has(lower)) return;
+			head += `${lower}: ${value}\r\n`;
+		});
+	} catch {
+		// A response without usable headers is not a reason to drop the upgrade.
+	}
+	socket.write(`${head}\r\n`);
+	// A live WebSocket is a long-lived idle-tolerant pipe: no inactivity timeout, and
+	// no Nagle delay on small frames. `Duplex` does not declare either method, so
+	// feature-detect (a test double may implement neither).
+	try {
+		const tunable = socket as Partial<{
+			setTimeout: (ms: number) => void;
+			setNoDelay: (enable: boolean) => void;
+		}>;
+		tunable.setTimeout?.(0);
+		tunable.setNoDelay?.(true);
+	} catch {
+		/* not a real socket */
+	}
+	ws.openWithHead(record.head);
+};
+
+// -- Reject / relay helpers --------------------------------------------------
+
+const STATUS_TEXT: Record<number, string> = {
+	404: "Not Found",
+	426: "Upgrade Required",
+	500: "Internal Server Error",
+	501: "Not Implemented",
+	502: "Bad Gateway",
+};
+
+/**
+ * Answer an upgrade with a plain HTTP response and close. Node gives us a raw socket
+ * for `'upgrade'` (no ServerResponse), so the bytes are written by hand. Always ends
+ * the socket: an unanswered upgrade socket leaks and leaves the client hanging.
+ */
+export const writeUpgradeRejection = (
+	socket: Duplex,
+	status: number,
+	reason: string,
+): void => {
+	const body = `${reason}\n`;
+	try {
+		socket.end(
+			`HTTP/1.1 ${status} ${STATUS_TEXT[status] ?? "Error"}\r\n` +
+				"connection: close\r\n" +
+				"content-type: text/plain\r\n" +
+				`content-length: ${Buffer.byteLength(body)}\r\n` +
+				"\r\n" +
+				body,
+		);
+	} catch {
+		try {
+			socket.destroy();
+		} catch {
+			/* already destroyed */
+		}
+	}
+};
+
+// -- The 'upgrade' listener --------------------------------------------------
+
+export type UpgradeListenerOptions = {
+	/** The user's `fetch` handler, already wrapped in the error boundary. */
+	fetch: (req: Request) => Response | Promise<Response>;
+	/** The user's legacy `upgrade` export, when they have one. */
+	upgrade?: UpgradeHandler | undefined;
+	/** Where diagnostics go. Defaults to stderr. */
+	log?: (message: string) => void;
+};
+
+/**
+ * Build the `'upgrade'` listener for the dev server.
+ *
+ * Precedence matches the deployed runtime exactly: a legacy `upgrade` export wins
+ * unconditionally, and only in its absence is the upgrade routed through `fetch` so
+ * `upgradeWebSocket()` can claim it. A function that does neither gets a clean 501
+ * rather than the misleading 200 Node produces with no listener at all.
+ */
+export const createUpgradeListener = ({
+	fetch: fetchHandler,
+	upgrade,
+	log = (message) => process.stderr.write(`${message}\n`),
+}: UpgradeListenerOptions) => {
+	return (req: IncomingMessage, socket: Duplex, head: Buffer): void => {
+		void handleUpgrade(req, socket, head, {
+			fetch: fetchHandler,
+			upgrade,
+			log,
+		}).catch((err: unknown) => {
+			const message =
+				err instanceof Error ? (err.stack ?? err.message) : String(err);
+			log(`WebSocket upgrade failed:\n${message}`);
+			try {
+				writeUpgradeRejection(socket, 500, "upgrade error");
+			} catch {
+				/* socket already gone */
+			}
+		});
+	};
+};
+
+const handleUpgrade = async (
+	req: IncomingMessage,
+	socket: Duplex,
+	head: Buffer,
+	{
+		fetch: fetchHandler,
+		upgrade,
+		log,
+	}: Required<Pick<UpgradeListenerOptions, "fetch" | "log">> & {
+		upgrade?: UpgradeHandler | undefined;
+	},
+): Promise<void> => {
+	// A non-WebSocket upgrade (h2c, or something bespoke) is not ours to answer.
+	if (!isWebSocketHandshake(req) && !upgrade) {
+		writeUpgradeRejection(socket, 426, "expected a websocket upgrade");
+		return;
+	}
+
+	// The launched contract wins, so local precedence matches deployed precedence.
+	if (upgrade) {
+		await upgrade(req, socket, head);
+		return;
+	}
+
+	const request = toWebRequest(req);
+	const record = registerUpgrade(request, { req, socket, head });
+
+	let response: Response;
+	try {
+		response = await upgradeStore.run(record, () => fetchHandler(request));
+	} catch (err) {
+		const message =
+			err instanceof Error ? (err.stack ?? err.message) : String(err);
+		log(`Request handler threw an error while upgrading:\n${message}`);
+		abortClaimedUpgrade(record);
+		writeUpgradeRejection(socket, 502, "handler error");
+		return;
+	}
+
+	if (readUpgradeRecord(response) === record) {
+		completeUpgrade(record, response);
+		return;
+	}
+
+	if (record.claimed) {
+		// upgradeWebSocket() ran, but its response never made it back intact.
+		log(
+			"websocket_upgrade_response_lost: upgradeWebSocket() was called for this " +
+				"request but the response returned from the handler is not the one it " +
+				"produced. `Response.clone()` and rebuilding a response " +
+				"(`new Response(res.body, res)`, as response-rewriting middleware does) " +
+				"both discard the upgrade. Return the `response` from upgradeWebSocket() " +
+				"unchanged.",
+		);
+		abortClaimedUpgrade(record);
+		writeUpgradeRejection(socket, 500, "websocket_upgrade_response_lost");
+		return;
+	}
+
+	// The handler ignored the upgrade. Same 501 the deployed runtime returns.
+	writeUpgradeRejection(
+		socket,
+		501,
+		"websocket not supported by this function",
+	);
+};
+
+/**
+ * The handler claimed the connection but we cannot honour it. Move the socket object
+ * to CLOSED so a customer holding it sees a close event instead of one stuck at
+ * CONNECTING — without touching the underlying socket, which still needs to carry an
+ * HTTP error response.
+ */
+const abortClaimedUpgrade = (record: UpgradeRecord): void => {
+	try {
+		record.ws?.abort(1011, "upgrade failed");
+	} catch {
+		/* best effort */
+	}
+};
+
+/**
+ * Build a Web `Request` from the Node upgrade. A handshake is a GET with no body, so
+ * there is nothing to stream — which is just as well, since the socket has already been
+ * detached from the HTTP parser.
+ */
+const toWebRequest = (req: IncomingMessage): Request => {
+	const host = headerValue(req, "host") || "localhost";
+	const target =
+		typeof req.url === "string" && req.url.startsWith("/") ? req.url : "/";
+	const headers = new Headers();
+	for (const [name, value] of Object.entries(req.headers)) {
+		// HTTP/2 pseudo-headers are not valid Header names.
+		if (name.startsWith(":")) continue;
+		if (Array.isArray(value)) {
+			for (const entry of value) headers.append(name, entry);
+		} else if (value != null) {
+			headers.set(name, value);
+		}
+	}
+	return new Request(`http://${host}${target}`, {
+		method: req.method ?? "GET",
+		headers,
+	});
+};
+
+// -- The WHATWG-shaped socket ------------------------------------------------
+
+type HandlerName = "open" | "message" | "close" | "error";
+
+/**
+ * A WHATWG `WebSocket` over an already-upgraded Node socket.
+ *
+ * Two deliberate divergences from a browser, both matching the deployed runtime:
+ * `binaryType` defaults to `"arraybuffer"` rather than `"blob"`, and `bufferedAmount`
+ * is what we have written and not yet seen flushed, which approximates rather than
+ * matches a browser's accounting.
+ */
+class DevServerWebSocket extends EventTarget {
+	static readonly CONNECTING = CONNECTING;
+	static readonly OPEN = OPEN;
+	static readonly CLOSING = CLOSING;
+	static readonly CLOSED = CLOSED;
+
+	readonly url: string;
+
+	#socket: Duplex;
+	#protocol: string;
+	#readyState: number = CONNECTING;
+	#binaryType: "arraybuffer" | "blob" = "arraybuffer";
+	#bufferedAmount = 0;
+	#chunks: Buffer[] = [];
+	#queued = 0;
+	#fragmentOpcode = 0;
+	#fragments: Buffer[] = [];
+	#fragmentBytes = 0;
+	#closeSent = false;
+	#closeTimer: NodeJS.Timeout | null = null;
+	#handlers: Record<HandlerName, EventListener | null> = {
+		open: null,
+		message: null,
+		close: null,
+		error: null,
+	};
+
+	constructor({
+		socket,
+		url,
+		protocol,
+	}: {
+		socket: Duplex;
+		url: string;
+		protocol: string;
+	}) {
+		super();
+		this.#socket = socket;
+		this.url = url;
+		this.#protocol = protocol;
+	}
+
+	get CONNECTING(): number {
+		return CONNECTING;
+	}
+	get OPEN(): number {
+		return OPEN;
+	}
+	get CLOSING(): number {
+		return CLOSING;
+	}
+	get CLOSED(): number {
+		return CLOSED;
+	}
+
+	get protocol(): string {
+		return this.#protocol;
+	}
+	get extensions(): string {
+		return "";
+	}
+	get readyState(): number {
+		return this.#readyState;
+	}
+	get bufferedAmount(): number {
+		return this.#bufferedAmount;
+	}
+
+	get binaryType(): "arraybuffer" | "blob" {
+		return this.#binaryType;
+	}
+	set binaryType(value: "arraybuffer" | "blob") {
+		if (value !== "arraybuffer" && value !== "blob") {
+			throw new DOMException(
+				`binaryType must be "arraybuffer" or "blob", got "${String(value)}"`,
+				"SyntaxError",
+			);
+		}
+		this.#binaryType = value;
+	}
+
+	get onopen(): EventListener | null {
+		return this.#handlers.open;
+	}
+	set onopen(fn: EventListener | null) {
+		this.#setHandler("open", fn);
+	}
+	get onmessage(): EventListener | null {
+		return this.#handlers.message;
+	}
+	set onmessage(fn: EventListener | null) {
+		this.#setHandler("message", fn);
+	}
+	get onclose(): EventListener | null {
+		return this.#handlers.close;
+	}
+	set onclose(fn: EventListener | null) {
+		this.#setHandler("close", fn);
+	}
+	get onerror(): EventListener | null {
+		return this.#handlers.error;
+	}
+	set onerror(fn: EventListener | null) {
+		this.#setHandler("error", fn);
+	}
+
+	#setHandler(type: HandlerName, fn: EventListener | null): void {
+		const previous = this.#handlers[type];
+		if (previous) this.removeEventListener(type, previous);
+		this.#handlers[type] = typeof fn === "function" ? fn : null;
+		const next = this.#handlers[type];
+		if (next) this.addEventListener(type, next);
+	}
+
+	send(data: string | ArrayBufferLike | ArrayBufferView | Blob): void {
+		if (this.#readyState === CONNECTING) {
+			throw new DOMException(
+				"cannot send() while the WebSocket is still CONNECTING; wait for the " +
+					"open event (the socket opens once the handler returns the upgrade response)",
+				"InvalidStateError",
+			);
+		}
+		// Per spec, sending on a closing/closed socket is counted and discarded.
+		if (typeof data === "string") {
+			const payload = Buffer.from(data, "utf8");
+			if (this.#readyState !== OPEN) {
+				this.#bufferedAmount += payload.length;
+				return;
+			}
+			this.#writeFrame(OP_TEXT, payload);
+			return;
+		}
+		if (data instanceof Blob) {
+			// Blobs read asynchronously; chain on the read so ordering holds.
+			const size = data.size;
+			this.#bufferedAmount += size;
+			data.arrayBuffer()
+				.then((buf) => {
+					this.#bufferedAmount -= size;
+					if (this.#readyState === OPEN) {
+						this.#writeFrame(OP_BINARY, Buffer.from(buf));
+					}
+				})
+				.catch(() => {
+					this.#bufferedAmount -= size;
+				});
+			return;
+		}
+		const payload = toBuffer(data);
+		if (payload === null) {
+			throw new TypeError(
+				"send() accepts a string, ArrayBuffer, TypedArray, DataView, or Blob",
+			);
+		}
+		if (this.#readyState !== OPEN) {
+			this.#bufferedAmount += payload.length;
+			return;
+		}
+		this.#writeFrame(OP_BINARY, payload);
+	}
+
+	close(code?: number, reason?: string): void {
+		if (code !== undefined && !isValidCloseCode(code)) {
+			throw new DOMException(
+				`close code ${code} is not allowed; use 1000 or a code in 3000-4999`,
+				"InvalidAccessError",
+			);
+		}
+		let reasonBuf = EMPTY;
+		if (reason !== undefined && reason !== null) {
+			reasonBuf = Buffer.from(String(reason), "utf8");
+			if (reasonBuf.length > MAX_CLOSE_REASON_BYTES) {
+				throw new DOMException(
+					`close reason must be at most ${MAX_CLOSE_REASON_BYTES} bytes of UTF-8`,
+					"SyntaxError",
+				);
+			}
+		}
+		if (this.#readyState === CLOSING || this.#readyState === CLOSED) return;
+		if (this.#readyState === CONNECTING) {
+			// Nothing to close yet — the handshake has not been written.
+			this.abort(code ?? 1000, reasonBuf.toString("utf8"));
+			return;
+		}
+		this.#readyState = CLOSING;
+		this.#sendClose(code ?? 1000, reasonBuf);
+		this.#closeTimer = setTimeout(() => {
+			this.#finishClose(code ?? 1000, reasonBuf.toString("utf8"), false);
+		}, CLOSE_HANDSHAKE_TIMEOUT_MS);
+		this.#closeTimer.unref?.();
+	}
+
+	// -- dev-server internal ---------------------------------------------
+
+	/** Called once the 101 is on the wire. */
+	openWithHead(head: Buffer): void {
+		if (this.#readyState !== CONNECTING) return;
+		const socket = this.#socket;
+		socket.on("data", (chunk: Buffer) => this.#onData(chunk));
+		socket.on("error", (err: Error) => {
+			this.#emitError(err);
+			this.#finishClose(1006, "", false);
+		});
+		socket.on("close", () => this.#finishClose(1006, "", false));
+		socket.on("end", () => this.#finishClose(1006, "", false));
+		this.#readyState = OPEN;
+		this.dispatchEvent(new Event("open"));
+		if (head.length) this.#onData(head);
+	}
+
+	/**
+	 * Give up before the handshake was written. Fires `close` so a caller holding the
+	 * socket is not left with something stuck at CONNECTING, but deliberately does not
+	 * touch the underlying socket: an HTTP error response still has to go out on it.
+	 */
+	abort(code = 1006, reason = ""): void {
+		if (this.#readyState === CLOSED) return;
+		this.#readyState = CLOSED;
+		if (this.#closeTimer) {
+			clearTimeout(this.#closeTimer);
+			this.#closeTimer = null;
+		}
+		this.dispatchEvent(
+			new CloseEvent("close", { code, reason, wasClean: false }),
+		);
+	}
+
+	#onData(chunk: Buffer): void {
+		if (this.#readyState === CLOSED) return;
+		this.#chunks.push(chunk);
+		this.#queued += chunk.length;
+		try {
+			this.#parse();
+		} catch (err) {
+			this.#emitError(err);
+			const code = (err as { wsCode?: number }).wsCode ?? 1002;
+			this.#fail(code, err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	#parse(): void {
+		for (;;) {
+			if (this.#queued < 2) return;
+			const b0 = this.#peek(0);
+			const b1 = this.#peek(1);
+			const fin = (b0 & 0x80) !== 0;
+			const rsv = b0 & 0x70;
+			const opcode = b0 & 0x0f;
+			const masked = (b1 & 0x80) !== 0;
+			let length = b1 & 0x7f;
+			let headerLen = 2;
+			if (length === 126) {
+				if (this.#queued < 4) return;
+				length = (this.#peek(2) << 8) | this.#peek(3);
+				headerLen = 4;
+			} else if (length === 127) {
+				if (this.#queued < 10) return;
+				let big = 0n;
+				for (let i = 0; i < 8; i++)
+					big = (big << 8n) | BigInt(this.#peek(2 + i));
+				if (big > BigInt(MAX_MESSAGE_BYTES)) {
+					throw protocolError(1009, "frame too large");
+				}
+				length = Number(big);
+				headerLen = 10;
+			}
+			if (masked) headerLen += 4;
+			if (this.#queued < headerLen + length) return;
+
+			// Validate before consuming, so a rejected frame cannot desync the parser.
+			if (rsv !== 0) {
+				throw protocolError(
+					1002,
+					"reserved bits must be clear (no extensions were negotiated)",
+				);
+			}
+			if (!masked)
+				throw protocolError(1002, "client frames must be masked");
+			const isControl = (opcode & 0x08) !== 0;
+			if (isControl) {
+				if (!fin) {
+					throw protocolError(
+						1002,
+						"control frames must not be fragmented",
+					);
+				}
+				if (length > MAX_CONTROL_PAYLOAD) {
+					throw protocolError(
+						1002,
+						"control frame payload exceeds 125 bytes",
+					);
+				}
+			}
+			if (
+				opcode !== OP_CONTINUATION &&
+				opcode !== OP_TEXT &&
+				opcode !== OP_BINARY &&
+				opcode !== OP_CLOSE &&
+				opcode !== OP_PING &&
+				opcode !== OP_PONG
+			) {
+				throw protocolError(
+					1002,
+					`reserved opcode 0x${opcode.toString(16)}`,
+				);
+			}
+
+			const header = this.#take(headerLen);
+			const payload = this.#take(length);
+			if (masked) {
+				const mask = header.subarray(headerLen - 4, headerLen);
+				for (let i = 0; i < payload.length; i++) {
+					payload[i] =
+						(payload[i] as number) ^ (mask[i & 3] as number);
+				}
+			}
+
+			if (isControl) {
+				this.#handleControl(opcode, payload);
+				if (this.#readyState === CLOSED) return;
+				continue;
+			}
+
+			if (opcode === OP_CONTINUATION) {
+				if (this.#fragmentOpcode === 0) {
+					throw protocolError(
+						1002,
+						"continuation frame without a start frame",
+					);
+				}
+				this.#pushFragment(payload);
+			} else {
+				if (this.#fragmentOpcode !== 0) {
+					throw protocolError(
+						1002,
+						"new data frame while a fragmented message was open",
+					);
+				}
+				if (!fin) {
+					this.#fragmentOpcode = opcode;
+					this.#pushFragment(payload);
+					continue;
+				}
+				this.#deliver(opcode, payload);
+				continue;
+			}
+			if (fin) {
+				const messageOpcode = this.#fragmentOpcode;
+				const full =
+					this.#fragments.length === 1
+						? (this.#fragments[0] as Buffer)
+						: Buffer.concat(this.#fragments);
+				this.#fragmentOpcode = 0;
+				this.#fragments = [];
+				this.#fragmentBytes = 0;
+				this.#deliver(messageOpcode, full);
+			}
+		}
+	}
+
+	#pushFragment(payload: Buffer): void {
+		this.#fragmentBytes += payload.length;
+		if (this.#fragmentBytes > MAX_MESSAGE_BYTES) {
+			throw protocolError(
+				1009,
+				`message exceeds the ${MAX_MESSAGE_BYTES} byte limit`,
+			);
+		}
+		this.#fragments.push(payload);
+	}
+
+	#deliver(opcode: number, payload: Buffer): void {
+		if (this.#readyState !== OPEN) return;
+		let data: string | ArrayBuffer | Blob;
+		if (opcode === OP_TEXT) {
+			try {
+				data = new TextDecoder("utf-8", { fatal: true }).decode(
+					payload,
+				);
+			} catch {
+				throw protocolError(1007, "text frame is not valid UTF-8");
+			}
+		} else if (this.#binaryType === "blob") {
+			// Copy into a plain Uint8Array: a Node Buffer is not a valid BlobPart.
+			data = new Blob([new Uint8Array(payload)]);
+		} else {
+			// A fresh ArrayBuffer, not a view onto our read buffer.
+			data = payload.buffer.slice(
+				payload.byteOffset,
+				payload.byteOffset + payload.byteLength,
+			) as ArrayBuffer;
+		}
+		this.dispatchEvent(
+			new MessageEvent("message", { data, origin: this.url }),
+		);
+	}
+
+	#handleControl(opcode: number, payload: Buffer): void {
+		if (opcode === OP_PING) {
+			if (this.#readyState === OPEN) this.#writeFrame(OP_PONG, payload);
+			return;
+		}
+		if (opcode === OP_PONG) return;
+		let code = 1005;
+		let reason = "";
+		if (payload.length === 1) {
+			throw protocolError(
+				1002,
+				"close frame payload must be empty or at least 2 bytes",
+			);
+		}
+		if (payload.length >= 2) {
+			code = ((payload[0] as number) << 8) | (payload[1] as number);
+			if (!isEchoableCloseCode(code)) {
+				throw protocolError(1002, `invalid close code ${code}`);
+			}
+			try {
+				reason = new TextDecoder("utf-8", { fatal: true }).decode(
+					payload.subarray(2),
+				);
+			} catch {
+				throw protocolError(1007, "close reason is not valid UTF-8");
+			}
+		}
+		if (!this.#closeSent) {
+			// Mirror the peer's code (§5.5.1). 1005 must never go on the wire.
+			this.#sendClose(code === 1005 ? 1000 : code, EMPTY);
+		}
+		this.#finishClose(code, reason, true);
+	}
+
+	#sendClose(code: number, reasonBuf: Buffer): void {
+		if (this.#closeSent) return;
+		this.#closeSent = true;
+		const payload = Buffer.allocUnsafe(2 + reasonBuf.length);
+		payload.writeUInt16BE(code, 0);
+		if (reasonBuf.length) reasonBuf.copy(payload, 2);
+		this.#writeFrame(OP_CLOSE, payload);
+	}
+
+	#fail(code: number, reason: string): void {
+		if (this.#readyState === OPEN) {
+			const reasonBuf = Buffer.from(
+				reason.slice(0, MAX_CLOSE_REASON_BYTES),
+				"utf8",
+			);
+			try {
+				this.#sendClose(code, reasonBuf);
+			} catch {
+				/* socket already gone */
+			}
+		}
+		this.#finishClose(code, reason, false);
+	}
+
+	#finishClose(code: number, reason: string, wasClean: boolean): void {
+		if (this.#readyState === CLOSED) return;
+		this.#readyState = CLOSED;
+		if (this.#closeTimer) {
+			clearTimeout(this.#closeTimer);
+			this.#closeTimer = null;
+		}
+		this.#chunks = [];
+		this.#queued = 0;
+		this.#fragments = [];
+		this.#fragmentBytes = 0;
+		try {
+			this.#socket.end();
+		} catch {
+			try {
+				this.#socket.destroy();
+			} catch {
+				/* already gone */
+			}
+		}
+		this.dispatchEvent(new CloseEvent("close", { code, reason, wasClean }));
+	}
+
+	#emitError(err: unknown): void {
+		const message = err instanceof Error ? err.message : String(err);
+		this.dispatchEvent(
+			new ErrorEventCtor("error", { message, error: err }),
+		);
+	}
+
+	#writeFrame(opcode: number, payload: Buffer): void {
+		const frame = encodeFrame(opcode, payload);
+		this.#bufferedAmount += frame.length;
+		try {
+			this.#socket.write(frame, () => {
+				this.#bufferedAmount -= frame.length;
+				if (this.#bufferedAmount < 0) this.#bufferedAmount = 0;
+			});
+		} catch (err) {
+			this.#bufferedAmount -= frame.length;
+			this.#emitError(err);
+			this.#finishClose(1006, "", false);
+		}
+	}
+
+	/** Read a byte without consuming it. */
+	#peek(index: number): number {
+		let remaining = index;
+		for (const chunk of this.#chunks) {
+			if (remaining < chunk.length) return chunk[remaining] as number;
+			remaining -= chunk.length;
+		}
+		return 0;
+	}
+
+	/** Remove `n` bytes from the queue and return them as one owned Buffer. */
+	#take(n: number): Buffer {
+		if (n === 0) return EMPTY;
+		this.#queued -= n;
+		const first = this.#chunks[0] as Buffer;
+		if (first.length === n) return this.#chunks.shift() as Buffer;
+		if (first.length > n) {
+			this.#chunks[0] = first.subarray(n);
+			// Copy: the caller unmasks in place and the remainder is still queued.
+			return Buffer.from(first.subarray(0, n));
+		}
+		const out = Buffer.allocUnsafe(n);
+		let offset = 0;
+		while (offset < n) {
+			const chunk = this.#chunks[0] as Buffer;
+			const take = Math.min(chunk.length, n - offset);
+			chunk.copy(out, offset, 0, take);
+			offset += take;
+			if (take === chunk.length) this.#chunks.shift();
+			else this.#chunks[0] = chunk.subarray(take);
+		}
+		return out;
+	}
+}
+
+const encodeFrame = (opcode: number, payload: Buffer): Buffer => {
+	const len = payload.length;
+	let header: Buffer;
+	if (len < 126) {
+		header = Buffer.allocUnsafe(2);
+		header[1] = len;
+	} else if (len < 65536) {
+		header = Buffer.allocUnsafe(4);
+		header[1] = 126;
+		header.writeUInt16BE(len, 2);
+	} else {
+		header = Buffer.allocUnsafe(10);
+		header[1] = 127;
+		header.writeBigUInt64BE(BigInt(len), 2);
+	}
+	header[0] = 0x80 | opcode;
+	return Buffer.concat([header, payload]);
+};
+
+const toBuffer = (data: ArrayBufferLike | ArrayBufferView): Buffer | null => {
+	if (data instanceof ArrayBuffer) return Buffer.from(new Uint8Array(data));
+	if (ArrayBuffer.isView(data)) {
+		return Buffer.from(
+			new Uint8Array(data.buffer, data.byteOffset, data.byteLength),
+		);
+	}
+	return null;
+};
+
+/** Codes a server may send (§7.4): 1000, or the private 3000-4999 range. */
+const isValidCloseCode = (code: number): boolean =>
+	code === 1000 || (Number.isInteger(code) && code >= 3000 && code <= 4999);
+
+/** Codes that may legally appear in a close frame we receive — wider than the above. */
+const isEchoableCloseCode = (code: number): boolean => {
+	if (!Number.isInteger(code)) return false;
+	if (code >= 3000 && code <= 4999) return true;
+	return (
+		code >= 1000 &&
+		code <= 1014 &&
+		code !== 1004 &&
+		code !== 1005 &&
+		code !== 1006
+	);
+};
+
+const protocolError = (code: number, message: string): Error => {
+	const err = new Error(message) as Error & { wsCode: number };
+	err.wsCode = code;
+	return err;
+};


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/neondatabase/neon-pkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/neondatabase/neon-pkgs/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

**WebSockets do not work under `neon dev` today, and they fail in the worst possible way — they look like they work.**

The dev server registers no `'upgrade'` listener (`packages/cli/src/dev/runtime.ts`, at the `createServer(...)` call). Node emits `'upgrade'` rather than `'request'` for anything carrying `Connection: Upgrade`, and with no listener registered it falls back to the ordinary request handler — which sees the handshake headers, does not recognise them, and answers `200 OK` on a connection the client is waiting to see a `101` on.

Verified on Node 24:

```
NO upgrade listener:   reqHandler=true  upgradeEvent=false  firstLine="HTTP/1.1 200 OK"
WITH upgrade listener: reqHandler=false upgradeEvent=true   firstLine="HTTP/1.1 101 Switching Protocols"
```

So a function's `upgrade` export was **never called** locally — `resolveFetchHandler` did not know the export existed — and the client failed against a nonsense 200. This is a bug in an already-launched contract, which is why it is worth fixing on its own.

### What changes

The dev server now handles upgrades the way the deployed runtime does, **including the precedence rule**, so local behaviour cannot disagree with deployed behaviour:

- **`export function upgrade(req, socket, head)`** is resolved by a new `resolveUpgradeHandler` (named export first, then an `upgrade` method on the default export — the same order the runtime uses) and handed the raw Node triple. This makes the launched contract work locally for the first time.
- **`upgradeWebSocket()`** from `@neon/functions` works too, reached only when there is no `upgrade` export — the legacy shape wins, exactly as deployed.
- A function that does neither gets a clean **501**, and a non-WebSocket upgrade (h2c, say) gets a **426**, rather than hanging or being answered with a bogus 200.

### Two details worth a reviewer's eye

**The upgrade path takes the raw fetch handler, not the error-boundary-wrapped one.** `withErrorBoundary` turns a throw into a 500 `Response`, which on this path is indistinguishable from a handler that deliberately declined the upgrade — so a crashing handler would have answered 501 ("no WebSocket support") and hidden the real error. The upgrade listener has its own equivalent boundary and reports a throw as the **502** the deployed runtime returns, so a user error still cannot kill the dev child process.

**The protocol implementation is duplicated from the deployed runtime, deliberately.** The runtime is a zero-dependency file baked into a microVM image and cannot import from npm, so sharing a module would mean new vendoring machinery for little gain. What the two sides actually share is the bridge global and the observable behaviour, and both are pinned by an equivalent test matrix on each side. `permessage-deflate` is not negotiated on either side.

### Tests

21 cases drive **real handshakes over loopback** with a client that speaks enough of RFC 6455 to verify masking, fragmentation, ping/pong and the close handshake:

- echo of text, binary, fragmented, and over-125-byte messages
- close from both directions (codes, reasons, `readyState` transitions, `wasClean`)
- subprotocol negotiation: echoed once when offered, header absent when not selected, throws when not offered
- the cloned-response failure — asserts a loud 500, never a silent 200
- an unmasked client frame fails the connection with 1002
- precedence when a module exports both shapes
- the Request-rebuilding path adapters take (Hono's Node adapter rebuilds it, so object identity is lost)
- the WHATWG surface: constants, `binaryType`, close-code and state guards

Plus 6 for `resolveUpgradeHandler`, including `this`-binding for the default-export method shape.

```
Test Files  2 passed (2)
     Tests  42 passed (42)
```

Typecheck and `biome check --error-on-warnings` are clean on the touched files. Three pre-existing `src/dev` test files fail to resolve unbuilt workspace deps (`@neon/config`, `@neon/config-runtime`); they fail identically on `main` and are untouched.

### Cross-repo note

This is self-contained: it needs nothing from the runtime side and is worth landing on its own, since it fixes the launched `{ fetch, upgrade }` contract locally today. The typed `upgradeWebSocket` export for `@neon/functions` is a separate PR, and the runtime that provides the upgrade when deployed lands separately again. A changeset for `neon` is included — note that a merged changeset is a version bump, not a published package.
