### PR TITLE
Correct the sampling and reasoning rules against what the gateway actually does

### DIFF
--- a/.changeset/new-model-sampling.md
+++ b/.changeset/new-model-sampling.md
@@ -21,3 +21,25 @@ future `gemini-3-6-flash-*` does not inherit a restriction nobody measured for i
 The penalty warning previously read "Only Gemini accepts penalties on the gateway's unified
 endpoint", which is no longer true and read as a contradiction to the Gemini users now hitting
 it. It now names the model instead of the family.
+
+Two further corrections found by review, both the same class of bug — a rule asserting the
+gateway lacks something it has:
+
+`gpt-5-5-pro` reads as version 5.5 to the minor-version rule and was told it accepts
+`temperature` and `topP`. It does not; the Responses API answers `Unsupported parameter`.
+It is now excluded, so the call succeeds with the parameter dropped instead of returning 400.
+
+Gemini does take `reasoning_effort` — the gateway maps it onto Gemini's thinking config, and
+`minimal` versus `high` measurably changes how much the model reasons. The provider dropped it
+and warned that the model did not take it, so callers lost control over reasoning they were
+billed for regardless. `providerOptions.neon.reasoningEffort` now reaches the gateway on Gemini.
+
+`getNeonModelCapabilities` returns different answers as a result: `supportsPenalties` is now
+false for `kimi-k3`, `gemini-3-6-flash` and `gemini-3-5-flash-lite`; `supportsTemperature` and
+`supportsTopP` are false for `gemini-3-6-flash` and `gpt-5-5-pro`; and `supportsReasoningEffort`
+is true for every Gemini id. Anything branching on those values will see the change.
+
+The three warning strings now name a remedy rather than restating what the AI SDK already
+prints ahead of them, and the README's capability table is corrected — it claimed Gemini was the
+only unified family accepting penalties, which is the same false statement this changeset removes
+from the warning.

--- a/.changeset/new-model-sampling.md
+++ b/.changeset/new-model-sampling.md
@@ -1,5 +1,5 @@
 ---
-"@neon/ai-sdk-provider": patch
+"@neon/ai-sdk-provider": minor
 ---
 
 Stop sending sampling parameters that three newly added models reject.

--- a/.changeset/new-model-sampling.md
+++ b/.changeset/new-model-sampling.md
@@ -1,0 +1,20 @@
+---
+"@neon/ai-sdk-provider": patch
+---
+
+Stop sending sampling parameters that three newly added models reject.
+
+The gateway added `kimi-k3`, `gemini-3-6-flash` and `gemini-3-5-flash-lite`, and all three
+are stricter than the rules covering them. `kimi-k3` fell through to the permissive default
+and `gemini-3-6-flash` inherited the Gemini rule, so setting `frequencyPenalty` or
+`presencePenalty` on any of them — or `temperature` or `topP` on `gemini-3-6-flash` — sent a
+parameter the gateway answers with `400`. Those are now dropped with a warning, the same way
+every other unsupported parameter is handled.
+
+The exceptions are listed by model id because nothing in the id predicts them:
+`gemini-3-1-flash-lite` accepts penalties and `gemini-3-5-flash-lite` does not, so neither the
+version nor the `-lite` suffix is the rule.
+
+The penalty warning previously read "Only Gemini accepts penalties on the gateway's unified
+endpoint", which is no longer true and read as a contradiction to the Gemini users now hitting
+it. It now names the model instead of the family.

--- a/.changeset/new-model-sampling.md
+++ b/.changeset/new-model-sampling.md
@@ -13,7 +13,10 @@ every other unsupported parameter is handled.
 
 The exceptions are listed by model id because nothing in the id predicts them:
 `gemini-3-1-flash-lite` accepts penalties and `gemini-3-5-flash-lite` does not, so neither the
-version nor the `-lite` suffix is the rule.
+version nor the `-lite` suffix is the rule. They are matched exactly rather than by prefix, so a
+future `gemini-3-6-flash-*` does not inherit a restriction nobody measured for it.
+
+`NEON_MODELS_DEV_IDS` gains the three ids, so they autocomplete.
 
 The penalty warning previously read "Only Gemini accepts penalties on the gateway's unified
 endpoint", which is no longer true and read as a contradiction to the Gemini users now hitting

--- a/.changeset/new-model-sampling.md
+++ b/.changeset/new-model-sampling.md
@@ -25,9 +25,11 @@ it. It now names the model instead of the family.
 Two further corrections found by review, both the same class of bug — a rule asserting the
 gateway lacks something it has:
 
