### PR TITLE
build(cli): emit `dist` with tsdown instead of `tsc`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,6 @@ jobs:
             - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
             - uses: ./.github/actions/prepare
             - run: pnpm build
-            # `pnpm build` compiles neon via tsconfig.build.json, which
-            # excludes *.test.ts. Type-check the full source (tsconfig.json
-            # includes src/**/*.ts, i.e. tests) so type regressions in cli test
-            # files can't slip through — no other CI job type-checks them.
-            - run: pnpm --filter neon typecheck
     lint:
         name: Lint
         runs-on:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
 		".": "./dist/index.js",
 		"./cli": "./dist/cli.js",
 		"./dist/_shared/*": null,
+		"./dist/_virtual/*": null,
 		"./dist/*": "./dist/*",
 		"./package.json": "./package.json"
 	},
@@ -43,8 +44,8 @@
 		"generateParams": "tsx generateOptionsFromSpec.ts",
 		"codegen": "node ../../scripts/sync-shared.mjs . && node scripts/set-vsx-gallery.mjs",
 		"clean": "rm -rf dist",
-		"build": "pnpm codegen && pnpm generateParams && pnpm clean && tsc -p tsconfig.build.json && cp src/*.html ./dist",
-		"build:internal": "node ../../scripts/sync-shared.mjs . && node scripts/set-vsx-gallery.mjs https://cursor-vsx-proxy.cloud.databricks.com/gallery && pnpm generateParams && pnpm clean && tsc -p tsconfig.build.json && cp src/*.html ./dist",
+		"build": "pnpm codegen && pnpm generateParams && tsc --noEmit && tsdown && cp src/*.html ./dist",
+		"build:internal": "node ../../scripts/sync-shared.mjs . && node scripts/set-vsx-gallery.mjs https://cursor-vsx-proxy.cloud.databricks.com/gallery && pnpm generateParams && tsc --noEmit && tsdown && cp src/*.html ./dist",
 		"bundle": "node pkg.js",
 		"typecheck": "pnpm codegen && tsc --noEmit",
 		"lint": "pnpm codegen && pnpm typecheck && biome check src",
@@ -106,6 +107,7 @@
 		"openapi-types": "12.1.3",
 		"rollup": "3.29.4",
 		"strip-ansi": "7.1.0",
+		"tsdown": "catalog:",
 		"tsx": "4.22.3",
 		"typescript": "catalog:",
 		"vitest": "catalog:"

--- a/packages/cli/src/package_exports.test.ts
+++ b/packages/cli/src/package_exports.test.ts
@@ -19,11 +19,14 @@ const exportMap = (): Record<string, unknown> => {
 };
 
 /**
- * `neon` publishes a `./dist/*` wildcard, so anything `tsc` emits is importable by path. That
+ * `neon` publishes a `./dist/*` wildcard, so every emitted file is importable by path. That
  * is fine for the CLI's own modules and wrong for `src/_shared`, which is source copied in from
  * `shared/` and compiled as ours: `reuse-secrets.js` mints and revokes branch credentials, and
  * `credentials.js` reads them off disk. Removing `@neon/env/runtime` accomplishes nothing if
  * the same function is reachable at `neon/dist/_shared/env-core/reuse-secrets.js`.
+ *
+ * `_virtual` is the same judgement applied to the build tool: tsdown emits rolldown's shared
+ * runtime helpers there, and how we compile is not a surface anyone should import.
  *
  * A `null` target blocks a subpath, and the more specific pattern wins over the wildcard, so
  * `./dist/commands/env.js` still resolves. Verified against Node: the blocked paths answer
@@ -32,6 +35,10 @@ const exportMap = (): Record<string, unknown> => {
 describe("the published export map", () => {
 	it("blocks the shared trees, which are implementation and not ours to publish", () => {
 		expect(exportMap()["./dist/_shared/*"]).toBeNull();
+	});
+
+	it("blocks the bundler's runtime helpers, which are an artifact of how we compile", () => {
+		expect(exportMap()["./dist/_virtual/*"]).toBeNull();
 	});
 
 	it("still exposes the dist wildcard the block is carved out of", () => {

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+	name: "neon",
+	bundle: false,
+	clean: true,
+	// `neon` publishes no declarations: `packages/cli/tsconfig.json` never set
+	// `declaration`, so `tsc` emitted none and `exports["."]` has no `types`.
+	dts: false,
+	// Every non-test source file, so each one keeps emitting to its own path under
+	// `dist/` — `neon` exports a `./dist/*` wildcard, and `src/_shared` is synced-in
+	// source that has to compile as this package's own.
+	entry: ["src/**/*.ts", "!src/**/*.test.ts", "!src/**/*.spec.ts"],
+	format: "esm",
+	outDir: "dist",
+	treeshake: true,
+	// Every bare specifier stays a runtime import, which is what `tsc` emitted. tsdown
+	// externalizes declared runtime dependencies only, so without this `src/test_utils/*`
+	// — which imports vitest, express and emocks — drags those devDependencies and their
+	// transitive graph into `dist/node_modules/`.
+	external: (id) => /^[@a-zA-Z]/.test(id),
+});

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -4,13 +4,15 @@ import { defineConfig } from "tsdown";
  * Whether a specifier is a package import rather than a file in this package.
  *
  * Shape rather than `isResolved`, because rolldown calls `external` for resolved ids too and a
