### PR TITLE
fix(cli): let a function refuse a WebSocket handshake, and shim CloseEvent

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,23 @@
+---
+"neon": patch
+---
+
+Fix WebSocket serving under `neon dev`.
+
+- A function can now refuse a handshake by returning an ordinary `Response`. A `401`,
+  `403` or `404` returned from `fetch` is relayed to the client with its status, headers
+  and body intact, instead of being replaced by `501 websocket not supported by this
+  function`. Refusing an unauthenticated connection is the normal case for a WebSocket
+  endpoint and there was previously no way to express it.
+- `CloseEvent` is only a Node global from v23, and this package supports Node >= 20.19,
+  so every close path threw `ReferenceError: CloseEvent is not defined` on Node 20 and
+  22. It is now shimmed, alongside the existing `ErrorEvent` shim.
+- A malformed handshake is answered as the client error it is: an unsupported
+  `Sec-WebSocket-Version` gets `426` with `Sec-WebSocket-Version: 13`, a
+  `Sec-WebSocket-Key` that is not a base64-encoded 16-byte value gets `400`, and a
+  non-`GET` handshake gets `405`. Previously all three reached the handler, threw, and
+  were reported as `502 handler error`.
+- A flood of empty continuation frames no longer grows the reassembly buffer without
+  bound; they add no bytes, so the byte ceiling never stopped them.
+- When the peer never answers a close, the close event now reports `1006` rather than
+  the code this side sent.

--- a/packages/cli/src/dev/websocket.test.ts
+++ b/packages/cli/src/dev/websocket.test.ts
@@ -1,6 +1,6 @@
 import { createServer, type Server } from "node:http";
 import { type AddressInfo, connect, type Socket } from "node:net";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
 	acceptKey,
@@ -317,6 +317,38 @@ describe("acceptKey", () => {
 	});
 });
 
