### PR TITLE
fix(cli): install config packages with the project's package manager

### DIFF
--- a/.changeset/quick-pandas-shake.md
+++ b/.changeset/quick-pandas-shake.md
@@ -1,0 +1,9 @@
+---
+"neon": patch
+---
+
+Install the config packages with the package manager the project actually uses
+
+`neon config init` (and the `neon link` prompt that runs it) picked a package manager from `npm_config_user_agent` alone, which is empty for a globally installed `neon`. It then fell back to the first manager on `PATH`, effectively always npm — so setting up a pnpm, yarn, or bun project shelled out to `npm install`. In a pnpm project that fails outright: npm's dependency resolver chokes on pnpm's symlinked `node_modules` with `Cannot read properties of null (reading 'matches')`. The install leaves a `neon.ts` whose `@neon/config/v1` import can't resolve, so the env pull that follows fails too.
+
+`resolvePackageManager` now reads the project's lockfile first, from the target directory and its parents up to the repo root — so a package in a monorepo finds the root lockfile, while a stray lockfile above the repository is ignored. A project with no lockfile falls back to the previous behaviour unchanged.

--- a/packages/cli/src/commands/config.init.test.ts
+++ b/packages/cli/src/commands/config.init.test.ts
@@ -67,6 +67,26 @@ describe("config init", () => {
 		expect(calls[0].cwd).toBe(workspace);
 	});
 