-`gpt-5-5-pro` reads as version 5.5 to the minor-version rule and was told it accepts
-`temperature` and `topP`. It does not; the Responses API answers `Unsupported parameter`.
-It is now excluded, so the call succeeds with the parameter dropped instead of returning 400.
+`gpt-5-5-pro` reads as version 5.5 to the minor-version rule, so
+`getNeonModelCapabilities('gpt-5-5-pro').supportsTemperature` answered `true`. The gateway
+rejects it — `/openai/v1/responses` returns `Unsupported parameter: 'temperature'`. The exported
+answer is now correct. This changes what the function reports, not what goes over the wire: the
+Responses route strips the parameter upstream, so those calls already succeeded.
 
 Gemini does take `reasoning_effort` — the gateway maps it onto Gemini's thinking config, and
 `minimal` versus `high` measurably changes how much the model reasons. The provider dropped it

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -69,7 +69,7 @@ Which ids your branch serves is account-specific during the beta; `GET $NEON_AI_
 
 Upstream backends behind the gateway accept different subsets of the OpenAI-style parameters the AI SDK emits, and sending one an upstream rejects is a hard `400`. The provider drops those before the request and records a warning in `result.warnings`, so a call succeeds instead of failing on a parameter you passed in good faith.
 
-These rules apply on the Anthropic Messages and Chat Completions routes. The Responses route (every `gpt-*` id) relies on the upstream OpenAI model's own stripping instead, so its behaviour is the AI SDK's rather than described here — but `getNeonModelCapabilities` still answers for those ids.
+These rules apply on the Anthropic Messages and Chat Completions routes. On the Responses route (every `gpt-*` id) penalties, `seed` and `stopSequences` are left to the upstream OpenAI model's own stripping, but `temperature` and `topP` are handled here, because the gateway rejects them on the four ids listed below.
 
 | Models | Dropped |
 | --- | --- |
@@ -77,9 +77,12 @@ These rules apply on the Anthropic Messages and Chat Completions routes. The Res
 | All Claude | `frequencyPenalty`, `presencePenalty`, `seed`, `reasoningEffort`, and `topP` when you set both `temperature` and `topP` (Anthropic accepts only one) |
 | `gpt-oss` | `frequencyPenalty`, `presencePenalty`, `seed`, `stopSequences` |
 | Qwen, Gemma | `frequencyPenalty`, `presencePenalty`, `seed` |
-| `glm-5-2`, `inkling` | `frequencyPenalty`, `presencePenalty` |
+| `glm-5-2`, `inkling`, `kimi-k3` | `frequencyPenalty`, `presencePenalty` |
 | Meta Llama | `frequencyPenalty`, `presencePenalty`, `seed` |
-| Gemini | `reasoningEffort` |
+| `gemini-3-5-flash-lite` | `frequencyPenalty`, `presencePenalty` |
+| `gemini-3-6-flash` | `temperature`, `topP`, `frequencyPenalty`, `presencePenalty` |
+| Every other Gemini | nothing |
+| `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-5-pro` | `temperature`, `topP` |
 
 **`temperature` on a Claude 5 model therefore has no effect.** That is the gateway's behaviour, not a provider choice; sending it returns `does not support the temperature parameter`. Steer those models with Anthropic's own effort control instead — note that this is `effort`, not the OpenAI-style `reasoningEffort`, which every Claude id drops:
 
@@ -100,7 +103,9 @@ getNeonModelCapabilities('claude-opus-5').supportsTemperature; // false
 getNeonModelCapabilities('glm-5-2').supportsPenalties; // false
 ```
 