+describe("event constructors below the supported Node floor", () => {
+	// `CloseEvent` is only global from Node 23, and this package supports >= 20.19,
+	// so every close path would throw a ReferenceError there without the shim.
+	it("uses a CloseEvent shim when the global is absent", async () => {
+		const host = globalThis as { CloseEvent?: unknown };
+		const original = host.CloseEvent;
+		host.CloseEvent = undefined;
+		vi.resetModules();
+		try {
+			const fresh = await import("./websocket.js");
+			const event = new fresh.CloseEventCtor("close", {
+				code: 4001,
+				reason: "bye",
+				wasClean: true,
+			});
+			expect(event).toBeInstanceOf(Event);
+			expect(event.type).toBe("close");
+			const shaped = event as Event & {
+				code: number;
+				reason: string;
+				wasClean: boolean;
+			};
+			expect(shaped.code).toBe(4001);
+			expect(shaped.reason).toBe("bye");
+			expect(shaped.wasClean).toBe(true);
+		} finally {
+			host.CloseEvent = original;
+			vi.resetModules();
+		}
+	});
+});
+
 describe("the legacy upgrade export under neon dev", () => {
 	it("is called with the raw Node triple (previously it never ran at all)", async () => {
 		const seen: { url: string | undefined; hasHead: boolean }[] = [];
@@ -624,15 +656,42 @@ describe("upgradeWebSocket under neon dev", () => {
 		expect((thrown as Error).message).toMatch(/already called/);
 	});
 
-	it("returns 501 when the handler ignores the upgrade", async () => {
+	it("relays the response verbatim when the handler declines the upgrade", async () => {
 		const port = await start({
 			fetch: () => new Response("ordinary body"),
 		});
 
 		const raw = await wsHandshakeFull(port);
 
-		expect(raw.startsWith("HTTP/1.1 501")).toBe(true);
-		expect(raw).not.toContain("ordinary body");
+		expect(raw.startsWith("HTTP/1.1 200 OK")).toBe(true);
+		expect(raw).toContain("ordinary body");
+	});
+
+	it("relays a 401 so a function can refuse an unauthenticated handshake", async () => {
+		const port = await start({
+			fetch: () =>
+				new Response("unauthorized", {
+					status: 401,
+					headers: { "x-reason": "no-token" },
+				}),
+		});
+
+		const raw = await wsHandshakeFull(port);
+
+		expect(raw.startsWith("HTTP/1.1 401 Unauthorized")).toBe(true);
+		expect(raw.toLowerCase()).toContain("x-reason: no-token");
+		expect(raw).toContain("unauthorized");
+	});
+
+	it("relays a 404 for an unknown websocket route", async () => {
+		const port = await start({
+			fetch: () => new Response("no such room", { status: 404 }),
+		});
+
+		const raw = await wsHandshakeFull(port);
+
+		expect(raw.startsWith("HTTP/1.1 404 Not Found")).toBe(true);
+		expect(raw).toContain("no such room");
 	});
 
 	it("finds the socket when the handler is handed a rebuilt Request", async () => {
@@ -748,6 +807,121 @@ describe("upgradeWebSocket under neon dev", () => {
 		});
 
 		expect(raw.startsWith("HTTP/1.1 426")).toBe(true);
+	});
+
+	it("answers an unsupported version with 426 and advertises version 13", async () => {
+		const port = await start({
+			fetch: (request) => upgradeWebSocket(request).response,
+		});
+
+		const raw = await new Promise<string>((resolveRaw, reject) => {
+			const sock = connect(port, "127.0.0.1", () => {
+				sock.write(
+					"GET /ws HTTP/1.1\r\nhost: localhost\r\n" +
+						"connection: Upgrade\r\nupgrade: websocket\r\n" +
+						"sec-websocket-version: 8\r\n" +
+						`sec-websocket-key: ${CLIENT_KEY}\r\n\r\n`,
+				);
+			});
+			const chunks: Buffer[] = [];
+			sock.on("data", (c: Buffer) => chunks.push(c));
+			sock.on("close", () =>
+				resolveRaw(Buffer.concat(chunks).toString("utf8")),
+			);
+			sock.on("error", reject);
+			sock.setTimeout(2000, () => {
+				sock.destroy();
+				reject(new Error("timeout"));
+			});
+		});
+
+		expect(raw.startsWith("HTTP/1.1 426 Upgrade Required")).toBe(true);
+		expect(raw.toLowerCase()).toContain("sec-websocket-version: 13");
+		// Never a 502: a bad version is the client's error, not the handler's.
+		expect(raw).not.toContain("502");
+	});
+
+	it("answers a malformed Sec-WebSocket-Key with 400", async () => {
+		const port = await start({
+			fetch: (request) => upgradeWebSocket(request).response,
+		});
+
+		const raw = await new Promise<string>((resolveRaw, reject) => {
+			const sock = connect(port, "127.0.0.1", () => {
+				sock.write(
+					"GET /ws HTTP/1.1\r\nhost: localhost\r\n" +
+						"connection: Upgrade\r\nupgrade: websocket\r\n" +
+						"sec-websocket-version: 13\r\n" +
+						"sec-websocket-key: not-a-valid-key\r\n\r\n",
+				);
+			});
+			const chunks: Buffer[] = [];
+			sock.on("data", (c: Buffer) => chunks.push(c));
+			sock.on("close", () =>
+				resolveRaw(Buffer.concat(chunks).toString("utf8")),
+			);
+			sock.on("error", reject);
+			sock.setTimeout(2000, () => {
+				sock.destroy();
+				reject(new Error("timeout"));
+			});
+		});
+
+		expect(raw.startsWith("HTTP/1.1 400 Bad Request")).toBe(true);
+	});
+
+	it("answers a non-GET handshake with 405", async () => {
+		const port = await start({
+			fetch: (request) => upgradeWebSocket(request).response,
+		});
+
+		const raw = await new Promise<string>((resolveRaw, reject) => {
+			const sock = connect(port, "127.0.0.1", () => {
+				sock.write(
+					"POST /ws HTTP/1.1\r\nhost: localhost\r\n" +
+						"connection: Upgrade\r\nupgrade: websocket\r\n" +
+						"sec-websocket-version: 13\r\n" +
+						`sec-websocket-key: ${CLIENT_KEY}\r\n\r\n`,
+				);
+			});
+			const chunks: Buffer[] = [];
+			sock.on("data", (c: Buffer) => chunks.push(c));
+			sock.on("close", () =>
+				resolveRaw(Buffer.concat(chunks).toString("utf8")),
+			);
+			sock.on("error", reject);
+			sock.setTimeout(2000, () => {
+				sock.destroy();
+				reject(new Error("timeout"));
+			});
+		});
+
+		expect(raw.startsWith("HTTP/1.1 405 Method Not Allowed")).toBe(true);
+	});
+
+	it("does not accumulate fragments for a flood of empty continuations", async () => {
+		const port = await start({
+			fetch: (request) => {
+				const { socket, response } = upgradeWebSocket(request);
+				socket.addEventListener("message", (event) => {
+					socket.send(
+						`len:${String((event as MessageEvent).data).length}`,
+					);
+				});
+				return response;
+			},
+		});
+
+		const { client } = await wsHandshake(port);
+		// Open a fragmented text message, then send many empty continuations. Each
+		// adds zero bytes, so a byte-only bound would never stop them.
+		client.send("", 0x1, false);
+		for (let i = 0; i < 20000; i++) client.send("", 0x0, false);
+		client.send("done", 0x0, true);
+
+		const frame = await client.next();
+		expect(frame.payload.toString("utf8")).toBe("len:4");
+		client.destroy();
 	});
 
 	it("throws off-platform, where no bridge is published", () => {

--- a/packages/cli/src/dev/websocket.ts
+++ b/packages/cli/src/dev/websocket.ts
@@ -61,8 +61,10 @@ const CLOSE_HANDSHAKE_TIMEOUT_MS = 5_000;
 const EMPTY = Buffer.alloc(0);
 
 /**
- * Node has global Event/MessageEvent/CloseEvent but not ErrorEvent, so fall back to a
- * shim with the same shape (`message` + `error`) when it is missing.
+ * `MessageEvent` has been global since Node 15, but `CloseEvent` only since Node 23
+ * (and even there it disappears under `--no-experimental-websocket`) and `ErrorEvent`
+ * only since Node 25. This package supports Node >= 20.19, so both are shimmed with
+ * the same shape rather than constructed directly.
  */
 type ErrorEventInit = { message?: string; error?: unknown };
 type ErrorEventCtorType = new (type: string, init?: ErrorEventInit) => Event;
@@ -82,6 +84,27 @@ const ErrorEventCtor: ErrorEventCtorType =
 		? ((globalThis as { ErrorEvent?: unknown })
 				.ErrorEvent as ErrorEventCtorType)
 		: ShimErrorEvent;
+
+type CloseEventInit = { code?: number; reason?: string; wasClean?: boolean };
+type CloseEventCtorType = new (type: string, init?: CloseEventInit) => Event;
+
+class ShimCloseEvent extends Event {
+	readonly code: number;
+	readonly reason: string;
+	readonly wasClean: boolean;
+	constructor(type: string, init: CloseEventInit = {}) {
+		super(type);
+		this.code = init.code ?? 0;
+		this.reason = init.reason ?? "";
+		this.wasClean = init.wasClean ?? false;
+	}
+}
+
+export const CloseEventCtor: CloseEventCtorType =
+	typeof (globalThis as { CloseEvent?: unknown }).CloseEvent === "function"
+		? ((globalThis as { CloseEvent?: unknown })
+				.CloseEvent as CloseEventCtorType)
+		: ShimCloseEvent;
 
 export type UpgradeWebSocketOptions = {
 	protocol?: string;
@@ -358,11 +381,19 @@ const completeUpgrade = (record: UpgradeRecord, response: Response): void => {
 // -- Reject / relay helpers --------------------------------------------------
 
 const STATUS_TEXT: Record<number, string> = {
+	200: "OK",
+	400: "Bad Request",
+	401: "Unauthorized",
+	403: "Forbidden",
 	404: "Not Found",
+	405: "Method Not Allowed",
+	409: "Conflict",
 	426: "Upgrade Required",
+	429: "Too Many Requests",
 	500: "Internal Server Error",
 	501: "Not Implemented",
 	502: "Bad Gateway",
+	503: "Service Unavailable",
 };
 
 /**
@@ -374,17 +405,19 @@ export const writeUpgradeRejection = (
 	socket: Duplex,
 	status: number,
 	reason: string,
+	extraHeaders: Record<string, string> = {},
 ): void => {
 	const body = `${reason}\n`;
+	let head =
+		`HTTP/1.1 ${status} ${STATUS_TEXT[status] ?? "Error"}\r\n` +
+		"connection: close\r\n" +
+		"content-type: text/plain\r\n" +
+		`content-length: ${Buffer.byteLength(body)}\r\n`;
+	for (const [name, value] of Object.entries(extraHeaders)) {
+		head += `${name.toLowerCase()}: ${value}\r\n`;
+	}
 	try {
-		socket.end(
-			`HTTP/1.1 ${status} ${STATUS_TEXT[status] ?? "Error"}\r\n` +
-				"connection: close\r\n" +
-				"content-type: text/plain\r\n" +
-				`content-length: ${Buffer.byteLength(body)}\r\n` +
-				"\r\n" +
-				body,
-		);
+		socket.end(`${head}\r\n${body}`);
 	} catch {
 		try {
 			socket.destroy();
@@ -392,6 +425,82 @@ export const writeUpgradeRejection = (
 			/* already destroyed */
 		}
 	}
+};
+
+/** Headers the raw writer owns; a handler value must not contradict them. */
+const RESERVED_RESPONSE_HEADERS = new Set([
+	"connection",
+	"content-length",
+	"transfer-encoding",
+	"keep-alive",
+	"upgrade",
+]);
+
+/**
+ * Write a `Response` the handler returned to decline the upgrade, verbatim: status,
+ * headers and body. Declining a handshake with a 401/403/404 is how a function refuses
+ * a connection, so the response has to reach the client instead of being replaced.
+ */
+const writeResponseToSocket = async (
+	socket: Duplex,
+	response: Response,
+): Promise<void> => {
+	const body = Buffer.from(await response.arrayBuffer());
+	const statusText =
+		response.statusText || (STATUS_TEXT[response.status] ?? "");
+	let head = `HTTP/1.1 ${response.status} ${statusText}\r\n`;
+	response.headers.forEach((value, name) => {
+		if (RESERVED_RESPONSE_HEADERS.has(name.toLowerCase())) return;
+		head += `${name.toLowerCase()}: ${value}\r\n`;
+	});
+	head += "connection: close\r\n";
+	head += `content-length: ${body.length}\r\n\r\n`;
+	socket.end(Buffer.concat([Buffer.from(head, "latin1"), body]));
+};
+
+/** RFC 6455 §4.1: a 16-byte nonce, base64-encoded. */
+const isValidWebSocketKey = (key: string): boolean =>
+	/^[A-Za-z0-9+/]{22}==$/.test(key) &&
+	Buffer.from(key, "base64").length === 16;
+
+type HandshakeRejection = {
+	status: number;
+	reason: string;
+	headers?: Record<string, string>;
+};
+
+/**
+ * Check the parts of the handshake the server owns before any user code runs, so a
+ * malformed client request is answered as the client error it is rather than
+ * surfacing later as a throw from `upgradeWebSocket()` (which the listener cannot
+ * tell apart from a genuine handler bug, and would report as a 502).
+ */
+export const validateHandshake = (
+	req: IncomingMessage,
+): HandshakeRejection | null => {
+	const method = (req.method ?? "GET").toUpperCase();
+	if (method !== "GET") {
+		return {
+			status: 405,
+			reason: `a WebSocket handshake must use GET, got ${method}`,
+		};
+	}
+	const version = headerValue(req, "sec-websocket-version");
+	if (version !== "13") {
+		return {
+			status: 426,
+			reason: `unsupported Sec-WebSocket-Version ${version === "" ? "(absent)" : version}; only version 13 is supported`,
+			// §4.4 requires advertising what the server does support.
+			headers: { "sec-websocket-version": "13" },
+		};
+	}
+	if (!isValidWebSocketKey(headerValue(req, "sec-websocket-key"))) {
+		return {
+			status: 400,
+			reason: "Sec-WebSocket-Key must be a base64-encoded 16-byte value",
+		};
+	}
+	return null;
 };
 
 // -- The 'upgrade' listener --------------------------------------------------
@@ -455,8 +564,20 @@ const handleUpgrade = async (
 	}
 
 	// The launched contract wins, so local precedence matches deployed precedence.
+	// It owns its own handshake, so it is handed the request unvalidated.
 	if (upgrade) {
 		await upgrade(req, socket, head);
+		return;
+	}
+
+	const rejection = validateHandshake(req);
+	if (rejection) {
+		writeUpgradeRejection(
+			socket,
+			rejection.status,
+			rejection.reason,
+			rejection.headers ?? {},
+		);
 		return;
 	}
 
@@ -495,12 +616,11 @@ const handleUpgrade = async (
 		return;
 	}
 
-	// The handler ignored the upgrade. Same 501 the deployed runtime returns.
-	writeUpgradeRejection(
-		socket,
-		501,
-		"websocket not supported by this function",
-	);
+	// The handler declined the upgrade and answered with an ordinary response.
+	// Relay it verbatim: returning a 401/403/404 is how a function refuses a
+	// handshake, and replacing it with a status of our own would throw away the
+	// only answer the client was given.
+	await writeResponseToSocket(socket, response);
 };
 
 /**
@@ -741,7 +861,9 @@ class DevServerWebSocket extends EventTarget {
 		this.#readyState = CLOSING;
 		this.#sendClose(code ?? 1000, reasonBuf);
 		this.#closeTimer = setTimeout(() => {
-			this.#finishClose(code ?? 1000, reasonBuf.toString("utf8"), false);
+			// The peer never answered, so no close frame was received: §7.1.5 makes
+			// that 1006, not the code we sent.
+			this.#finishClose(1006, "", false);
 		}, CLOSE_HANDSHAKE_TIMEOUT_MS);
 		this.#closeTimer.unref?.();
 	}
@@ -777,7 +899,7 @@ class DevServerWebSocket extends EventTarget {
 			this.#closeTimer = null;
 		}
 		this.dispatchEvent(
-			new CloseEvent("close", { code, reason, wasClean: false }),
+			new CloseEventCtor("close", { code, reason, wasClean: false }),
 		);
 	}
 
@@ -922,6 +1044,10 @@ class DevServerWebSocket extends EventTarget {
 				`message exceeds the ${MAX_MESSAGE_BYTES} byte limit`,
 			);
 		}
+		// An empty continuation frame is legal and contributes nothing to the
+		// message. Dropping it here keeps a flood of them from growing the fragment
+		// list without ever moving `#fragmentBytes` toward the limit above.
+		if (payload.length === 0) return;
 		this.#fragments.push(payload);
 	}
 
@@ -1029,7 +1155,9 @@ class DevServerWebSocket extends EventTarget {
 				/* already gone */
 			}
 		}
-		this.dispatchEvent(new CloseEvent("close", { code, reason, wasClean }));
+		this.dispatchEvent(
+			new CloseEventCtor("close", { code, reason, wasClean }),
+		);
 	}
 
 	#emitError(err: unknown): void {


### PR DESCRIPTION
## The problem

Porting `neondatabase/examples/with-realtime-chat` onto `upgradeWebSocket` and running it against `neon dev` produced 17/21 passing checks. The four failures were one bug, and looking for its cause turned up four more.

### A function cannot refuse a handshake

The example's first act on a handshake is rejecting unauthenticated clients:

```ts
const identity = await verifyToken(url.searchParams.get('token'));
if (!identity) return new Response('unauthorized', { status: 401 });
```

The client received:

```
HTTP/1.1 501 Not Implemented
websocket not supported by this function
```

The returned `Response` was discarded — status, headers and body — and replaced. Refusing a connection is the normal case for a WebSocket endpoint (401 unauthenticated, 403 wrong tenant, 404 unknown room), and there was no way to express it. The old `upgrade(req, socket, head)` export could write `HTTP/1.1 401` by hand, so this was a capability regression for anything moving to the new API.

This also diverges from `Deno.upgradeWebSocket`, which the API otherwise follows, where returning a normal `Response` is how you decline.

### `CloseEvent` is not a global on supported Node versions

`websocket.ts` constructs `new CloseEvent(...)` unconditionally. Per Node's own docs:

| Global | Added in |
|---|---|
| `MessageEvent` | v15.0.0 |
| `CloseEvent` | **v23.0.0**, and removed again by `--no-experimental-websocket` |
| `ErrorEvent` | v25.0.0 |

`packages/cli` declares `engines.node: ">=20.19.0"`. On Node 20 and 22 every close path — clean close, peer close, socket error, abort — throws `ReferenceError: CloseEvent is not defined`.

The file already shims `ErrorEvent`, which is the identical bug one version apart. A probe on Node 24 shows why only half got fixed: `CloseEvent` is present there and `ErrorEvent` is not, so the gap that was visible on the author's machine is the one that got handled.

### Client errors were reported as server errors

A malformed handshake reached the handler, threw inside `upgradeWebSocket()`, and surfaced as `502 handler error` with a dev log reading "Request handler threw an error while upgrading" — blaming the user's code for the client's mistake. Reproduced:

```
sec-websocket-version: 8   ->  HTTP/1.1 502 Bad Gateway   (no Sec-WebSocket-Version header)
POST + handshake headers   ->  HTTP/1.1 502 Bad Gateway
```

### Empty continuation frames evaded the message ceiling

`#pushFragment` bounds `#fragmentBytes`, but a zero-length continuation adds no bytes while still being pushed onto `#fragments`. A stream of them grows the list without ever approaching the 16 MB limit.

### An unanswered close reported the wrong code

The close-handshake timeout fired with the code this side sent. No close frame was received, which RFC 6455 §7.1.5 defines as 1006.

## What changes

A declined upgrade is relayed verbatim:

```ts
export default {
  async fetch(request: Request): Promise<Response> {
    if (request.headers.get('upgrade')?.toLowerCase() !== 'websocket') {
      return app.fetch(request);
    }
    const identity = await verifyToken(new URL(request.url).searchParams.get('token'));
    if (!identity) return new Response('unauthorized', { status: 401 });  // now reaches the client

    const { socket, response } = upgradeWebSocket(request);
    socket.addEventListener('message', (event) => socket.send(event.data));
    return response;
  },
};
```

```
HTTP/1.1 401 Unauthorized
x-reason: no-token
content-length: 13

unauthorized
```

Handshake validation now runs before any user code, with RFC-correct statuses:

| Request | Before | After |
|---|---|---|
| `Sec-WebSocket-Version: 8` | `502 Bad Gateway` | `426 Upgrade Required` + `Sec-WebSocket-Version: 13` |
| `Sec-WebSocket-Key: not-a-valid-key` | `101` (accepted) | `400 Bad Request` |
| missing `Sec-WebSocket-Version` | `101` (accepted) | `426` + `Sec-WebSocket-Version: 13` |
| `POST` with handshake headers | `502 Bad Gateway` | `405 Method Not Allowed` |

A legacy `upgrade` export still receives the request unvalidated — it owns its own handshake, and its precedence is unchanged.

`CloseEvent` is shimmed next to the existing `ErrorEvent` shim, empty continuations are no longer retained, and an unanswered close reports 1006.

## Behaviour change to be aware of

A handler that returns a plain `200` on an upgrade request now relays that 200 instead of answering `501`. That is the point — the handler's answer is the answer — but it does mean the "handler ignored the upgrade" case is no longer distinguishable from a deliberate 200. The test asserting `501` was rewritten to assert the relay; it is the only intentional behaviour change to an existing test.

## Verification

```
Test Files  2 passed (2)
     Tests  49 passed (49)
```

Up from 42. New cases: relaying a declined 401 and 404 with headers and body intact, the three malformed-handshake statuses, a 20,000-frame empty-continuation flood, and the `CloseEvent` shim exercised with the global deleted and the module re-imported. `pnpm --filter neon build` (which type-checks) and `biome check --error-on-warnings` are clean.

Beyond the suite, the ported example was driven over loopback against a real `neon dev`: 101 with a correct accept key, text fan-out to a second client, binary as `ArrayBuffer`, a 70 KB message across both extended length forms, subprotocol negotiation, server-initiated close with code and reason, ping/pong, and an upgrade routed through Hono.

## Not fixed here

Deliberately left, to keep this reviewable:

- The deployed runtime must make the same choice about relaying a declined response, or local and deployed will disagree — the case for the local behaviour is that returning a `Response` is the only way to refuse. Worth settling on LKB-15856 before the runtime side ships.
- Frame validation still happens after the payload is buffered, so an illegal 16 MiB control frame is fully read before being rejected with 1002.
- Non-minimal length encodings are accepted, and a 127-form length with the high bit set reports 1009 where 1002 is required.
- `Blob` sends are neither ordered nor queued: `send(blob); send("x")` puts `x` first, and `send(blob); close()` drops the blob.
- `startRuntime` still has no test, so the `server.on('upgrade', …)` registration that is the whole point of #389 is not covered by anything.
- The protocol implementation is still duplicated from the deployed runtime with no shared fixture pinning the two together.