+	test("installs with the package manager the project uses, not the one that invoked us", async () => {
+		// yarn on purpose: this repo and its test runner are both pnpm, so a pnpm
+		// lockfile here would pass even if the cwd never reached the resolver.
+		writeFileSync(join(workspace, "yarn.lock"), "");
+		const calls: { cmd: string; args: string[] }[] = [];
+
+		await initCmd({
+			cwd: workspace,
+			install: true,
+			run: (cmd, args) => {
+				calls.push({ cmd, args });
+				return Promise.resolve(true);
+			},
+		});
+
+		expect(calls).toHaveLength(1);
+		expect(calls[0].cmd).toBe("yarn");
+		expect(calls[0].args[0]).toBe("add");
+	});
+
 	test("only installs the packages that aren't already declared", async () => {
 		writeFileSync(
 			join(workspace, "package.json"),

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -375,7 +375,7 @@ export const initCmd = async (props: ConfigInitProps): Promise<void> => {
 	if (missing.length === 0) {
 		log.info("%s are already installed.", REQUIRED_PACKAGES.join(" and "));
 	} else {
-		const pm = resolvePackageManager();
+		const pm = resolvePackageManager(cwd);
 		const args = addDependenciesArgs(pm, missing);
 		if (props.install === false) {
 			log.info(

--- a/packages/cli/src/utils/package_manager.test.ts
+++ b/packages/cli/src/utils/package_manager.test.ts
@@ -1,0 +1,110 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	detectProjectPackageManager,
+	resolvePackageManager,
+} from "./package_manager.js";
+
+describe("detectProjectPackageManager", () => {
+	let project: string;
+
+	beforeEach(() => {
+		project = mkdtempSync(join(tmpdir(), "neonctl-pm-detect-"));
+		// Marks the temp dir as a repo root so the walk stops here instead of
+		// climbing into $TMPDIR and beyond, where another process's stray
+		// lockfile would decide these assertions.
+		mkdirSync(join(project, ".git"));
+	});
+
+	afterEach(() => {
+		rmSync(project, { recursive: true, force: true });
+	});
+
+	it.each([
+		["pnpm-lock.yaml", "pnpm"],
+		["yarn.lock", "yarn"],
+		["bun.lock", "bun"],
+		["bun.lockb", "bun"],
+		["package-lock.json", "npm"],
+	])("reads %s as %s", (lockfile, expected) => {
+		writeFileSync(join(project, lockfile), "");
+		expect(detectProjectPackageManager(project)).toBe(expected);
+	});
+
+	it("finds the root lockfile from a nested package directory", () => {
+		// The reason the walk exists. The root is also the boundary, so this only
+		// works because each directory's lockfiles are checked before its `.git`.
+		writeFileSync(join(project, "pnpm-lock.yaml"), "");
+		const nested = join(project, "packages", "app");
+		mkdirSync(nested, { recursive: true });
+
+		expect(detectProjectPackageManager(nested)).toBe("pnpm");
+	});
+
+	it("prefers a package's own lockfile over the one at the root", () => {
+		writeFileSync(join(project, "pnpm-lock.yaml"), "");
+		const nested = join(project, "vendored");
+		mkdirSync(nested);
+		writeFileSync(join(nested, "yarn.lock"), "");
+
+		expect(detectProjectPackageManager(nested)).toBe("yarn");
+	});
+
+	it("treats a leftover package-lock.json next to a pnpm one as pnpm", () => {
+		writeFileSync(join(project, "pnpm-lock.yaml"), "");
+		writeFileSync(join(project, "package-lock.json"), "");
+
+		expect(detectProjectPackageManager(project)).toBe("pnpm");
+	});
+
+	it("does not look outside the repo for a lockfile", () => {
+		const inner = join(project, "vendored");
+		mkdirSync(join(inner, ".git"), { recursive: true });
+		writeFileSync(join(project, "pnpm-lock.yaml"), "");
+
+		expect(detectProjectPackageManager(inner)).toBeUndefined();
+	});
+
+	it("reports no lockfile for a project without one", () => {
+		expect(detectProjectPackageManager(project)).toBeUndefined();
+	});
+});
+
+describe("resolvePackageManager", () => {
+	let project: string;
+	const originalUserAgent = process.env.npm_config_user_agent;
+
+	beforeEach(() => {
+		project = mkdtempSync(join(tmpdir(), "neonctl-pm-resolve-"));
+		mkdirSync(join(project, ".git"));
+	});
+
+	afterEach(() => {
+		rmSync(project, { recursive: true, force: true });
+		if (originalUserAgent === undefined) {
+			delete process.env.npm_config_user_agent;
+		} else {
+			process.env.npm_config_user_agent = originalUserAgent;
+		}
+	});
+
+	it("prefers the project over the package manager that invoked us", () => {
+		// The bug this guards: `npx neon link` in a pnpm repo ran `npm install`,
+		// and npm's arborist crashed on pnpm's symlinked node_modules.
+		process.env.npm_config_user_agent =
+			"npm/11.11.0 node/v24.14.1 darwin x64";
+		writeFileSync(join(project, "pnpm-lock.yaml"), "");
+
+		expect(resolvePackageManager(project)).toBe("pnpm");
+	});
+
+	it("falls back to the invoking package manager when the project has no lockfile", () => {
+		process.env.npm_config_user_agent =
+			"yarn/4.1.0 npm/? node/v24.14.1 darwin x64";
+
+		expect(resolvePackageManager(project)).toBe("yarn");
+	});
+});

--- a/packages/cli/src/utils/package_manager.ts
+++ b/packages/cli/src/utils/package_manager.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
 import which from "which";
 import { log } from "../log.js";
 
@@ -12,6 +14,43 @@ export const PACKAGE_MANAGERS: PackageManager[] = [
 	"yarn",
 	"bun",
 ];
+
+/**
+ * Lockfiles, and the package manager each one belongs to. npm is last on
+ * purpose: a repo with both a pnpm lockfile and a leftover `package-lock.json`
+ * (which a failed run like the one this fixes can leave behind) is a pnpm repo.
+ */
+const LOCKFILES: [file: string, pm: PackageManager][] = [
+	["pnpm-lock.yaml", "pnpm"],
+	["yarn.lock", "yarn"],
+	// bun 1.2+ writes the text `bun.lock`; older versions the binary `bun.lockb`.
+	["bun.lock", "bun"],
+	["bun.lockb", "bun"],
+	["package-lock.json", "npm"],
+];
+
+/**
+ * The package manager the project at `cwd` uses, from its lockfile. Searches
+ * `cwd` and then each parent up to the repo root: in a monorepo the lockfile
+ * sits at the root while we scaffold into a package. Stopping at the root keeps
+ * a stray lockfile above the repository from deciding how we install into it.
+ */
+export const detectProjectPackageManager = (
+	cwd: string,
+): PackageManager | undefined => {
+	let dir = cwd;
+	for (;;) {
+		for (const [file, pm] of LOCKFILES) {
+			if (existsSync(join(dir, file))) return pm;
+		}
+		// After the lockfiles, not before: the repo root's own lockfile counts.
+		// `.git` is a file rather than a directory in a worktree or submodule.
+		if (existsSync(join(dir, ".git"))) return undefined;
+		const parent = dirname(dir);
+		if (parent === dir) return undefined;
+		dir = parent;
+	}
+};
 
 /**
  * The package manager the CLI was invoked through, read from the
@@ -35,12 +74,21 @@ export const installedPackageManagers = (): PackageManager[] =>
 	PACKAGE_MANAGERS.filter((pm) => which.sync(pm, { nothrow: true }) !== null);
 
 /**
- * Pick a package manager without prompting: the one the CLI was invoked through,
- * else the first one installed, else npm. Used by non-interactive flows (e.g.
- * `config init`) where there's no scaffold prompt to hang a picker off.
+ * Pick a package manager without prompting: the one the project at `cwd` uses,
+ * else the one the CLI was invoked through, else the first one installed, else
+ * npm. Used by non-interactive flows (e.g. `config init`) where there's no
+ * scaffold prompt to hang a picker off.
+ *
+ * The project wins over the invocation on purpose. `npx neon …` inside a pnpm
+ * repo should still install with pnpm — which tool launched us says nothing
+ * about which one owns that project's `node_modules`, and running npm against
+ * pnpm's symlinked tree is what this ordering exists to prevent.
  */
-export const resolvePackageManager = (): PackageManager =>
-	detectPackageManager() ?? installedPackageManagers()[0] ?? "npm";
+export const resolvePackageManager = (cwd: string): PackageManager =>
+	detectProjectPackageManager(cwd) ??
+	detectPackageManager() ??
+	installedPackageManagers()[0] ??
+	"npm";
 
 /**
  * The argv that adds `packages` as runtime dependencies with `pm`. npm spells it


### PR DESCRIPTION
## Summary

`neon config init`, and the `neon link` prompt that runs it, picked a package manager from `npm_config_user_agent` and then from the first manager on `PATH`. That user agent is empty for a globally installed `neon` and npm is first in `PACKAGE_MANAGERS`, so setting up a pnpm project shelled out to `npm install` — which crashed on pnpm's symlinked `node_modules` with `Cannot read properties of null (reading 'matches')` and left a `neon.ts` whose `@neon/config/v1` import couldn't resolve, failing the env pull after it.

`resolvePackageManager` now takes the target directory and reads its lockfile first, walking parents up to the repo root so a package in a monorepo finds the root lockfile while a stray lockfile above the repository is ignored. Every existing fallback is kept, so a project with no lockfile behaves exactly as before.

Two details worth a reviewer's attention:

- **The project wins over the invocation**, so `npx neon link` inside a pnpm repo still installs with pnpm. Which tool launched us says nothing about which one owns that project's `node_modules`.
- **`installedPackageManagers()[0]` stays in the chain.** The goal is to add a signal, not remove one — dropping it would change behaviour on a machine with no npm on `PATH`.

## Deliberately out of scope

- `bootstrap.ts` still picks from the invocation. It scaffolds a brand-new directory from a template that has no lockfile yet, and it prompts interactively.
- `init/neonctl.ts` keeps its own `detectPackageManager` for **global** installs, where the project's manager is irrelevant.

`config.ts` is the only place in the CLI that installs dependencies into an existing project, so this is the complete fix rather than a first slice.

## Test plan

- [x] `pnpm --filter neon test:ci` — 3887 passed, 6 skipped
- [x] `pnpm lint:ci` and `pnpm --filter neon typecheck`
- [x] Built binary against real fixtures, invoked with plain `node` so `npm_config_user_agent` stays empty and reproduces a globally installed `neon`:
  - pnpm repo -> `pnpm add @neon/config @neon/env`
  - pnpm monorepo, run from `packages/app` -> `pnpm add ...` via the parent walk
  - npm repo -> `npm install ...`, unchanged
  - no lockfile -> `npm install ...` via the existing fallback