-Gemini is the only family on the unified endpoint that accepts penalties. A model none of these rules match is left untouched, so a brand-new id gets the gateway's own error rather than a guess.
+**The rules are per model, not per family.** Two Gemini ids reject penalties while their siblings accept them, and `gemini-3-6-flash` rejects `temperature` and `topP` outright, so reading a row for "Gemini" is not enough — check the id. Every entry above is measured against the gateway rather than inherited from the upstream provider's own documentation, which disagrees in both directions.
+
+A model none of these rules match is left untouched, so a brand-new id gets the gateway's own error rather than a guess. That is also why the table can lag: an id added since the last release inherits the permissive default until someone measures it.
 
 ## Image generation
 

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -69,7 +69,7 @@ Which ids your branch serves is account-specific during the beta; `GET $NEON_AI_
 
 Upstream backends behind the gateway accept different subsets of the OpenAI-style parameters the AI SDK emits, and sending one an upstream rejects is a hard `400`. The provider drops those before the request and records a warning in `result.warnings`, so a call succeeds instead of failing on a parameter you passed in good faith.
 
-These rules apply on the Anthropic Messages and Chat Completions routes. On the Responses route (every `gpt-*` id) penalties, `seed` and `stopSequences` are left to the upstream OpenAI model's own stripping, but `temperature` and `topP` are handled here, because the gateway rejects them on the four ids listed below.
+These rules apply on the Anthropic Messages and Chat Completions routes. The Responses route (every `gpt-*` id) relies on the upstream OpenAI model's own stripping instead, so its behaviour and its warning wording are the AI SDK's rather than described here — but `getNeonModelCapabilities` still answers for those ids, and the last row below is what it reports rather than something this provider drops.
 
 | Models | Dropped |
 | --- | --- |
@@ -82,7 +82,7 @@ These rules apply on the Anthropic Messages and Chat Completions routes. On the 
 | `gemini-3-5-flash-lite` | `frequencyPenalty`, `presencePenalty` |
 | `gemini-3-6-flash` | `temperature`, `topP`, `frequencyPenalty`, `presencePenalty` |
 | Every other Gemini | nothing |
-| `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-5-pro` | `temperature`, `topP` |
+| `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, `gpt-5-5-pro` (reported only — Responses strips these upstream) | `temperature`, `topP` |
 
 **`temperature` on a Claude 5 model therefore has no effect.** That is the gateway's behaviour, not a provider choice; sending it returns `does not support the temperature parameter`. Steer those models with Anthropic's own effort control instead — note that this is `effort`, not the OpenAI-style `reasoningEffort`, which every Claude id drops:
 

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -69,7 +69,7 @@ Which ids your branch serves is account-specific during the beta; `GET $NEON_AI_
 
 Upstream backends behind the gateway accept different subsets of the OpenAI-style parameters the AI SDK emits, and sending one an upstream rejects is a hard `400`. The provider drops those before the request and records a warning in `result.warnings`, so a call succeeds instead of failing on a parameter you passed in good faith.
 
-These rules apply on the Anthropic Messages and Chat Completions routes. The Responses route (every `gpt-*` id) relies on the upstream OpenAI model's own stripping instead, so its behaviour and its warning wording are the AI SDK's rather than described here — but `getNeonModelCapabilities` still answers for those ids, and the last row below is what it reports rather than something this provider drops.
+These rules apply on the Anthropic Messages and Chat Completions routes. The Responses route (every `gpt-*` id) relies on the upstream OpenAI model's own stripping instead, so its behaviour and its warning wording are the AI SDK's rather than described here — but `getNeonModelCapabilities` still answers for those ids, and the `gpt-5` row below is what it reports rather than something this provider drops.
 
 | Models | Dropped |
 | --- | --- |

--- a/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
@@ -289,6 +289,39 @@ describe.skipIf(!hasGatewayEnv())(
 			}, 120_000);
 		});
 
+		// The provider used to drop reasoningEffort on Gemini and tell the caller
+		// the model did not take it. The gateway maps it onto Gemini's thinking
+		// config, so that cost people control over spend they were billed for
+		// either way. Asserted live because the claim was about the gateway.
+		describe("reasoningEffort on Gemini", () => {
+			it("changes how much the model reasons", async () => {
+				const reason = async (effort: "minimal" | "high") => {
+					const result = await generateText({
+						model: neon("gemini-3-6-flash"),
+						prompt: "A farmer has 17 sheep. All but 9 run away. How many remain? Think it through.",
+						maxOutputTokens: 900,
+						providerOptions: { neon: { reasoningEffort: effort } },
+					});
+					expect(result.warnings ?? []).toEqual([]);
+					const usage = (
+						result as {
+							response?: {
+								body?: { usage?: Record<string, number> };
+							};
+						}
+					).response?.body?.usage;
+					return usage?.reasoning_tokens ?? 0;
+				};
+
+				const [minimal, high] = [
+					await reason("minimal"),
+					await reason("high"),
+				];
+				expect(minimal).toBe(0);
+				expect(high).toBeGreaterThan(0);
+			}, 180_000);
+		});
+
 		describe("gpt-oss harmony normalization (#308)", () => {
 			// The gateway returns gpt-oss `message.content` as a harmony parts
 			// array; the provider normalizes it to the OpenAI Chat Completions

--- a/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
@@ -229,6 +229,66 @@ describe.skipIf(!hasGatewayEnv())(
 			}, 120_000);
 		});
 
+		// Every one of these returns 400 if the provider forwards the parameter,
+		// so the capability table is the only thing keeping the call alive. A
+		// unit test proves the table says the right thing; only a live call
+		// proves the table still matches the gateway.
+		describe("sampling parameters the gateway rejects per model", () => {
+			it.each([
+				{
+					model: "kimi-k3",
+					dropped: ["frequencyPenalty", "presencePenalty"],
+				},
+				{
+					model: "gemini-3-5-flash-lite",
+					dropped: ["frequencyPenalty", "presencePenalty"],
+				},
+				{
+					model: "gemini-3-6-flash",
+					dropped: [
+						"temperature",
+						"topP",
+						"frequencyPenalty",
+						"presencePenalty",
+					],
+				},
+			])("$model answers instead of 400ing, and reports what was dropped", async ({
+				model,
+				dropped,
+			}) => {
+				const result = await generateText({
+					model: neon(model),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+					temperature: 0.2,
+					topP: 0.9,
+					frequencyPenalty: 0.5,
+					presencePenalty: 0.5,
+				});
+
+				expect(result.text.trim().length).toBeGreaterThan(0);
+				const reported = (result.warnings ?? [])
+					.map((w) => ("feature" in w ? w.feature : undefined))
+					.filter(Boolean);
+				expect(new Set(reported)).toEqual(new Set(dropped));
+			}, 120_000);
+
+			// The older Gemini models still take penalties. If this starts
+			// failing, the restriction has spread and the id list needs widening
+			// rather than the assertion loosening.
+			it("still sends penalties to the Gemini models that accept them", async () => {
+				const result = await generateText({
+					model: neon("gemini-3-flash"),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+					frequencyPenalty: 0.5,
+				});
+
+				expect(result.text.trim().length).toBeGreaterThan(0);
+				expect(result.warnings ?? []).toEqual([]);
+			}, 120_000);
+		});
+
 		describe("gpt-oss harmony normalization (#308)", () => {
 			// The gateway returns gpt-oss `message.content` as a harmony parts
 			// array; the provider normalizes it to the OpenAI Chat Completions

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
@@ -101,6 +101,16 @@ describe("applyNeonCapabilities warnings", () => {
 		}
 	});
 
+	it("points a Claude caller at the effort option when reasoningEffort is dropped", () => {
+		const [warning] = detailsFor("claude-opus-5", {
+			providerOptions: { neon: { reasoningEffort: "high" } },
+		});
+
+		expect(warning.feature).toBe("reasoningEffort");
+		expect(warning.details).toContain("The request was sent without it");
+		expect(warning.details).toContain("providerOptions.anthropic.effort");
+	});
+
 	it("hedges rather than asserting a 400 for an unrecognised Claude id", () => {
 		const [warning] = detailsFor("claude-3-5-sonnet-20241022", {
 			temperature: 0.2,

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
@@ -62,7 +62,9 @@ describe("applyNeonCapabilities warnings", () => {
 				id,
 				details: expect.not.stringContaining("Only Gemini"),
 			});
-			expect(warning.details).toContain("This model rejects penalties");
+			// The sentence has to add something the SDK's own prefix did not; it
+			// already prints provider, model, feature and "is not supported".
+			expect(warning.details).toContain("getNeonModelCapabilities");
 		}
 	});
 

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
@@ -66,6 +66,21 @@ describe("applyNeonCapabilities warnings", () => {
 		}
 	});
 
+	// Claude routes through /anthropic/v1, not the unified chat endpoint, so a
+	// penalty warning phrased around "the unified endpoint" would be false for
+	// every Claude model that receives it.
+	it("keeps the penalty warning true on routes other than unified chat", () => {
+		for (const id of ["claude-opus-5", "kimi-k3", "gemini-3-6-flash"]) {
+			const warning = detailsFor(id, { frequencyPenalty: 0.5 }).find(
+				(w) => w.feature === "frequencyPenalty",
+			);
+			expect({ id, details: warning?.details }).toEqual({
+				id,
+				details: expect.not.stringContaining("unified endpoint"),
+			});
+		}
+	});
+
 	it("hedges rather than asserting a 400 for an unrecognised Claude id", () => {
 		const [warning] = detailsFor("claude-3-5-sonnet-20241022", {
 			temperature: 0.2,

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
@@ -83,6 +83,24 @@ describe("applyNeonCapabilities warnings", () => {
 		}
 	});
 
+	// temperature and topP read `samplingDetails`, not GENERIC_DETAILS, so the
+	// penalty assertions above did not cover them and the old wording survived
+	// one round of review on exactly the parameter the finding was about.
+	it("gives temperature and topP the same actionable wording as everything else", () => {
+		const warnings = detailsFor("gemini-3-6-flash", {
+			temperature: 0.2,
+			topP: 0.9,
+		});
+
+		expect(warnings.map((w) => w.feature)).toEqual(["temperature", "topP"]);
+		for (const warning of warnings) {
+			expect(warning.details).toContain(
+				"The request was sent without it",
+			);
+			expect(warning.details).toContain("getNeonModelCapabilities");
+		}
+	});
+
 	it("hedges rather than asserting a 400 for an unrecognised Claude id", () => {
 		const [warning] = detailsFor("claude-3-5-sonnet-20241022", {
 			temperature: 0.2,
@@ -99,6 +117,7 @@ describe("applyNeonCapabilities warnings", () => {
 
 		expect(warning.type).toBe("unsupported");
 		expect(warning.details).toContain("Claude 4.7 and newer");
+		expect(warning.details).toContain("The request was sent without it");
 	});
 
 	it("keeps temperature and drops topP when a Claude call sets both", () => {

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.test.ts
@@ -52,6 +52,20 @@ describe("applyNeonCapabilities warnings", () => {
 		}
 	});
 
+	it("does not tell a Gemini caller that only Gemini accepts penalties", () => {
+		// gemini-3-6-flash and gemini-3-5-flash-lite reject penalties while their
+		// older siblings accept them, so a rule phrased around the family reads as
+		// a contradiction to exactly the users who now hit it.
+		for (const id of ["gemini-3-6-flash", "gemini-3-5-flash-lite"]) {
+			const [warning] = detailsFor(id, { frequencyPenalty: 0.5 });
+			expect({ id, details: warning.details }).toEqual({
+				id,
+				details: expect.not.stringContaining("Only Gemini"),
+			});
+			expect(warning.details).toContain("This model rejects penalties");
+		}
+	});
+
 	it("hedges rather than asserting a 400 for an unrecognised Claude id", () => {
 		const [warning] = detailsFor("claude-3-5-sonnet-20241022", {
 			temperature: 0.2,

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
@@ -7,9 +7,9 @@ import type {
 import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
 
 const PENALTY_DETAILS =
-	"The request was sent without it. Check getNeonModelCapabilities(id).supportsPenalties before setting penalties.";
+	"The request was sent without it. Check getNeonModelCapabilities('<model-id>').supportsPenalties before setting penalties.";
 const GENERIC_DETAILS =
-	"The request was sent without it. Call getNeonModelCapabilities(id) to see which sampling parameters this model takes, or steer it through the prompt.";
+	"The request was sent without it. Call getNeonModelCapabilities('<model-id>') to see which sampling parameters this model takes, or steer it through the prompt.";
 const REASONING_EFFORT_DETAILS =
 	"The request was sent without it. Claude takes providerOptions.anthropic.effort instead.";
 
@@ -45,10 +45,10 @@ export function applyNeonCapabilities(
 	// would contradict the hedge in the sentence that follows it.
 	const unrecognizedClaude = caps.claudeSamplingUnrecognized === true;
 	const samplingDetails = unrecognizedClaude
-		? "This Claude version was not recognised. Claude 4.7 and newer reject sampling parameters, so it was dropped as a precaution; set `providerOptions.anthropic.effort` instead."
+		? "This Claude version was not recognised. Claude 4.7 and newer reject sampling parameters, so the request was sent without it as a precaution; set `providerOptions.anthropic.effort` instead."
 		: caps.family === "anthropic"
-			? "Claude 4.7 and newer reject sampling parameters, so it was dropped rather than sent. Use `providerOptions.anthropic.effort` (low | medium | high | xhigh | max) to steer these models."
-			: "The Neon AI Gateway rejects this parameter for this model, so it was dropped rather than sent.";
+			? "The request was sent without it. Claude 4.7 and newer reject sampling parameters; use `providerOptions.anthropic.effort` (low | medium | high | xhigh | max) to steer these models."
+			: GENERIC_DETAILS;
 	const samplingType = unrecognizedClaude ? "compatibility" : "unsupported";
 
 	if (options.temperature != null && !caps.supportsTemperature) {

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
@@ -7,11 +7,11 @@ import type {
 import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
 
 const PENALTY_DETAILS =
-	"This model rejects penalties, so it was dropped rather than sent.";
+	"The request was sent without it. Check getNeonModelCapabilities(id).supportsPenalties before setting penalties.";
 const GENERIC_DETAILS =
-	"The Neon AI Gateway rejects this parameter for this model, so it was dropped rather than sent.";
+	"The request was sent without it. Call getNeonModelCapabilities(id) to see which sampling parameters this model takes, or steer it through the prompt.";
 const REASONING_EFFORT_DETAILS =
-	"This model does not take the OpenAI reasoning_effort field, so it was dropped rather than sent.";
+	"The request was sent without it. Claude takes providerOptions.anthropic.effort instead.";
 
 /**
  * Drop call options the resolved model's upstream backend does not accept and

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
@@ -7,7 +7,7 @@ import type {
 import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
 
 const PENALTY_DETAILS =
-	"This model rejects penalties on the gateway's unified endpoint, so it was dropped rather than sent.";
+	"This model rejects penalties, so it was dropped rather than sent.";
 const GENERIC_DETAILS =
 	"The Neon AI Gateway rejects this parameter for this model, so it was dropped rather than sent.";
 const REASONING_EFFORT_DETAILS =

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
@@ -7,7 +7,7 @@ import type {
 import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
 
 const PENALTY_DETAILS =
-	"Only Gemini accepts penalties on the gateway's unified endpoint, so it was dropped rather than sent.";
+	"This model rejects penalties on the gateway's unified endpoint, so it was dropped rather than sent.";
 const GENERIC_DETAILS =
 	"The Neon AI Gateway rejects this parameter for this model, so it was dropped rather than sent.";
 const REASONING_EFFORT_DETAILS =

--- a/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-capabilities.ts
@@ -27,11 +27,10 @@ export function applyNeonCapabilities(
 	const patch: Partial<LanguageModelV3CallOptions> = {};
 
 	// The AI SDK prints the provider, the model id and the feature name ahead of
-	// `details`, so each reason says only what those cannot: why the gateway
-	// refuses it, and what to use instead. Each carries its own "was dropped"
-	// clause rather than a shared suffix — appending one everywhere restated the
-	// penalty reason and asserted a 400 for the unrecognised case, which is the
-	// overstatement this wording exists to avoid.
+	// `details`, so each reason says only what those cannot: that the call still
+	// went out, and what to reach for instead. Restating the feature name or
+	// asserting a 400 for the unrecognised case is the overstatement this
+	// wording exists to avoid.
 	const drop = (
 		feature: string,
 		details: string,

--- a/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
@@ -55,6 +55,8 @@ export const NEON_MODELS_DEV_IDS = [
 	"gemini-3-1-flash-lite",
 	"gemini-3-1-pro",
 	"gemini-3-5-flash",
+	"gemini-3-5-flash-lite",
+	"gemini-3-6-flash",
 	"gemini-3-flash",
 	"gemma-3-12b",
 	// Meta (unified MLflow endpoint)
@@ -68,6 +70,8 @@ export const NEON_MODELS_DEV_IDS = [
 	"glm-5-2",
 	// Thinking Machines (unified MLflow endpoint)
 	"inkling",
+	// Moonshot (unified MLflow endpoint)
+	"kimi-k3",
 ] as const;
 
 /** A known Neon AI Gateway model id. */

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
@@ -196,6 +196,39 @@ describe("getNeonModelCapabilities", () => {
 		}
 	});
 
+	// The gateway maps reasoning_effort onto Gemini's thinking config, so dropping
+	// it cost callers control they were being billed for either way.
+	it("forwards reasoningEffort to Gemini", () => {
+		for (const id of ["gemini-3-flash", "gemini-3-6-flash"]) {
+			expect({
+				id,
+				effort: getNeonModelCapabilities(id).supportsReasoningEffort,
+			}).toEqual({ id, effort: true });
+		}
+	});
+
+	// gpt-5-5-pro reads as version 5.5 to the minor-version rule, so it was told
+	// it takes sampling parameters. The Responses API answers
+	// `Unsupported parameter: temperature`.
+	it("keeps gpt-5-5-pro out of the minor-version sampling rule", () => {
+		const pro = getNeonModelCapabilities("gpt-5-5-pro");
+		expect({
+			temperature: pro.supportsTemperature,
+			topP: pro.supportsTopP,
+		}).toEqual({
+			temperature: false,
+			topP: false,
+		});
+
+		// Its siblings on the same rule are unaffected.
+		expect(getNeonModelCapabilities("gpt-5-5").supportsTemperature).toBe(
+			true,
+		);
+		expect(getNeonModelCapabilities("gpt-5-1").supportsTemperature).toBe(
+			true,
+		);
+	});
+
 	it("applies the strict Gemini rules through the databricks- prefix", () => {
 		const prefixed = getNeonModelCapabilities(
 			"databricks-gemini-3-6-flash",

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
@@ -127,8 +127,8 @@ describe("getNeonModelCapabilities", () => {
 		}
 	});
 
-	// Every MLflow-routed family except Gemini rejects penalties with
-	// `parameter "frequency_penalty" must be equal to 0`.
+	// Every MLflow-routed family except the older Gemini models rejects
+	// penalties with `parameter "frequency_penalty" must be equal to 0`.
 	it("drops penalties for every unified-endpoint family that rejects them", () => {
 		for (const id of [
 			"gpt-oss-20b",
@@ -138,6 +138,7 @@ describe("getNeonModelCapabilities", () => {
 			"gemma-3-12b",
 			"glm-5-2",
 			"inkling",
+			"kimi-k3",
 		]) {
 			expect({
 				id,
@@ -149,10 +150,48 @@ describe("getNeonModelCapabilities", () => {
 		}
 	});
 
-	it("keeps penalties for Gemini, the one unified family that accepts them", () => {
-		expect(
-			getNeonModelCapabilities("gemini-3-flash").supportsPenalties,
-		).toBe(true);
+	it("keeps penalties for the older Gemini models that accept them", () => {
+		for (const id of [
+			"gemini-3-flash",
+			"gemini-3-5-flash",
+			"gemini-3-1-pro",
+			"gemini-3-1-flash-lite",
+		]) {
+			expect({
+				id,
+				penalties: getNeonModelCapabilities(id).supportsPenalties,
+			}).toEqual({ id, penalties: true });
+		}
+	});
+
+	it("drops penalties for the newer Gemini models that reject them", () => {
+		// Measured, not derived: gemini-3-1-flash-lite accepts penalties and
+		// gemini-3-5-flash-lite does not, so neither the version nor the -lite
+		// suffix predicts this.
+		for (const id of [
+			"gemini-3-5-flash-lite",
+			"gemini-3-6-flash",
+			"databricks-gemini-3-6-flash",
+		]) {
+			expect({
+				id,
+				penalties: getNeonModelCapabilities(id).supportsPenalties,
+			}).toEqual({ id, penalties: false });
+		}
+	});
+
+	it("drops temperature and topP for gemini-3-6-flash only", () => {
+		const strict = getNeonModelCapabilities("gemini-3-6-flash");
+		expect({
+			temperature: strict.supportsTemperature,
+			topP: strict.supportsTopP,
+		}).toEqual({ temperature: false, topP: false });
+
+		const lenient = getNeonModelCapabilities("gemini-3-5-flash-lite");
+		expect({
+			temperature: lenient.supportsTemperature,
+			topP: lenient.supportsTopP,
+		}).toEqual({ temperature: true, topP: true });
 	});
 
 	it("separates seed and stop support across the unified families", () => {

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
@@ -180,6 +180,34 @@ describe("getNeonModelCapabilities", () => {
 		}
 	});
 
+	// Substring matching would hand a measured restriction to any future id that
+	// merely starts the same way, which is exactly how the blanket Gemini rule
+	// got gemini-3-6-flash wrong.
+	it("matches the strict Gemini ids exactly, not by prefix", () => {
+		for (const id of [
+			"gemini-3-6-flash-lite",
+			"gemini-3-5-flash-lite-preview",
+		]) {
+			expect({
+				id,
+				penalties: getNeonModelCapabilities(id).supportsPenalties,
+				temperature: getNeonModelCapabilities(id).supportsTemperature,
+			}).toEqual({ id, penalties: true, temperature: true });
+		}
+	});
+
+	it("applies the strict Gemini rules through the databricks- prefix", () => {
+		const prefixed = getNeonModelCapabilities(
+			"databricks-gemini-3-6-flash",
+		);
+
+		expect({
+			penalties: prefixed.supportsPenalties,
+			temperature: prefixed.supportsTemperature,
+			topP: prefixed.supportsTopP,
+		}).toEqual({ penalties: false, temperature: false, topP: false });
+	});
+
 	it("drops temperature and topP for gemini-3-6-flash only", () => {
 		const strict = getNeonModelCapabilities("gemini-3-6-flash");
 		expect({

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
@@ -56,6 +56,12 @@ export interface NeonModelCapabilities {
 	claudeSamplingUnrecognized?: boolean;
 }
 
+/**
+ * Gemini models the gateway rejects penalties on, by measurement. Their older
+ * siblings accept penalties, so this cannot be derived from the id.
+ */
+const GEMINI_NO_PENALTIES = ["gemini-3-5-flash-lite", "gemini-3-6-flash"];
+
 const PERMISSIVE: Omit<NeonModelCapabilities, "family"> = {
 	supportsTemperature: true,
 	supportsTopP: true,
@@ -132,10 +138,22 @@ export function getNeonModelCapabilities(
 
 	// Google (Gemini): accepts standard sampling params but rejects the OpenAI
 	// `reasoning_effort` field (not part of Gemini's generation config).
+	//
+	// Newer Gemini models are stricter, and not in a way the id predicts: the
+	// gateway rejects penalties on `gemini-3-5-flash-lite` while accepting them
+	// on `gemini-3-1-flash-lite`, so neither the version nor the `-lite` suffix
+	// is the rule. `gemini-3-6-flash` refuses temperature and topP outright
+	// ("does not support the temperature parameter"). Both are listed by id
+	// because that is what was measured; a new Gemini model inherits the
+	// permissive default until someone measures it.
 	if (id.includes("gemini")) {
+		const strict = GEMINI_NO_PENALTIES.some((m) => id.includes(m));
 		return {
 			family: "google",
 			...PERMISSIVE,
+			supportsTemperature: !id.includes("gemini-3-6-flash"),
+			supportsTopP: !id.includes("gemini-3-6-flash"),
+			supportsPenalties: !strict,
 			supportsReasoningEffort: false,
 		};
 	}
@@ -177,9 +195,9 @@ export function getNeonModelCapabilities(
 	}
 
 	// Everything else on the unified endpoint rejects penalties with
-	// `parameter "frequency_penalty" must be equal to 0`. Gemini, handled above,
-	// is the only MLflow-routed family that accepts them. Seed and stop vary, so
-	// each family carries what was measured rather than inheriting a guess.
+	// `parameter "frequency_penalty" must be equal to 0`. Only the older Gemini
+	// models, handled above, accept them. Seed and stop vary, so each family
+	// carries what was measured rather than inheriting a guess.
 	if (id.includes("gpt-oss")) {
 		return {
 			family: "other",
@@ -199,7 +217,7 @@ export function getNeonModelCapabilities(
 		};
 	}
 
-	if (id.includes("glm") || id.includes("inkling")) {
+	if (id.includes("glm") || id.includes("inkling") || id.includes("kimi")) {
 		return { family: "other", ...PERMISSIVE, supportsPenalties: false };
 	}
 

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
@@ -74,6 +74,15 @@ const GEMINI_NO_PENALTIES = new Set([
 const GEMINI_NO_SAMPLING = new Set(["gemini-3-6-flash"]);
 
 /**
+ * GPT-5 ids that reject `temperature` despite carrying a minor version.
+ *
+ * The version rule below reads `gpt-5-5-pro` as 5.5 and concludes it takes
+ * sampling parameters. It does not — the Responses API answers
+ * `Unsupported parameter: temperature`.
+ */
+const GPT5_NO_SAMPLING = new Set(["gpt-5-5-pro"]);
+
+/**
  * The gateway accepts an optional `databricks-` prefix on any id, so strip it
  * before an exact-match lookup. Prefix rules elsewhere in this file tolerate it
  * incidentally; exact matches do not.
@@ -156,8 +165,10 @@ export function getNeonModelCapabilities(
 		};
 	}
 
-	// Google (Gemini): accepts standard sampling params but rejects the OpenAI
-	// `reasoning_effort` field (not part of Gemini's generation config).
+	// Google (Gemini): accepts standard sampling params, and does take
+	// `reasoning_effort` — the gateway maps it onto Gemini's thinking config.
+	// Measured on gemini-3-6-flash: `minimal` produces 0 reasoning tokens and
+	// `high` produces 310, against 130 with the field absent.
 	//
 	// Newer Gemini models are stricter, and not in a way the id predicts: the
 	// gateway rejects penalties on `gemini-3-5-flash-lite` while accepting them
@@ -175,7 +186,6 @@ export function getNeonModelCapabilities(
 			supportsTemperature: acceptsSampling,
 			supportsTopP: acceptsSampling,
 			supportsPenalties: !GEMINI_NO_PENALTIES.has(canonical),
-			supportsReasoningEffort: false,
 		};
 	}
 
@@ -188,7 +198,8 @@ export function getNeonModelCapabilities(
 	// reject topP, while gpt-5.1+ (a minor version digit follows) accept them
 	// again. The regex matches both prefixed and unprefixed ids.
 	if (/gpt-5/.test(id)) {
-		const hasMinorVersion = /gpt-5[.-]\d/.test(id);
+		const hasMinorVersion =
+			/gpt-5[.-]\d/.test(id) && !GPT5_NO_SAMPLING.has(canonicalId(id));
 		return {
 			family: "openai",
 			supportsTemperature: hasMinorVersion,

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
@@ -58,9 +58,29 @@ export interface NeonModelCapabilities {
 
 /**
  * Gemini models the gateway rejects penalties on, by measurement. Their older
- * siblings accept penalties, so this cannot be derived from the id.
+ * siblings accept them, so this cannot be derived from the id.
+ *
+ * Matched exactly rather than by substring: `gemini-3-6-flash` is a prefix of
+ * any `gemini-3-6-flash-*` id Google may ship next, and inheriting a measured
+ * restriction on the strength of a shared prefix is how the Gemini rule was
+ * wrong for these two in the first place.
  */
-const GEMINI_NO_PENALTIES = ["gemini-3-5-flash-lite", "gemini-3-6-flash"];
+const GEMINI_NO_PENALTIES = new Set([
+	"gemini-3-5-flash-lite",
+	"gemini-3-6-flash",
+]);
+
+/** Gemini models that reject `temperature` and `topP` outright. */
+const GEMINI_NO_SAMPLING = new Set(["gemini-3-6-flash"]);
+
+/**
+ * The gateway accepts an optional `databricks-` prefix on any id, so strip it
+ * before an exact-match lookup. Prefix rules elsewhere in this file tolerate it
+ * incidentally; exact matches do not.
+ */
+function canonicalId(id: string): string {
+	return id.startsWith("databricks-") ? id.slice("databricks-".length) : id;
+}
 
 const PERMISSIVE: Omit<NeonModelCapabilities, "family"> = {
 	supportsTemperature: true,
@@ -147,13 +167,14 @@ export function getNeonModelCapabilities(
 	// because that is what was measured; a new Gemini model inherits the
 	// permissive default until someone measures it.
 	if (id.includes("gemini")) {
-		const strict = GEMINI_NO_PENALTIES.some((m) => id.includes(m));
+		const canonical = canonicalId(id);
+		const acceptsSampling = !GEMINI_NO_SAMPLING.has(canonical);
 		return {
 			family: "google",
 			...PERMISSIVE,
-			supportsTemperature: !id.includes("gemini-3-6-flash"),
-			supportsTopP: !id.includes("gemini-3-6-flash"),
-			supportsPenalties: !strict,
+			supportsTemperature: acceptsSampling,
+			supportsTopP: acceptsSampling,
+			supportsPenalties: !GEMINI_NO_PENALTIES.has(canonical),
 			supportsReasoningEffort: false,
 		};
 	}


### PR DESCRIPTION
## The problem

Today's catalog release added `kimi-k3`, `gemini-3-6-flash` and `gemini-3-5-flash-lite`, all
stricter than the rules covering them. Measuring that turned up three more rules that assert
something the gateway does not do:

```ts
await generateText({
  model: neon('kimi-k3'),
  prompt: 'Say hi.',
  frequencyPenalty: 0.5,     // → 400  parameter "frequency_penalty" must be equal to 0
});