- * resolved absolute path must never be treated as a package: `C:\…` on Windows starts with a
- * letter, and rolldown's virtual modules start with a NUL. `#` is a package's own subpath import,
- * which resolves locally.
+ * resolved absolute path must never be treated as a package. Both Windows forms have to be
+ * rejected on any host, since neither looks absolute to POSIX: a drive letter, and a UNC path.
+ * rolldown's virtual modules start with a NUL, and `#` is a package's own subpath import, which
+ * resolves locally.
  */
 const isPackageImport = (id: string): boolean =>
 	!id.startsWith(".") &&
 	!id.startsWith("/") &&
+	!id.startsWith("\\") &&
 	!id.startsWith("#") &&
 	!id.startsWith("\0") &&
 	!/^[a-zA-Z]:[\\/]/.test(id);

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,5 +1,20 @@
 import { defineConfig } from "tsdown";
 
+/**
+ * Whether a specifier is a package import rather than a file in this package.
+ *
+ * Shape rather than `isResolved`, because rolldown calls `external` for resolved ids too and a
+ * resolved absolute path must never be treated as a package: `C:\…` on Windows starts with a
+ * letter, and rolldown's virtual modules start with a NUL. `#` is a package's own subpath import,
+ * which resolves locally.
+ */
+const isPackageImport = (id: string): boolean =>
+	!id.startsWith(".") &&
+	!id.startsWith("/") &&
+	!id.startsWith("#") &&
+	!id.startsWith("\0") &&
+	!/^[a-zA-Z]:[\\/]/.test(id);
+
 export default defineConfig({
 	name: "neon",
 	bundle: false,
@@ -18,5 +33,5 @@ export default defineConfig({
 	// externalizes declared runtime dependencies only, so without this `src/test_utils/*`
 	// — which imports vitest, express and emocks — drags those devDependencies and their
 	// transitive graph into `dist/node_modules/`.
-	external: (id) => /^[@a-zA-Z]/.test(id),
+	external: isPackageImport,
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,6 +247,9 @@ importers:
       strip-ansi:
         specifier: 7.1.0
         version: 7.1.0
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.14.1(@arethetypeswrong/core@0.18.3)(typescript@5.9.3)
       tsx:
         specifier: 4.22.3
         version: 4.22.3


### PR DESCRIPTION
## Problem

Shared private code between the two CLIs reached them by being copied. `scripts/sync-shared.mjs` copied `shared/cli-core/src` and `shared/env-core/src` into `packages/cli/src/_shared/` and `packages/env/src/_shared/` before either package compiled, so the code was compiled as each consumer's own source.

That existed because neither publisher bundled. `shared/cli-core/README.md` recorded the reason:

> Every package builds with `bundle: false` (tsdown) or plain `tsc`, so a bare specifier survives into `dist` and has to resolve from `node_modules` at runtime. An unpublished package cannot, for anyone who installed `neon` or `@neon/env` from npm.

The standard mechanism — a `"private": true` workspace package in the consumer's `devDependencies`, inlined by a bundler — needs both publishers to be capable of inlining. `neon` was the only package here still on plain `tsc`, and `tsc` cannot inline anything: `paths` mapping [does not change how import paths are emitted](https://www.typescriptlang.org/tsconfig/paths.html).

This PR makes `neon` capable of it and changes nothing else. The shared trees stay exactly as they are; #416 moves them.

## What this does not change

The emitted layout. `entry` lists every non-test source file, so each one still compiles to its own path under `dist/`, and the `./dist/*` wildcard export keeps resolving. Diffing the built output against `tsc`'s — every emitted file, and every bare specifier the emitted JavaScript imports — the only difference is one added file:

```
$ diff <(report tsc-built/dist) <(report tsdown-built/dist)
8a9
> _virtual/_rolldown/runtime.js
```

201 emitted modules at identical paths; identical set of 53 bare specifiers. Nothing changes for anyone installing `neon` or `neonctl`, and no published entry point moves.

Two differences that are **not** real, both confirmed by inspection:

- `tsc` preserves line comments and rolldown strips them, so `// Do NOT "simplify" this back to import('esbuild')` in `src/utils/esbuild.ts` no longer appears in the output. The mechanism that comment protects is intact: `loadEsbuild: (name) => import(name)` with `const name = ["es", "build"].join("")` survives, so `esbuild` is still resolved by a computed specifier and still invisible to the `@yao-pkg/pkg` scanner.
- `config_template.ts` renders an `import ... from "@neon/config/v1"` into the user's generated `neon.ts`. It is a template literal, and its contents are byte-identical.

## The build

```jsonc
// packages/cli/package.json
"build": "pnpm codegen && pnpm generateParams && tsc --noEmit && tsdown && cp src/*.html ./dist"
```

```ts
// packages/cli/tsdown.config.ts
export default defineConfig({
	name: "neon",
	bundle: false,
	dts: false,
	entry: ["src/**/*.ts", "!src/**/*.test.ts", "!src/**/*.spec.ts"],
	format: "esm",
	outDir: "dist",
	external: isPackageImport,
});
```

`external` is load-bearing rather than defensive. tsdown externalizes declared runtime dependencies only, so without it `src/test_utils/fixtures.ts` and `src/test_utils/oauth_server.ts` — which import `vitest`, `express`, `emocks` and `oauth2-mock-server` — pull those devDependencies and their transitive graph in. The first build produced 504 files and a `dist/node_modules/.pnpm/...` tree; with the predicate it produces 202.

It tests the specifier's **shape**, not its first character, because rolldown calls `external` for resolved ids as well as raw specifiers:

```ts
const isPackageImport = (id: string): boolean =>
	!id.startsWith(".") &&
	!id.startsWith("/") &&
	!id.startsWith("\\") &&
	!id.startsWith("#") &&
	!id.startsWith("\0") &&
	!/^[a-zA-Z]:[\\/]/.test(id);
```

A resolved absolute path must never be treated as a package, and both Windows forms have to be rejected on any host because neither looks absolute to POSIX: a drive letter, `C:\…`, and a UNC path, `\\server\share\…`. rolldown's virtual modules start with a NUL. `#` is a package's own subpath import and resolves locally. Any of these marked external would survive into `dist` as an unresolvable import. On this platform the emitted output is the same either way, because every file the CLI imports is also an entry.

`dts: false` matches what shipped: `packages/cli/tsconfig.json` does not extend `tsconfig.base.json` and never set `declaration`, so `tsc` emitted no `.d.ts` and `exports["."]` has no `types` field.

## Also in here

- **`"./dist/_virtual/*": null` in `exports`,** pinned by `src/package_exports.test.ts`. rolldown emits its shared runtime helpers there. It is the same judgement already applied to `./dist/_shared/*`: how we compile is not a surface to publish, and the `./dist/*` wildcard would otherwise expose it.
- **The separate `pnpm --filter neon typecheck` step is removed from CI.** It existed because `pnpm build` ran `tsc -p tsconfig.build.json`, which excludes `*.test.ts`. The build now runs `tsc --noEmit` against `tsconfig.json`, which includes `src/**/*.ts` and `e2e/`, so the step ran the same check twice.
- **`pnpm clean` is dropped from `build` and `build:internal`.** tsdown's `clean: true` does it, matching every other package. The `clean` script itself stays.
- **`tsdown` added to `packages/cli` devDependencies** (`catalog:`), and the lockfile with it.

No changeset: no published interface changes, so there is nothing a consumer would read in a changelog.

## Verification

Against `3cb16e1`, on Node 22, with the tsdown pinned in the catalog (0.14.1 / rolldown 1.2.1):

- `pnpm --filter neon test:ci` — 3957 passed, 6 skipped across 149 files
- `pnpm build` — all 13 packages
- `pnpm lint:ci` — 620 files, clean
- `dist` fingerprint diffed against the `tsc` build, as above
- `node dist/cli.js --version` → `2.47.0`; `--help` renders the full command tree
- the shebang survives: `dist/cli.js` starts `#!/usr/bin/env node`
- `import("./dist/commands/env.js")` resolves, so the `./dist/*` wildcard still works on a real subpath
- `pnpm --filter neon bundle` — all four `@yao-pkg/pkg` targets built (`linux-x64`, `linux-arm64`, `macos-x64`, `win-x64`), and `./bundle/neon-macos-x64 --version` prints `2.47.0`. `pkg.js` rollups `dist/cli.js`, so it consumes whatever produced it; the pre-existing "Failed to make bytecode" warnings for ESM dependencies are unchanged.

Not verified: the OAuth callback flow end to end. `src/auth.ts` reads `callback.html` via `new URL(".", import.meta.url)`, which depends on `dist/auth.js` staying at that depth — it does, and the file is present, but the browser round trip was not exercised. The live e2e suites (`test:e2e:live`) and psql conformance were not run; the conformance workflow's path filter does not select this branch, so it needs a manual run.

## For your attention

- **`src/test_utils/*` ships in the published `neon` tarball today** — `dist/test_utils/fixtures.js` and `dist/test_utils/oauth_server.js`, importing `vitest` and `express`, which cannot resolve for anyone installing from npm. `tsconfig.build.json` excludes only `*.test.ts`. Pre-existing, unchanged here, and the reason `external` is a predicate rather than a list. Excluding them would change what the tarball contains, which is its own concern.
- **This PR takes on build-tool risk before the payoff.** It is the prerequisite for #416; on its own it buys consistency with the other 12 packages. Split this way so a regression in "the compiler changed" is bisectable separately from "shared code became a package".
- **A failed `tsc --noEmit` now aborts before tsdown cleans `dist`,** where `pnpm clean` used to wipe it first. A stale `dist` therefore survives a failed build and a later `pnpm bundle` could package it. Publishing still stops, because it runs the build.
- **The `bundle` option warns as deprecated** in favour of `unbundle`, on all 13 configs now. Renaming them is a separate pass.
