### PR TITLE
feat(functions): add upgradeWebSocket for serving WebSockets from fetch

### DIFF
--- a/.changeset/brown-pandas-listen.md
+++ b/.changeset/brown-pandas-listen.md
@@ -1,0 +1,13 @@
+---
+"@neon/functions": minor
+---
+
+Add `upgradeWebSocket(request, options?)` for serving WebSockets from a `fetch` handler.
+
+Returns `{ socket, response }`, mirroring `Deno.upgradeWebSocket`: `socket` is a standard
+`WebSocket`, and returning `response` from your handler completes the upgrade and opens it.
+No extra export and no `ws` dependency needed — the existing
+`export function upgrade(req, socket, head)` shape keeps working unchanged.
+
+Requires a runtime that provides the upgrade (deployed, or locally under `neon dev`); on an
+older runtime it throws a clear `TypeError` rather than misbehaving.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -1,6 +1,9 @@
 # @neon/functions
 
-Runtime helpers for [Neon Functions](https://neon.com). Currently provides a `waitUntil` primitive for deferring background work past a response.
+Runtime helpers for [Neon Functions](https://neon.com):
+
+- **`waitUntil`** — defer background work past a response.
+- **`upgradeWebSocket`** — serve WebSockets from a `fetch` handler.
 
 ## Install
 
@@ -10,7 +13,7 @@ npm install @neon/functions
 
 > **Requirements:** Node.js >= 20.19.
 
-## Usage
+## `waitUntil`
 
 The API mirrors [`@vercel/functions`](https://vercel.com/docs/functions/functions-api-reference/vercel-functions-package): import `waitUntil` and call it directly with the promise you want to keep alive.
 
@@ -33,9 +36,78 @@ a **no-op**: the promise is accepted and ignored (it still runs on its own, it j
 isn't tracked), so the same code runs everywhere without branching. Passing a
 non-`Promise` throws a `TypeError`.
 
+## `upgradeWebSocket`
+
+Turn an incoming WebSocket handshake into a live connection from inside your normal
+`fetch` handler. The API mirrors
+[`Deno.upgradeWebSocket`](https://docs.deno.com/api/deno/~/Deno.upgradeWebSocket):
+
+```ts
+import { upgradeWebSocket } from "@neon/functions";
+
+export default {
+	async fetch(req: Request): Promise<Response> {
+		if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+			return new Response("expected a websocket upgrade", { status: 426 });
+		}
+
+		const { socket, response } = upgradeWebSocket(req);
+		socket.addEventListener("message", (event) => socket.send(event.data));
+		return response;
+	},
+};
+```
+
+`socket` is a standard [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket),
+so both `addEventListener` and the `onmessage`/`onopen`/`onclose`/`onerror` properties work.
+It is still `CONNECTING` when you get it: the runtime writes the `101` only once your
+handler returns `response`, and the socket opens (firing `open`) at that point.
+
+**Return `response` unchanged.** A `101` cannot be expressed as a plain `Response` — the
+fetch spec restricts constructed responses to statuses 200–599 — so the runtime hands back
+a response object that carries the pending upgrade. Cloning it, or rebuilding it
+(`new Response(res.body, res)`, which response-rewriting middleware does), discards the
+upgrade; the runtime detects that and fails the request loudly rather than leaving your
+client waiting on a connection nobody upgraded.
+
+### Subprotocols
+
+Pass `protocol` to select one of the subprotocols the client offered, which is echoed back
+in `Sec-WebSocket-Protocol`:
+
+```ts
+const { socket, response } = upgradeWebSocket(req, { protocol: "chat.v2" });
+```
+
+Per [RFC 6455 §4.2.2](https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.2) a server
+may only select a protocol the client offered, so passing one the client did not offer
+throws a `TypeError` instead of producing a handshake the client will reject. Omit it and
+no protocol is negotiated: the response header is absent and `socket.protocol` is `""`.
+
+### Notes
+
+- `binaryType` defaults to `"arraybuffer"` rather than the browser default of `"blob"`,
+  matching Deno and other server runtimes. Setting it to `"blob"` is supported.
+- `extensions` is always `""`. No extensions — including `permessage-deflate` — are
+  negotiated.
+- Unlike `waitUntil`, this **throws a `TypeError` off-platform** (and on a request that is
+  not a WebSocket handshake). There is no meaningful degraded WebSocket, so an error that
+  says so beats a socket that could never open.
+
+### Requires a runtime with WebSocket support
+
+`upgradeWebSocket` needs a Neon Functions runtime that provides the upgrade — deployed, or
+locally under `neon dev`. On an older runtime it throws the "only available inside a Neon
+Functions invocation" `TypeError` rather than misbehaving.
+
 ## Runtime integration
 
 The runtime publishes the active invocation context on `globalThis.NEON_REQUEST_CONTEXT`
 as a getter that returns the live context object directly — `{ waitUntil }` during an
 invocation, `undefined` outside one. `waitUntil` reads that value straight off the
 global, so there is nothing for application code to wire up.
+
+`upgradeWebSocket` works the same way, reading a bridge the runtime publishes under
+`Symbol.for("neon.websocket.bridge")`. All of the protocol work — the handshake, framing,
+fragmentation, ping/pong and the close handshake — lives in the runtime; this package is
+only a typed facade over it.

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,14 +1,15 @@
 {
 	"name": "@neon/functions",
 	"version": "0.6.0",
-	"description": "Runtime helpers for Neon Functions. Currently provides a `waitUntil` primitive for deferring async work past a response.",
+	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, and `upgradeWebSocket` for serving WebSockets from a fetch handler.",
 	"keywords": [
 		"neon",
 		"database",
 		"postgres",
 		"functions",
 		"serverless",
-		"platform"
+		"platform",
+		"websocket"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -4,6 +4,14 @@
  * - `waitUntil(promise)` — defers async work past the response by handing the promise to
  *   the current invocation context. No-op off-platform (local dev, tests, non-Neon hosts).
  *   Mirrors `@vercel/functions`.
+ * - `upgradeWebSocket(request)` — turns a WebSocket handshake into a live connection from
+ *   inside a `fetch` handler, returning `{ socket, response }`. Mirrors
+ *   `Deno.upgradeWebSocket`. Throws off-platform, where no socket can be upgraded.
  */
 
+export {
+	type UpgradeWebSocketOptions,
+	upgradeWebSocket,
+	type WebSocketUpgrade,
+} from "./lib/upgrade-websocket.js";
 export { waitUntil } from "./lib/wait-until.js";

--- a/packages/functions/src/lib/upgrade-websocket.test.ts
+++ b/packages/functions/src/lib/upgrade-websocket.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+	type UpgradeWebSocketOptions,
+	upgradeWebSocket,
+	type WebSocketUpgrade,
+} from "./upgrade-websocket.js";
+
+const WS_BRIDGE_KEY = Symbol.for("neon.websocket.bridge");
+
+type BridgeHost = Record<
+	symbol,
+	| {
+			upgrade: (
+				request: Request,
+				options?: UpgradeWebSocketOptions,
+			) => WebSocketUpgrade;
+	  }
+	| undefined
+>;
+
+const host = globalThis as unknown as BridgeHost;
+
+/** Stand in for the runtime's bridge, recording what the facade forwards. */
+const installBridge = (
+	impl?: (
+		request: Request,
+		options?: UpgradeWebSocketOptions,
+	) => WebSocketUpgrade,
+) => {
+	const calls: { request: Request; options?: UpgradeWebSocketOptions }[] = [];
+	const result = {
+		socket: { readyState: 0 } as unknown as WebSocket,
+		response: new Response(null, { status: 200 }),
+	};
+	host[WS_BRIDGE_KEY] = {
+		upgrade: (request, options) => {
+			calls.push({ request, options });
+			return impl ? impl(request, options) : result;
+		},
+	};
+	return { calls, result };
+};
+
+const handshake = () =>
+	new Request("http://localhost/ws", {
+		headers: {
+			connection: "Upgrade",
+			upgrade: "websocket",
+			"sec-websocket-key": "dGhlIHNhbXBsZSBub25jZQ==",
+			"sec-websocket-version": "13",
+		},
+	});
+
+afterEach(() => {
+	delete host[WS_BRIDGE_KEY];
+});
+
+describe("upgradeWebSocket", () => {
+	it("returns the runtime's socket and response", () => {
+		const { result } = installBridge();
+		const upgrade = upgradeWebSocket(handshake());
+
+		expect(upgrade.socket).toBe(result.socket);
+		expect(upgrade.response).toBe(result.response);
+	});
+
+	it("forwards the request and options to the runtime unchanged", () => {
+		const { calls } = installBridge();
+		const request = handshake();
+
+		upgradeWebSocket(request, { protocol: "chat.v2" });
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.request).toBe(request);
+		expect(calls[0]?.options).toEqual({ protocol: "chat.v2" });
+	});
+
+	it("passes no options through when none were given", () => {
+		const { calls } = installBridge();
+
+		upgradeWebSocket(handshake());
+
+		expect(calls[0]?.options).toBeUndefined();
+	});
+
+	it("throws a TypeError off-platform, rather than a socket that never opens", () => {
+		expect(() => upgradeWebSocket(handshake())).toThrow(TypeError);
+		expect(() => upgradeWebSocket(handshake())).toThrow(
+			/only available inside a Neon Functions invocation/,
+		);
+	});
+
+	it("reads the bridge at call time, so a later-published runtime is picked up", () => {
+		expect(() => upgradeWebSocket(handshake())).toThrow(TypeError);
+
+		const { calls } = installBridge();
+		upgradeWebSocket(handshake());
+
+		expect(calls).toHaveLength(1);
+	});
+
+	it("propagates the runtime's error when the same request is upgraded twice", () => {
+		let claimed = false;
+		installBridge(() => {
+			if (claimed) {
+				throw new TypeError(
+					"upgradeWebSocket() was already called for this request",
+				);
+			}
+			claimed = true;
+			return {
+				socket: {} as unknown as WebSocket,
+				response: new Response(null),
+			};
+		});
+		const request = handshake();
+
+		upgradeWebSocket(request);
+
+		expect(() => upgradeWebSocket(request)).toThrow(/already called/);
+	});
+
+	it("propagates the runtime's error for a subprotocol the client did not offer", () => {
+		installBridge((_request, options) => {
+			if (options?.protocol === "not-offered") {
+				throw new TypeError(
+					`the client did not offer the subprotocol "${options.protocol}"`,
+				);
+			}
+			return {
+				socket: {} as unknown as WebSocket,
+				response: new Response(null),
+			};
+		});
+
+		expect(() =>
+			upgradeWebSocket(handshake(), { protocol: "not-offered" }),
+		).toThrow(/did not offer the subprotocol/);
+	});
+
+	it("propagates the runtime's error for a request that is not a handshake", () => {
+		installBridge(() => {
+			throw new TypeError(
+				"upgradeWebSocket() requires a WebSocket handshake",
+			);
+		});
+
+		expect(() =>
+			upgradeWebSocket(new Request("http://localhost/not-ws")),
+		).toThrow(/requires a WebSocket handshake/);
+	});
+
+	it("adds no protocol code of its own: the runtime is the only implementation", () => {
+		const upgrade = vi.fn(
+			(_request: Request, _options?: UpgradeWebSocketOptions) => ({
+				socket: {} as unknown as WebSocket,
+				response: new Response(null),
+			}),
+		);
+		host[WS_BRIDGE_KEY] = { upgrade };
+		const request = handshake();
+
+		upgradeWebSocket(request, { protocol: "chat.v1" });
+
+		// One delegation, with exactly the arguments the caller passed.
+		expect(upgrade).toHaveBeenCalledTimes(1);
+		expect(upgrade).toHaveBeenCalledWith(request, { protocol: "chat.v1" });
+	});
+});

--- a/packages/functions/src/lib/upgrade-websocket.ts
+++ b/packages/functions/src/lib/upgrade-websocket.ts
@@ -1,0 +1,90 @@
+/**
+ * `upgradeWebSocket(request)` turns an incoming WebSocket handshake into a live
+ * connection from inside an ordinary `fetch` handler:
+ *
+ * ```ts
+ * const { socket, response } = upgradeWebSocket(request);
+ * socket.addEventListener("message", (event) => socket.send(event.data));
+ * return response;
+ * ```
+ *
+ * Semantics follow `Deno.upgradeWebSocket`. `socket` is a standard `WebSocket`,
+ * still `CONNECTING` when you get it: the runtime writes the `101` only when the
+ * handler returns `response`, and the socket opens (firing `open`) at that
+ * point. Not returning `response` means the upgrade never completes.
+ *
+ * Return `response` **unchanged**. A `101` cannot be expressed as a plain
+ * `Response` — the fetch spec restricts constructed responses to 200-599 — so
+ * the runtime hands back a response object carrying the pending upgrade.
+ * Cloning it, or rebuilding it (`new Response(res.body, res)`, which
+ * response-rewriting middleware does), discards the upgrade; the runtime detects
+ * that and fails the request loudly rather than leaving the client hanging.
+ *
+ * There is no meaningful degraded WebSocket, so unlike `waitUntil` this throws
+ * off-platform instead of silently doing nothing: a socket that could never open
+ * is worse than an error that says so.
+ */
+
+/** The bridge global the Neon Functions runtime publishes. */
+const WS_BRIDGE_KEY = Symbol.for("neon.websocket.bridge");
+
+export interface UpgradeWebSocketOptions {
+	/**
+	 * The subprotocol to select, echoed back in `Sec-WebSocket-Protocol`.
+	 *
+	 * Per RFC 6455 §4.2.2 a server may only select a protocol the client
+	 * offered, so passing one the client did not offer throws a `TypeError`
+	 * rather than producing a handshake the client will reject. Omit it and no
+	 * protocol is negotiated: the header is absent and `socket.protocol` is `""`.
+	 */
+	protocol?: string;
+}
+
+export interface WebSocketUpgrade {
+	/**
+	 * The server side of the connection. `CONNECTING` until the runtime writes
+	 * the `101`; `open` fires once it has.
+	 *
+	 * `binaryType` defaults to `"arraybuffer"` rather than the browser default of
+	 * `"blob"`, matching Deno and other server runtimes. `extensions` is always
+	 * `""` — no extensions (including `permessage-deflate`) are negotiated.
+	 */
+	socket: WebSocket;
+	/** Return this from `fetch`, unchanged, to complete the upgrade. */
+	response: Response;
+}
+
+interface WebSocketBridge {
+	upgrade(
+		request: Request,
+		options?: UpgradeWebSocketOptions,
+	): WebSocketUpgrade;
+}
+
+// The runtime publishes the bridge under a symbol key, which a `declare global`
+// cannot describe (global augmentation only names identifiers), so read it
+// through an indexed view of `globalThis` instead of a bare cast.
+type WebSocketBridgeHost = Record<symbol, WebSocketBridge | undefined>;
+
+/**
+ * Upgrade an incoming request to a WebSocket connection.
+ *
+ * @throws {TypeError} off-platform (no Neon Functions runtime), when the request
+ * is not a WebSocket handshake, when called twice for the same request, or when
+ * `options.protocol` is not one the client offered.
+ */
+export function upgradeWebSocket(
+	request: Request,
+	options?: UpgradeWebSocketOptions,
+): WebSocketUpgrade {
+	const bridge = (globalThis as unknown as WebSocketBridgeHost)[
+		WS_BRIDGE_KEY
+	];
+	if (!bridge) {
+		throw new TypeError(
+			"upgradeWebSocket() is only available inside a Neon Functions invocation. " +
+				"Run your function with `neon dev` locally, or deploy it.",
+		);
+	}
+	return bridge.upgrade(request, options);
+}


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/neondatabase/neon-pkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/neondatabase/neon-pkgs/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Serving a WebSocket from a Neon Function today means importing `ws`, bundling it, hand-crafting the `101`, and exporting an extra `upgrade(req, socket, head)` next to `fetch` that receives raw Node objects rather than a `Request`. Nothing else in the platform works that way, and the split entrypoint breaks the single-handler mental model.

This adds the web-standard alternative, following [`Deno.upgradeWebSocket`](https://docs.deno.com/api/deno/~/Deno.upgradeWebSocket):

```ts
import { upgradeWebSocket } from "@neon/functions";

export default {
	async fetch(req: Request): Promise<Response> {
		if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
			return new Response("expected a websocket upgrade", { status: 426 });
		}

		const { socket, response } = upgradeWebSocket(req);
		socket.addEventListener("message", (event) => socket.send(event.data));
		return response;
	},
};
```

`socket` is a standard `WebSocket`, still `CONNECTING` on return; returning `response` completes the upgrade and opens it. No extra export, no dependency, no protocol code in the bundle.

### Design

**The package stays a thin typed facade**, exactly like `waitUntil`: it reads a bridge the runtime publishes (under `Symbol.for("neon.websocket.bridge")`) and forwards to it. Every piece of protocol work — handshake, framing, fragmentation, ping/pong, the close handshake, subprotocol negotiation — lives in the runtime, so nothing here needs to change as that evolves. That is why the diff is small and the tests are about delegation rather than protocol behaviour.

**Unlike `waitUntil`, this throws off-platform rather than degrading to a no-op.** `waitUntil`'s no-op is meaningful: the promise still runs, it just isn't tracked. There is no equivalent for a WebSocket — a socket that can never open is not a degraded WebSocket, it is a bug — so an error naming the problem is the better failure.

### Two details worth knowing (both documented in the README)

**Return `response` unchanged.** A `101` cannot be expressed as a constructed `Response`: the fetch spec restricts those to 200–599 and Node enforces it, so the runtime returns an object that reports `101` and carries the pending upgrade. `clone()` drops both the status and the internal brand; rebuilding it (`new Response(res.body, res)`, as response-rewriting middleware does) throws outright. The runtime detects the lost-upgrade case and fails loudly with a named, searchable error rather than leaving the client waiting on a connection nobody upgraded.

**`binaryType` defaults to `"arraybuffer"`**, not the browser default of `"blob"` — matching Deno and other server runtimes, and what server code actually wants. `"blob"` is still accepted. `extensions` is always `""`; no extensions, including `permessage-deflate`, are negotiated.

### Backward compatibility

The existing `export function upgrade(req, socket, head)` shape is untouched and keeps working. On the runtime side it takes precedence unconditionally, so adding this API to a shared handler cannot silently re-route deployed WebSocket traffic onto a new code path.

### Tests

9 cases with a mock bridge: the happy path, that the request and options are forwarded unchanged, that the bridge is read at call time (so a later-published runtime is picked up), the off-platform throw, and that runtime-side errors propagate untouched — double upgrade, an un-offered subprotocol, and a request that is not a handshake.

```
Test Files  2 passed (2)
     Tests  14 passed (14)
```

`tsc --noEmit` and `biome check --error-on-warnings` are both clean.

### Cross-repo note

This needs a runtime that provides the upgrade. On an older runtime the export throws a clear "only available inside a Neon Functions invocation" `TypeError` rather than misbehaving, so it can ship in either order — but it is **not worth announcing until the runtime side is deployed**, since a published export that throws everywhere is worse than no export. `neon dev` support is a separate PR. A changeset is included; note that a merged changeset is a version bump, not a published package.