await generateText({
  model: neon('gemini-3-6-flash'),
  prompt: 'Say hi.',
  temperature: 0.2,          // → 400  Model gemini-3.6-flash does not support the temperature parameter
});
```

`kimi-k3` matched nothing and fell through to the permissive default. `gemini-3-6-flash` was worse
than unhandled — it matched the Gemini rule, which states Gemini is the one unified family that
*accepts* penalties. And the provider was dropping `reasoning_effort` on **every** Gemini model
while telling the caller the model does not take it, which is false and cost people control over
reasoning they were billed for anyway.

## The interface

Both calls above now succeed, reporting what was dropped and what to do instead:

```ts
const { text, warnings } = await generateText({
  model: neon('gemini-3-6-flash'),
  prompt: 'Say hi.',
  temperature: 0.2,
  frequencyPenalty: 0.5,
});

// warnings, read off the built provider:
//   temperature       → "The request was sent without it. Call getNeonModelCapabilities('<model-id>')
//                        to see which sampling parameters this model takes, or steer it through the prompt."
//   frequencyPenalty  → "The request was sent without it. Check
//                        getNeonModelCapabilities('<model-id>').supportsPenalties before setting penalties."
```

Reasoning effort now reaches Gemini, where it was previously discarded:

```ts
await generateText({
  model: neon('gemini-3-6-flash'),
  prompt: 'Think this through.',
  providerOptions: { neon: { reasoningEffort: 'minimal' } },  // 0 reasoning tokens
  // providerOptions: { neon: { reasoningEffort: 'high' } },  // several hundred
});
```

**The group is `neon`, not `openai`.** A wrong group is discarded silently — see Known gaps.

## Measured, not inherited

| Model | temperature / topP | penalties | reasoningEffort |
| --- | --- | --- | --- |
| `kimi-k3` | accepted | **rejected** | accepted |
| `gemini-3-5-flash-lite` | accepted | **rejected** | accepted |
| `gemini-3-6-flash` | **rejected** | **rejected** | accepted |
| every other Gemini | accepted | accepted | accepted |
| Claude | 4.7+ reject | rejected | **rejected** — use `providerOptions.anthropic.effort` |

The Gemini exceptions are ids matched **exactly**, not by prefix: `gemini-3-1-flash-lite` accepts
penalties and `gemini-3-5-flash-lite` does not, so neither the version nor the `-lite` suffix
predicts it, and a future `gemini-3-6-flash-*` must not inherit a restriction nobody measured for
it. The gateway's optional `databricks-` prefix is stripped explicitly rather than tolerated by
accident. A model matching no rule keeps the permissive default.

`NEON_MODELS_DEV_IDS` gains the three ids, so they autocomplete.

## Behaviour change to an exported function

`getNeonModelCapabilities` returns different answers, which matters if you branch on it:

- `supportsPenalties` → `false` for `kimi-k3`, `gemini-3-6-flash`, `gemini-3-5-flash-lite`
- `supportsTemperature` / `supportsTopP` → `false` for `gemini-3-6-flash` and `gpt-5-5-pro`
- `supportsReasoningEffort` → `true` for every Gemini id

`gpt-5-5-pro` read as version 5.5 to the minor-version rule and claimed to accept sampling
parameters; the gateway answers `Unsupported parameter: 'temperature'`. That corrects **only the
reported answer** — `applyNeonCapabilities` is not called on the Responses route, which strips the
parameter upstream, so those calls already succeeded.

## Documentation

The README said *"Gemini is the only family on the unified endpoint that accepts penalties"* — the
same false claim this PR removes from the warning, left standing in the consumer entry point, with
a table carrying no `kimi-k3` row and one Gemini row wrong for two of six ids. Rewritten, and it
now states the rules are per model rather than per family.

## Verification

- **94 unit tests**, covering each rule, exact-vs-prefix matching, the `databricks-` prefix, and
  every warning string — including `temperature`, which is how one round caught that it alone had
  kept the old wording, and `reasoningEffort`, which was the last string with no assertion on it.
- **5 live e2e tests** against a real branch: each strict model answers instead of `400`ing and
  reports exactly what was dropped; `gemini-3-flash` still gets penalties through with no warning,
  so a spreading restriction fails the suite rather than widening silently; and Gemini reasoning
  responds to the effort setting.
- `pnpm test:drift` green against the deployed models.dev catalog.
- Warnings above were read off the built provider, not composed by hand.

## Known gaps

**A wrong `providerOptions` group is silently ignored.** `providerOptions.neon.reasoningEffort`
works; `openai`, `google` or any other group is discarded with no warning and lands in the same
reasoning-token band as passing nothing. Before this PR the parameter was always dropped with a
warning, so nobody regresses from working code — but the correct and incorrect spellings are now
indistinguishable from the call site. The next change should warn when `reasoningEffort` sits in a
group the route will not read, and add a `providerOptions: { neon: … }` example to the README.

Also deferred: `REASONING_EFFORT_FAMILIES` in the e2e helpers still excludes `google`;
`usage.reasoningTokens` reports `0` while the response body carries the real count, which matters
more now that reasoning effort is a controllable billable knob; `kimi-k3` returns empty text at low
`maxOutputTokens` because it reasons by default and its `thinking` toggle has no mapping; a
`gemini-3-6-flash` call emits four warnings in two identical pairs.

The package's e2e suite is **not** in the repo's `test:e2e:live` workflow, which filters to
`@neon/sdk`, `@neon/config`, `@neon/config-runtime`, `@neon/env` and `neon`. These tests run on
demand rather than on a schedule; wiring them up would have caught this class of bug the day the
gateway changed.

## Release

Minor, not patch: `reasoningEffort` reaching Gemini changes output, latency and spend for anyone
already setting it, `getNeonModelCapabilities` answers differently for five ids, and
`NeonKnownModelId` gains three members. Nothing breaks, but a caller should look.
