### PR TITLE
ci: shard CLI tests across runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,16 +70,24 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare
             - if: matrix.suite == 'cli'
-              run: pnpm --filter neon test:ci --coverage --shard=${{ matrix.shard }}/4
+              run: pnpm --filter neon test:ci --coverage --coverage.reporter=json --shard=${{ matrix.shard }}/4
             - if: matrix.suite == 'cli' && matrix.shard == 4
-              run: pnpm --filter neonctl test:ci --coverage
+              run: pnpm --filter neonctl test:ci --coverage --coverage.reporter=json
             - if: matrix.suite == 'non-cli'
-              run: pnpm --recursive --filter='./packages/**' --filter='!neon' --filter='!neonctl' test:ci --coverage
+              run: pnpm --recursive --filter='./packages/**' --filter='!neon' --filter='!neonctl' test:ci --coverage --coverage.reporter=json
+            - name: Collect coverage
+              run: |
+                  for report in packages/*/coverage/coverage-final.json; do
+                      package_dir=${report#packages/}
+                      package=${package_dir%%/*}
+                      mkdir -p "coverage-upload/$package"
+                      cp "$report" "coverage-upload/$package/coverage-final.json"
+                  done
             - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   if-no-files-found: error
                   name: coverage-${{ matrix.upload }}
-                  path: packages/*/coverage/lcov.info
+                  path: coverage-upload
     coverage:
         name: Coverage
         needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
             - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
               with:
                   fail_ci_if_error: true
+                  slug: neondatabase/neon-pkgs
                   use_oidc: true
 
 name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,24 @@ jobs:
               run: pnpm --filter neonctl test:ci --coverage
             - if: matrix.suite == 'non-cli'
               run: pnpm --recursive --filter='./packages/**' --filter='!neon' --filter='!neonctl' test:ci --coverage
