### PR TITLE
Make externalPackages ship a package's files, with includeFiles to opt out

### DIFF
--- a/.changeset/tidy-moons-gather.md
+++ b/.changeset/tidy-moons-gather.md
@@ -1,0 +1,9 @@
+---
+"@neon/config": minor
+---
+
+Add `nativePackages` to a `neon.ts` function definition, declaring packages backed by a
+native binary whose real files should ship into the deployed archive alongside the bundle.
+This is the schema and type surface only; the bundler change that acts on the list follows
+separately. A package may not appear in both `nativePackages` and `externalPackages`, and
+entries are package names without a subpath.

--- a/.changeset/tidy-moons-gather.md
+++ b/.changeset/tidy-moons-gather.md
@@ -2,8 +2,31 @@
 "@neon/config": minor
 ---
 
-Add `nativePackages` to a `neon.ts` function definition, declaring packages backed by a
-native binary whose real files should ship into the deployed archive alongside the bundle.
-This is the schema and type surface only; the bundler change that acts on the list follows
-separately. A package may not appear in both `nativePackages` and `externalPackages`, and
-entries are package names without a subpath.
+**Breaking:** `externalPackages` now ships a package's real files into the deployed archive
+by default, instead of externalizing the import and shipping nothing.
+
+A bare string is the common form and produces a function that works:
+
+```ts
+externalPackages: ["sharp"],
+```
+
+The previous behaviour — externalize the import, ship nothing, throw `Cannot find module`
+if the function reaches it — is now the opt-out, for a package that cannot be staged and is
+never actually reached:
+
+```ts
+externalPackages: ["sharp", { name: "canvas", includeFiles: false }],
+```
+
+`ResolvedFunctionConfig.externalPackages` changes from `string[]` to
+`{ name: string; includeFiles: boolean }[]`, which affects anything reading a resolved
+config or implementing a custom `FunctionBundler`. Two pure helpers are exported for that
+case: `packagesToStage` and `externalPackageRoot`.
+
+A function that declares no `externalPackages`, or whose every entry sets
+`includeFiles: false`, deploys exactly the archive it did before.
+
+Validation additionally rejects the same package listed twice, and a bare name and a subpath
+of it that disagree about `includeFiles`. This is the schema and type surface; the bundler
+change that stages the files lands separately.

--- a/.changeset/tidy-moons-gather.md
+++ b/.changeset/tidy-moons-gather.md
@@ -27,6 +27,9 @@ case: `packagesToStage` and `externalPackageRoot`.
 A function that declares no `externalPackages`, or whose every entry sets
 `includeFiles: false`, deploys exactly the archive it did before.
 
-Validation additionally rejects the same package listed twice, and a bare name and a subpath
-of it that disagree about `includeFiles`. This is the schema and type surface; the bundler
-change that stages the files lands separately.
+A package named here must be installed in your project: the deploy stages the version you
+have rather than guessing one, and refuses if it cannot find it.
+
+Validation additionally rejects the same package listed twice, a bare name and a subpath of it
+that disagree about `includeFiles`, and an entry that does not name one installable package
+(a wildcard or a bare scope) unless it sets `includeFiles: false`.

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -75,7 +75,11 @@ const neonctlBundler: FunctionBundler = async (fn) =>
 	zipBundle(
 		await bundleEntry(fn.source, {
 			...(fn.externalPackages
-				? { externalPackages: fn.externalPackages }
+				? {
+						externalPackages: fn.externalPackages.map(
+							(pkg) => pkg.name,
+						),
+					}
 				: {}),
 		}),
 	);

--- a/packages/cli/src/dev/functions.ts
+++ b/packages/cli/src/dev/functions.ts
@@ -79,8 +79,14 @@ export const resolveFunctionsFromConfig = async (
 				? { port: devPort(fn.dev) as number }
 				: {}),
 			env: { ...fn.env },
+			// Names only: locally every entry is simply left unbundled, and `includeFiles`
+			// governs the deployed archive, which `neon dev` does not build.
 			...(fn.externalPackages
-				? { externalPackages: [...fn.externalPackages] }
+				? {
+						externalPackages: fn.externalPackages.map(
+							(pkg) => pkg.name,
+						),
+					}
 				: {}),
 		};
 	});

--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -24,7 +24,14 @@ function fn(
 		source,
 		env: {},
 		runtime: "nodejs24",
-		...(externalPackages ? { externalPackages } : {}),
+		...(externalPackages
+			? {
+					externalPackages: externalPackages.map((name) => ({
+						name,
+						includeFiles: true,
+					})),
+				}
+			: {}),
 	};
 }
 

--- a/packages/config-runtime/src/lib/function-bundle.ts
+++ b/packages/config-runtime/src/lib/function-bundle.ts
@@ -74,11 +74,10 @@ export async function buildFunctionBundle(
 			// `platform: "node"`. The banner re-creates require/__filename/__dirname so
 			// bundled CommonJS deps work inside the ESM output.
 			banner: { js: ESM_CJS_INTEROP_BANNER },
-			// Packages the policy declared unbundleable (native addons, optional peers on
-			// dead code paths). Their imports survive into the bundle and resolve against a
-			// directory with no node_modules, so reaching one at runtime throws — which is
-			// the documented contract of `FunctionDef.externalPackages`, not a bug here.
-			external: [...(fn.externalPackages ?? [])],
+			// Packages the policy declared unbundleable. Their imports survive into the
+			// bundle; whether they then resolve depends on `includeFiles`, which the deploy
+			// bundler acts on after this build. Both modes are external to esbuild.
+			external: (fn.externalPackages ?? []).map((pkg) => pkg.name),
 			logLevel: "silent",
 		});
 	} catch (cause) {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -45,38 +45,9 @@ Service toggles accept `true` / `{}` / `{ enabled: true }` (enabled) and `false`
 
 ### Unbundleable dependencies (`externalPackages`)
 
-A function's `source` is bundled with esbuild at deploy time, and some packages cannot be bundled at all: a native `.node` addon has no esbuild loader, and a library may reference an optional peer dependency on a code path the function never takes. Either one fails the deploy with a resolve or loader error naming the package, and neither is fixable from the function's own source.
+A function's `source` is bundled with esbuild at deploy time, and a package backed by a native `.node` binary cannot be bundled by anything: the binary is a compiled object the platform loads from a real path. `sharp` is the common case, and it does not even fail the build — it loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
 
-`externalPackages` is the escape hatch, and the deploy-time counterpart of Next.js's `serverExternalPackages` — every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed:
-
-```ts
-export default defineConfig({
-  preview: {
-    functions: {
-      agent: {
-        name: "Agent",
-        source: "./functions/agent.ts",
-        externalPackages: ["microsandbox", "@mongodb-js/zstd"],
-      },
-    },
-  },
-});
-```
-
-**An external package is not resolvable at runtime.** The deployed archive is a single `index.mjs` with no `node_modules` beside it, so anything listed here throws `Cannot find module` if the function actually reaches it. The option unblocks an import that is never evaluated; it does not make a dependency usable.
-
-A dependency the handler actually calls has to be bundled, and whether that is possible depends on what it is:
-
-- **Pure JavaScript** — bundling is the normal case, and a failure is usually something specific and fixable in the entry.
-- **Backed by a native `.node` binary** — cannot be bundled by any bundler; the binary is a compiled object the platform loads from a real path. Such a package needs its files shipped next to the bundle, which is `nativePackages` below. Listing it here does not help, it only moves the error from deploy to invoke.
-
-A native package may also bundle without needing this option at all. `sharp` loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
-
-Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. `neon dev` applies the same list, so a local run bundles like a deploy.
-
-### Native dependencies (`nativePackages`)
-
-`nativePackages` names packages backed by a native binary whose real files should ship into the deployed archive. Where `externalPackages` only stops such a package failing the build, this is the option that makes it work:
+`externalPackages` is the deploy-time counterpart of Next.js's `serverExternalPackages`. Every entry is passed to esbuild's `external`, so the import survives into the bundle instead of being followed, and the package's own files are shipped into the archive beside the bundle so that import resolves:
 
 ```ts
 export default defineConfig({
@@ -85,16 +56,16 @@ export default defineConfig({
       resize: {
         name: "Resize",
         source: "./functions/resize.ts",
-        nativePackages: ["sharp"],
+        externalPackages: ["sharp"],
       },
     },
   },
 });
 ```
 
-Each entry is kept out of the bundle and then installed for the Functions runtime target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it actually reaches, and copied into the archive under `node_modules/` with its directory layout intact. The layout matters: a `.node` addon finds its sibling shared libraries relative to its own directory, so a flattened tree fails to load.
+Each declared package is installed for the Functions runtime target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it actually reaches, and copied into the archive under `node_modules/` with its directory layout intact. The layout matters: a `.node` addon finds its sibling shared libraries relative to its own directory, so a flattened tree fails to load.
 
-Your own `node_modules` is never read for those files or modified. Its binaries are built for your machine rather than the deploy target, and a cross-platform install does not survive your next plain `npm install`, so the target's packages are resolved fresh on each deploy. The version installed is the one your project already resolved, read from your dependency tree — the deploy honours your lockfile without trusting the binaries beside it.
+Your own `node_modules` is never read for those files or modified. Its binaries are built for your machine rather than the deploy target, and a cross-platform install does not survive your next plain `npm install`, so the target's packages are resolved fresh on each deploy.
 
 Requirements, all checked at deploy time rather than left to fail at invoke:
 
@@ -102,7 +73,17 @@ Requirements, all checked at deploy time rather than left to fail at invoke:
 - `npm` is on `PATH`
 - the archive stays within the deploy size limits — native binaries are large, so a couple of them is the practical ceiling
 
-Entries are package names without a subpath (`sharp`, `@scope/pkg`), since the whole package is installed and traced. A package must not appear in both lists.
+#### Excluding a package's files
+
+`includeFiles: false` externalizes an import without shipping anything for it. That is the escape hatch for a package that cannot be staged — no build for the runtime target, or too large — and that the function never actually reaches:
+
+```ts
+externalPackages: ["sharp", { name: "canvas", includeFiles: false }],
+```
+
+**An excluded package is not resolvable at runtime.** Nothing is shipped for it, so it throws `Cannot find module` if the function reaches it. It unblocks an import that is never evaluated; it does not make a dependency usable.
+
+Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. Files are staged per package, so a subpath narrows what esbuild leaves unresolved without narrowing what ships.
 
 Under `neon dev` the list only keeps the package out of the bundle. Nothing is installed or copied, and it resolves from your own `node_modules` against your host architecture — which is what you want locally.
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -43,7 +43,7 @@ A policy is split into a **static** existential set and a **dynamic** `branch` c
 
 Service toggles accept `true` / `{}` / `{ enabled: true }` (enabled) and `false` / `{ enabled: false }` (disabled). Function slugs (record keys) must match `^[a-z0-9]{1,20}$`.
 
-### Unbundleable dependencies (`externalPackages`)
+### Shipping a dependency's files (`externalPackages`)
 
 A function's `source` is bundled with esbuild at deploy time, and a package backed by a native `.node` binary cannot be bundled by anything: the binary is a compiled object the platform loads from a real path. `sharp` is the common case, and it does not even fail the build — it loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
 
@@ -69,9 +69,24 @@ Your own `node_modules` is never read for those files or modified. Its binaries 
 
 Requirements, all checked at deploy time rather than left to fail at invoke:
 
+- the package is installed in your project — the deploy stages the version you have, and refuses rather than guessing one
 - the package publishes a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages do; anything compiled from source at install time does not)
 - `npm` is on `PATH`
 - the archive stays within the deploy size limits — native binaries are large, so a couple of them is the practical ceiling