-            - if: always()
-              uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+              with:
+                  if-no-files-found: error
+                  name: coverage-${{ matrix.upload }}
+                  path: packages/*/coverage/lcov.info
+    coverage:
+        name: Coverage
+        needs: test
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+              with:
+                  path: coverage
+                  pattern: coverage-*
+            - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
               with:
                   fail_ci_if_error: true
-                  name: ${{ matrix.upload }}
                   use_oidc: true
 
 name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,31 @@ jobs:
             - uses: ./.github/actions/prepare
             - run: pnpm lint:ci
     test:
-        name: Test
+        name: Test (${{ matrix.name }})
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - name: CLI 1/4
+                      suite: cli
+                      shard: 1
+                      upload: cli-1-of-4
+                    - name: CLI 2/4
+                      suite: cli
+                      shard: 2
+                      upload: cli-2-of-4
+                    - name: CLI 3/4
+                      suite: cli
+                      shard: 3
+                      upload: cli-3-of-4
+                    - name: CLI 4/4
+                      suite: cli
+                      shard: 4
+                      upload: cli-4-of-4
+                    - name: non-CLI packages
+                      suite: non-cli
+                      shard: 0
+                      upload: non-cli
         runs-on:
             group: neondatabase-protected-runner-group
             labels: linux-ubuntu-latest
@@ -45,9 +69,18 @@ jobs:
 
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare
-            - run: pnpm test:ci --coverage
+            - if: matrix.suite == 'cli'
+              run: pnpm --filter neon test:ci --coverage --shard=${{ matrix.shard }}/4
+            - if: matrix.suite == 'cli' && matrix.shard == 4
+              run: pnpm --filter neonctl test:ci --coverage
+            - if: matrix.suite == 'non-cli'
+              run: pnpm --recursive --filter='./packages/**' --filter='!neon' --filter='!neonctl' test:ci --coverage
             - if: always()
               uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+              with:
+                  fail_ci_if_error: true
+                  name: ${{ matrix.upload }}
+                  use_oidc: true
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
               with:
                   path: coverage
                   pattern: coverage-*
-            - uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+            - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
               with:
                   fail_ci_if_error: true
                   use_oidc: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,9 @@ pnpm --filter neon-new test
 pnpm --filter vite-plugin-neon-new test
 ```
 
+See [CONTRIBUTING.md's Testing section](CONTRIBUTING.md#testing) for local test semantics,
+the pull-request CI sharding layout, and the coverage artifact handoff.
+
 #### Live Neon e2e tests
 
 `pnpm test:e2e:live` runs the `@neon/sdk`, `@neon/config`, `@neon/config-runtime`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,8 @@ pnpm --filter @neon/config test:ci
 ```
 
 `neonctl` is the important exception: its tests import `neon/dist/cli.js`, but its `test` script
-does not build `neon`. Build `neon` first when running that suite locally. CI starts from a fresh
-checkout where `pnpm install` has built package dependencies.
+does not build `neon`. Build `neon` first when running that suite locally. CI handles this
+explicitly: shard 4 runs `neon test:ci`, which builds the CLI, before it runs `neonctl test:ci`.
 
 ### Pull request CI
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,6 @@ pnpm --filter @neon/env build
 pnpm --filter @neon/env test:ci
 ```
 
-Workspace packages import each other through their build output (`dist`), not their source, so
-a package's tests see a dependency's **last build** — not the source you just edited. `pnpm test`
-therefore builds the package and its workspace dependencies first (`pnpm --filter <pkg>... build`),
-which is what makes a single-package test run trustworthy after an edit anywhere in the graph.
-`test:ci` skips that: on CI, `pnpm install` runs each package's `prepare` (a build) on a fresh
-checkout, so everything is current already. Run `test:ci` locally only right after a build.
-
 See [`AGENTS.md`](./AGENTS.md) for the deeper architecture and per-package notes (especially the
 CLI package, which keeps its own toolchain).
 
@@ -65,6 +58,50 @@ package's file before changing it:
 | Package | Notes |
 | --- | --- |
 | [`@neon/env`](./packages/env/CONTRIBUTING.md) | Why the credential-reuse half lives in `shared/env-core` rather than on the published surface, and the branch-credential rules |
+
+## Testing
+
+The standard suite uses [Vitest](https://vitest.dev/) and does not call live Neon services:
+
+```bash
+pnpm test:ci                          # every package
+pnpm --filter @neon/config test:ci   # one package
+```
+
+Workspace packages import each other through their build output (`dist`), not their source, so a
+package's tests can see a dependency's last build instead of the source you just edited. Use a
+package's `test` script while developing when it has one: it builds the package and its workspace
+dependencies before running Vitest. `test:ci` skips that dependency build and is intended for a
+fresh CI checkout or a local tree you have just built.
+
+### Pull request CI
+
+The `CI` workflow splits the standard suite into five parallel jobs:
+
+- four Vitest file shards for `neon`, the CLI package
+- one job for every non-CLI package except `neonctl`
+
+`neonctl` runs after CLI shard 4 because its compatibility shim imports the built `neon` CLI.
+The four shards together select every CLI test file exactly once:
+
+```bash
+pnpm --filter neon test:ci \
+  --coverage --coverage.reporter=json --shard=1/4
+
+pnpm --recursive \
+  --filter='./packages/**' --filter='!neon' --filter='!neonctl' \
+  test:ci --coverage --coverage.reporter=json
+```
+
+Replace `1/4` with `2/4`, `3/4`, or `4/4` to reproduce another shard. Vitest shards test
+**files**, not individual tests. A large generated matrix inside one file remains on one
+runner; splitting that file is the way to distribute it further.
+
+The test runners belong to the protected runner group. They can install packages from the
+Databricks mirror but cannot reach Codecov's public verification endpoints. Each job therefore
+emits Istanbul JSON coverage, uploads the package-named reports as a GitHub artifact, and stops
+there. A dependent `Coverage` job on `ubuntu-latest` downloads all five artifacts and performs
+one OIDC-authenticated Codecov upload. Coverage upload errors fail that job.
 
 ## Live Neon e2e tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,10 +69,18 @@ pnpm --filter @neon/config test:ci   # one package
 ```
 
 Workspace packages import each other through their build output (`dist`), not their source, so a
-package's tests can see a dependency's last build instead of the source you just edited. Use a
-package's `test` script while developing when it has one: it builds the package and its workspace
-dependencies before running Vitest. `test:ci` skips that dependency build and is intended for a
-fresh CI checkout or a local tree you have just built.
+package's tests can see a dependency's last build instead of the source you just edited. Some
+packages build their workspace dependencies in `test`; check the package script rather than
+assuming it does. The reliable sequence is:
+
+```bash
+pnpm --filter @neon/config... build
+pnpm --filter @neon/config test:ci
+```
+
+`neonctl` is the important exception: its tests import `neon/dist/cli.js`, but its `test` script
+does not build `neon`. Build `neon` first when running that suite locally. CI starts from a fresh
+checkout where `pnpm install` has built package dependencies.
 
 ### Pull request CI
 


### PR DESCRIPTION
## Problem

The CI test step is the pull-request critical path. A representative run took 14m37s after setup; `packages/cli` accounted for 12m47s while the other package suites completed in roughly one minute.

## Diagnosis

`pnpm --recursive` already runs up to four workspace scripts concurrently, but nearly all remaining time sits inside one Vitest invocation for `neon`: 149 files and 3,962 tests. More workspace concurrency cannot divide that package.

Coverage also cannot upload directly from the protected runner. The existing tokenless Codecov step reported `Token required - not valid tokenless upload` while exiting successfully; enabling OIDC exposed that the runner cannot fetch Codecov's public verification endpoints. The pinned Codecov v5 action reads its signing key from a retired Keybase account, and Codecov's automatic repository lookup fails after this repository's rename from `neondb-cli` to `neon-pkgs`.

## Solution

Run the CLI suite as four Vitest file shards and the remaining packages as a fifth matrix entry. `neonctl` follows shard 4 because its shim imports the built `neon` CLI.

```text
Test (CLI 1/4) ───────────┐
Test (CLI 2/4) ───────────┤
Test (CLI 3/4) ───────────┼─> Coverage (GitHub-hosted runner) ─> Codecov
Test (CLI 4/4 + neonctl) ─┤
Test (non-CLI packages) ──┘
```

Every suite emits Istanbul JSON coverage. Each protected-runner job collects package-named reports into a uniquely named GitHub artifact. A dependent GitHub-hosted job downloads all five artifacts and performs one OIDC-authenticated upload through the SHA-pinned Codecov v7 action with fatal error handling and the current repository slug set explicitly. JSON reports retain absolute source paths, so reports from different packages and CLI shards remain unambiguous after the artifact transfer.

`CONTRIBUTING.md` documents local test semantics, exact shard reproduction commands, the `neonctl` build ordering, the file-level sharding constraint, and the coverage handoff. `AGENTS.md` points agents to that testing section.

The package and test interfaces do not change.

## Verification

- Parsed `.github/workflows/ci.yml` successfully and ran `git diff --check`.
- Ran `pnpm lint:ci`: 619 files passed.
- Ran all four CLI shard commands with coverage. Together they selected all 149 files and 3,962 tests exactly once.
- Ran the exact non-CLI matrix command with coverage: 12 package scripts passed.
- Ran `pnpm --filter neonctl test:ci --coverage --coverage.reporter=json`: 1 file and 4 tests passed against the CLI build.
- Verified JSON coverage output for the CLI, compatibility shim, configured-report packages, and packages with no test files.
- [Current PR CI](https://github.com/neondatabase/neon-pkgs/actions/runs/31312626974) is fully green: all five matrix entries pass, all five coverage artifacts transfer, Codecov verifies its CLI, discovers all 16 JSON reports, and completes the upload.
- Engineering review converged with no findings after the green run.

## For attention

- Vitest shards files, not tests. `src/init/agent_snapshot.test.ts` remains one 281-test file and determines the slowest shard. The latest CI run took 9m54s for shard 3 while the other shards took 2m48s–4m05s. Splitting that file is separate work after this PR.
- Runner availability and shard 3 now determine the final critical path.