+
+#### When the deploy warns about a package you did not declare
+
+A deploy (and `neon dev`) reports a package it bundled that carries native code and is not in
+`externalPackages`, because such a package deploys cleanly and then fails at invoke — `sharp`
+produces no build error at all.
+
+**The report is advisory and never fails a deploy.** It can only see that the package contains
+compiled code, not whether your function reaches it. A package with a native accelerator behind
+a working JavaScript fallback — `ws` with `bufferutil` installed is the common one — is reported
+and is already correct; no change is needed.
+
+Do not use `includeFiles: false` to silence it. That externalizes the package and ships nothing
+for it, so an import that *is* reached then fails on every invoke.
 
 #### Excluding a package's files
 

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -68,11 +68,43 @@ export default defineConfig({
 A dependency the handler actually calls has to be bundled, and whether that is possible depends on what it is:
 
 - **Pure JavaScript** — bundling is the normal case, and a failure is usually something specific and fixable in the entry.
-- **Backed by a native `.node` binary** — cannot be bundled by any bundler; the binary is a compiled object the platform loads from a real path. Such a package cannot work on Functions until the archive can carry files alongside the bundle. Listing it here does not help, it only moves the error from deploy to invoke.
+- **Backed by a native `.node` binary** — cannot be bundled by any bundler; the binary is a compiled object the platform loads from a real path. Such a package needs its files shipped next to the bundle, which is `nativePackages` below. Listing it here does not help, it only moves the error from deploy to invoke.
 
 A native package may also bundle without needing this option at all. `sharp` loads its binary through `createRequire`, which esbuild does not follow, so it bundles cleanly and then fails at invoke with `Could not load the "sharp" module`.
 
 Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`). A relative or absolute path is rejected at validation time. `neon dev` applies the same list, so a local run bundles like a deploy.
+
+### Native dependencies (`nativePackages`)
+
+`nativePackages` names packages backed by a native binary whose real files should ship into the deployed archive. Where `externalPackages` only stops such a package failing the build, this is the option that makes it work:
+
+```ts
+export default defineConfig({
+  preview: {
+    functions: {
+      resize: {
+        name: "Resize",
+        source: "./functions/resize.ts",
+        nativePackages: ["sharp"],
+      },
+    },
+  },
+});
+```
+
+Each entry is kept out of the bundle and then installed for the Functions runtime target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it actually reaches, and copied into the archive under `node_modules/` with its directory layout intact. The layout matters: a `.node` addon finds its sibling shared libraries relative to its own directory, so a flattened tree fails to load.
+
+Your own `node_modules` is never read for those files or modified. Its binaries are built for your machine rather than the deploy target, and a cross-platform install does not survive your next plain `npm install`, so the target's packages are resolved fresh on each deploy. The version installed is the one your project already resolved, read from your dependency tree — the deploy honours your lockfile without trusting the binaries beside it.
+
+Requirements, all checked at deploy time rather than left to fail at invoke:
+
+- the package publishes a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages do; anything compiled from source at install time does not)
+- `npm` is on `PATH`
+- the archive stays within the deploy size limits — native binaries are large, so a couple of them is the practical ceiling
+
+Entries are package names without a subpath (`sharp`, `@scope/pkg`), since the whole package is installed and traced. A package must not appear in both lists.
+
+Under `neon dev` the list only keeps the package out of the bundle. Nothing is installed or copied, and it resolves from your own `node_modules` against your host architecture — which is what you want locally.
 
 ### Data API
 

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -188,6 +188,85 @@ describe("resolveConfig", () => {
 		]);
 	});
 
+	test("passes nativePackages through to the resolved function", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./functions/hello-world.ts",
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions).toEqual([
+			{
+				slug: "fn1",
+				name: "Hello World",
+				source: "./functions/hello-world.ts",
+				env: {},
+				nativePackages: ["sharp"],
+				runtime: "nodejs24",
+			},
+		]);
+	});
+
+	test("omits nativePackages entirely when the policy does not declare it", () => {
+		const config = defineConfig({
+			preview: {
+				functions: { fn1: { name: "Hello", source: "./hello.ts" } },
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		// Absent rather than `[]`. The bundler keys the ship-native-files path off this
+		// property being present, so an empty array here would change every deploy.
+		expect(resolved.preview?.functions[0]).not.toHaveProperty(
+			"nativePackages",
+		);
+	});
+
+	test("copies nativePackages so mutating the policy array cannot reach the resolved config", () => {
+		const nativePackages = ["sharp"];
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						nativePackages,
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		nativePackages.push("mutated-after-resolve");
+		expect(resolved.preview?.functions[0]?.nativePackages).toEqual([
+			"sharp",
+		]);
+	});
+
+	test("resolves both package lists independently", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						externalPackages: ["microsandbox"],
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions[0]).toMatchObject({
+			externalPackages: ["microsandbox"],
+			nativePackages: ["sharp"],
+		});
+	});
+
 	test("applies per-branch function runtime tuning", () => {
 		const config = defineConfig({
 			preview: {

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -130,14 +130,14 @@ describe("resolveConfig", () => {
 		});
 	});
 
-	test("passes externalPackages through to the resolved function", () => {
+	test("resolves a bare externalPackages string to includeFiles: true", () => {
 		const config = defineConfig({
 			preview: {
 				functions: {
 					fn1: {
 						name: "Hello World",
 						source: "./functions/hello-world.ts",
-						externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+						externalPackages: ["sharp", "@mongodb-js/zstd"],
 					},
 				},
 			},
@@ -149,9 +149,54 @@ describe("resolveConfig", () => {
 				name: "Hello World",
 				source: "./functions/hello-world.ts",
 				env: {},
-				externalPackages: ["microsandbox", "@mongodb-js/zstd"],
+				externalPackages: [
+					{ name: "sharp", includeFiles: true },
+					{ name: "@mongodb-js/zstd", includeFiles: true },
+				],
 				runtime: "nodejs24",
 			},
+		]);
+	});
+
+	test("carries includeFiles: false through from the object form", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						externalPackages: [
+							"sharp",
+							{ name: "canvas", includeFiles: false },
+						],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions[0]?.externalPackages).toEqual([
+			{ name: "sharp", includeFiles: true },
+			{ name: "canvas", includeFiles: false },
+		]);
+	});
+
+	test("treats an explicit includeFiles: true the same as the bare string", () => {
+		const config = defineConfig({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello",
+						source: "./hello.ts",
+						externalPackages: [
+							{ name: "sharp", includeFiles: true },
+						],
+					},
+				},
+			},
+		});
+		const resolved = resolveConfig(config, { name: "main", exists: true });
+		expect(resolved.preview?.functions[0]?.externalPackages).toEqual([
+			{ name: "sharp", includeFiles: true },
 		]);
 	});
 
@@ -162,7 +207,8 @@ describe("resolveConfig", () => {
 			},
 		});
 		const resolved = resolveConfig(config, { name: "main", exists: true });
-		// Absent rather than `[]`, so an existing policy resolves to the shape it always did.
+		// Absent rather than `[]`. The bundler keys the stage-files path off there being a
+		// shipping entry, and an undeclared policy must produce the archive it always did.
 		expect(resolved.preview?.functions[0]).not.toHaveProperty(
 			"externalPackages",
 		);
@@ -184,87 +230,8 @@ describe("resolveConfig", () => {
 		const resolved = resolveConfig(config, { name: "main", exists: true });
 		externalPackages.push("mutated-after-resolve");
 		expect(resolved.preview?.functions[0]?.externalPackages).toEqual([
-			"microsandbox",
+			{ name: "microsandbox", includeFiles: true },
 		]);
-	});
-
-	test("passes nativePackages through to the resolved function", () => {
-		const config = defineConfig({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./functions/hello-world.ts",
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		expect(resolved.preview?.functions).toEqual([
-			{
-				slug: "fn1",
-				name: "Hello World",
-				source: "./functions/hello-world.ts",
-				env: {},
-				nativePackages: ["sharp"],
-				runtime: "nodejs24",
-			},
-		]);
-	});
-
-	test("omits nativePackages entirely when the policy does not declare it", () => {
-		const config = defineConfig({
-			preview: {
-				functions: { fn1: { name: "Hello", source: "./hello.ts" } },
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		// Absent rather than `[]`. The bundler keys the ship-native-files path off this
-		// property being present, so an empty array here would change every deploy.
-		expect(resolved.preview?.functions[0]).not.toHaveProperty(
-			"nativePackages",
-		);
-	});
-
-	test("copies nativePackages so mutating the policy array cannot reach the resolved config", () => {
-		const nativePackages = ["sharp"];
-		const config = defineConfig({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello",
-						source: "./hello.ts",
-						nativePackages,
-					},
-				},
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		nativePackages.push("mutated-after-resolve");
-		expect(resolved.preview?.functions[0]?.nativePackages).toEqual([
-			"sharp",
-		]);
-	});
-
-	test("resolves both package lists independently", () => {
-		const config = defineConfig({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello",
-						source: "./hello.ts",
-						externalPackages: ["microsandbox"],
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		const resolved = resolveConfig(config, { name: "main", exists: true });
-		expect(resolved.preview?.functions[0]).toMatchObject({
-			externalPackages: ["microsandbox"],
-			nativePackages: ["sharp"],
-		});
 	});
 
 	test("applies per-branch function runtime tuning", () => {

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -1,5 +1,6 @@
 import { parseBranchTtl } from "./duration.js";
 import { ConfigValidationError } from "./errors.js";
+import { normalizeExternalPackage } from "./external-packages.js";
 import {
 	branchTuningSchema,
 	configInputSchema,
@@ -341,15 +342,15 @@ function resolveFunctionConfig(
 		source: def.source,
 		env: { ...(def.env ?? {}) },
 		runtime: tuning.runtime ?? DEFAULT_FUNCTION_RUNTIME,
-		// Copied only when declared, so a policy without it resolves unchanged. Both
-		// bundlers read it; `neon dev` mirrors it so a local run bundles like a deploy.
+		// Normalized only when declared, so a policy without it resolves unchanged and takes
+		// the pre-existing bundling path. Both bundlers read it; `neon dev` mirrors it so a
+		// local run leaves the same packages unbundled as a deploy.
 		...(def.externalPackages
-			? { externalPackages: [...def.externalPackages] }
-			: {}),
-		// Same discipline: absent when undeclared, so the bundler can key the
-		// ship-native-files path off its presence and leave every other deploy untouched.
-		...(def.nativePackages
-			? { nativePackages: [...def.nativePackages] }
+			? {
+					externalPackages: def.externalPackages.map(
+						normalizeExternalPackage,
+					),
+				}
 			: {}),
 		// Passed through untouched (no defaults); only `neon dev` reads it.
 		...(def.dev ? { dev: def.dev } : {}),

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -346,6 +346,11 @@ function resolveFunctionConfig(
 		...(def.externalPackages
 			? { externalPackages: [...def.externalPackages] }
 			: {}),
+		// Same discipline: absent when undeclared, so the bundler can key the
+		// ship-native-files path off its presence and leave every other deploy untouched.
+		...(def.nativePackages
+			? { nativePackages: [...def.nativePackages] }
+			: {}),
 		// Passed through untouched (no defaults); only `neon dev` reads it.
 		...(def.dev ? { dev: def.dev } : {}),
 	};

--- a/packages/config/src/lib/external-packages.test.ts
+++ b/packages/config/src/lib/external-packages.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "vitest";
+import {
+	externalPackageRoot,
+	normalizeExternalPackage,
+	packagesToStage,
+} from "./external-packages.js";
+
+describe("externalPackageRoot", () => {
+	test("returns a bare name unchanged", () => {
+		expect(externalPackageRoot("sharp")).toBe("sharp");
+	});
+
+	test("keeps both segments of a scoped name", () => {
+		expect(externalPackageRoot("@img/sharp-linux-arm64")).toBe(
+			"@img/sharp-linux-arm64",
+		);
+	});
+
+	test("drops a subpath", () => {
+		expect(externalPackageRoot("sharp/lib/index.js")).toBe("sharp");
+	});
+
+	test("drops a subpath under a scope", () => {
+		expect(externalPackageRoot("@scope/pkg/sub/deep.js")).toBe(
+			"@scope/pkg",
+		);
+	});
+});
+
+describe("normalizeExternalPackage", () => {
+	test("defaults a bare string to shipping its files", () => {
+		expect(normalizeExternalPackage("sharp")).toEqual({
+			name: "sharp",
+			includeFiles: true,
+		});
+	});
+
+	test("defaults the object form to shipping its files", () => {
+		expect(normalizeExternalPackage({ name: "sharp" })).toEqual({
+			name: "sharp",
+			includeFiles: true,
+		});
+	});
+
+	test("carries includeFiles: false through", () => {
+		expect(
+			normalizeExternalPackage({ name: "canvas", includeFiles: false }),
+		).toEqual({ name: "canvas", includeFiles: false });
+	});
+});
+
+describe("packagesToStage", () => {
+	test("returns the packages that ship, in declaration order", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "@napi-rs/canvas", includeFiles: true },
+			]),
+		).toEqual(["sharp", "@napi-rs/canvas"]);
+	});
+
+	test("omits packages that opted out", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "canvas", includeFiles: false },
+			]),
+		).toEqual(["sharp"]);
+	});
+
+	test("is empty when every entry opted out, so nothing is staged", () => {
+		expect(
+			packagesToStage([{ name: "microsandbox", includeFiles: false }]),
+		).toEqual([]);
+	});
+
+	test("collapses a subpath onto its package", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp/lib/index.js", includeFiles: true },
+			]),
+		).toEqual(["sharp"]);
+	});
+
+	test("stages a package once when named both bare and through a subpath", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "sharp/lib/index.js", includeFiles: true },
+			]),
+		).toEqual(["sharp"]);
+	});
+});

--- a/packages/config/src/lib/external-packages.test.ts
+++ b/packages/config/src/lib/external-packages.test.ts
@@ -74,19 +74,32 @@ describe("packagesToStage", () => {
 		).toEqual([]);
 	});
 
-	test("collapses a subpath onto its package", () => {
+	// Specifiers are kept whole rather than reduced to their package. A package may export
+	// only a subpath, in which case importing the root throws and a trace of it finds
+	// nothing — so the trace has to import exactly what was authored. Reducing to the package
+	// is the caller's job, via `externalPackageRoot`, and only to decide what to install.
+	test("keeps a subpath specifier as authored", () => {
 		expect(
 			packagesToStage([
 				{ name: "sharp/lib/index.js", includeFiles: true },
 			]),
-		).toEqual(["sharp"]);
+		).toEqual(["sharp/lib/index.js"]);
 	});
 
-	test("stages a package once when named both bare and through a subpath", () => {
+	test("keeps a bare name and a subpath of it as two specifiers", () => {
 		expect(
 			packagesToStage([
 				{ name: "sharp", includeFiles: true },
 				{ name: "sharp/lib/index.js", includeFiles: true },
+			]),
+		).toEqual(["sharp", "sharp/lib/index.js"]);
+	});
+
+	test("deduplicates an exactly repeated specifier", () => {
+		expect(
+			packagesToStage([
+				{ name: "sharp", includeFiles: true },
+				{ name: "sharp", includeFiles: true },
 			]),
 		).toEqual(["sharp"]);
 	});

--- a/packages/config/src/lib/external-packages.ts
+++ b/packages/config/src/lib/external-packages.ts
@@ -1,0 +1,46 @@
+import type { ExternalPackageEntry, ResolvedExternalPackage } from "./types.js";
+
+/**
+ * The package a specifier belongs to, dropping any subpath: `sharp` from `sharp/lib/x`,
+ * `@scope/pkg` from `@scope/pkg/sub`.
+ *
+ * Files are installed and traced one package at a time, so this is the unit the deploy
+ * stages. A subpath narrows what esbuild leaves unresolved; it does not narrow what ships.
+ */
+export const externalPackageRoot = (specifier: string): string => {
+	const segments = specifier.split("/");
+	const keep = specifier.startsWith("@") ? 2 : 1;
+	return segments.slice(0, keep).join("/");
+};
+
+/**
+ * Normalize one authored entry into the shape every consumer reads.
+ *
+ * `includeFiles` defaults to **true**: the bare-string form is the one users reach for, and
+ * it should produce a function that works. Turning it off is the deliberate gesture.
+ */
+export const normalizeExternalPackage = (
+	entry: ExternalPackageEntry,
+): ResolvedExternalPackage =>
+	typeof entry === "string"
+		? { name: entry, includeFiles: true }
+		: { name: entry.name, includeFiles: entry.includeFiles !== false };
+
+/**
+ * The distinct packages whose files a function ships, in declaration order.
+ *
+ * Subpath entries collapse onto their package root, so declaring both `pkg` and `pkg/sub`
+ * stages `pkg` once. The schema has already rejected any pair that disagrees about
+ * `includeFiles`, so collapsing here cannot silently pick a side.
+ */
+export const packagesToStage = (
+	entries: readonly ResolvedExternalPackage[],
+): string[] => {
+	const roots: string[] = [];
+	for (const entry of entries) {
+		if (!entry.includeFiles) continue;
+		const root = externalPackageRoot(entry.name);
+		if (!roots.includes(root)) roots.push(root);
+	}
+	return roots;
+};

--- a/packages/config/src/lib/external-packages.ts
+++ b/packages/config/src/lib/external-packages.ts
@@ -27,20 +27,21 @@ export const normalizeExternalPackage = (
 		: { name: entry.name, includeFiles: entry.includeFiles !== false };
 
 /**
- * The distinct packages whose files a function ships, in declaration order.
+ * The specifiers whose files a function ships, in declaration order and deduplicated.
  *
- * Subpath entries collapse onto their package root, so declaring both `pkg` and `pkg/sub`
- * stages `pkg` once. The schema has already rejected any pair that disagrees about
- * `includeFiles`, so collapsing here cannot silently pick a side.
+ * These are the specifiers **as authored**, subpath included, because that is what the trace
+ * has to import. A package may export only a subpath — `exports: { "./native": … }` with no
+ * `.` — in which case importing the root throws `ERR_PACKAGE_PATH_NOT_EXPORTED` and the
+ * trace finds nothing. Use {@link externalPackageRoot} on these to get what to *install*,
+ * which is always the whole package.
  */
 export const packagesToStage = (
 	entries: readonly ResolvedExternalPackage[],
 ): string[] => {
-	const roots: string[] = [];
+	const specifiers: string[] = [];
 	for (const entry of entries) {
 		if (!entry.includeFiles) continue;
-		const root = externalPackageRoot(entry.name);
-		if (!roots.includes(root)) roots.push(root);
+		if (!specifiers.includes(entry.name)) specifiers.push(entry.name);
 	}
-	return roots;
+	return specifiers;
 };

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -282,6 +282,33 @@ describe("configInputSchema", () => {
 		).toBe(true);
 	});
 
+	// A staged entry's root is handed to `npm install`, so it has to name one package.
+	// esbuild's `external` also accepts a wildcard and a bare scope, which name a set.
+	test("rejects a wildcard entry that would be staged", () => {
+		const result = withExternalPackages(["@scope/*"]);
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(formatZodIssues(result.error).join("\n")).toMatch(
+				/does not name a single installable package/,
+			);
+		}
+	});
+
+	test("accepts a wildcard entry that stages nothing", () => {
+		expect(
+			withExternalPackages([{ name: "@scope/*", includeFiles: false }])
+				.success,
+		).toBe(true);
+	});
+
+	test("rejects a bare scope that would be staged", () => {
+		expect(withExternalPackages(["@scope"]).success).toBe(false);
+	});
+
+	test("rejects a protocol specifier that would be staged", () => {
+		expect(withExternalPackages(["node:fs"]).success).toBe(false);
+	});
+
 	test("accepts two scoped packages sharing a scope", () => {
 		// Same scope, different packages — not the same root, so not a conflict.
 		expect(

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -184,6 +184,161 @@ describe("configInputSchema", () => {
 		expect(result.success).toBe(false);
 	});
 
+	test("accepts nativePackages with bare and scoped names", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["sharp", "@napi-rs/canvas"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("accepts an empty nativePackages list", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: [],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects a relative path in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["./local-addon.node"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(formatZodIssues(result.error).join("\n")).toMatch(
+				/not a relative or absolute path/,
+			);
+		}
+	});
+
+	test("rejects an absolute path in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["/opt/addon.node"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	test("rejects a non-string entry in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: [42],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+	});
+
+	// A native package is installed and traced whole, so a subpath names nothing the
+	// option can act on — unlike externalPackages, where esbuild accepts one.
+	test("rejects a subpath in nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["sharp/lib/sharp.node"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(formatZodIssues(result.error).join("\n")).toMatch(
+				/without a subpath/,
+			);
+		}
+	});
+
+	test("accepts a scoped nativePackages name, which has one legitimate slash", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						nativePackages: ["@img/sharp-linux-arm64"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
+	test("rejects a package listed in both externalPackages and nativePackages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: ["microsandbox", "sharp"],
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issues = formatZodIssues(result.error).join("\n");
+			expect(issues).toMatch(/also in externalPackages/);
+			// Reported against the offending entry, not the whole function.
+			expect(issues).toMatch(/nativePackages\[0\]/);
+		}
+	});
+
+	test("accepts the two lists side by side when they name different packages", () => {
+		const result = configInputSchema.safeParse({
+			preview: {
+				functions: {
+					fn1: {
+						name: "Hello World",
+						source: "./hello.ts",
+						externalPackages: ["microsandbox"],
+						nativePackages: ["sharp"],
+					},
+				},
+			},
+		});
+		expect(result.success).toBe(true);
+	});
+
 	test("rejects an unknown key in the function dev block (e.g. removed `portless`)", () => {
 		const result = configInputSchema.safeParse({
 			preview: {

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -309,6 +309,28 @@ describe("configInputSchema", () => {
 		expect(withExternalPackages(["node:fs"]).success).toBe(false);
 	});
 
+	// Whatever passes here becomes an `npm install` argument, so the root is held to npm's
+	// own naming rules rather than merely "not a path".
+	test.each([
+		["a space", "foo bar"],
+		["a leading hash", "#alias"],
+		["an empty path segment", "foo//bar"],
+		["a parent-directory segment", "@scope/pkg/../../escape"],
+		["an uppercase name", "Foo"],
+		["a name starting with a dot", ".hidden"],
+	])("rejects %s in a staged entry", (_label, value) => {
+		expect(withExternalPackages([value]).success).toBe(false);
+	});
+
+	test.each([
+		["a plain name", "sharp"],
+		["a scoped name", "@img/sharp-linux-arm64"],
+		["a name with dots and underscores", "some.pkg_name"],
+		["a subpath", "pkg/sub/deep.js"],
+	])("accepts %s in a staged entry", (_label, value) => {
+		expect(withExternalPackages([value]).success).toBe(true);
+	});
+
 	test("accepts two scoped packages sharing a scope", () => {
 		// Same scope, different packages — not the same root, so not a conflict.
 		expect(

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -184,48 +184,60 @@ describe("configInputSchema", () => {
 		expect(result.success).toBe(false);
 	});
 
-	test("accepts nativePackages with bare and scoped names", () => {
-		const result = configInputSchema.safeParse({
+	const withExternalPackages = (externalPackages: unknown) =>
+		configInputSchema.safeParse({
 			preview: {
 				functions: {
 					fn1: {
 						name: "Hello World",
 						source: "./hello.ts",
-						nativePackages: ["sharp", "@napi-rs/canvas"],
+						externalPackages,
 					},
 				},
 			},
 		});
+
+	test("accepts the object form with includeFiles false", () => {
+		const result = withExternalPackages([
+			"sharp",
+			{ name: "canvas", includeFiles: false },
+		]);
 		expect(result.success).toBe(true);
 	});
 
-	test("accepts an empty nativePackages list", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: [],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(true);
+	test("accepts an explicit includeFiles: true", () => {
+		expect(
+			withExternalPackages([{ name: "sharp", includeFiles: true }])
+				.success,
+		).toBe(true);
 	});
 
-	test("rejects a relative path in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["./local-addon.node"],
-					},
-				},
-			},
-		});
+	test("accepts the object form without includeFiles", () => {
+		expect(withExternalPackages([{ name: "sharp" }]).success).toBe(true);
+	});
+
+	test("rejects an unknown key in the object form", () => {
+		expect(
+			withExternalPackages([{ name: "sharp", includeFile: false }])
+				.success,
+		).toBe(false);
+	});
+
+	test("rejects a non-boolean includeFiles", () => {
+		expect(
+			withExternalPackages([{ name: "sharp", includeFiles: "yes" }])
+				.success,
+		).toBe(false);
+	});
+
+	test("rejects an object entry with no name", () => {
+		expect(withExternalPackages([{ includeFiles: false }]).success).toBe(
+			false,
+		);
+	});
+
+	test("rejects a relative path in the object form too", () => {
+		const result = withExternalPackages([{ name: "./local-addon.node" }]);
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(formatZodIssues(result.error).join("\n")).toMatch(
@@ -234,109 +246,50 @@ describe("configInputSchema", () => {
 		}
 	});
 
-	test("rejects an absolute path in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["/opt/addon.node"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(false);
+	// A subpath is legal: it narrows what esbuild leaves unresolved. Files are staged per
+	// package, so the subpath's package is what ships.
+	test("accepts a subpath entry", () => {
+		expect(withExternalPackages(["pkg/sub"]).success).toBe(true);
 	});
 
-	test("rejects a non-string entry in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: [42],
-					},
-				},
-			},
-		});
+	test("rejects the same package listed twice", () => {
+		const result = withExternalPackages(["sharp", "sharp"]);
 		expect(result.success).toBe(false);
+		if (!result.success) {
+			const issues = formatZodIssues(result.error).join("\n");
+			expect(issues).toMatch(/listed more than once/);
+			// Reported against the offending entry, not the whole function.
+			expect(issues).toMatch(/externalPackages\[1\]/);
+		}
 	});
 
-	// A native package is installed and traced whole, so a subpath names nothing the
-	// option can act on — unlike externalPackages, where esbuild accepts one.
-	test("rejects a subpath in nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["sharp/lib/sharp.node"],
-					},
-				},
-			},
-		});
+	test("rejects a bare name and a subpath of it that disagree about includeFiles", () => {
+		const result = withExternalPackages([
+			"sharp",
+			{ name: "sharp/lib/index.js", includeFiles: false },
+		]);
 		expect(result.success).toBe(false);
 		if (!result.success) {
 			expect(formatZodIssues(result.error).join("\n")).toMatch(
-				/without a subpath/,
+				/disagree about includeFiles/,
 			);
 		}
 	});
 
-	test("accepts a scoped nativePackages name, which has one legitimate slash", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						nativePackages: ["@img/sharp-linux-arm64"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(true);
+	test("accepts a bare name and a subpath of it that agree", () => {
+		expect(
+			withExternalPackages(["sharp", "sharp/lib/index.js"]).success,
+		).toBe(true);
 	});
 
-	test("rejects a package listed in both externalPackages and nativePackages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						externalPackages: ["microsandbox", "sharp"],
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(false);
-		if (!result.success) {
-			const issues = formatZodIssues(result.error).join("\n");
-			expect(issues).toMatch(/also in externalPackages/);
-			// Reported against the offending entry, not the whole function.
-			expect(issues).toMatch(/nativePackages\[0\]/);
-		}
-	});
-
-	test("accepts the two lists side by side when they name different packages", () => {
-		const result = configInputSchema.safeParse({
-			preview: {
-				functions: {
-					fn1: {
-						name: "Hello World",
-						source: "./hello.ts",
-						externalPackages: ["microsandbox"],
-						nativePackages: ["sharp"],
-					},
-				},
-			},
-		});
-		expect(result.success).toBe(true);
+	test("accepts two scoped packages sharing a scope", () => {
+		// Same scope, different packages — not the same root, so not a conflict.
+		expect(
+			withExternalPackages([
+				{ name: "@img/sharp-linux-arm64", includeFiles: false },
+				"@img/colour",
+			]).success,
+		).toBe(true);
 	});
 
 	test("rejects an unknown key in the function dev block (e.g. removed `portless`)", () => {

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -224,13 +224,29 @@ const externalPackageNameSchema = z
  * being installed for them.
  */
 const stageablePackageName = (value: string): boolean => {
-	if (value.includes("*")) return false;
 	// A protocol (`node:fs`, `npm:pkg`) is a specifier, not something to install.
 	if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
-	const root = externalPackageRoot(value);
+	// An empty segment (`foo//bar`) or a traversal is not a subpath the deploy can act on.
+	const segments = value.split("/");
+	if (segments.some((segment) => segment === "" || segment === "..")) {
+		return false;
+	}
+	return isNpmPackageName(externalPackageRoot(value));
+};
+
+/**
+ * npm's own rules for a package name, which is what the deploy hands to `npm install`.
+ * Deliberately strict: whatever slips through here becomes a subprocess argument.
+ */
+const NPM_NAME_SEGMENT = /^[a-z0-9~][a-z0-9._~-]*$/;
+
+const isNpmPackageName = (root: string): boolean => {
+	if (root.length === 0 || root.length > 214) return false;
+	if (!root.startsWith("@")) return NPM_NAME_SEGMENT.test(root);
+	const [scope, name, ...rest] = root.slice(1).split("/");
 	// A bare scope names every package in it, not one package.
-	if (root.startsWith("@")) return /^@[^/]+\/[^/]+$/.test(root);
-	return root.length > 0;
+	if (rest.length > 0 || name === undefined) return false;
+	return NPM_NAME_SEGMENT.test(scope) && NPM_NAME_SEGMENT.test(name);
 };
 
 /**

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -224,20 +224,57 @@ const externalPackageSchema = z
  */
 const functionExternalPackagesSchema = z.array(externalPackageSchema);
 
+/**
+ * A package whose real files ship alongside the bundle. Same specifier grammar as
+ * {@link externalPackageSchema}, minus the subpath: a native package is installed and
+ * traced as a whole, so the unit is the package, not a file inside it.
+ */
+const nativePackageSchema = externalPackageSchema.refine(
+	(value) => value.split("/").length === (value.startsWith("@") ? 2 : 1),
+	{
+		error: 'must be a package name such as "sharp" or "@scope/pkg", without a subpath',
+	},
+);
+
+/**
+ * Per-function list of packages shipped as real files next to the bundle. See
+ * {@link FunctionDef.nativePackages}.
+ */
+const functionNativePackagesSchema = z.array(nativePackageSchema);
+
 const runtimeSchema = z.literal("nodejs24");
 
 /**
  * Static definition of a function (existence). The slug is the record key (validated by
  * {@link functionSlugSchema}), so it is not a field here. Deploy tuning (`runtime`) lives
  * in the `branch` closure, not here.
+ *
+ * `externalPackages` and `nativePackages` are mutually exclusive per package: the first
+ * means "leave the import unresolved", the second "leave it unresolved AND ship the files".
+ * Listing one package in both states two different intents for it, so it is rejected here
+ * rather than silently resolved in favour of one.
  */
-export const functionDefSchema = z.strictObject({
-	name: z.string().min(1).max(255),
-	source: z.string().min(1),
-	env: functionEnvSchema.optional(),
-	externalPackages: functionExternalPackagesSchema.optional(),
-	dev: functionDevConfigSchema.optional(),
-});
+export const functionDefSchema = z
+	.strictObject({
+		name: z.string().min(1).max(255),
+		source: z.string().min(1),
+		env: functionEnvSchema.optional(),
+		externalPackages: functionExternalPackagesSchema.optional(),
+		nativePackages: functionNativePackagesSchema.optional(),
+		dev: functionDevConfigSchema.optional(),
+	})
+	.check((ctx) => {
+		const external = new Set(ctx.value.externalPackages ?? []);
+		(ctx.value.nativePackages ?? []).forEach((pkg, index) => {
+			if (!external.has(pkg)) return;
+			ctx.issues.push({
+				code: "custom",
+				input: pkg,
+				path: ["nativePackages", index],
+				message: `"${pkg}" is also in externalPackages; a package belongs to one list or the other`,
+			});
+		});
+	});
 
 /** Static definition of a bucket (existence). Name is the record key. */
 export const bucketDefSchema = z.strictObject({

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -218,6 +218,22 @@ const externalPackageNameSchema = z
 	});
 
 /**
+ * An entry whose files are staged has to name one installable package, because the deploy
+ * hands its root to `npm install`. esbuild's `external` additionally accepts a `*` wildcard
+ * and a bare scope, which name a set rather than a package — legal only when nothing is
+ * being installed for them.
+ */
+const stageablePackageName = (value: string): boolean => {
+	if (value.includes("*")) return false;
+	// A protocol (`node:fs`, `npm:pkg`) is a specifier, not something to install.
+	if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
+	const root = externalPackageRoot(value);
+	// A bare scope names every package in it, not one package.
+	if (root.startsWith("@")) return /^@[^/]+\/[^/]+$/.test(root);
+	return root.length > 0;
+};
+
+/**
  * One entry of `externalPackages`. A bare string is the common case and ships the package's
  * files; the object form exists only to turn that off. See {@link FunctionDef.externalPackages}.
  */
@@ -276,6 +292,19 @@ export const functionDefSchema = z
 		entries.forEach((entry, index) => {
 			const name = entryName(entry);
 			const includeFiles = entryIncludesFiles(entry);
+
+			if (includeFiles && !stageablePackageName(name)) {
+				ctx.issues.push({
+					code: "custom",
+					input: entry,
+					path: ["externalPackages", index],
+					message:
+						`"${name}" does not name a single installable package, so its files cannot ` +
+						`be staged. Name one package, or set includeFiles: false to leave the ` +
+						`import unresolved without shipping anything for it`,
+				});
+				return;
+			}
 
 			const firstIndex = seenNames.get(name);
 			if (firstIndex !== undefined) {

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { parseBranchTtl, parseSuspendTimeout } from "./duration.js";
+import { externalPackageRoot } from "./external-packages.js";
 import { isWildcardPattern, validatePattern } from "./patterns.js";
 
 /**
@@ -204,12 +205,12 @@ const functionDevConfigSchema = z.strictObject({
 });
 
 /**
- * A package the bundler must leave alone. Accepts what esbuild's `external` accepts for a
- * package — a bare name, a scope, or a subpath — and rejects a relative or absolute path,
- * which names a local module rather than a dependency and is never the right thing to
- * externalize (the bundle would ship an import of a file that isn't deployed).
+ * The name of a package the bundler must leave alone. Accepts what esbuild's `external`
+ * accepts for a package — a bare name, a scope, or a subpath — and rejects a relative or
+ * absolute path, which names a local module rather than a dependency and is never the right
+ * thing to externalize (the bundle would ship an import of a file that isn't deployed).
  */
-const externalPackageSchema = z
+const externalPackageNameSchema = z
 	.string()
 	.min(1)
 	.refine((value) => !value.startsWith(".") && !value.startsWith("/"), {
@@ -217,42 +218,44 @@ const externalPackageSchema = z
 	});
 
 /**
+ * One entry of `externalPackages`. A bare string is the common case and ships the package's
+ * files; the object form exists only to turn that off. See {@link FunctionDef.externalPackages}.
+ */
+const externalPackageEntrySchema = z.union([
+	externalPackageNameSchema,
+	z.strictObject({
+		name: externalPackageNameSchema,
+		includeFiles: z.boolean().optional(),
+	}),
+]);
+
+/**
  * Per-function list of packages esbuild leaves unresolved at deploy time. See
- * {@link FunctionDef.externalPackages} for when this is the right tool — the deployed
- * archive has no `node_modules`, so an externalized package must never be reached at
- * runtime.
+ * {@link FunctionDef.externalPackages}.
  */
-const functionExternalPackagesSchema = z.array(externalPackageSchema);
-
-/**
- * A package whose real files ship alongside the bundle. Same specifier grammar as
- * {@link externalPackageSchema}, minus the subpath: a native package is installed and
- * traced as a whole, so the unit is the package, not a file inside it.
- */
-const nativePackageSchema = externalPackageSchema.refine(
-	(value) => value.split("/").length === (value.startsWith("@") ? 2 : 1),
-	{
-		error: 'must be a package name such as "sharp" or "@scope/pkg", without a subpath',
-	},
-);
-
-/**
- * Per-function list of packages shipped as real files next to the bundle. See
- * {@link FunctionDef.nativePackages}.
- */
-const functionNativePackagesSchema = z.array(nativePackageSchema);
+const functionExternalPackagesSchema = z.array(externalPackageEntrySchema);
 
 const runtimeSchema = z.literal("nodejs24");
+
+/** The declared name of an entry, whichever form it was written in. */
+const entryName = (
+	entry: z.infer<typeof externalPackageEntrySchema>,
+): string => (typeof entry === "string" ? entry : entry.name);
+
+/** Whether an entry ships its files. Absent means yes — see `FunctionDef.externalPackages`. */
+const entryIncludesFiles = (
+	entry: z.infer<typeof externalPackageEntrySchema>,
+): boolean => (typeof entry === "string" ? true : entry.includeFiles !== false);
 
 /**
  * Static definition of a function (existence). The slug is the record key (validated by
  * {@link functionSlugSchema}), so it is not a field here. Deploy tuning (`runtime`) lives
  * in the `branch` closure, not here.
  *
- * `externalPackages` and `nativePackages` are mutually exclusive per package: the first
- * means "leave the import unresolved", the second "leave it unresolved AND ship the files".
- * Listing one package in both states two different intents for it, so it is rejected here
- * rather than silently resolved in favour of one.
+ * `externalPackages` entries are checked for contradictions: the same package named twice,
+ * or named once bare and once through a subpath with a different `includeFiles`. Both state
+ * two intents for one package, and files are staged per package rather than per subpath, so
+ * neither can be honoured as written.
  */
 export const functionDefSchema = z
 	.strictObject({
@@ -260,19 +263,48 @@ export const functionDefSchema = z
 		source: z.string().min(1),
 		env: functionEnvSchema.optional(),
 		externalPackages: functionExternalPackagesSchema.optional(),
-		nativePackages: functionNativePackagesSchema.optional(),
 		dev: functionDevConfigSchema.optional(),
 	})
 	.check((ctx) => {
-		const external = new Set(ctx.value.externalPackages ?? []);
-		(ctx.value.nativePackages ?? []).forEach((pkg, index) => {
-			if (!external.has(pkg)) return;
-			ctx.issues.push({
-				code: "custom",
-				input: pkg,
-				path: ["nativePackages", index],
-				message: `"${pkg}" is also in externalPackages; a package belongs to one list or the other`,
-			});
+		const entries = ctx.value.externalPackages ?? [];
+		const seenNames = new Map<string, number>();
+		const rootIntent = new Map<
+			string,
+			{ includeFiles: boolean; at: string }
+		>();
+
+		entries.forEach((entry, index) => {
+			const name = entryName(entry);
+			const includeFiles = entryIncludesFiles(entry);
+
+			const firstIndex = seenNames.get(name);
+			if (firstIndex !== undefined) {
+				ctx.issues.push({
+					code: "custom",
+					input: entry,
+					path: ["externalPackages", index],
+					message: `"${name}" is listed more than once (first at index ${firstIndex})`,
+				});
+				return;
+			}
+			seenNames.set(name, index);
+
+			// Files are installed and traced per package, so two specifiers that resolve to the
+			// same package cannot disagree about whether that package's files ship.
+			const root = externalPackageRoot(name);
+			const prior = rootIntent.get(root);
+			if (prior !== undefined && prior.includeFiles !== includeFiles) {
+				ctx.issues.push({
+					code: "custom",
+					input: entry,
+					path: ["externalPackages", index],
+					message:
+						`"${name}" and "${prior.at}" are both part of the "${root}" package but disagree ` +
+						`about includeFiles; files ship per package, so the whole package either ships or does not`,
+				});
+				return;
+			}
+			rootIntent.set(root, { includeFiles, at: name });
 		});
 	});
 

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -355,9 +355,9 @@ export interface FunctionDef {
 	 * possible depends on what it is. A pure-JavaScript package can be bundled, and a
 	 * failure to do so is usually something specific and fixable. A package backed by a
 	 * native `.node` binary cannot be bundled by anything — the binary is a compiled
-	 * object the platform loads from a real path — so such a package cannot work on
-	 * Functions until the deployed archive can carry files alongside the bundle. Do not
-	 * reach for `externalPackages` to try: it moves the error from deploy to invoke.
+	 * object the platform loads from a real path — so it needs its files shipped next to
+	 * the bundle instead. That is what {@link FunctionDef.nativePackages} does; reaching
+	 * for `externalPackages` only moves the error from deploy to invoke.
 	 *
 	 * Note that a native package may bundle without ever needing this option. `sharp`, for
 	 * instance, loads its binary through `createRequire`, which esbuild does not follow, so
@@ -370,6 +370,40 @@ export interface FunctionDef {
 	 * @example ["microsandbox", "@mongodb-js/zstd"]
 	 */
 	externalPackages?: string[];
+	/**
+	 * Packages backed by a native binary, whose real files ship into the deployed archive
+	 * alongside the bundle. This is the option that makes a native dependency *work*, where
+	 * {@link FunctionDef.externalPackages} only stops it failing the build.
+	 *
+	 * Each entry is left out of the bundle and then installed for the Functions runtime
+	 * target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it
+	 * actually reaches, and copied into the archive under `node_modules/` with its directory
+	 * layout preserved. That layout is load-bearing, not cosmetic: a `.node` addon locates
+	 * its sibling shared libraries relative to its own directory, so a flattened tree fails
+	 * to load.
+	 *
+	 * Your own `node_modules` is never read for these files or modified. Its binaries are
+	 * built for your machine rather than the deploy target, and a cross-platform install
+	 * does not survive your next plain `npm install`, so the target's packages are resolved
+	 * fresh on each deploy. The version installed is the one your project already resolved,
+	 * read from your dependency tree — the deploy honours your lockfile without trusting the
+	 * binaries sitting next to it.
+	 *
+	 * Requirements and failure modes, all reported at deploy time rather than at invoke: the
+	 * package must publish a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages
+	 * do; anything compiled from source at install time does not), `npm` must be on `PATH`,
+	 * and the archive must stay inside the deploy size limits — native binaries are large.
+	 *
+	 * Entries are package names without a subpath (`sharp`, `@scope/pkg`): the whole package
+	 * is installed and traced, so naming a file inside one means nothing here. A package
+	 * listed here must not also appear in `externalPackages`.
+	 *
+	 * Under `neon dev` the list only keeps the package out of the bundle — nothing is
+	 * installed or copied, and it resolves from your own `node_modules` against your host
+	 * architecture, which is what you want locally.
+	 * @example ["sharp"]
+	 */
+	nativePackages?: string[];
 	/**
 	 * Local-development settings used by `neon dev` when serving every function from
 	 * `neon.ts`. Ignored at deploy time. See {@link FunctionDevConfig}.
@@ -557,6 +591,13 @@ export interface ResolvedFunctionConfig {
 	 * policy that never mentions it resolves to the same shape it always did.
 	 */
 	externalPackages?: string[];
+	/**
+	 * Packages whose real files ship alongside the bundle, passed through from
+	 * {@link FunctionDef.nativePackages}. Absent rather than empty when undeclared: a policy
+	 * that never mentions it takes the pre-existing bundling path and produces the archive
+	 * it always did.
+	 */
+	nativePackages?: string[];
 	runtime: FunctionRuntime;
 	/**
 	 * Local-development settings, passed through untouched from {@link FunctionDef.dev}

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -369,10 +369,13 @@ export interface FunctionDef {
 	 */
 	env?: Record<string, string>;
 	/**
-	 * Packages the bundler must leave alone — the deploy-time equivalent of Next.js's
-	 * `serverExternalPackages`. Every entry is passed to esbuild's `external`, so the import
-	 * survives into the bundle instead of being followed, and the package's own files are
-	 * shipped into the deployed archive beside the bundle so that import resolves.
+	 * Ship a dependency's real files into the deployed archive instead of bundling it —
+	 * `sharp` and other packages backed by a native binary.
+	 *
+	 * The deploy-time equivalent of Next.js's `serverExternalPackages`. Every entry is passed
+	 * to esbuild's `external`, so the import survives into the bundle instead of being
+	 * followed, and the package's own files are shipped beside the bundle so that import
+	 * resolves.
 	 *
 	 * Reach for this when bundling a package is impossible rather than merely undesirable.
 	 * The case that comes up is a package backed by a native `.node` binary: the binary is a

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -295,6 +295,40 @@ export interface FunctionDevConfig {
 }
 
 /**
+ * The object form of an {@link FunctionDef.externalPackages} entry, for the one case the
+ * bare string cannot express: externalizing a package without shipping its files.
+ */
+export interface ExternalPackageDef {
+	/** Package name, optionally with a subpath: `sharp`, `@scope/pkg`, `pkg/sub`. */
+	name: string;
+	/**
+	 * Whether the package's real files ship into the deployed archive next to the bundle.
+	 *
+	 * Defaults to `true`, which is the state where the import resolves and the function
+	 * works. Set it to `false` only for a package the function never reaches: nothing is
+	 * shipped for it, so reaching it throws `Cannot find module` at invoke.
+	 */
+	includeFiles?: boolean;
+}
+
+/**
+ * One entry of {@link FunctionDef.externalPackages}. A bare string is the common form and
+ * ships the package's files; {@link ExternalPackageDef} exists to turn that off.
+ */
+export type ExternalPackageEntry = string | ExternalPackageDef;
+
+/**
+ * An {@link ExternalPackageEntry} with its default applied, as every consumer downstream of
+ * `resolveConfig` reads it.
+ */
+export interface ResolvedExternalPackage {
+	/** Package name as declared, subpath included. */
+	name: string;
+	/** Whether this package's files are staged into the archive. */
+	includeFiles: boolean;
+}
+
+/**
  * Static definition of a Neon Function (Preview feature). Declares that the function
  * **exists** on every branch; its branch-unique slug is the **record key** in
  * {@link PreviewInput.functions} (not a field here), so slugs are statically enumerable,
@@ -335,75 +369,64 @@ export interface FunctionDef {
 	 */
 	env?: Record<string, string>;
 	/**
-	 * Packages the bundler must leave alone, by name — the deploy-time equivalent of
-	 * Next.js's `serverExternalPackages`. Every entry is passed to esbuild's `external`,
-	 * so the import survives into the bundle instead of being followed.
+	 * Packages the bundler must leave alone — the deploy-time equivalent of Next.js's
+	 * `serverExternalPackages`. Every entry is passed to esbuild's `external`, so the import
+	 * survives into the bundle instead of being followed, and the package's own files are
+	 * shipped into the deployed archive beside the bundle so that import resolves.
 	 *
 	 * Reach for this when bundling a package is impossible rather than merely undesirable.
-	 * The cases that come up: a native `.node` addon or a `node-gyp` dependency esbuild has
-	 * no loader for, and an optional peer dependency a library references on a code path
-	 * this function never takes. Both fail the deploy at bundle time with a resolve or
-	 * loader error naming the package, and neither is fixable from the function's own
-	 * source.
+	 * The case that comes up is a package backed by a native `.node` binary: the binary is a
+	 * compiled object the platform loads from a real path, so no bundler can inline it.
+	 * `sharp` is the common one, and it does not even fail at build time — it loads its
+	 * binary through `createRequire`, which esbuild does not follow, so it bundles cleanly
+	 * and then fails at invoke with "Could not load the sharp module".
 	 *
-	 * **An external package is not resolvable at runtime.** The deployed archive is a
-	 * single `index.mjs` with no `node_modules` beside it, so anything listed here throws
-	 * `Cannot find module` if the function actually reaches it. This option therefore only
-	 * unblocks an import that is never evaluated; it does not make a dependency usable.
+	 * ```ts
+	 * externalPackages: ["sharp"]
+	 * ```
 	 *
-	 * A dependency the handler actually calls has to be bundled, and whether that is
-	 * possible depends on what it is. A pure-JavaScript package can be bundled, and a
-	 * failure to do so is usually something specific and fixable. A package backed by a
-	 * native `.node` binary cannot be bundled by anything — the binary is a compiled
-	 * object the platform loads from a real path — so it needs its files shipped next to
-	 * the bundle instead. That is what {@link FunctionDef.nativePackages} does; reaching
-	 * for `externalPackages` only moves the error from deploy to invoke.
-	 *
-	 * Note that a native package may bundle without ever needing this option. `sharp`, for
-	 * instance, loads its binary through `createRequire`, which esbuild does not follow, so
-	 * it bundles cleanly and then fails at invoke with "Could not load the sharp module".
-	 *
-	 * Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`,
-	 * `pkg/sub`), matching esbuild. A relative or absolute path is rejected at validation
-	 * time: those are local modules, and a local module that cannot be bundled is a
-	 * different problem.
-	 * @example ["microsandbox", "@mongodb-js/zstd"]
-	 */
-	externalPackages?: string[];
-	/**
-	 * Packages backed by a native binary, whose real files ship into the deployed archive
-	 * alongside the bundle. This is the option that makes a native dependency *work*, where
-	 * {@link FunctionDef.externalPackages} only stops it failing the build.
-	 *
-	 * Each entry is left out of the bundle and then installed for the Functions runtime
-	 * target — **linux-arm64, glibc** — into a throwaway directory, traced for the files it
-	 * actually reaches, and copied into the archive under `node_modules/` with its directory
-	 * layout preserved. That layout is load-bearing, not cosmetic: a `.node` addon locates
-	 * its sibling shared libraries relative to its own directory, so a flattened tree fails
-	 * to load.
+	 * Each declared package is installed for the Functions runtime target — **linux-arm64,
+	 * glibc** — into a throwaway directory, traced for the files it actually reaches, and
+	 * copied into the archive under `node_modules/` with its directory layout preserved. That
+	 * layout is load-bearing rather than cosmetic: a `.node` addon locates its sibling shared
+	 * libraries relative to its own directory, so a flattened tree fails to load.
 	 *
 	 * Your own `node_modules` is never read for these files or modified. Its binaries are
-	 * built for your machine rather than the deploy target, and a cross-platform install
-	 * does not survive your next plain `npm install`, so the target's packages are resolved
-	 * fresh on each deploy. The version installed is the one your project already resolved,
-	 * read from your dependency tree — the deploy honours your lockfile without trusting the
-	 * binaries sitting next to it.
+	 * built for your machine rather than the deploy target, and a cross-platform install does
+	 * not survive your next plain `npm install`, so the target's packages are resolved fresh
+	 * on each deploy.
 	 *
-	 * Requirements and failure modes, all reported at deploy time rather than at invoke: the
-	 * package must publish a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages
-	 * do; anything compiled from source at install time does not), `npm` must be on `PATH`,
-	 * and the archive must stay inside the deploy size limits — native binaries are large.
+	 * Requirements, all reported at deploy time rather than at invoke: the package must
+	 * publish a linux-arm64 glibc build (`sharp` and most `@napi-rs/*` packages do; anything
+	 * compiled from source at install time does not), `npm` must be on `PATH`, and the
+	 * archive must stay inside the deploy size limits — native binaries are large.
 	 *
-	 * Entries are package names without a subpath (`sharp`, `@scope/pkg`): the whole package
-	 * is installed and traced, so naming a file inside one means nothing here. A package
-	 * listed here must not also appear in `externalPackages`.
+	 * ### Excluding a package's files
+	 *
+	 * `includeFiles: false` externalizes the import without shipping anything, which is the
+	 * escape hatch for a package that cannot be staged — no build for the target, or too
+	 * large — and that the function never actually reaches:
+	 *
+	 * ```ts
+	 * externalPackages: ["sharp", { name: "canvas", includeFiles: false }]
+	 * ```
+	 *
+	 * **An excluded package is not resolvable at runtime.** Nothing is shipped for it, so it
+	 * throws `Cannot find module` if the function reaches it. It unblocks an import that is
+	 * never evaluated; it does not make a dependency usable.
+	 *
+	 * Entries are package names, optionally with a subpath (`pkg`, `@scope/pkg`, `pkg/sub`),
+	 * matching esbuild. A relative or absolute path is rejected at validation time: those are
+	 * local modules, and a local module that cannot be bundled is a different problem. Files
+	 * are staged per package, so a subpath narrows what esbuild leaves unresolved without
+	 * narrowing what ships.
 	 *
 	 * Under `neon dev` the list only keeps the package out of the bundle — nothing is
 	 * installed or copied, and it resolves from your own `node_modules` against your host
 	 * architecture, which is what you want locally.
-	 * @example ["sharp"]
+	 * @example ["sharp", { name: "canvas", includeFiles: false }]
 	 */
-	nativePackages?: string[];
+	externalPackages?: ExternalPackageEntry[];
 	/**
 	 * Local-development settings used by `neon dev` when serving every function from
 	 * `neon.ts`. Ignored at deploy time. See {@link FunctionDevConfig}.
@@ -586,18 +609,13 @@ export interface ResolvedFunctionConfig {
 	source: string;
 	env: Record<string, string>;
 	/**
-	 * Packages the bundler leaves unresolved, passed through from
-	 * {@link FunctionDef.externalPackages}. Absent rather than empty when undeclared, so a
-	 * policy that never mentions it resolves to the same shape it always did.
+	 * Packages the bundler leaves unresolved, normalized from
+	 * {@link FunctionDef.externalPackages} with `includeFiles` defaulted.
+	 *
+	 * Absent rather than empty when undeclared, so a policy that never mentions it takes the
+	 * pre-existing bundling path and produces the archive it always did.
 	 */
-	externalPackages?: string[];
-	/**
-	 * Packages whose real files ship alongside the bundle, passed through from
-	 * {@link FunctionDef.nativePackages}. Absent rather than empty when undeclared: a policy
-	 * that never mentions it takes the pre-existing bundling path and produces the archive
-	 * it always did.
-	 */
-	nativePackages?: string[];
+	externalPackages?: ResolvedExternalPackage[];
 	runtime: FunctionRuntime;
 	/**
 	 * Local-development settings, passed through untouched from {@link FunctionDef.dev}

--- a/packages/config/src/v1.test.ts
+++ b/packages/config/src/v1.test.ts
@@ -63,9 +63,11 @@ describe("@neon/config public value surface", () => {
 			  "deriveCredentialScopes",
 			  "diffConfig",
 			  "errors",
+			  "externalPackageRoot",
 			  "isPartialBranchCreateError",
 			  "isPlatformError",
 			  "loadConfigFromFile",
+			  "packagesToStage",
 			  "resolveConfig",
 			  "schemas",
 			]

--- a/packages/config/src/v1.ts
+++ b/packages/config/src/v1.ts
@@ -131,6 +131,11 @@ export {
 	PushAbortedError,
 	PushConflictError,
 } from "./lib/errors.js";
+// ─── External packages (pure; also for a custom FunctionBundler) ──────────────
+export {
+	externalPackageRoot,
+	packagesToStage,
+} from "./lib/external-packages.js";
 export type { LoadConfigOptions } from "./lib/loader.js";
 export { loadConfigFromFile } from "./lib/loader.js";
 // ─── NeonApi types (needed by callers implementing their own adapters) ────────
@@ -180,6 +185,8 @@ export type {
 	DataApiSettings,
 	DurationString,
 	DurationUnit,
+	ExternalPackageDef,
+	ExternalPackageEntry,
 	FunctionDef,
 	FunctionDevConfig,
 	FunctionRuntime,
@@ -191,6 +198,7 @@ export type {
 	ResolvedBranchConfig,
 	ResolvedBucketConfig,
 	ResolvedDataApiConfig,
+	ResolvedExternalPackage,
 	ResolvedFunctionConfig,
 	ResolvedPreviewConfig,
 	ServiceEnabled,


### PR DESCRIPTION
Replaces [#387](https://github.com/neondatabase/neon-pkgs/pull/387), which is the same
change on a fork branch where CI cannot run: a `pull_request` from a fork receives no OIDC
token, so `./.github/actions/prepare` cannot authenticate to the JFrog mirror and no job gets
as far as installing. That PR's checks had been stuck at `action_required` since 5 August and
fail at the OIDC step once approved. Nothing else differs.

The schema discipline, the `nativePackages` naming research, and the archive-layout reasoning
are @monsterzz's, carried over from that PR; what changed is the shape of the option users
write.

---

## The problem

`externalPackages` shipped in `@neon/config@0.11.0` and is live on npm today. It externalizes
an import and ships nothing, so the package throws `Cannot find module` if the function ever
reaches it. Its own JSDoc on `main` spends twenty lines saying so:

> **An external package is not resolvable at runtime.** […] This option therefore only
> unblocks an import that is never evaluated; it does not make a dependency usable.
>
> […] such a package cannot work on Functions until the deployed archive can carry files
> alongside the bundle. Do not reach for `externalPackages` to try: it moves the error from
> deploy to invoke.

An option whose documentation is mostly a warning against using it has the wrong default.

The name is the load-bearing part. `externalPackages` is what a user guesses, because
Next.js's `serverExternalPackages` means *externalize and it still works* — Vercel traces the
package's files into the deployment automatically, so externalizing implies shipping. A user
carrying that model reaches for the name they know and silently gets the broken-at-invoke
behaviour, while the working one hides behind a second name they have to be told about.

## What changed

One list, with a mode. `nativePackages` is gone.

```ts
export default defineConfig({
  preview: {
    functions: {
      resize: {
        name: "Resize",
        source: "./functions/resize.ts",
        externalPackages: [
          "sharp",                                  // unbundled, files ship — it works
          { name: "canvas", includeFiles: false },  // unbundled, nothing ships
        ],
      },
    },
  },
});
```

| Form | Meaning |
| --- | --- |
| `"sharp"` | externalized, the package's real files are staged into the archive |
| `{ name, includeFiles: true }` | identical to the bare string |
| `{ name, includeFiles: false }` | externalized, nothing staged — the previous behaviour |

`includeFiles` is the noun Vercel already uses for this operation (`functions.includeFiles`
in `vercel.json`). Theirs takes a glob and ours takes a boolean on a package entry, which is
the one wrinkle in borrowing the name.

**Why one list and not two.** The two options were one concept with a mode, and the tell was
the cross-list validation rule the previous design needed: a rule that exists only to reject
an incoherent combination means the split is artificial. Nothing validates that `env` and
`dev` do not overlap. With a union entry the contradiction is unrepresentable.

## Types

`ResolvedFunctionConfig.externalPackages` changes from `string[]` to a normalized shape, so
nothing downstream re-derives the default:

```ts
interface ResolvedExternalPackage {
  name: string;
  includeFiles: boolean;
}

externalPackages?: ResolvedExternalPackage[];
```

Two pure helpers are exported for anyone implementing a custom `FunctionBundler`, which is a
documented extension point that receives a resolved config:

```ts
import { packagesToStage, externalPackageRoot } from "@neon/config";

packagesToStage([{ name: "sharp", includeFiles: true }]);        // ["sharp"]
externalPackageRoot("@scope/pkg/sub/deep.js");                    // "@scope/pkg"
```

## Validation

Subpaths stay legal — esbuild accepts them, and the specifier is passed through to the trace
as authored, because a package may export only a subpath and be unimportable by its root.
Three new rules replace the cross-list overlap check:

```
externalPackages[1]: "sharp" is listed more than once (first at index 0)

externalPackages[1]: "sharp/lib/index.js" and "sharp" are both part of the "sharp" package
but disagree about includeFiles; files ship per package, so the whole package either ships
or does not

externalPackages[0]: "@scope/*" does not name a single installable package, so its files
cannot be staged. Name one package, or set includeFiles: false to leave the import
unresolved without shipping anything for it
```

That last rule is new exposure created by the flip: esbuild's `external` accepts a `*`
wildcard and a bare scope, which name a set rather than a package. Before, nothing was
installed for them. Now a staged entry's root is handed to `npm install`, so it has to name
one package — unless it stages nothing, where the wildcard forms stay legal.

## What does not change

A function that declares no `externalPackages` resolves to exactly the shape it did before —
the property is absent rather than `[]`, so the bundler's pre-existing path is untouched and
the archive is byte-identical. Same for a function whose every entry sets
`includeFiles: false`.

## Also in here

- The in-repo readers of `ResolvedFunctionConfig.externalPackages` (`neonctlBundler`,
  `neon dev`'s function planner, `buildFunctionBundle`'s esbuild call) map to names, so the
  repo stays green on this commit alone. Their behaviour is unchanged: everything is
  externalized exactly as before, and nothing is staged until the bundler half lands.
- Rebased onto `main`, which had moved 9 commits ahead.

## Verification

`pnpm build`, `pnpm lint:ci`, and `pnpm test:ci` are green across the workspace —
`@neon/config` at 267 tests. (Workspace totals are deliberately not quoted — they move
with every merge to `main`.)

New coverage, as behaviours:

- a bare string resolves to `includeFiles: true`; the object form with and without the flag;
  an explicit `true` is identical to the bare string
- an undeclared policy resolves with the property absent, not empty
- the policy array is copied, so mutating it afterwards cannot reach the resolved config
- the object form rejects an unknown key, a non-boolean `includeFiles`, a missing `name`, and
  a relative path
- a subpath entry is accepted; a duplicate name is rejected against the offending index; a
  bare name and a subpath of it are rejected when they disagree and accepted when they agree;
  two packages sharing a scope are not treated as one
- `externalPackageRoot` across bare, scoped, subpath, and scoped-subpath specifiers
- `packagesToStage` drops opted-out entries, keeps a subpath specifier as authored, and
  deduplicates an exactly repeated one
- a wildcard, a bare scope, and a protocol specifier are rejected when staged and accepted
  with `includeFiles: false`

## For your attention

- **This changes behaviour that is already published.** `@neon/config` 0.11.0–0.14.0 are on
  npm with the old meaning, so `externalPackages: ["x"]` today ships nothing and after this
  stages `x`. The exposure is four days of a preview-only option on a 0.x package, and the
  break is loud rather than silent: a package with no linux-arm64 build fails the deploy with
  a message naming `includeFiles: false` as the fix. A reviewer who thinks that is the wrong
  trade should say so now, because it is much more expensive to reverse after another release.
- **`ResolvedFunctionConfig.externalPackages` is a public type.** Anything reading a resolved
  config or implementing `FunctionBundler` sees the shape change. `packagesToStage` exists so
  those callers do not hand-roll the default.
- The subpath rule is looser than the previous `nativePackages` rule, which rejected subpaths
  outright. Rejecting them here would have broken published configs that use one.



