### PR TITLE
Add exact variable selection to neon env pull

### DIFF
--- a/.changeset/select-env-vars.md
+++ b/.changeset/select-env-vars.md
@@ -3,4 +3,4 @@
 "@neon/env": patch
 ---
 
-Add exact environment-variable selection to `neon env pull` and scope `fetchEnv({ keys })` credential issuance to the selected variables.
+Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly; runtime-built lists now return safely optional fields.

--- a/.changeset/select-env-vars.md
+++ b/.changeset/select-env-vars.md
@@ -3,4 +3,4 @@
 "@neon/env": patch
 ---
 
-Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly, runtime-built lists return safely optional fields, and storage credential halves must be selected together.
+Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly, runtime-built lists return safely optional fields, and storage credential halves must be selected together. Pre-bound untyped key arrays that previously fell through to the full-env overload now fail type checking instead of promising unselected values.

--- a/.changeset/select-env-vars.md
+++ b/.changeset/select-env-vars.md
@@ -3,4 +3,4 @@
 "@neon/env": patch
 ---
 
-Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly; runtime-built lists now return safely optional fields.
+Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly, runtime-built lists return safely optional fields, and storage credential halves must be selected together.

--- a/.changeset/select-env-vars.md
+++ b/.changeset/select-env-vars.md
@@ -1,5 +1,6 @@
 ---
 "neon": patch
+"@neon/env": patch
 ---
 
-Add `neon env pull -e, --env` to pull exact environment variables, alone or unioned with `--service`.
+Add exact environment-variable selection to `neon env pull` and scope `fetchEnv({ keys })` credential issuance to the selected variables.

--- a/.changeset/select-env-vars.md
+++ b/.changeset/select-env-vars.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+Add `neon env pull -e, --env` to pull exact environment variables, alone or unioned with `--service`.

--- a/internals/env-core/src/env.ts
+++ b/internals/env-core/src/env.ts
@@ -419,6 +419,10 @@ export type SelectedNeonEnv<Keys extends readonly string[]> =
 
 type StorageCredentialEnvKey = "AWS_ACCESS_KEY_ID" | "AWS_SECRET_ACCESS_KEY";
 
+type StorageKeyPairError = {
+	readonly "fetchEnv keys must include AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY together": never;
+};
+
 type TupleDefinitelyContains<
 	Keys extends readonly string[],
 	Key extends string,
@@ -457,7 +461,7 @@ type StorageKeyPairConstraint<Keys extends readonly string[]> = [
 	InvalidStorageKeyTuple<Keys>,
 ] extends [never]
 	? unknown
-	: never;
+	: StorageKeyPairError;
 
 type FetchEnvKeysFromArgs<Args extends readonly unknown[]> = Args[0] extends {
 	keys: infer Keys extends readonly string[];
@@ -475,7 +479,7 @@ type StorageKeyUnionConstraint<K extends string> = [
 	? unknown
 	: StorageCredentialEnvKey extends K
 		? unknown
-		: never;
+		: StorageKeyPairError;
 
 export interface FetchEnvOptions {
 	/**
@@ -601,6 +605,14 @@ export async function fetchEnv<const C extends Config>(
 	config: C,
 	options: FetchEnvOptions & { keys?: never },
 ): Promise<NeonEnv<C>>;
+/** Diagnostic-only fallback: valid keyed calls resolve through the exact overload above. */
+export async function fetchEnv<
+	const C extends Config,
+	const Keys extends readonly SelectableEnvKey<C>[],
+>(
+	config: C,
+	options: FetchEnvOptions & { keys: Keys } & StorageKeyPairError,
+): Promise<never>;
 export async function fetchEnv(
 	config: Config,
 	options: FetchEnvOptions & { keys?: readonly string[] },

--- a/internals/env-core/src/env.ts
+++ b/internals/env-core/src/env.ts
@@ -482,6 +482,14 @@ export async function fetchEnv(
 	return fetchEnvKeys(config, options, options.keys ?? null);
 }
 
+/** Fail loudly when selected-key dependency planning and execution disagree. */
+function requiredValue<T>(value: T | null, description: string): T {
+	if (value === null) {
+		throw new Error(`fetchEnv: missing ${description}.`);
+	}
+	return value;
+}
+
 /**
  * The {@link fetchEnv} body, with the key selection as a plain argument and no generic
  * narrowing. Exists for callers that compute the selection at runtime — notably
@@ -505,55 +513,86 @@ export async function fetchEnvKeys(
 		selection === null || selection.has(key);
 
 	const result: ResolvedNeonEnv = {};
-	const [roles, databases] = await Promise.all([
-		api.listBranchRoles(projectId, branch.id),
-		api.listBranchDatabases(projectId, branch.id),
-	]);
-
-	const roleName = pickRoleName(roles, branch, options.roleName);
-	const databaseName = pickDatabaseName(
-		databases,
-		branch,
-		options.databaseName,
-	);
-
-	// Fan out: always fetch both Postgres URIs — the direct one also derives the AI Gateway
-	// host, so a selection that drops `DATABASE_URL_UNPOOLED` still needs it. Conditionally
-	// fetch auth + dataApi based on the branch policy and the selection. Auth key fields are
-	// only returned at integration creation time; for Better Auth they may legitimately be
-	// empty, so they can come back as empty strings.
 	const K = NEON_ENV_VAR_KEYS;
+	const wantsPooled = wants(K.postgres.databaseUrl);
+	const wantsUnpooled = wants(K.postgres.databaseUrlUnpooled);
 	const wantsAuth =
 		desired.authEnabled && (wants(K.auth.baseUrl) || wants(K.auth.jwksUrl));
 	const wantsDataApi = desired.dataApiEnabled && wants(K.dataApi.url);
+	const gatewayEnabled = desired.preview?.aiGatewayEnabled ?? false;
+	const needsUnpooled =
+		wantsUnpooled || (gatewayEnabled && wants(K.aiGateway.baseUrl));
+	const needsConnectionTarget = wantsPooled || needsUnpooled;
+	const needsDatabase = needsConnectionTarget || wantsDataApi;
+	const [roles, databases] = await Promise.all([
+		needsConnectionTarget
+			? api.listBranchRoles(projectId, branch.id)
+			: Promise.resolve([]),
+		needsDatabase
+			? api.listBranchDatabases(projectId, branch.id)
+			: Promise.resolve([]),
+	]);
 
+	const databaseName = needsDatabase
+		? pickDatabaseName(databases, branch, options.databaseName)
+		: null;
+	const connectionTarget = needsConnectionTarget
+		? {
+				roleName: pickRoleName(roles, branch, options.roleName),
+				databaseName: requiredValue(
+					databaseName,
+					"database for a selected connection URI",
+				),
+			}
+		: null;
+	const getConnectionUri = (pooled: boolean) => {
+		const target = requiredValue(
+			connectionTarget,
+			"role and database for a selected connection URI",
+		);
+		return api.getConnectionUri(projectId, {
+			branchId: branch.id,
+			...target,
+			pooled,
+		});
+	};
+
+	// Fetch only what the selected keys depend on. The direct Postgres URI also derives the
+	// AI Gateway host, while Auth, storage, branch identity, and gateway tokens need no
+	// Postgres metadata. Auth key fields are only returned at integration creation time; for
+	// Better Auth they may legitimately be empty, so they can come back as empty strings.
 	const [pooled, unpooled, authSnapshot, dataApiSnapshot] = await Promise.all(
 		[
-			api.getConnectionUri(projectId, {
-				branchId: branch.id,
-				databaseName,
-				roleName,
-				pooled: true,
-			}),
-			api.getConnectionUri(projectId, {
-				branchId: branch.id,
-				databaseName,
-				roleName,
-				pooled: false,
-			}),
+			wantsPooled ? getConnectionUri(true) : Promise.resolve(null),
+			needsUnpooled ? getConnectionUri(false) : Promise.resolve(null),
 			wantsAuth
 				? api.getNeonAuth(projectId, branch.id)
 				: Promise.resolve(null),
 			wantsDataApi
-				? api.getNeonDataApi(projectId, branch.id, databaseName)
+				? api.getNeonDataApi(
+						projectId,
+						branch.id,
+						requiredValue(
+							databaseName,
+							"database for the selected Data API URL",
+						),
+					)
 				: Promise.resolve(null),
 		],
 	);
 
 	const postgres: Partial<NeonPostgresEnv> = {};
-	if (wants(K.postgres.databaseUrl)) postgres.databaseUrl = pooled.uri;
-	if (wants(K.postgres.databaseUrlUnpooled)) {
-		postgres.databaseUrlUnpooled = unpooled.uri;
+	if (wantsPooled) {
+		postgres.databaseUrl = requiredValue(
+			pooled,
+			"pooled connection URI response",
+		).uri;
+	}
+	if (wantsUnpooled) {
+		postgres.databaseUrlUnpooled = requiredValue(
+			unpooled,
+			"direct connection URI response",
+		).uri;
 	}
 	if (Object.keys(postgres).length > 0) result.postgres = postgres;
 
@@ -585,17 +624,21 @@ export async function fetchEnvKeys(
 
 	if (wantsDataApi) {
 		if (!dataApiSnapshot) {
+			const selectedDatabase = requiredValue(
+				databaseName,
+				"database for the selected Data API URL",
+			);
 			throw new PlatformError(
 				ErrorCode.NotFound,
 				[
-					`fetchEnv: branch policy enables dataApi but no Data API integration is enabled on branch ${branch.name} (${branch.id}) database ${databaseName}.`,
+					`fetchEnv: branch policy enables dataApi but no Data API integration is enabled on branch ${branch.name} (${branch.id}) database ${selectedDatabase}.`,
 					"Enable it via `apply(config, { projectId, branchId })` or in the Neon Console — then re-run fetchEnv. Or return dataApi.enabled=false.",
 				].join(" "),
 				{
 					details: {
 						projectId,
 						branchId: branch.id,
-						databaseName,
+						databaseName: selectedDatabase,
 					},
 				},
 			);
@@ -609,7 +652,6 @@ export async function fetchEnvKeys(
 	// never touches the credentials/storage endpoints (and keeps working on production, where
 	// they may not exist yet).
 	const storageEnabled = (desired.preview?.buckets.length ?? 0) > 0;
-	const gatewayEnabled = desired.preview?.aiGatewayEnabled ?? false;
 	const wantsStorage =
 		storageEnabled &&
 		(wants(K.storage.accessKeyId) ||
@@ -683,7 +725,13 @@ export async function fetchEnvKeys(
 				// Bare branch-scoped gateway host derived from the branch's connection URI —
 				// not the control-plane API origin (which doesn't serve the gateway). Clients
 				// append the dialect route (/v1, /openai/v1, /anthropic/v1) themselves.
-				gateway.baseUrl = aiGatewayBaseUrl(branch.id, unpooled.uri);
+				gateway.baseUrl = aiGatewayBaseUrl(
+					branch.id,
+					requiredValue(
+						unpooled,
+						"direct connection URI for the selected AI Gateway base URL",
+					).uri,
+				);
 			}
 			result.aiGateway = gateway;
 		}

--- a/internals/env-core/src/env.ts
+++ b/internals/env-core/src/env.ts
@@ -423,14 +423,31 @@ type StorageCredentialEnvKey = "AWS_ACCESS_KEY_ID" | "AWS_SECRET_ACCESS_KEY";
  * Reject a fixed key tuple that contains only one half of the storage credential. Dynamic
  * arrays are checked at runtime because their contents are not known to TypeScript.
  */
-type StorageKeyPairConstraint<Keys extends readonly string[]> =
-	number extends Keys["length"]
-		? unknown
-		: [Extract<Keys[number], StorageCredentialEnvKey>] extends [never]
-			? unknown
-			: StorageCredentialEnvKey extends Keys[number]
-				? unknown
-				: never;
+type InvalidStorageKeyTuple<Keys extends readonly string[]> =
+	Keys extends unknown
+		? number extends Keys["length"]
+			? never
+			: [Extract<Keys[number], StorageCredentialEnvKey>] extends [never]
+				? never
+				: StorageCredentialEnvKey extends Keys[number]
+					? never
+					: Keys
+		: never;
+
+type StorageKeyPairConstraint<Keys extends readonly string[]> = [
+	InvalidStorageKeyTuple<Keys>,
+] extends [never]
+	? unknown
+	: never;
+
+type FetchEnvKeysFromArgs<Args extends readonly unknown[]> = Args[0] extends {
+	keys: infer Keys extends readonly string[];
+}
+	? Keys
+	: never;
+
+type StorageKeyPairArgsConstraint<Args extends readonly unknown[]> =
+	StorageKeyPairConstraint<FetchEnvKeysFromArgs<Args>>;
 
 /** Preserve the same pair rule for callers that explicitly provide the legacy `K` generic. */
 type StorageKeyUnionConstraint<K extends string> = [
@@ -524,42 +541,46 @@ export interface FetchEnvOptions {
  */
 export async function fetchEnv<
 	const C extends Config,
-	const Keys extends readonly SelectableEnvKey<C>[],
+	const Args extends readonly [
+		options: FetchEnvOptions & {
+			/**
+			 * Fetch only these OS-level env vars, instead of everything the policy enables. The
+			 * keys autocomplete from the policy ({@link SelectableEnvKey}), and the result is
+			 * narrowed to match ({@link SelectedNeonEnv}). Inline literal arrays produce an exact
+			 * result; runtime-built arrays make their possible namespaces and properties optional.
+			 * `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be selected together.
+			 *
+			 * The point is not just a smaller result: **work is skipped too.** Leave out
+			 * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `NEON_AI_GATEWAY_TOKEN` and no branch
+			 * credential is minted at all, so a caller that already holds valid secrets can refresh
+			 * everything else without issuing a new one. The non-secret vars of the same features
+			 * (`AWS_ENDPOINT_URL_S3`, `AWS_REGION`, `NEON_AI_GATEWAY_BASE_URL`) are not
+			 * credential-backed and stay available on their own.
+			 *
+			 * The selection **intersects** with the policy rather than overriding it: naming a var
+			 * the branch policy does not enable is not an error, it simply yields nothing.
+			 */
+			keys: readonly SelectableEnvKey<C>[];
+		},
+	],
 >(
 	config: C,
-	options: FetchEnvOptions & {
-		/**
-		 * Fetch only these OS-level env vars, instead of everything the policy enables. The
-		 * keys autocomplete from the policy ({@link SelectableEnvKey}), and the result is
-		 * narrowed to match ({@link SelectedNeonEnv}). Inline literal arrays produce an exact
-		 * result; runtime-built arrays make their possible namespaces and properties optional.
-		 * `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be selected together.
-		 *
-		 * The point is not just a smaller result: **work is skipped too.** Leave out
-		 * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `NEON_AI_GATEWAY_TOKEN` and no branch
-		 * credential is minted at all, so a caller that already holds valid secrets can refresh
-		 * everything else without issuing a new one. The non-secret vars of the same features
-		 * (`AWS_ENDPOINT_URL_S3`, `AWS_REGION`, `NEON_AI_GATEWAY_BASE_URL`) are not
-		 * credential-backed and stay available on their own.
-		 *
-		 * The selection **intersects** with the policy rather than overriding it: naming a var
-		 * the branch policy does not enable is not an error, it simply yields nothing.
-		 */
-		keys: Keys & StorageKeyPairConstraint<Keys>;
-	},
-): Promise<SelectedNeonEnv<Keys>>;
+	...args: Args & StorageKeyPairArgsConstraint<NoInfer<Args>>
+): Promise<SelectedNeonEnv<FetchEnvKeysFromArgs<NoInfer<Args>>>>;
 export async function fetchEnv<
 	const C extends Config,
-	const K extends SelectableEnvKey<C>,
+	const K extends SelectableEnvKey<C> = never,
 >(
 	config: C,
-	options: FetchEnvOptions & {
-		keys: readonly K[] & StorageKeyUnionConstraint<K>;
-	},
-): Promise<FilteredNeonEnv<K>>;
+	options: [NoInfer<K>] extends [never]
+		? never
+		: FetchEnvOptions & {
+				keys: readonly NoInfer<K>[];
+			} & StorageKeyUnionConstraint<NoInfer<K>>,
+): Promise<FilteredNeonEnv<NoInfer<K>>>;
 export async function fetchEnv<const C extends Config>(
 	config: C,
-	options: FetchEnvOptions,
+	options: FetchEnvOptions & { keys?: never },
 ): Promise<NeonEnv<C>>;
 export async function fetchEnv(
 	config: Config,

--- a/internals/env-core/src/env.ts
+++ b/internals/env-core/src/env.ts
@@ -366,6 +366,57 @@ export type FilteredNeonEnv<K extends string> = {
 	};
 };
 
+/**
+ * A filtered result when the exact runtime contents of a key array are unknown. Both the
+ * namespace and its selected properties are optional because the array may omit any member of
+ * its element union, or be empty.
+ */
+type OptionalFilteredNeonEnv<K extends string> = {
+	[N in keyof EnvKeysByNamespace as [
+		Extract<K, EnvKeysByNamespace[N]>,
+	] extends [never]
+		? never
+		: N]?: {
+		[P in Extract<K, EnvKeysByNamespace[N]> as EnvKeyToProp[P &
+			keyof EnvKeyToProp]]?: NamespaceEnv[N][EnvKeyToProp[P &
+			keyof EnvKeyToProp] &
+			keyof NamespaceEnv[N]];
+	};
+};
+
+/** Whether `T` is a union rather than one concrete type. */
+type IsUnion<T, Whole = T> = T extends Whole
+	? [Whole] extends [T]
+		? false
+		: true
+	: never;
+
+/** Whether any fixed tuple position can hold more than one key at runtime. */
+type TupleHasUnion<T extends readonly unknown[]> = T extends readonly []
+	? false
+	: T extends readonly [infer Head, ...infer Tail extends readonly unknown[]]
+		? true extends IsUnion<Head>
+			? true
+			: TupleHasUnion<Tail>
+		: true;
+
+/**
+ * The sound result of selecting an array of OS-level env-var keys.
+ *
+ * Inline literal tuples remain exact. Widened arrays, rest tuples, and tuple positions whose
+ * value is a union are conservative because their runtime contents may be any subset of the
+ * element type. The leading conditional distributes unions of whole literal tuples, preserving
+ * each exact alternative.
+ */
+export type SelectedNeonEnv<Keys extends readonly string[]> =
+	Keys extends readonly string[]
+		? number extends Keys["length"]
+			? OptionalFilteredNeonEnv<Keys[number]>
+			: TupleHasUnion<Keys> extends true
+				? OptionalFilteredNeonEnv<Keys[number]>
+				: FilteredNeonEnv<Keys[number]>
+		: never;
+
 export interface FetchEnvOptions {
 	/**
 	 * Neon project id. **Required** — the management API addresses branches through their
@@ -449,14 +500,16 @@ export interface FetchEnvOptions {
  */
 export async function fetchEnv<
 	const C extends Config,
-	const K extends SelectableEnvKey<C>,
+	K extends SelectableEnvKey<C>,
+	const Keys extends readonly K[] = readonly K[],
 >(
 	config: C,
 	options: FetchEnvOptions & {
 		/**
 		 * Fetch only these OS-level env vars, instead of everything the policy enables. The
 		 * keys autocomplete from the policy ({@link SelectableEnvKey}), and the result is
-		 * narrowed to match ({@link FilteredNeonEnv}).
+		 * narrowed to match ({@link SelectedNeonEnv}). Inline literal arrays produce an exact
+		 * result; runtime-built arrays make their possible namespaces and properties optional.
 		 *
 		 * The point is not just a smaller result: **work is skipped too.** Leave out
 		 * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `NEON_AI_GATEWAY_TOKEN` and no branch
@@ -468,9 +521,9 @@ export async function fetchEnv<
 		 * The selection **intersects** with the policy rather than overriding it: naming a var
 		 * the branch policy does not enable is not an error, it simply yields nothing.
 		 */
-		keys: readonly K[];
+		keys: Keys;
 	},
-): Promise<FilteredNeonEnv<K>>;
+): Promise<SelectedNeonEnv<Keys>>;
 export async function fetchEnv<const C extends Config>(
 	config: C,
 	options: FetchEnvOptions,

--- a/internals/env-core/src/env.ts
+++ b/internals/env-core/src/env.ts
@@ -622,11 +622,11 @@ export async function fetchEnvKeys(
 	// A credential is minted only for its *secrets*. The endpoint, region and gateway host
 	// are plain branch metadata, so selecting only those touches no credential at all — which
 	// is how a caller holding valid secrets refreshes the rest without issuing a new one.
-	const wantsCredential =
-		(storageEnabled &&
-			(wants(K.storage.accessKeyId) ||
-				wants(K.storage.secretAccessKey))) ||
-		(gatewayEnabled && wants(K.aiGateway.apiKey));
+	const wantsStorageCredential =
+		storageEnabled &&
+		(wants(K.storage.accessKeyId) || wants(K.storage.secretAccessKey));
+	const wantsGatewayCredential = gatewayEnabled && wants(K.aiGateway.apiKey);
+	const wantsCredential = wantsStorageCredential || wantsGatewayCredential;
 
 	if (wantsStorage || wantsGateway) {
 		// Read the branch's storage settings *before* minting: a policy that declares buckets
@@ -653,7 +653,10 @@ export async function fetchEnvKeys(
 					projectId,
 					branchId: branch.id,
 					branchName: branch.name,
-					scopes: previewCredentialScopes(desired.preview),
+					scopes: previewCredentialScopes(desired.preview, {
+						storage: wantsStorageCredential,
+						aiGateway: wantsGatewayCredential,
+					}),
 				})
 			: null;
 
@@ -740,18 +743,17 @@ export async function resolveBranchPolicy(
 }
 
 /**
- * Scopes the branch credential should carry for a resolved branch policy. Only object storage
- * and the AI Gateway *require* a credential; functions never force one (they have no credential
- * of their own), but `functions:invoke` is added to the scope set when a credential is already
- * being minted for storage / the AI Gateway, so the one credential can invoke the branch's
- * functions too. Returns `[]` only when nothing credential-bearing is enabled.
+ * Scopes the branch credential should carry for a resolved branch policy and optional key
+ * selection. Only object storage and the AI Gateway *require* a credential; functions never
+ * force one, but `functions:invoke` rides along when another selected feature mints one.
  */
 export function previewCredentialScopes(
 	preview: ResolvedPreviewConfig | undefined,
+	selected?: { storage: boolean; aiGateway: boolean },
 ): CredentialScope[] {
 	if (!preview) return [];
-	const storage = preview.buckets.length > 0;
-	const aiGateway = preview.aiGatewayEnabled;
+	const storage = preview.buckets.length > 0 && (selected?.storage ?? true);
+	const aiGateway = preview.aiGatewayEnabled && (selected?.aiGateway ?? true);
 	if (!storage && !aiGateway) return [];
 	return deriveCredentialScopes({
 		storage,

--- a/internals/env-core/src/env.ts
+++ b/internals/env-core/src/env.ts
@@ -417,6 +417,30 @@ export type SelectedNeonEnv<Keys extends readonly string[]> =
 				: FilteredNeonEnv<Keys[number]>
 		: never;
 
+type StorageCredentialEnvKey = "AWS_ACCESS_KEY_ID" | "AWS_SECRET_ACCESS_KEY";
+
+/**
+ * Reject a fixed key tuple that contains only one half of the storage credential. Dynamic
+ * arrays are checked at runtime because their contents are not known to TypeScript.
+ */
+type StorageKeyPairConstraint<Keys extends readonly string[]> =
+	number extends Keys["length"]
+		? unknown
+		: [Extract<Keys[number], StorageCredentialEnvKey>] extends [never]
+			? unknown
+			: StorageCredentialEnvKey extends Keys[number]
+				? unknown
+				: never;
+
+/** Preserve the same pair rule for callers that explicitly provide the legacy `K` generic. */
+type StorageKeyUnionConstraint<K extends string> = [
+	Extract<K, StorageCredentialEnvKey>,
+] extends [never]
+	? unknown
+	: StorageCredentialEnvKey extends K
+		? unknown
+		: never;
+
 export interface FetchEnvOptions {
 	/**
 	 * Neon project id. **Required** — the management API addresses branches through their
@@ -500,8 +524,7 @@ export interface FetchEnvOptions {
  */
 export async function fetchEnv<
 	const C extends Config,
-	K extends SelectableEnvKey<C>,
-	const Keys extends readonly K[] = readonly K[],
+	const Keys extends readonly SelectableEnvKey<C>[],
 >(
 	config: C,
 	options: FetchEnvOptions & {
@@ -510,6 +533,7 @@ export async function fetchEnv<
 		 * keys autocomplete from the policy ({@link SelectableEnvKey}), and the result is
 		 * narrowed to match ({@link SelectedNeonEnv}). Inline literal arrays produce an exact
 		 * result; runtime-built arrays make their possible namespaces and properties optional.
+		 * `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be selected together.
 		 *
 		 * The point is not just a smaller result: **work is skipped too.** Leave out
 		 * `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `NEON_AI_GATEWAY_TOKEN` and no branch
@@ -521,9 +545,18 @@ export async function fetchEnv<
 		 * The selection **intersects** with the policy rather than overriding it: naming a var
 		 * the branch policy does not enable is not an error, it simply yields nothing.
 		 */
-		keys: Keys;
+		keys: Keys & StorageKeyPairConstraint<Keys>;
 	},
 ): Promise<SelectedNeonEnv<Keys>>;
+export async function fetchEnv<
+	const C extends Config,
+	const K extends SelectableEnvKey<C>,
+>(
+	config: C,
+	options: FetchEnvOptions & {
+		keys: readonly K[] & StorageKeyUnionConstraint<K>;
+	},
+): Promise<FilteredNeonEnv<K>>;
 export async function fetchEnv<const C extends Config>(
 	config: C,
 	options: FetchEnvOptions,
@@ -532,7 +565,19 @@ export async function fetchEnv(
 	config: Config,
 	options: FetchEnvOptions & { keys?: readonly string[] },
 ): Promise<unknown> {
+	if (options.keys) assertStorageCredentialKeyPair(options.keys);
 	return fetchEnvKeys(config, options, options.keys ?? null);
+}
+
+function assertStorageCredentialKeyPair(keys: readonly string[]): void {
+	const hasAccessKey = keys.includes(NEON_ENV_VAR_KEYS.storage.accessKeyId);
+	const hasSecretKey = keys.includes(
+		NEON_ENV_VAR_KEYS.storage.secretAccessKey,
+	);
+	if (hasAccessKey === hasSecretKey) return;
+	throw new TypeError(
+		"fetchEnv: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be selected together. Pass both in `keys`, or omit both.",
+	);
 }
 
 /** Fail loudly when selected-key dependency planning and execution disagree. */

--- a/internals/env-core/src/env.ts
+++ b/internals/env-core/src/env.ts
@@ -419,6 +419,25 @@ export type SelectedNeonEnv<Keys extends readonly string[]> =
 
 type StorageCredentialEnvKey = "AWS_ACCESS_KEY_ID" | "AWS_SECRET_ACCESS_KEY";
 
+type TupleDefinitelyContains<
+	Keys extends readonly string[],
+	Key extends string,
+> = Keys extends readonly [
+	infer Head extends string,
+	...infer Tail extends readonly string[],
+]
+	? [Head] extends [Key]
+		? true
+		: TupleDefinitelyContains<Tail, Key>
+	: false;
+
+type TupleDefinitelyContainsStoragePair<Keys extends readonly string[]> =
+	TupleDefinitelyContains<Keys, "AWS_ACCESS_KEY_ID"> extends true
+		? TupleDefinitelyContains<Keys, "AWS_SECRET_ACCESS_KEY"> extends true
+			? true
+			: false
+		: false;
+
 /**
  * Reject a fixed key tuple that contains only one half of the storage credential. Dynamic
  * arrays are checked at runtime because their contents are not known to TypeScript.
@@ -429,7 +448,7 @@ type InvalidStorageKeyTuple<Keys extends readonly string[]> =
 			? never
 			: [Extract<Keys[number], StorageCredentialEnvKey>] extends [never]
 				? never
-				: StorageCredentialEnvKey extends Keys[number]
+				: TupleDefinitelyContainsStoragePair<Keys> extends true
 					? never
 					: Keys
 		: never;

--- a/internals/env-core/src/reuse-secrets.ts
+++ b/internals/env-core/src/reuse-secrets.ts
@@ -170,18 +170,21 @@ export async function fetchEnvReusingSecrets<const C extends Config>(
 	}
 
 	const persisted = readPersistedSecrets(source);
+	const storageCredentialManaged =
+		requested === null || storageCredentialSelected;
+	const gatewayCredentialManaged =
+		requested === null || gatewayCredentialSelected;
 	const complete =
 		(!storageCredentialSelected ||
 			Boolean(persisted.accessKeyId && persisted.secretAccessKey)) &&
 		(!gatewayCredentialSelected || Boolean(persisted.apiToken));
 
-	// Look the persisted secrets up whenever there are any — not only when they're complete.
-	// An incomplete set still names the credential a newly-enabled feature is about to
-	// supersede (a storage-only credential on a branch that just gained the AI Gateway), and
-	// that one should be revoked rather than left live.
+	// An unscoped pull replaces the branch's complete env, so persisted secrets from a feature
+	// the policy just disabled still name a credential the replacement supersedes. An explicit
+	// key selection manages only the selected credential halves.
 	const named =
-		(storageCredentialSelected && persisted.accessKeyId !== "") ||
-		(gatewayCredentialSelected && persisted.apiToken !== "")
+		(storageCredentialManaged && persisted.accessKeyId !== "") ||
+		(gatewayCredentialManaged && persisted.apiToken !== "")
 			? namedCredentials(
 					await api.listCredentials(options.projectId, branch.id),
 					persisted,
@@ -241,8 +244,8 @@ export async function fetchEnvReusingSecrets<const C extends Config>(
 	// Revoked *after* the fetch, so a failed fetch leaves the caller's existing secrets working.
 	const ours = new Set<string>();
 	for (const meta of [
-		storageCredentialSelected ? named.storage : null,
-		gatewayCredentialSelected ? named.gateway : null,
+		storageCredentialManaged ? named.storage : null,
+		gatewayCredentialManaged ? named.gateway : null,
 	]) {
 		if (
 			meta !== null &&

--- a/internals/env-core/src/reuse-secrets.ts
+++ b/internals/env-core/src/reuse-secrets.ts
@@ -103,6 +103,11 @@ export async function fetchEnvReusingSecrets<const C extends Config>(
 		 */
 		env?: NodeJS.ProcessEnv;
 		/**
+		 * Resolve only these OS-level env vars. Omit for every key the policy enables.
+		 * Credential verification and minting are scoped to this same selection.
+		 */
+		keys?: readonly string[];
+		/**
 		 * Revoke the credential a freshly-minted one supersedes. Defaults to `true`.
 		 *
 		 * Pass `false` when this resolve covers only *part* of what the branch has. Object
@@ -110,31 +115,49 @@ export async function fetchEnvReusingSecrets<const C extends Config>(
 		 * whether the credential its persisted secrets name also backs a service it is not
 		 * resolving — and revoking it would kill that service while its vars, which this call
 		 * is not rewriting, stay on disk and stop working. The cost is an orphaned credential,
-		 * which is the safer of the two failures. `neon env pull --service` is the caller that
-		 * needs this.
+		 * which is the safer of the two failures. An explicitly scoped `neon env pull`
+		 * (`--service` or `--env`) is the caller that needs this.
 		 */
 		revokeSuperseded?: boolean;
 	},
 ): Promise<ReusedBranchEnv> {
 	const {
 		env: source = process.env,
+		keys: requestedKeys,
 		revokeSuperseded = true,
 		...fetchOptions
 	} = options;
 	const api = options.api ?? createApiFromOptions(options);
 	const { branch, desired } = await resolveBranchPolicy(config, options, api);
 
-	const storageEnabled = (desired.preview?.buckets.length ?? 0) > 0;
-	const gatewayEnabled = desired.preview?.aiGatewayEnabled ?? false;
+	const allPolicyKeys = policyEnvKeys(desired);
+	const requested = requestedKeys ? new Set(requestedKeys) : null;
+	const selectedPolicyKeys =
+		requested === null
+			? allPolicyKeys
+			: allPolicyKeys.filter((key) => requested.has(key));
+	const selected = new Set(selectedPolicyKeys);
+	const K = NEON_ENV_VAR_KEYS;
+	const storageCredentialSelected =
+		(desired.preview?.buckets.length ?? 0) > 0 &&
+		(selected.has(K.storage.accessKeyId) ||
+			selected.has(K.storage.secretAccessKey));
+	const gatewayCredentialSelected =
+		(desired.preview?.aiGatewayEnabled ?? false) &&
+		selected.has(K.aiGateway.apiKey);
 	const secretKeys = credentialEnvKeys({
-		storage: storageEnabled,
-		aiGateway: gatewayEnabled,
-	});
+		storage: storageCredentialSelected,
+		aiGateway: gatewayCredentialSelected,
+	}).filter((key) => selected.has(key));
 
-	// Nothing credential-backed on this branch, so there is nothing to preserve and no
-	// credential to spend: fetch everything and skip the credentials endpoint entirely.
+	// Nothing credential-backed was selected, so there is nothing to preserve and no
+	// credential to spend: fetch the selected values and skip the credentials endpoint.
 	if (secretKeys.length === 0) {
-		const fetched = await fetchEnvKeys(config, fetchOptions, null);
+		const fetched = await fetchEnvKeys(
+			config,
+			fetchOptions,
+			requested === null ? null : selectedPolicyKeys,
+		);
 		return {
 			vars: preferPersisted(toEntries(fetched), source),
 			credential: {
@@ -148,16 +171,17 @@ export async function fetchEnvReusingSecrets<const C extends Config>(
 
 	const persisted = readPersistedSecrets(source);
 	const complete =
-		(!storageEnabled ||
+		(!storageCredentialSelected ||
 			Boolean(persisted.accessKeyId && persisted.secretAccessKey)) &&
-		(!gatewayEnabled || Boolean(persisted.apiToken));
+		(!gatewayCredentialSelected || Boolean(persisted.apiToken));
 
 	// Look the persisted secrets up whenever there are any — not only when they're complete.
 	// An incomplete set still names the credential a newly-enabled feature is about to
 	// supersede (a storage-only credential on a branch that just gained the AI Gateway), and
 	// that one should be revoked rather than left live.
 	const named =
-		persisted.accessKeyId !== "" || persisted.apiToken !== ""
+		(storageCredentialSelected && persisted.accessKeyId !== "") ||
+		(gatewayCredentialSelected && persisted.apiToken !== "")
 			? namedCredentials(
 					await api.listCredentials(options.projectId, branch.id),
 					persisted,
@@ -165,18 +189,23 @@ export async function fetchEnvReusingSecrets<const C extends Config>(
 			: { storage: null, gateway: null };
 
 	const reusable = complete
-		? reusableCredential(named, { storageEnabled, gatewayEnabled })
+		? reusableCredential(named, {
+				storageEnabled: storageCredentialSelected,
+				gatewayEnabled: gatewayCredentialSelected,
+			})
 		: null;
-	const scopes = previewCredentialScopes(desired.preview);
+	const scopes = previewCredentialScopes(desired.preview, {
+		storage: storageCredentialSelected,
+		aiGateway: gatewayCredentialSelected,
+	});
 	const keep =
 		reusable !== null && credentialScopesSatisfied(reusable.scopes, scopes);
 
-	// Ask for everything the policy produces, minus the secrets we're keeping — which is what
+	// Ask for the selected policy values, minus the secrets we're keeping — which is what
 	// stops `fetchEnv` from minting a credential it doesn't need.
-	const allKeys = policyEnvKeys(desired);
 	const fetchKeys = keep
-		? allKeys.filter((key) => !secretKeys.includes(key))
-		: allKeys;
+		? selectedPolicyKeys.filter((key) => !secretKeys.includes(key))
+		: selectedPolicyKeys;
 	const fetched = await fetchEnvKeys(
 		config,
 		// Pass the resolved id so `fetchEnv` targets the same branch this call verified against,
@@ -211,7 +240,10 @@ export async function fetchEnvReusingSecrets<const C extends Config>(
 	//
 	// Revoked *after* the fetch, so a failed fetch leaves the caller's existing secrets working.
 	const ours = new Set<string>();
-	for (const meta of [named.storage, named.gateway]) {
+	for (const meta of [
+		storageCredentialSelected ? named.storage : null,
+		gatewayCredentialSelected ? named.gateway : null,
+	]) {
 		if (
 			meta !== null &&
 			meta.principalType === "user" &&

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -423,7 +423,7 @@ The human-readable summary line goes to stderr and the diff body to stdout, so `
 
 1. **`--service` and/or `--env`**, when you pass either — their union is the complete selection, ignoring `neon.ts` and unselected branch variables. `--service` adds a service's complete variable bundle; `--env` adds only the individual variables you name.
 2. **`neon.ts`**, when the working directory has one — the policy is the source of truth, same as `neon dev` and `neon deploy`.
-3. **Everything the branch has** otherwise — Postgres, Neon Auth, the Data API, and object storage read back from the branch, plus the AI Gateway. The gateway has no branch-level state to read back (it is credential-gated, not provisioned), so a bare `env pull` asks for it rather than detecting it, which mints a branch credential. To leave it out, name the services you do want with `--service`.
+3. **Everything the branch has** otherwise — Postgres, Neon Auth, the Data API, and object storage read back from the branch, plus the AI Gateway. The gateway has no branch-level state to read back, so a bare `env pull` asks for it rather than detecting it and may mint a branch credential. To leave it out, name only what you do want with `--service` and/or `--env`.
 
 If the gateway can't be resolved, it is dropped with a warning and the rest of the pull still lands. Gateway variables already in your file for *this* branch are left alone — a pull that couldn't reach the gateway is no evidence the branch has stopped having one — while ones left over from a different branch are pruned like any other stale value.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -421,7 +421,7 @@ The human-readable summary line goes to stderr and the diff body to stdout, so `
 
 **What gets pulled**, in precedence order:
 
-1. **`--service`**, when you pass it — exactly those services, whatever else is on the branch and whatever a `neon.ts` says.
+1. **`--service` and/or `--env`**, when you pass either — their union is the complete selection, ignoring `neon.ts` and unselected branch variables. `--service` adds a service's complete variable bundle; `--env` adds only the individual variables you name.
 2. **`neon.ts`**, when the working directory has one — the policy is the source of truth, same as `neon dev` and `neon deploy`.
 3. **Everything the branch has** otherwise — Postgres, Neon Auth, the Data API, and object storage read back from the branch, plus the AI Gateway. The gateway has no branch-level state to read back (it is credential-gated, not provisioned), so a bare `env pull` asks for it rather than detecting it, which mints a branch credential. To leave it out, name the services you do want with `--service`.
 
@@ -440,6 +440,13 @@ neon env pull --service ai-gateway
 # Repeat the flag or comma-separate; -s, --service and --services are all accepted
 neon env pull -s postgres -s data-api
 neon env pull -s postgres,auth
+
+# Pull one exact variable; repeat -e or comma-separate for more
+neon env pull -e DATABASE_URL
+neon env pull -e DATABASE_URL,NEON_AUTH_BASE_URL
+
+# The selectors compose as a union: all Auth vars plus DATABASE_URL
+neon env pull -s auth -e DATABASE_URL
 ```
 
 Every services flag in the CLI takes those three spellings, the same value syntax, and the same service names — see [`config init --services`](#getting-a-neonts-config-init).
@@ -452,11 +459,13 @@ Every services flag in the CLI takes those three spellings, the same value synta
 | `object-storage` | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_ENDPOINT_URL_S3`, `AWS_REGION` |
 | `ai-gateway` | `NEON_AI_GATEWAY_TOKEN`, `NEON_AI_GATEWAY_BASE_URL` |
 
-`NEON_BRANCH` is written by every pull — it is branch identity, not a service.
+`-e, --env` accepts any variable in the table plus `NEON_BRANCH`. It is case-sensitive and rejects unknown names rather than silently widening the pull. `NEON_BRANCH` is written by unscoped and service-scoped pulls because it is branch identity, not a service; an env-only pull writes it only when you select it.
 
-**A scoped pull is scoped in both directions.** An unscoped `env pull` owns the Neon-named variables: pointing a directory at a branch without Neon Auth prunes the stale `NEON_AUTH_*` lines. `--service` narrows that to the services you named, so `env pull -s ai-gateway` never touches your `DATABASE_URL`. (`AWS_*` is never pruned by any pull: those names collide with credentials you may set yourself, so `env pull` only ever writes them.)
+**A scoped pull is scoped in both directions.** An unscoped `env pull` owns the Neon-named variables: pointing a directory at a branch without Neon Auth prunes the stale `NEON_AUTH_*` lines. `--service` narrows that to the services you named, while `--env` narrows it to the exact keys you named, so `env pull -e DATABASE_URL` never touches `DATABASE_URL_UNPOOLED`. (`AWS_*` is never pruned by any pull: those names collide with credentials you may set yourself, so `env pull` only ever writes them.)
 
-**A scoped pull also never revokes a credential.** Where an unscoped pull revokes the credential it replaces, a scoped one leaves the old one live — it can't tell which other services still use it. It says so when it happens; revoke it in the Neon Console if nothing does.
+**A scoped pull also never revokes a credential.** Where an unscoped pull revokes the credential it replaces, a scoped one leaves the old one live — it can't tell which other variables still use it. It says so when it happens; revoke it in the Neon Console if nothing does.
+
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be selected together. Neon issues them as one object-storage credential; pulling only one would pair a fresh half with whatever old half remains in the file.
 
 Naming a service the branch does not have is an error, not an empty pull:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -461,6 +461,8 @@ Every services flag in the CLI takes those three spellings, the same value synta
 
 `-e, --env` accepts any variable in the table plus `NEON_BRANCH`. It is case-sensitive and rejects unknown names rather than silently widening the pull. `NEON_BRANCH` is written by unscoped and service-scoped pulls because it is branch identity, not a service; an env-only pull writes it only when you select it.
 
+`--env` never narrows `--service`: `neon env pull -s postgres -e DATABASE_URL` still pulls the complete Postgres bundle (`DATABASE_URL`, `DATABASE_URL_UNPOOLED`, and `NEON_BRANCH`). The two selectors always form a union.
+
 **A scoped pull is scoped in both directions.** An unscoped `env pull` owns the Neon-named variables: pointing a directory at a branch without Neon Auth prunes the stale `NEON_AUTH_*` lines. `--service` narrows that to the services you named, while `--env` narrows it to the exact keys you named, so `env pull -e DATABASE_URL` never touches `DATABASE_URL_UNPOOLED`. (`AWS_*` is never pruned by any pull: those names collide with credentials you may set yourself, so `env pull` only ever writes them.)
 
 **A scoped pull also never revokes a credential.** Where an unscoped pull revokes the credential it replaces, a scoped one leaves the old one live — it can't tell which other variables still use it. It says so when it happens; revoke it in the Neon Console if nothing does.

--- a/packages/cli/e2e/env.e2e.test.ts
+++ b/packages/cli/e2e/env.e2e.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { apiRequest } from "@neon/e2e-harness";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { readEnvFile } from "../src/env_file.js";
+import {
+	createProject,
+	deleteProject,
+	runCli,
+	uniqueProjectName,
+} from "./helpers.js";
+
+describe.sequential("e2e — neon env pull against the real API", () => {
+	let projectId: string;
+	let branchId: string;
+	let cwd: string;
+
+	beforeAll(async () => {
+		cwd = mkdtempSync(join(tmpdir(), "neon-env-pull-e2e-"));
+		projectId = await createProject({
+			name: uniqueProjectName("cli-env"),
+		});
+		const { branches } = await apiRequest<{
+			branches: { id: string; default?: boolean }[];
+		}>(`/projects/${projectId}/branches`);
+		const branch = branches.find((candidate) => candidate.default);
+		if (!branch) throw new Error("project has no default branch");
+		branchId = branch.id;
+	});
+
+	afterAll(async () => {
+		if (projectId) await deleteProject(projectId);
+		if (cwd) rmSync(cwd, { recursive: true, force: true });
+	});
+
+	it("writes only the env variable selected with -e", async () => {
+		const result = await runCli(
+			[
+				"env",
+				"pull",
+				"--project-id",
+				projectId,
+				"--branch",
+				branchId,
+				"--file",
+				".env.selected",
+				"-e",
+				"DATABASE_URL",
+			],
+			{ cwd, json: false },
+		);
+
+		expect(result.code, result.stderr).toBe(0);
+		const env = readEnvFile(join(cwd, ".env.selected"));
+		expect(env).toEqual({
+			DATABASE_URL: expect.stringMatching(/^postgresql:\/\//),
+		});
+	});
+});

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -767,6 +767,18 @@ describe("env pull --env", () => {
 		expect(api.credentialCreateCalls).toBe(0);
 	});
 
+	it("rejects the AI Gateway base URL when the gateway is not enabled", async () => {
+		await expect(
+			pull({
+				...baseProps(new NoCredentialsNeonApi(), cwd),
+				envKeys: ["NEON_AI_GATEWAY_BASE_URL"],
+			}),
+		).rejects.toThrow(
+			/--env NEON_AI_GATEWAY_BASE_URL: AI Gateway is not available for this Neon project/,
+		);
+		expect(existsSync(join(cwd, ".env.local"))).toBe(false);
+	});
+
 	it("names --env when the selected variable is unavailable", async () => {
 		await expect(
 			pull({

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -770,12 +770,22 @@ describe("env pull --env", () => {
 	it("rejects the AI Gateway base URL when the gateway is not enabled", async () => {
 		await expect(
 			pull({
-				...baseProps(new NoCredentialsNeonApi(), cwd),
+				...baseProps(new UnsupportedCredentialsNeonApi(), cwd),
 				envKeys: ["NEON_AI_GATEWAY_BASE_URL"],
 			}),
 		).rejects.toThrow(
 			/--env NEON_AI_GATEWAY_BASE_URL: AI Gateway is not available for this Neon project/,
 		);
+		expect(existsSync(join(cwd, ".env.local"))).toBe(false);
+	});
+
+	it("preserves transient AI Gateway credential-read failures", async () => {
+		await expect(
+			pull({
+				...baseProps(new NoCredentialsNeonApi(), cwd),
+				envKeys: ["NEON_AI_GATEWAY_BASE_URL"],
+			}),
+		).rejects.toThrow(/HTTP 503 Service Unavailable/);
 		expect(existsSync(join(cwd, ".env.local"))).toBe(false);
 	});
 
@@ -832,6 +842,7 @@ class NoCredentialsNeonApi extends FakeNeonApi {
 		throw new PlatformError(
 			ErrorCode.FeatureUnavailable,
 			"Branch credentials isn't available for this Neon project (HTTP 503 Service Unavailable).",
+			{ details: { status: 503 } },
 		);
 	};
 	override async createCredential(): Promise<NeonCredentialSecret> {
@@ -839,6 +850,17 @@ class NoCredentialsNeonApi extends FakeNeonApi {
 	}
 	override async listCredentials(): Promise<NeonCredentialMeta[]> {
 		return this.unavailable();
+	}
+}
+
+/** A project whose region does not expose the branch-credentials endpoint. */
+class UnsupportedCredentialsNeonApi extends FakeNeonApi {
+	override async listCredentials(): Promise<NeonCredentialMeta[]> {
+		throw new PlatformError(
+			ErrorCode.FeatureUnavailable,
+			"Branch credentials isn't available for this Neon project (HTTP 404 Not Found).",
+			{ details: { status: 404 } },
+		);
 	}
 }
 

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -27,10 +27,12 @@ import type {
 } from "@neon/config";
 import { ErrorCode, PlatformError } from "@neon/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import yargs from "yargs/yargs";
 
 import { readEnvFile } from "../env_file.js";
 import {
 	autoPullEnvAfterPin,
+	builder,
 	type EnvPullProps,
 	type PullOutcome,
 	pull,
@@ -1040,5 +1042,19 @@ describe("autoPullEnvAfterPin (bundled into link / checkout)", () => {
 		expect(result.status).toBe("failed");
 		// Nothing is written when the pull fails before resolving any vars.
 		expect(existsSync(join(cwd, ".env.local"))).toBe(false);
+	});
+});
+
+describe("env pull option parsing", () => {
+	it("rejects a misspelled selector before starting an unscoped pull", () => {
+		const parser = builder(
+			yargs(["pull", "--envs", "DATABASE_URL"])
+				.exitProcess(false)
+				.fail((message, error) => {
+					throw error ?? new Error(message);
+				}),
+		);
+
+		expect(() => parser.parse()).toThrow("Unknown argument: envs");
 	});
 });

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -50,6 +50,8 @@ type FakeOverrides = {
  * the NEON_AUTH_BASE_URL pull.
  */
 class FakeNeonApi implements NeonApi {
+	credentialCreateCalls = 0;
+
 	constructor(private readonly overrides: FakeOverrides = {}) {}
 
 	async listProjects(): Promise<NeonProjectSnapshot[]> {
@@ -182,6 +184,7 @@ class FakeNeonApi implements NeonApi {
 		branchId: string,
 		input: CreateCredentialInput,
 	): Promise<NeonCredentialSecret> {
+		this.credentialCreateCalls += 1;
 		return {
 			tokenId: "cred-fake-0000",
 			tokenIdShort: "credfake0000",
@@ -655,6 +658,122 @@ describe("env pull --service", () => {
 				services: ["object-storage"],
 			}),
 		).rejects.toThrow(/isn't available for this Neon project/);
+	});
+});
+
+describe("env pull --env", () => {
+	let cwd: string;
+	beforeEach(() => {
+		cwd = mkdtempSync(join(tmpdir(), "neonctl-env-keys-"));
+	});
+	afterEach(() => {
+		rmSync(cwd, { recursive: true, force: true });
+	});
+
+	it("writes exactly the selected env variable", async () => {
+		await pull({
+			...baseProps(new FakeNeonApi(), cwd),
+			envKeys: ["DATABASE_URL"],
+		});
+
+		expect(readEnvFile(join(cwd, ".env.local"))).toEqual({
+			DATABASE_URL:
+				"postgresql://neondb_owner:pw@br-snowy-frost-12345-pooler.fake.neon.tech/neondb?sslmode=require",
+		});
+	});
+
+	it("unions exact env variables with complete service bundles", async () => {
+		const api = new FakeNeonApi({
+			getNeonAuth: async () => ({
+				projectId: "auth-project",
+				jwksUrl: "https://auth.fake.neon.tech/.well-known/jwks.json",
+				baseUrl: "https://auth.fake.neon.tech",
+			}),
+		});
+
+		await pull({
+			...baseProps(api, cwd),
+			services: ["auth"],
+			envKeys: ["DATABASE_URL"],
+		});
+
+		expect(readEnvFile(join(cwd, ".env.local"))).toEqual({
+			DATABASE_URL:
+				"postgresql://neondb_owner:pw@br-snowy-frost-12345-pooler.fake.neon.tech/neondb?sslmode=require",
+			NEON_BRANCH: "main",
+			NEON_AUTH_BASE_URL: "https://auth.fake.neon.tech",
+			NEON_AUTH_JWKS_URL:
+				"https://auth.fake.neon.tech/.well-known/jwks.json",
+		});
+	});
+
+	it("overrides neon.ts instead of intersecting with it", async () => {
+		writeFileSync(join(cwd, "neon.ts"), "export default { auth: {} };\n");
+		const api = new FakeNeonApi({
+			getNeonAuth: async () => ({
+				projectId: "auth-project",
+				jwksUrl: "https://auth.fake.neon.tech/.well-known/jwks.json",
+				baseUrl: "https://auth.fake.neon.tech",
+			}),
+		});
+
+		await pull({
+			...baseProps(api, cwd),
+			envKeys: ["DATABASE_URL"],
+		});
+
+		expect(readEnvFile(join(cwd, ".env.local"))).toEqual({
+			DATABASE_URL:
+				"postgresql://neondb_owner:pw@br-snowy-frost-12345-pooler.fake.neon.tech/neondb?sslmode=require",
+		});
+	});
+
+	it("leaves every unselected existing variable untouched", async () => {
+		writeFileSync(
+			join(cwd, ".env"),
+			[
+				"DATABASE_URL=postgres://stale",
+				"DATABASE_URL_UNPOOLED=postgres://mine",
+				"NEON_AUTH_BASE_URL=https://mine.example",
+				"",
+			].join("\n"),
+		);
+
+		await pull({
+			...baseProps(new FakeNeonApi(), cwd),
+			envKeys: ["DATABASE_URL"],
+		});
+
+		const env = readEnvFile(join(cwd, ".env"));
+		expect(env.DATABASE_URL).toContain("-pooler.fake.neon.tech");
+		expect(env.DATABASE_URL_UNPOOLED).toBe("postgres://mine");
+		expect(env.NEON_AUTH_BASE_URL).toBe("https://mine.example");
+	});
+
+	it("does not mint a credential for the AI Gateway base URL alone", async () => {
+		const api = new FakeNeonApi();
+
+		await pull({
+			...baseProps(api, cwd),
+			envKeys: ["NEON_AI_GATEWAY_BASE_URL"],
+		});
+
+		expect(readEnvFile(join(cwd, ".env.local"))).toEqual({
+			NEON_AI_GATEWAY_BASE_URL:
+				"https://br-snowy-frost-12345-api.ai.fake.neon.tech",
+		});
+		expect(api.credentialCreateCalls).toBe(0);
+	});
+
+	it("names --env when the selected variable is unavailable", async () => {
+		await expect(
+			pull({
+				...baseProps(new FakeNeonApi(), cwd),
+				envKeys: ["NEON_AUTH_BASE_URL"],
+			}),
+		).rejects.toThrow(
+			/--env NEON_AUTH_BASE_URL: branch .* no Neon Auth integration/,
+		);
 	});
 });
 

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -154,9 +154,6 @@ export const builder = (argv: yargs.Argv) =>
 				const envKeys = rawEnvKeys
 					? parseEnvPullKeys(rawEnvKeys, "--env")
 					: undefined;
-				if (services !== undefined || envKeys !== undefined) {
-					envKeysForSelection(services ?? [], envKeys ?? []);
-				}
 				// Explicit `env pull` announces the branch it's reading from up front so the user
 				// can catch "pulled env from the wrong branch" before it overwrites their .env. The
 				// bundled auto-pull (link / checkout / apply) stays quiet — those already report the

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -97,7 +97,7 @@ export const builder = (argv: yargs.Argv) =>
 							describe:
 								`Pull only these individual variables: ${ENV_PULL_KEYS.join(", ")}. ` +
 								"Repeat the flag or comma-separate. Overrides neon.ts. Combines " +
-								"with --service as a union.",
+								"with --service as a union; it never narrows a service bundle.",
 							type: "array",
 							string: true,
 						},
@@ -135,7 +135,8 @@ export const builder = (argv: yargs.Argv) =>
 					.example(
 						"$0 env pull -s auth -e DATABASE_URL",
 						"Pull all Auth variables plus DATABASE_URL",
-					),
+					)
+					.strict(),
 			async (args) => {
 				const rawServices = servicesFlagValue(args.service);
 				const rawEnvKeys = envPullFlagValue(args.env);

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -8,10 +8,14 @@ import { ensureGitignored } from "../context.js";
 import { resolveNeonEnvVars } from "../dev/env.js";
 import { mergeEnvFile, readEnvFile, resolveEnvFilePath } from "../env_file.js";
 import {
+	ENV_PULL_KEYS,
 	ENV_PULL_SERVICES,
 	ENV_PULL_UNAVAILABLE,
-	envServiceKeys,
+	type EnvPullKey,
+	envKeysForSelection,
+	envPullFlagValue,
 	ownedEnvServiceKeys,
+	parseEnvPullKeys,
 } from "../env_services.js";
 import { log } from "../log.js";
 import {
@@ -40,6 +44,11 @@ export type EnvPullProps = BranchScopeProps & {
 	 * within them.
 	 */
 	services?: readonly NeonService[];
+	/**
+	 * Pull exactly these OS-level env vars (`--env`). Combined with `services` as a union:
+	 * complete service bundles plus these individual keys.
+	 */
+	envKeys?: readonly EnvPullKey[];
 };
 
 export const command = "env";
@@ -79,14 +88,25 @@ export const builder = (argv: yargs.Argv) =>
 							key: "service",
 							allowed: ENV_PULL_SERVICES,
 							describe: "Pull only these services' variables",
-							also: "Overrides neon.ts, and prunes only within the services you name.",
+							also:
+								"Overrides neon.ts, and prunes only within the services you name. " +
+								"Combines with --env as a union.",
 						}),
+						env: {
+							alias: "e",
+							describe:
+								`Pull only these individual variables: ${ENV_PULL_KEYS.join(", ")}. ` +
+								"Repeat the flag or comma-separate. Overrides neon.ts. Combines " +
+								"with --service as a union.",
+							type: "array",
+							string: true,
+						},
 					})
 					.epilogue(
 						[
 							"",
 							"What gets pulled, in precedence order:",
-							"  1. --service, when given — exactly those, ignoring neon.ts.",
+							"  1. --service / --env, when given — their union, ignoring neon.ts.",
 							"  2. neon.ts, when this directory has one.",
 							"  3. Otherwise everything the branch has, plus the AI Gateway —",
 							"     which mints a branch credential for it.",
@@ -107,9 +127,35 @@ export const builder = (argv: yargs.Argv) =>
 					.example(
 						"$0 env pull -s ai-gateway -s postgres",
 						"Pull only the AI Gateway and Postgres variables",
+					)
+					.example(
+						"$0 env pull -e DATABASE_URL",
+						"Pull only the pooled Postgres connection string",
+					)
+					.example(
+						"$0 env pull -s auth -e DATABASE_URL",
+						"Pull all Auth variables plus DATABASE_URL",
 					),
 			async (args) => {
-				const raw = servicesFlagValue(args.service);
+				const rawServices = servicesFlagValue(args.service);
+				const rawEnvKeys = envPullFlagValue(args.env);
+				const services = rawServices
+					? parseServices(rawServices, {
+							allowed: ENV_PULL_SERVICES,
+							whyUnavailable: ENV_PULL_UNAVAILABLE,
+							flag: "--service",
+							onDeprecated: (used, canonical) =>
+								log.warning(
+									deprecatedServiceMessage(used, canonical),
+								),
+						})
+					: undefined;
+				const envKeys = rawEnvKeys
+					? parseEnvPullKeys(rawEnvKeys, "--env")
+					: undefined;
+				if (services !== undefined || envKeys !== undefined) {
+					envKeysForSelection(services ?? [], envKeys ?? []);
+				}
 				// Explicit `env pull` announces the branch it's reading from up front so the user
 				// can catch "pulled env from the wrong branch" before it overwrites their .env. The
 				// bundled auto-pull (link / checkout / apply) stays quiet — those already report the
@@ -122,24 +168,15 @@ export const builder = (argv: yargs.Argv) =>
 				await pull(
 					{
 						...(args as any),
-						...(raw
-							? {
-									services: parseServices(raw, {
-										allowed: ENV_PULL_SERVICES,
-										whyUnavailable: ENV_PULL_UNAVAILABLE,
-										flag: "--service",
-										onDeprecated: (used, canonical) =>
-											log.warning(
-												deprecatedServiceMessage(
-													used,
-													canonical,
-												),
-											),
-									}),
-								}
-							: {}),
+						...(services ? { services } : {}),
+						...(envKeys ? { envKeys } : {}),
 					},
-					{ announce: true, implyAiGateway: raw === undefined },
+					{
+						announce: true,
+						implyAiGateway:
+							rawServices === undefined &&
+							rawEnvKeys === undefined,
+					},
 				);
 			},
 		)
@@ -165,7 +202,7 @@ const NEON_VAR_NAMES = Object.values(NEON_ENV_VAR_KEYS).flatMap((group) =>
  * writes them, never prunes them. The AI Gateway is emitted solely under its Neon-branded
  * vars (`NEON_AI_GATEWAY_*`), which are owned and pruned.
  */
-const NEON_OWNED_ENV_KEYS: readonly string[] = [
+const NEON_OWNED_ENV_KEYS: readonly EnvPullKey[] = [
 	...Object.values(NEON_ENV_VAR_KEYS.postgres),
 	...Object.values(NEON_ENV_VAR_KEYS.auth),
 	...Object.values(NEON_ENV_VAR_KEYS.dataApi),
@@ -201,6 +238,10 @@ export const pull = async (
 	opts: { announce?: boolean; implyAiGateway?: boolean } = {},
 ): Promise<PullOutcome> => {
 	const cwd = props.cwd ?? process.cwd();
+	const selectedKeys =
+		props.services !== undefined || props.envKeys !== undefined
+			? envKeysForSelection(props.services ?? [], props.envKeys ?? [])
+			: undefined;
 	const branch = await resolveBranchRef(props);
 	if (opts.announce) {
 		announceTargetBranch(props, branch, "Pulling env from branch");
@@ -224,13 +265,14 @@ export const pull = async (
 		branchId,
 		env: { ...process.env, ...existingEnv },
 		...(props.services ? { services: props.services } : {}),
+		...(props.envKeys ? { envKeys: props.envKeys } : {}),
 		...(opts.implyAiGateway ? { implyAiGateway: true } : {}),
 		...(props.apiKey ? { apiKey: props.apiKey } : {}),
 		...(props.apiHost ? { apiHost: props.apiHost } : {}),
 		...(props.runtimeApi ? { api: props.runtimeApi } : {}),
 	});
 
-	const neonVars = pickServiceVars(pickNeonVars(vars), props.services);
+	const neonVars = pickSelectedVars(pickNeonVars(vars), selectedKeys);
 	if (Object.keys(neonVars).length === 0) {
 		log.info(
 			"No Neon env variables to pull for this branch (no DATABASE_URL or " +
@@ -244,7 +286,7 @@ export const pull = async (
 	// from a previous project/branch). Non-Neon lines are always preserved.
 	const { written, removed } = mergeEnvFile(targetPath, neonVars, {
 		managedKeys: managedKeysFor(
-			props.services,
+			selectedKeys,
 			unreachedButCurrent(skipped, existingEnv, branchId),
 		),
 	});
@@ -284,8 +326,8 @@ export const pull = async (
 			// actually declined to revoke, so a first pull (which supersedes nothing) does
 			// not send the user hunting for a credential that was never there.
 			log.info(
-				"Left the credential it replaced live (%s): a pull scoped with --service " +
-					"can't tell which other services still use it. Revoke it in the Neon " +
+				"Left the credential it replaced live (%s): an explicitly scoped pull " +
+					"can't tell which other variables still use it. Revoke it in the Neon " +
 					"Console if nothing does.",
 				credential.superseded.join(", "),
 			);
@@ -327,17 +369,17 @@ export const pull = async (
 /**
  * The keys this pull is allowed to prune, i.e. the ones it is authoritative for.
  *
- * A `--service` selection narrows that to the services it named: `env pull -s ai-gateway`
- * says nothing about `DATABASE_URL`, so it must not read that variable's absence from this
- * pull as "the branch no longer has it". `unreached` is subtracted for the same reason — see
+ * An explicit selection narrows that to the service bundles and individual keys it named:
+ * `env pull -s ai-gateway` and `env pull -e NEON_AI_GATEWAY_TOKEN` both say nothing about
+ * `DATABASE_URL`. `unreached` is subtracted for the same reason — see
  * {@link unreachedButCurrent}.
  */
 const managedKeysFor = (
-	services: readonly NeonService[] | undefined,
+	selectedKeys: readonly EnvPullKey[] | undefined,
 	unreached: readonly NeonService[],
 ): string[] => {
-	const owned = services
-		? ownedEnvServiceKeys(services)
+	const owned = selectedKeys
+		? NEON_OWNED_ENV_KEYS.filter((key) => selectedKeys.includes(key))
 		: [...NEON_OWNED_ENV_KEYS];
 	if (unreached.length === 0) return owned;
 	const keep = new Set(ownedEnvServiceKeys(unreached));
@@ -388,17 +430,16 @@ const isBranchGatewayUrl = (baseUrl: string, branchId: string): boolean =>
 	new URL(baseUrl).hostname.startsWith(`${branchId}-api.ai.`);
 
 /**
- * Narrow the resolved vars to the selected services (plus `NEON_BRANCH`, which every pull
- * refreshes). Needed because the two `DATABASE_URL*` vars are always resolved — `fetchEnv`
- * reads both connection URIs regardless, since the AI Gateway host is derived from the direct
- * one — so `--service ai-gateway` has to drop them here rather than avoid fetching them.
+ * Narrow the resolved vars to the explicit service/key union. `fetchEnv` may resolve
+ * supporting values that were not selected (the direct connection URI derives the AI Gateway
+ * host, for example); those must not land in the target file.
  */
-const pickServiceVars = (
+const pickSelectedVars = (
 	vars: Record<string, string>,
-	services: readonly NeonService[] | undefined,
+	selectedKeys: readonly EnvPullKey[] | undefined,
 ): Record<string, string> => {
-	if (!services) return vars;
-	const wanted = envServiceKeys(services);
+	if (!selectedKeys) return vars;
+	const wanted = new Set<string>(selectedKeys);
 	return Object.fromEntries(
 		Object.entries(vars).filter(([key]) => wanted.has(key)),
 	);

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -13,6 +13,13 @@ import {
 	fetchEnvReusingSecrets,
 	type ReusedBranchEnv,
 } from "@neon-internals/env-core/reuse-secrets";
+import {
+	ENV_PULL_SERVICES,
+	type EnvPullKey,
+	envKeysForSelection,
+	serviceForEnvKey,
+	servicesForEnvKeys,
+} from "../env_services.js";
 import { log } from "../log.js";
 import type { NeonService } from "../neon_services.js";
 import { getCliName } from "../utils/cli_name.js";
@@ -46,6 +53,12 @@ export type DevEnvContext = {
 	 * live state instead.
 	 */
 	services?: readonly NeonService[];
+	/**
+	 * Resolve exactly these OS-level env vars. Like {@link DevEnvContext.services}, this is
+	 * an explicit selection that ignores `neon.ts`; when both are present their output is
+	 * the union of complete service bundles and these individual keys.
+	 */
+	envKeys?: readonly EnvPullKey[];
 	/**
 	 * Add the AI Gateway to the **no-`neon.ts`** resolution. `pullConfig` cannot detect the
 	 * gateway — it has no branch-level enabled state, only a credential — so a caller that
@@ -85,7 +98,7 @@ export class MissingBranchContextError extends Error {
 }
 
 /**
- * Thrown when an explicit `--service` selection names a service the branch does not have.
+ * Thrown when an explicit `--service` / `--env` selection needs a service the branch lacks.
  * Unlike the policy path — where the same situation is a {@link DevEnvMismatchError} pointing
  * at `deploy` — the user named the service on the command line, so the fix is to provision it
  * or drop it from the selection.
@@ -112,8 +125,9 @@ export type ResolvedNeonEnvVars = ReusedBranchEnv & {
  *
  * Tiered:
  *
- *   0. {@link DevEnvContext.services} is set -> that selection *is* the policy, and any
- *      `neon.ts` is ignored. See {@link resolveSelectedServices}.
+ *   0. {@link DevEnvContext.services} or {@link DevEnvContext.envKeys} is set -> that
+ *      selection *is* the policy, and any `neon.ts` is ignored. See
+ *      {@link resolveSelectedServices}.
  *   1. a `neon.ts` policy is found -> the policy is the source of truth. We first
  *      check it against the branch's live state (`plan`); if it declares a resource
  *      the branch is missing, we stop with a {@link DevEnvMismatchError} pointing at
@@ -132,8 +146,12 @@ export type ResolvedNeonEnvVars = ReusedBranchEnv & {
 export const resolveNeonEnvVars = async (
 	ctx: DevEnvContext,
 ): Promise<ResolvedNeonEnvVars> => {
-	if (ctx.services) {
-		return await resolveSelectedServices(ctx, ctx.services);
+	if (ctx.services !== undefined || ctx.envKeys !== undefined) {
+		return await resolveSelectedServices(
+			ctx,
+			ctx.services ?? [],
+			ctx.envKeys ?? [],
+		);
 	}
 
 	const config = await loadNeonConfig(ctx.cwd);
@@ -267,7 +285,7 @@ const apiFor = (ctx: DevEnvContext): NeonApi =>
 	});
 
 /**
- * Tier-0: resolve exactly the services `--service` named, with `neon.ts` out of the picture.
+ * Tier-0: resolve exactly what `--service` / `--env` selected, with `neon.ts` ignored.
  *
  * The selection is checked against the branch's live state so a service that is named but not
  * provisioned fails by name, instead of quietly contributing no vars. `postgres` and the AI
@@ -276,16 +294,24 @@ const apiFor = (ctx: DevEnvContext): NeonApi =>
  */
 const resolveSelectedServices = async (
 	ctx: DevEnvContext,
-	services: readonly NeonService[],
+	directServices: readonly NeonService[],
+	envKeys: readonly EnvPullKey[],
 ): Promise<ResolvedNeonEnvVars> => {
 	const { projectId, branchId } = ctx;
 	if (!projectId || !branchId) {
 		throw new MissingBranchContextError(
-			"--service needs a project and branch to read from. " +
+			"An explicit env selection needs a project and branch to read from. " +
 				`Run \`${getCliName()} link\` and \`${getCliName()} checkout <branch>\`, or pass ` +
 				"--project-id / --branch.",
 		);
 	}
+	const impliedServices = servicesForEnvKeys(envKeys);
+	const services = ENV_PULL_SERVICES.filter(
+		(service) =>
+			directServices.includes(service) ||
+			impliedServices.includes(service),
+	);
+	const selectedKeys = envKeysForSelection(directServices, envKeys);
 
 	// Read only the services that were named, rather than going through `pullConfig`. That
 	// keeps a selection independent of everything else on the branch — `pullConfig` also
@@ -293,7 +319,8 @@ const resolveSelectedServices = async (
 	// keeps an "object storage isn't available for this project" error intact, which
 	// `pullConfig` degrades to an empty bucket list and would report as "no buckets".
 	const api = apiFor(ctx);
-	const has = (service: NeonService): boolean => services.includes(service);
+	const has = (service: (typeof ENV_PULL_SERVICES)[number]): boolean =>
+		services.includes(service);
 	const [auth, dataApiEnabled, buckets] = await Promise.all([
 		has("auth") ? api.getNeonAuth(projectId, branchId) : null,
 		has("data-api") ? readDataApiEnabled(api, projectId, branchId) : null,
@@ -302,15 +329,23 @@ const resolveSelectedServices = async (
 			: null,
 	]);
 
-	const config = configForServices(services, branchId, {
-		authEnabled: auth !== null,
-		dataApiEnabled,
-		buckets: buckets ?? [],
-	});
+	const config = configForServices(
+		services,
+		branchId,
+		{
+			authEnabled: auth !== null,
+			dataApiEnabled,
+			buckets: buckets ?? [],
+		},
+		{ directServices, envKeys },
+	);
 	// A selection resolves part of the branch, so it must not revoke: the credential its
 	// persisted secrets name may also back a service it is not resolving. See
 	// `fetchEnvReusingSecrets`'s `revokeSuperseded`.
-	return await fetchAndProject(config, ctx, { revokeSuperseded: false });
+	return await fetchAndProject(config, ctx, {
+		keys: selectedKeys,
+		revokeSuperseded: false,
+	});
 };
 
 /**
@@ -345,7 +380,7 @@ const readDataApiEnabled = async (
 const NEON_DEFAULT_DATABASE = "neondb";
 
 /**
- * Build the `Config` an explicit `--service` selection stands for, raising
+ * Build the `Config` an explicit `--service` / `--env` selection stands for, raising
  * {@link ServiceNotOnBranchError} for anything the branch does not have. Naming a service
  * that isn't there has to fail rather than contribute no vars, or a scoped pull would report
  * "no Neon env variables to pull" — which reads as a statement about the branch rather than
@@ -360,6 +395,10 @@ const configForServices = (
 		dataApiEnabled: boolean | null;
 		buckets: NeonBucketSnapshot[];
 	},
+	selection: {
+		directServices: readonly NeonService[];
+		envKeys: readonly EnvPullKey[];
+	},
 ): Config => {
 	// The command that provisions each one, for a user who may well have no `neon.ts` — in
 	// which case `deploy` / `config apply` would be no help at all.
@@ -369,6 +408,17 @@ const configForServices = (
 		"object-storage": `${getCliName()} buckets create <name>`,
 	};
 	const notOnBranch = (service: NeonService, what: string): never => {
+		if (!selection.directServices.includes(service)) {
+			const keys = selection.envKeys.filter(
+				(key) => serviceForEnvKey(key) === service,
+			);
+			const names = keys.join(", ");
+			throw new ServiceNotOnBranchError(
+				`--env ${names}: branch ${branchId} has no ${what}, so ${names} cannot be pulled. ` +
+					`Provision it first (\`${provisionWith[service]}\`, or in the Neon Console), ` +
+					`or drop ${names} from --env.`,
+			);
+		}
 		throw new ServiceNotOnBranchError(
 			`--service ${service}: branch ${branchId} has no ${what}, so there are no ` +
 				`${service} env vars to pull. Provision it first (\`${provisionWith[service]}\`, ` +
@@ -530,13 +580,14 @@ const isMissingResource = (change: AppliedChange): boolean =>
 const fetchAndProject = async (
 	config: Config,
 	ctx: DevEnvContext,
-	opts: { revokeSuperseded?: boolean } = {},
+	opts: { keys?: readonly string[]; revokeSuperseded?: boolean } = {},
 ): Promise<ReusedBranchEnv> =>
 	fetchEnvReusingSecrets(config, {
 		projectId: ctx.projectId as string,
 		branch: ctx.branchId as string,
 		...apiOptions(ctx),
 		...(ctx.env ? { env: ctx.env } : {}),
+		...(opts.keys ? { keys: opts.keys } : {}),
 		...(opts.revokeSuperseded === false ? { revokeSuperseded: false } : {}),
 	});
 

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -1,6 +1,8 @@
 import {
 	type Config,
 	createNeonApiFromOptions,
+	ErrorCode,
+	isPlatformError,
 	loadConfigFromFile,
 	type NeonApi,
 	type NeonBucketSnapshot,
@@ -61,10 +63,10 @@ export type DevEnvContext = {
 	envKeys?: readonly EnvPullKey[];
 	/**
 	 * Add the AI Gateway to the **no-`neon.ts`** resolution. `pullConfig` cannot detect the
-	 * gateway — it has no branch-level enabled state, only a credential — so a caller that
-	 * wants it in the "everything this branch has" set has to ask. `neon env pull` does;
-	 * `neon dev` and the pull bundled into `link` / `checkout` / `apply` do not. Ignored when
-	 * {@link DevEnvContext.services} is set, since that selection already says.
+	 * gateway — it has no branch-level enabled state, only branch-credential capability — so
+	 * a caller that wants it in the "everything this branch has" set has to ask. `neon env
+	 * pull` does; `neon dev` and the pull bundled into `link` / `checkout` / `apply` do not.
+	 * Ignored when {@link DevEnvContext.services} is set, since that selection already says.
 	 */
 	implyAiGateway?: boolean;
 };
@@ -287,10 +289,9 @@ const apiFor = (ctx: DevEnvContext): NeonApi =>
 /**
  * Tier-0: resolve exactly what `--service` / `--env` selected, with `neon.ts` ignored.
  *
- * The selection is checked against the branch's live state so a service that is named but not
- * provisioned fails by name, instead of quietly contributing no vars. `postgres` and the AI
- * Gateway are not checked: every branch has Postgres, and the gateway has no branch-level
- * state to check (an unavailable one surfaces when its credential is minted).
+ * The selection is checked against live project and branch state so a service that is named
+ * but not provisioned fails by name, instead of quietly contributing dead vars. `postgres`
+ * needs no check because every branch has it.
  */
 const resolveSelectedServices = async (
 	ctx: DevEnvContext,
@@ -321,13 +322,22 @@ const resolveSelectedServices = async (
 	const api = apiFor(ctx);
 	const has = (service: (typeof ENV_PULL_SERVICES)[number]): boolean =>
 		services.includes(service);
-	const [auth, dataApiEnabled, buckets] = await Promise.all([
-		has("auth") ? api.getNeonAuth(projectId, branchId) : null,
-		has("data-api") ? readDataApiEnabled(api, projectId, branchId) : null,
-		has("object-storage")
-			? api.listBranchBuckets(projectId, branchId)
-			: null,
-	]);
+	const checkAiGateway =
+		has("ai-gateway") &&
+		!selectedKeys.includes(NEON_ENV_VAR_KEYS.aiGateway.apiKey);
+	const [auth, dataApiEnabled, buckets, aiGatewayAvailable] =
+		await Promise.all([
+			has("auth") ? api.getNeonAuth(projectId, branchId) : null,
+			has("data-api")
+				? readDataApiEnabled(api, projectId, branchId)
+				: null,
+			has("object-storage")
+				? api.listBranchBuckets(projectId, branchId)
+				: null,
+			checkAiGateway
+				? readAiGatewayAvailable(api, projectId, branchId)
+				: null,
+		]);
 
 	const config = configForServices(
 		services,
@@ -336,6 +346,9 @@ const resolveSelectedServices = async (
 			authEnabled: auth !== null,
 			dataApiEnabled,
 			buckets: buckets ?? [],
+			// A token selection validates availability while minting. The read-only check is
+			// needed only when the base URL was selected on its own.
+			aiGatewayAvailable: aiGatewayAvailable ?? true,
 		},
 		{ directServices, envKeys },
 	);
@@ -376,6 +389,25 @@ const readDataApiEnabled = async (
 	return dataApi !== null;
 };
 
+const readAiGatewayAvailable = async (
+	api: NeonApi,
+	projectId: string,
+	branchId: string,
+): Promise<boolean> => {
+	try {
+		await api.listCredentials(projectId, branchId);
+		return true;
+	} catch (error) {
+		if (
+			isPlatformError(error) &&
+			error.code === ErrorCode.FeatureUnavailable
+		) {
+			return false;
+		}
+		throw error;
+	}
+};
+
 /** Neon's default database, and the one `fetchEnv` prefers when a branch has several. */
 const NEON_DEFAULT_DATABASE = "neondb";
 
@@ -394,6 +426,7 @@ const configForServices = (
 		/** `null` when the read could not decide — see {@link readDataApiEnabled}. */
 		dataApiEnabled: boolean | null;
 		buckets: NeonBucketSnapshot[];
+		aiGatewayAvailable: boolean;
 	},
 	selection: {
 		directServices: readonly NeonService[];
@@ -425,6 +458,22 @@ const configForServices = (
 				`or in the Neon Console), or drop ${service} from --service.`,
 		);
 	};
+	const aiGatewayUnavailable = (): never => {
+		const reason =
+			"AI Gateway is not available for this Neon project because branch credentials are unavailable";
+		if (selection.directServices.includes("ai-gateway")) {
+			throw new ServiceNotOnBranchError(
+				`--service ai-gateway: ${reason}. Use another project, or drop ai-gateway from --service.`,
+			);
+		}
+		const names = selection.envKeys
+			.filter((key) => serviceForEnvKey(key) === "ai-gateway")
+			.join(", ");
+		throw new ServiceNotOnBranchError(
+			`--env ${names}: ${reason}, so ${names} cannot be pulled. ` +
+				`Use another project, or drop ${names} from --env.`,
+		);
+	};
 
 	const config: Config = {};
 	if (services.includes("auth")) {
@@ -451,7 +500,10 @@ const configForServices = (
 			]),
 		);
 	}
-	if (services.includes("ai-gateway")) preview.aiGateway = true;
+	if (services.includes("ai-gateway")) {
+		if (!branch.aiGatewayAvailable) aiGatewayUnavailable();
+		preview.aiGateway = true;
+	}
 	if (Object.keys(preview).length > 0) config.preview = preview;
 
 	return config;

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -400,7 +400,8 @@ const readAiGatewayAvailable = async (
 	} catch (error) {
 		if (
 			isPlatformError(error) &&
-			error.code === ErrorCode.FeatureUnavailable
+			error.code === ErrorCode.FeatureUnavailable &&
+			(error.details.status === 404 || error.details.status === 501)
 		) {
 			return false;
 		}

--- a/packages/cli/src/env_services.test.ts
+++ b/packages/cli/src/env_services.test.ts
@@ -23,6 +23,18 @@ describe("env pull key selection", () => {
 		);
 	});
 
+	it("does not echo a value pasted into --env", () => {
+		const secret = "postgres://user:s3cr3t@example.com/db";
+		expect(() =>
+			parseEnvPullKeys([`DATABASE_URL=${secret}`], "--env"),
+		).toThrow("Unknown env variable DATABASE_URL=<redacted>.");
+		try {
+			parseEnvPullKeys([`DATABASE_URL=${secret}`], "--env");
+		} catch (error) {
+			expect(String(error)).not.toContain(secret);
+		}
+	});
+
 	it("maps selected keys to only the services needed to resolve them", () => {
 		expect(
 			servicesForEnvKeys([

--- a/packages/cli/src/env_services.test.ts
+++ b/packages/cli/src/env_services.test.ts
@@ -19,19 +19,22 @@ describe("env pull key selection", () => {
 
 	it("rejects unknown keys instead of silently widening the pull", () => {
 		expect(() => parseEnvPullKeys(["DATABSE_URL"], "--env")).toThrow(
-			`Unknown env variable DATABSE_URL. Supported values: ${ENV_PULL_KEYS.join(", ")}.`,
+			`Unknown env variable <redacted invalid value>. Supported values: ${ENV_PULL_KEYS.join(", ")}.`,
 		);
 	});
 
 	it("does not echo a value pasted into --env", () => {
-		const secret = "postgres://user:s3cr3t@example.com/db";
-		expect(() =>
-			parseEnvPullKeys([`DATABASE_URL=${secret}`], "--env"),
-		).toThrow("Unknown env variable DATABASE_URL=<redacted>.");
-		try {
-			parseEnvPullKeys([`DATABASE_URL=${secret}`], "--env");
-		} catch (error) {
-			expect(String(error)).not.toContain(secret);
+		expect.assertions(3);
+		for (const value of [
+			"DATABASE_URL=postgres://user:s3cr3t@example.com/db",
+			"napi_live_secret123",
+			"secret_prefix,secret_suffix",
+		]) {
+			try {
+				parseEnvPullKeys([value], "--env");
+			} catch (error) {
+				expect(String(error)).not.toContain(value);
+			}
 		}
 	});
 

--- a/packages/cli/src/env_services.test.ts
+++ b/packages/cli/src/env_services.test.ts
@@ -50,7 +50,7 @@ describe("env pull key selection", () => {
 
 	it("requires the two object-storage credential variables together", () => {
 		expect(() => envKeysForSelection([], ["AWS_ACCESS_KEY_ID"])).toThrow(
-			"AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be selected together",
+			/AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be selected together.*Add the missing key to --env, or use --service object-storage/,
 		);
 
 		expect(

--- a/packages/cli/src/env_services.test.ts
+++ b/packages/cli/src/env_services.test.ts
@@ -19,7 +19,7 @@ describe("env pull key selection", () => {
 
 	it("rejects unknown keys instead of silently widening the pull", () => {
 		expect(() => parseEnvPullKeys(["DATABSE_URL"], "--env")).toThrow(
-			`Unknown env variable <redacted invalid value>. Supported values: ${ENV_PULL_KEYS.join(", ")}.`,
+			`Unknown env variable <redacted invalid value>. Did you mean DATABASE_URL? Supported values: ${ENV_PULL_KEYS.join(", ")}.`,
 		);
 	});
 

--- a/packages/cli/src/env_services.test.ts
+++ b/packages/cli/src/env_services.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	ENV_PULL_KEYS,
+	envKeysForSelection,
+	parseEnvPullKeys,
+	servicesForEnvKeys,
+} from "./env_services.js";
+
+describe("env pull key selection", () => {
+	it("parses repeated and comma-separated keys in canonical order", () => {
+		expect(
+			parseEnvPullKeys(
+				["NEON_AUTH_BASE_URL,DATABASE_URL", "NEON_AUTH_JWKS_URL"],
+				"--env",
+			),
+		).toEqual(["DATABASE_URL", "NEON_AUTH_BASE_URL", "NEON_AUTH_JWKS_URL"]);
+	});
+
+	it("rejects unknown keys instead of silently widening the pull", () => {
+		expect(() => parseEnvPullKeys(["DATABSE_URL"], "--env")).toThrow(
+			`Unknown env variable DATABSE_URL. Supported values: ${ENV_PULL_KEYS.join(", ")}.`,
+		);
+	});
+
+	it("maps selected keys to only the services needed to resolve them", () => {
+		expect(
+			servicesForEnvKeys([
+				"NEON_BRANCH",
+				"DATABASE_URL",
+				"NEON_AUTH_BASE_URL",
+			]),
+		).toEqual(["postgres", "auth"]);
+	});
+
+	it("unions full service bundles with exact env keys", () => {
+		expect(envKeysForSelection(["auth"], ["DATABASE_URL"])).toEqual([
+			"DATABASE_URL",
+			"NEON_BRANCH",
+			"NEON_AUTH_BASE_URL",
+			"NEON_AUTH_JWKS_URL",
+		]);
+	});
+
+	it("does not add NEON_BRANCH to an env-only selection", () => {
+		expect(envKeysForSelection([], ["DATABASE_URL"])).toEqual([
+			"DATABASE_URL",
+		]);
+	});
+
+	it("requires the two object-storage credential variables together", () => {
+		expect(() => envKeysForSelection([], ["AWS_ACCESS_KEY_ID"])).toThrow(
+			"AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be selected together",
+		);
+
+		expect(
+			envKeysForSelection(["object-storage"], ["AWS_ACCESS_KEY_ID"]),
+		).toContain("AWS_SECRET_ACCESS_KEY");
+	});
+});

--- a/packages/cli/src/env_services.ts
+++ b/packages/cli/src/env_services.ts
@@ -165,13 +165,11 @@ const redactUnknownEnvValue = (value: string): string => {
 	const separator = value.indexOf("=");
 	if (separator !== -1) {
 		const key = value.slice(0, separator);
-		return /^[A-Za-z][A-Za-z0-9_]*$/.test(key)
+		return ENV_PULL_KEYS.some((supportedKey) => supportedKey === key)
 			? `${key}=<redacted>`
 			: "<redacted invalid value>";
 	}
-	return /^[A-Za-z][A-Za-z0-9_]*$/.test(value)
-		? value
-		: "<redacted invalid value>";
+	return "<redacted invalid value>";
 };
 
 /** Narrow yargs' array option value without accepting any other runtime shape. */

--- a/packages/cli/src/env_services.ts
+++ b/packages/cli/src/env_services.ts
@@ -152,12 +152,26 @@ export const parseEnvPullKeys = (
 		(name) => !ENV_PULL_KEYS.some((key) => key === name),
 	);
 	if (unknown.length > 0) {
+		const displayNames = unknown.map(redactUnknownEnvValue);
 		throw new Error(
-			`Unknown env variable${unknown.length === 1 ? "" : "s"} ${unknown.join(", ")}. ${supported}`,
+			`Unknown env variable${unknown.length === 1 ? "" : "s"} ${displayNames.join(", ")}. ${supported}`,
 		);
 	}
 
 	return ENV_PULL_KEYS.filter((key) => names.includes(key));
+};
+
+const redactUnknownEnvValue = (value: string): string => {
+	const separator = value.indexOf("=");
+	if (separator !== -1) {
+		const key = value.slice(0, separator);
+		return /^[A-Za-z][A-Za-z0-9_]*$/.test(key)
+			? `${key}=<redacted>`
+			: "<redacted invalid value>";
+	}
+	return /^[A-Za-z][A-Za-z0-9_]*$/.test(value)
+		? value
+		: "<redacted invalid value>";
 };
 
 /** Narrow yargs' array option value without accepting any other runtime shape. */

--- a/packages/cli/src/env_services.ts
+++ b/packages/cli/src/env_services.ts
@@ -17,8 +17,19 @@ export const ENV_PULL_UNAVAILABLE: Partial<Record<NeonService, string>> = {
 		"a function's env comes from your neon.ts, not from the branch, so there is nothing to pull",
 };
 
+/** Every OS-level env var `env pull` can write, in stable emit order. */
+export const ENV_PULL_KEYS = [
+	...Object.values(NEON_ENV_VAR_KEYS.postgres),
+	NEON_ENV_VAR_KEYS.branch.name,
+	...Object.values(NEON_ENV_VAR_KEYS.auth),
+	...Object.values(NEON_ENV_VAR_KEYS.dataApi),
+	...Object.values(NEON_ENV_VAR_KEYS.storage),
+	...Object.values(NEON_ENV_VAR_KEYS.aiGateway),
+] as const;
+export type EnvPullKey = (typeof ENV_PULL_KEYS)[number];
+
 /** The OS-level env vars each service contributes to a pulled `.env`. */
-const SERVICE_ENV_KEYS: Record<NeonService, readonly string[]> = {
+const SERVICE_ENV_KEYS: Record<NeonService, readonly EnvPullKey[]> = {
 	postgres: Object.values(NEON_ENV_VAR_KEYS.postgres),
 	auth: Object.values(NEON_ENV_VAR_KEYS.auth),
 	"data-api": Object.values(NEON_ENV_VAR_KEYS.dataApi),
@@ -44,6 +55,33 @@ const SERVICE_OWNED_ENV_KEYS: Record<NeonService, readonly string[]> = {
  */
 export const BRANCH_ENV_KEY = NEON_ENV_VAR_KEYS.branch.name;
 
+/** The service that produces a key, or `null` for branch identity. */
+const ENV_KEY_SERVICE: Record<EnvPullKey, NeonService | null> = {
+	DATABASE_URL: "postgres",
+	DATABASE_URL_UNPOOLED: "postgres",
+	NEON_BRANCH: null,
+	NEON_AUTH_BASE_URL: "auth",
+	NEON_AUTH_JWKS_URL: "auth",
+	NEON_DATA_API_URL: "data-api",
+	AWS_ACCESS_KEY_ID: "object-storage",
+	AWS_SECRET_ACCESS_KEY: "object-storage",
+	AWS_ENDPOINT_URL_S3: "object-storage",
+	AWS_REGION: "object-storage",
+	NEON_AI_GATEWAY_TOKEN: "ai-gateway",
+	NEON_AI_GATEWAY_BASE_URL: "ai-gateway",
+};
+
+export const serviceForEnvKey = (key: EnvPullKey): NeonService | null =>
+	ENV_KEY_SERVICE[key];
+
+/** Services that must be resolved to produce the selected env keys. */
+export const servicesForEnvKeys = (
+	keys: readonly EnvPullKey[],
+): NeonService[] =>
+	ENV_PULL_SERVICES.filter((service) =>
+		keys.some((key) => ENV_KEY_SERVICE[key] === service),
+	);
+
 /** Every env var the selected services contribute, plus branch identity. */
 export const envServiceKeys = (
 	services: readonly NeonService[],
@@ -63,3 +101,64 @@ export const envServiceKeys = (
 export const ownedEnvServiceKeys = (
 	services: readonly NeonService[],
 ): string[] => services.flatMap((service) => SERVICE_OWNED_ENV_KEYS[service]);
+
+/**
+ * The exact env vars an explicit selection writes. Services contribute their complete
+ * bundles plus branch identity; `--env` contributes only the named keys. The two selectors
+ * compose as a union.
+ */
+export const envKeysForSelection = (
+	services: readonly NeonService[],
+	envKeys: readonly EnvPullKey[],
+): EnvPullKey[] => {
+	const selected =
+		services.length > 0 ? envServiceKeys(services) : new Set<string>();
+	for (const key of envKeys) selected.add(key);
+
+	const hasStorageAccessKey = selected.has(
+		NEON_ENV_VAR_KEYS.storage.accessKeyId,
+	);
+	const hasStorageSecret = selected.has(
+		NEON_ENV_VAR_KEYS.storage.secretAccessKey,
+	);
+	if (hasStorageAccessKey !== hasStorageSecret) {
+		throw new Error(
+			"AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be selected together: " +
+				"they are two halves of one newly issued object-storage credential.",
+		);
+	}
+
+	return ENV_PULL_KEYS.filter((key) => selected.has(key));
+};
+
+/** Parse repeated or comma-separated `--env` values into canonical env-key order. */
+export const parseEnvPullKeys = (
+	raw: readonly string[],
+	flag: string,
+): EnvPullKey[] => {
+	const names = raw
+		.flatMap((value) => value.split(","))
+		.map((name) => name.trim())
+		.filter((name) => name !== "");
+	const supported = `Supported values: ${ENV_PULL_KEYS.join(", ")}.`;
+	if (names.length === 0) {
+		throw new Error(
+			`${flag} needs at least one env variable. ${supported}`,
+		);
+	}
+
+	const unknown = names.filter(
+		(name) => !ENV_PULL_KEYS.some((key) => key === name),
+	);
+	if (unknown.length > 0) {
+		throw new Error(
+			`Unknown env variable${unknown.length === 1 ? "" : "s"} ${unknown.join(", ")}. ${supported}`,
+		);
+	}
+
+	return ENV_PULL_KEYS.filter((key) => names.includes(key));
+};
+
+/** Narrow yargs' array option value without accepting any other runtime shape. */
+export const envPullFlagValue = (value: unknown): string[] | undefined =>
+	Array.isArray(value) ? value.map(String) : undefined;

--- a/packages/cli/src/env_services.ts
+++ b/packages/cli/src/env_services.ts
@@ -124,7 +124,8 @@ export const envKeysForSelection = (
 	if (hasStorageAccessKey !== hasStorageSecret) {
 		throw new Error(
 			"AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be selected together: " +
-				"they are two halves of one newly issued object-storage credential.",
+				"they are two halves of one newly issued object-storage credential. " +
+				"Add the missing key to --env, or use --service object-storage.",
 		);
 	}
 

--- a/packages/cli/src/env_services.ts
+++ b/packages/cli/src/env_services.ts
@@ -153,8 +153,19 @@ export const parseEnvPullKeys = (
 	);
 	if (unknown.length > 0) {
 		const displayNames = unknown.map(redactUnknownEnvValue);
+		const suggestions = [
+			...new Set(
+				unknown
+					.map(suggestEnvPullKey)
+					.filter((key): key is EnvPullKey => key !== null),
+			),
+		];
+		const suggestion =
+			suggestions.length > 0
+				? ` Did you mean ${suggestions.join(" or ")}?`
+				: "";
 		throw new Error(
-			`Unknown env variable${unknown.length === 1 ? "" : "s"} ${displayNames.join(", ")}. ${supported}`,
+			`Unknown env variable${unknown.length === 1 ? "" : "s"} ${displayNames.join(", ")}.${suggestion} ${supported}`,
 		);
 	}
 
@@ -170,6 +181,34 @@ const redactUnknownEnvValue = (value: string): string => {
 			: "<redacted invalid value>";
 	}
 	return "<redacted invalid value>";
+};
+
+const suggestEnvPullKey = (value: string): EnvPullKey | null => {
+	if (value.includes("=")) return null;
+	const closest = ENV_PULL_KEYS.map(
+		(key) => [key, editDistance(value, key)] as const,
+	).sort((a, b) => a[1] - b[1])[0];
+	return closest && closest[1] <= 2 ? closest[0] : null;
+};
+
+const editDistance = (left: string, right: string): number => {
+	let previous = Array.from(
+		{ length: right.length + 1 },
+		(_, index) => index,
+	);
+	for (let leftIndex = 1; leftIndex <= left.length; leftIndex += 1) {
+		const current = [leftIndex];
+		for (let rightIndex = 1; rightIndex <= right.length; rightIndex += 1) {
+			current[rightIndex] = Math.min(
+				(previous[rightIndex] ?? 0) + 1,
+				(current[rightIndex - 1] ?? 0) + 1,
+				(previous[rightIndex - 1] ?? 0) +
+					(left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1),
+			);
+		}
+		previous = current;
+	}
+	return previous[right.length] ?? right.length;
 };
 
 /** Narrow yargs' array option value without accepting any other runtime shape. */

--- a/packages/cli/src/utils/middlewares.test.ts
+++ b/packages/cli/src/utils/middlewares.test.ts
@@ -1,9 +1,35 @@
 import { credentialInputs } from "@neon-internals/cli-core/auth_selection";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { resolveApiKeyFromEnv } from "./middlewares.js";
+import yargs from "yargs/yargs";
+import { fillInArgs, resolveApiKeyFromEnv } from "./middlewares.js";
 
 afterEach(() => {
 	vi.unstubAllEnvs();
+});
+
+describe("fillInArgs", () => {
+	test("leaves array-valued options intact under strict validation", async () => {
+		const parsed = await yargs(["-e", "DATABASE_URL", "-s", "postgres"])
+			.exitProcess(false)
+			.option("env", {
+				alias: "e",
+				type: "array",
+				string: true,
+			})
+			.option("service", {
+				alias: ["s", "services"],
+				type: "array",
+				string: true,
+			})
+			.middleware((args) => {
+				fillInArgs(args);
+			}, true)
+			.strict()
+			.parse();
+
+		expect(parsed.env).toEqual(["DATABASE_URL"]);
+		expect(parsed.service).toEqual(["postgres"]);
+	});
 });
 
 /**

--- a/packages/cli/src/utils/middlewares.ts
+++ b/packages/cli/src/utils/middlewares.ts
@@ -43,6 +43,9 @@ export const fillInArgs = (
 		if (k === "_" || k === "--") {
 			return;
 		}
+		if (Array.isArray(v)) {
+			return;
+		}
 		// check if the value is an Object
 		if (typeof v === "object" && v !== null) {
 			fillInArgs(args, v as any, [...acc, k]);

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -163,6 +163,8 @@ selected.postgres?.databaseUrl; // string | undefined
 selected.branch?.name; // string | undefined
 ```
 
+`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are one credential and must be selected together. Literal lists that contain only one half are a type error; a runtime-built list that resolves to one half throws before any API request or credential issuance.
+
 Work is skipped, not just the result narrowed. Leave out `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `NEON_AI_GATEWAY_TOKEN` and **no credential is minted at all** — which is exactly how `fetchEnvReusingSecrets` refreshes everything else while keeping secrets you already have. The non-secret vars of those features (`AWS_ENDPOINT_URL_S3`, `AWS_REGION`, `NEON_AI_GATEWAY_BASE_URL`) are branch metadata and stay available on their own.
 
 ## Connection role & database selection

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -152,6 +152,17 @@ const { storage } = await fetchEnv(config, {
 storage.endpoint; // string — `accessKeyId` is absent, and never fetched
 ```
 
+Inline key arrays autocomplete from the services enabled in `config`, reject unknown or disabled keys, and narrow the result exactly without `as const`. A runtime-built array returns the same selected values with optional namespaces and properties, because the array may contain any subset of its declared key union:
+
+```ts
+const keys: Array<"DATABASE_URL" | "NEON_BRANCH"> =
+    process.env.INCLUDE_BRANCH ? ["DATABASE_URL", "NEON_BRANCH"] : ["DATABASE_URL"];
+const selected = await fetchEnv(config, { projectId, branch: "main", keys });
+
+selected.postgres?.databaseUrl; // string | undefined
+selected.branch?.name; // string | undefined
+```
+
 Work is skipped, not just the result narrowed. Leave out `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `NEON_AI_GATEWAY_TOKEN` and **no credential is minted at all** — which is exactly how `fetchEnvReusingSecrets` refreshes everything else while keeping secrets you already have. The non-secret vars of those features (`AWS_ENDPOINT_URL_S3`, `AWS_REGION`, `NEON_AI_GATEWAY_BASE_URL`) are branch metadata and stay available on their own.
 
 ## Connection role & database selection

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -27,6 +27,7 @@ export type {
 	NeonStorageEnv,
 	ResolvedNeonEnv,
 	SelectableEnvKey,
+	SelectedNeonEnv,
 } from "@neon-internals/env-core/env";
 export {
 	fetchEnv,

--- a/packages/env/src/lib/env.completions.test.ts
+++ b/packages/env/src/lib/env.completions.test.ts
@@ -41,6 +41,9 @@ const compilerOptions: ts.CompilerOptions = {
 	baseUrl: here,
 	paths: {
 		"@neon/config/v1": [resolve(here, "../../../config/src/v1.ts")],
+		"@neon-internals/env-core/env": [
+			resolve(here, "../../../../internals/env-core/src/env.ts"),
+		],
 	},
 };
 
@@ -105,6 +108,19 @@ function fixture(configBody: string, call: string): string {
 	].join("\n");
 }
 
+/** A fixture that reaches `fetchEnv` through the package's public entry point. */
+function fetchFixture(configBody: string, call: string): string {
+	return [
+		'import { defineConfig } from "@neon/config/v1";',
+		'import { fetchEnv } from "../index.js";',
+		"",
+		`const config = defineConfig(${configBody});`,
+		"",
+		`export const env = ${call};`,
+		"",
+	].join("\n");
+}
+
 const TWO_FUNCTIONS = `{
 	preview: {
 		functions: {
@@ -140,6 +156,26 @@ describe("parseEnv autocomplete", () => {
 			),
 		);
 		// Postgres + auth only: no storage / AI Gateway keys, since the policy enables neither.
+		expect(entries).toEqual([
+			"DATABASE_URL",
+			"DATABASE_URL_UNPOOLED",
+			"NEON_AUTH_BASE_URL",
+			"NEON_AUTH_JWKS_URL",
+			"NEON_BRANCH",
+		]);
+	});
+
+	test("offers policy-scoped keys through fetchEnv's public package export", () => {
+		const entries = completionsAt(
+			fetchFixture(
+				`{ auth: true, ${TWO_FUNCTIONS.slice(1)}`,
+				`fetchEnv(config, {
+					projectId: "proj",
+					branch: "main",
+					keys: ["${CARET}"],
+				})`,
+			),
+		);
 		expect(entries).toEqual([
 			"DATABASE_URL",
 			"DATABASE_URL_UNPOOLED",

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -236,6 +236,33 @@ describe("fetchEnv key filter (types)", () => {
 		fetchEnv(config, options);
 	});
 
+	test("requires both storage credential halves in every tuple-position alternative", () => {
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		const eitherCredential =
+			Math.random() > 0.5
+				? ("AWS_ACCESS_KEY_ID" as const)
+				: ("AWS_SECRET_ACCESS_KEY" as const);
+		const secretOrRegion =
+			Math.random() > 0.5
+				? ("AWS_SECRET_ACCESS_KEY" as const)
+				: ("AWS_REGION" as const);
+
+		// @ts-expect-error each runtime alternative contains only one credential half
+		fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys: [eitherCredential],
+		});
+		// @ts-expect-error the secret key is not guaranteed to accompany the access key
+		fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys: ["AWS_ACCESS_KEY_ID", secretOrRegion],
+		});
+	});
+
 	test("preserves valid storage tuple alternatives exactly", () => {
 		const config = defineConfig({
 			preview: { buckets: { uploads: {} } },

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -328,10 +328,10 @@ describe("fetchEnv key filter (types)", () => {
 		const config = defineConfig({});
 		// @ts-expect-error not a real Neon env var
 		fetchEnv(config, { projectId: "proj", branch: "main", keys: ["NOPE"] });
-		// @ts-expect-error auth is not enabled by this policy
 		fetchEnv(config, {
 			projectId: "proj",
 			branch: "main",
+			// @ts-expect-error auth is not enabled by this policy
 			keys: ["NEON_AUTH_BASE_URL"],
 		});
 	});

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -10,7 +10,9 @@ import type {
 	NeonPostgresEnv,
 	NeonStorageEnv,
 	SelectableEnvKey,
+	SelectedNeonEnv,
 } from "@neon-internals/env-core/env";
+import { fetchEnv } from "@neon-internals/env-core/env";
 import { describe, expectTypeOf, test } from "vitest";
 import type {
 	FunctionSlugOf,
@@ -72,6 +74,137 @@ describe("parseEnv key filter (types)", () => {
 		expectTypeOf<SelectableEnvKey<typeof config>>().toEqualTypeOf<
 			"DATABASE_URL" | "DATABASE_URL_UNPOOLED" | "NEON_BRANCH"
 		>();
+	});
+});
+
+describe("fetchEnv key filter (types)", () => {
+	test("keeps an inline literal selection exact", () => {
+		const config = defineConfig({});
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys: ["DATABASE_URL"],
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{ postgres: { databaseUrl: string } }>
+		>();
+	});
+
+	test("makes a dynamic selection safely optional", () => {
+		const config = defineConfig({});
+		const keys: Array<"DATABASE_URL" | "NEON_BRANCH"> =
+			Math.random() > 0.5 ? ["DATABASE_URL"] : ["NEON_BRANCH"];
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys,
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{
+				postgres?: { databaseUrl?: string };
+				branch?: { name?: string };
+			}>
+		>();
+	});
+
+	test("an empty dynamic selection does not claim its element type is present", () => {
+		const config = defineConfig({});
+		const keys: "DATABASE_URL"[] = [];
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys,
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{ postgres?: { databaseUrl?: string } }>
+		>();
+	});
+
+	test("a tuple containing a union-valued key stays conservative", () => {
+		const config = defineConfig({});
+		const key =
+			Math.random() > 0.5
+				? ("DATABASE_URL" as const)
+				: ("NEON_BRANCH" as const);
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys: [key],
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{
+				postgres?: { databaseUrl?: string };
+				branch?: { name?: string };
+			}>
+		>();
+	});
+
+	test("a rest tuple never overstates which repeated keys are present", () => {
+		const config = defineConfig({});
+		const keys: readonly ["DATABASE_URL", ..."NEON_BRANCH"[]] = [
+			"DATABASE_URL",
+		];
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys,
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{
+				postgres?: { databaseUrl?: string };
+				branch?: { name?: string };
+			}>
+		>();
+	});
+
+	test("a union of whole literal tuples preserves its exact alternatives", () => {
+		const config = defineConfig({});
+		const keys =
+			Math.random() > 0.5
+				? (["DATABASE_URL"] as const)
+				: (["NEON_BRANCH"] as const);
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys,
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<
+				| { postgres: { databaseUrl: string } }
+				| { branch: { name: string } }
+			>
+		>();
+	});
+
+	test("keeps existing explicit generic calls valid and conservative", () => {
+		const config = defineConfig({});
+		const env = fetchEnv<typeof config, "DATABASE_URL">(config, {
+			projectId: "proj",
+			branch: "main",
+			keys: ["DATABASE_URL"],
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{ postgres?: { databaseUrl?: string } }>
+		>();
+	});
+
+	test("rejects unknown and policy-disabled keys", () => {
+		const config = defineConfig({});
+		// @ts-expect-error not a real Neon env var
+		fetchEnv(config, { projectId: "proj", branch: "main", keys: ["NOPE"] });
+		// @ts-expect-error auth is not enabled by this policy
+		fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys: ["NEON_AUTH_BASE_URL"],
+		});
 	});
 });
 
@@ -424,6 +557,9 @@ describe("env type-export surface", () => {
 		expectTypeOf<NeonFunctionEnv<typeof sample, "hello">>().not.toBeAny();
 		expectTypeOf<NeonPostgresEnv>().not.toBeAny();
 		expectTypeOf<NeonStorageEnv>().not.toBeAny();
+		expectTypeOf<
+			SelectedNeonEnv<readonly ["DATABASE_URL"]>
+		>().not.toBeAny();
 		expectTypeOf<SelectableEnvKey<typeof sample>>().not.toBeAny();
 	});
 });

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -182,7 +182,7 @@ describe("fetchEnv key filter (types)", () => {
 		>();
 	});
 
-	test("keeps existing explicit generic calls valid and conservative", () => {
+	test("keeps existing explicit generic calls exact", () => {
 		const config = defineConfig({});
 		const env = fetchEnv<typeof config, "DATABASE_URL">(config, {
 			projectId: "proj",
@@ -191,7 +191,47 @@ describe("fetchEnv key filter (types)", () => {
 		});
 
 		expectTypeOf(env).toEqualTypeOf<
-			Promise<{ postgres?: { databaseUrl?: string } }>
+			Promise<{ postgres: { databaseUrl: string } }>
+		>();
+	});
+
+	test("requires both storage credential halves in a literal selection", () => {
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+		});
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{
+				storage: { accessKeyId: string; secretAccessKey: string };
+			}>
+		>();
+
+		fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			// @ts-expect-error storage credential halves must be selected together
+			keys: ["AWS_ACCESS_KEY_ID"],
+		});
+	});
+
+	test("accepts a dynamic storage selection for runtime validation", () => {
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		const keys: Array<"AWS_ACCESS_KEY_ID" | "AWS_SECRET_ACCESS_KEY"> = [];
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys,
+		});
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<{
+				storage?: { accessKeyId?: string; secretAccessKey?: string };
+			}>
 		>();
 	});
 

--- a/packages/env/src/lib/env.test-d.ts
+++ b/packages/env/src/lib/env.test-d.ts
@@ -210,12 +210,74 @@ describe("fetchEnv key filter (types)", () => {
 			}>
 		>();
 
+		// @ts-expect-error storage credential halves must be selected together
 		fetchEnv(config, {
 			projectId: "proj",
 			branch: "main",
-			// @ts-expect-error storage credential halves must be selected together
 			keys: ["AWS_ACCESS_KEY_ID"],
 		});
+	});
+
+	test("requires both storage credential halves in every tuple alternative", () => {
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		const keys =
+			Math.random() > 0.5
+				? (["AWS_ACCESS_KEY_ID"] as const)
+				: (["AWS_SECRET_ACCESS_KEY"] as const);
+
+		const options = {
+			projectId: "proj",
+			branch: "main",
+			keys,
+		};
+		// @ts-expect-error every tuple alternative must contain both credential halves
+		fetchEnv(config, options);
+	});
+
+	test("preserves valid storage tuple alternatives exactly", () => {
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		const keys =
+			Math.random() > 0.5
+				? (["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"] as const)
+				: (["AWS_ENDPOINT_URL_S3"] as const);
+		const env = fetchEnv(config, {
+			projectId: "proj",
+			branch: "main",
+			keys,
+		});
+
+		expectTypeOf(env).toEqualTypeOf<
+			Promise<
+				| {
+						storage: {
+							accessKeyId: string;
+							secretAccessKey: string;
+						};
+				  }
+				| { storage: { endpoint: string } }
+			>
+		>();
+	});
+
+	test("does not infer the explicit-generic overload from a contextual return", () => {
+		const config = defineConfig({
+			preview: { buckets: { uploads: {} } },
+		});
+		// @ts-expect-error an invalid selection cannot produce a complete storage credential
+		const completeStorage: Promise<{
+			storage: { accessKeyId: string; secretAccessKey: string };
+		}> =
+			// @ts-expect-error inferred callers cannot bypass the storage pair rule
+			fetchEnv(config, {
+				projectId: "proj",
+				branch: "main",
+				keys: ["AWS_ACCESS_KEY_ID"],
+			});
+		void completeStorage;
 	});
 
 	test("accepts a dynamic storage selection for runtime validation", () => {

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -194,6 +194,25 @@ describe("fetchEnv", () => {
 		expect(connectionCalls[0]?.args[1]).toMatchObject({ pooled: true });
 	});
 
+	test("rejects an incomplete storage credential selection before API reads", async () => {
+		const { api, projectId } = seededFake();
+		const keys: Array<"AWS_ACCESS_KEY_ID" | "AWS_SECRET_ACCESS_KEY"> = [
+			"AWS_ACCESS_KEY_ID",
+		];
+
+		await expect(
+			fetchEnv(defineConfig({ preview: { buckets: { uploads: {} } } }), {
+				api,
+				projectId,
+				branchId: "br-main",
+				keys,
+			}),
+		).rejects.toThrow(
+			"fetchEnv: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be selected together. Pass both in `keys`, or omit both.",
+		);
+		expect(api.history).toHaveLength(0);
+	});
+
 	test("requires auth integration when policy enables auth", async () => {
 		const { api, projectId } = seededFake();
 		const config = defineConfig({ auth: true });

--- a/packages/env/src/lib/env.test.ts
+++ b/packages/env/src/lib/env.test.ts
@@ -159,6 +159,41 @@ describe("fetchEnv", () => {
 		expect(toEntries(env).NEON_BRANCH).toBe("main");
 	});
 
+	test("a branch-only key filter skips unrelated Postgres reads", async () => {
+		const { api, projectId } = seededFake();
+		const env = await fetchEnv(defineConfig({}), {
+			api,
+			projectId,
+			branchId: "br-main",
+			keys: ["NEON_BRANCH"],
+		});
+
+		expect(toEntries(env)).toEqual({ NEON_BRANCH: "main" });
+		const methods = api.history.map((entry) => entry.method);
+		expect(methods).not.toContain("listBranchRoles");
+		expect(methods).not.toContain("listBranchDatabases");
+		expect(methods).not.toContain("getConnectionUri");
+	});
+
+	test("a pooled-URL key filter fetches no direct connection URI", async () => {
+		const { api, projectId } = seededFake();
+		const env = await fetchEnv(defineConfig({}), {
+			api,
+			projectId,
+			branchId: "br-main",
+			keys: ["DATABASE_URL"],
+		});
+
+		expect(toEntries(env)).toEqual({
+			DATABASE_URL: expect.stringContaining("postgresql://"),
+		});
+		const connectionCalls = api.history.filter(
+			(entry) => entry.method === "getConnectionUri",
+		);
+		expect(connectionCalls).toHaveLength(1);
+		expect(connectionCalls[0]?.args[1]).toMatchObject({ pooled: true });
+	});
+
 	test("requires auth integration when policy enables auth", async () => {
 		const { api, projectId } = seededFake();
 		const config = defineConfig({ auth: true });

--- a/packages/env/src/lib/reuse-secrets.test.ts
+++ b/packages/env/src/lib/reuse-secrets.test.ts
@@ -282,6 +282,55 @@ describe("fetchEnvReusingSecrets", () => {
 		expect(vars.NEON_BRANCH).toBe("main");
 	});
 
+	test("does not mint a credential when only a non-secret gateway variable is selected", async () => {
+		const { api, projectId } = seededFake();
+
+		const { vars, credential } = await fetchEnvReusingSecrets(
+			gatewayPolicy,
+			{
+				api,
+				projectId,
+				branch: "main",
+				keys: ["NEON_AI_GATEWAY_BASE_URL"],
+			},
+		);
+
+		expect(vars).toEqual({
+			NEON_AI_GATEWAY_BASE_URL:
+				"https://br-main-api.ai.aws-us-east-1.fake.neon.tech",
+		});
+		expect(callsTo(api, "listCredentials")).toBe(0);
+		expect(callsTo(api, "createCredential")).toBe(0);
+		expect(credential).toEqual({
+			issued: false,
+			keys: [],
+			revoked: [],
+			superseded: [],
+		});
+	});
+
+	test("does not widen a credential for a selected non-secret variable", async () => {
+		const { api, projectId } = seededFake();
+
+		await fetchEnvReusingSecrets(bothPolicy, {
+			api,
+			projectId,
+			branch: "main",
+			keys: [
+				"AWS_ACCESS_KEY_ID",
+				"AWS_SECRET_ACCESS_KEY",
+				"NEON_AI_GATEWAY_BASE_URL",
+			],
+		});
+
+		const create = api.history.find(
+			(entry) => entry.method === "createCredential",
+		);
+		expect(create?.args[2]).toMatchObject({
+			scopes: ["storage:read", "storage:write"],
+		});
+	});
+
 	test("does not look up credentials when nothing is persisted to verify", async () => {
 		// A first run has nothing to check, so the list call would be wasted.
 		const { api, projectId } = seededFake();

--- a/packages/env/src/lib/reuse-secrets.test.ts
+++ b/packages/env/src/lib/reuse-secrets.test.ts
@@ -161,6 +161,32 @@ describe("fetchEnvReusingSecrets", () => {
 		expect(live[0]?.tokenId).toBe(widened.vars.AWS_ACCESS_KEY_ID);
 	});
 
+	test("revokes the credential it replaces when the branch switches features", async () => {
+		const { api, projectId } = seededFake();
+		const storageOnly = await fetchEnvReusingSecrets(storagePolicy, {
+			api,
+			projectId,
+			branch: "main",
+		});
+
+		const gatewayOnly = await fetchEnvReusingSecrets(gatewayPolicy, {
+			api,
+			projectId,
+			branch: "main",
+			env: { ...process.env, ...storageOnly.vars },
+		});
+
+		expect(gatewayOnly.credential).toEqual({
+			issued: true,
+			keys: ["NEON_AI_GATEWAY_TOKEN"],
+			revoked: [storageOnly.vars.AWS_ACCESS_KEY_ID],
+			superseded: [],
+		});
+		const live = await api.listCredentials(projectId, "br-main");
+		expect(live).toHaveLength(1);
+		expect(live[0]?.scopes).toEqual(["ai_gateway:invoke"]);
+	});
+
 	test("keeps the superseded credential live when the caller resolves only part of the branch", async () => {
 		// `revokeSuperseded: false` is for a caller resolving a subset — `neon env pull
 		// --service`. Here the branch has both features on one credential, but the resolve

--- a/packages/env/src/lib/reuse-secrets.test.ts
+++ b/packages/env/src/lib/reuse-secrets.test.ts
@@ -282,6 +282,68 @@ describe("fetchEnvReusingSecrets", () => {
 		expect(vars.NEON_BRANCH).toBe("main");
 	});
 
+	test("mints and reuses only the selected gateway secret", async () => {
+		const { api, projectId } = seededFake();
+		const first = await fetchEnvReusingSecrets(bothPolicy, {
+			api,
+			projectId,
+			branch: "main",
+			keys: ["NEON_AI_GATEWAY_TOKEN"],
+		});
+
+		expect(Object.keys(first.vars)).toEqual(["NEON_AI_GATEWAY_TOKEN"]);
+		expect(first.vars.NEON_AI_GATEWAY_TOKEN).toMatch(/^nt_live_/);
+		const create = api.history.find(
+			(entry) => entry.method === "createCredential",
+		);
+		expect(create?.args[2]).toMatchObject({
+			scopes: ["ai_gateway:invoke"],
+		});
+
+		const second = await fetchEnvReusingSecrets(bothPolicy, {
+			api,
+			projectId,
+			branch: "main",
+			keys: ["NEON_AI_GATEWAY_TOKEN"],
+			env: { ...process.env, ...first.vars },
+		});
+
+		expect(callsTo(api, "createCredential")).toBe(1);
+		expect(second.vars).toEqual(first.vars);
+		expect(second.credential).toEqual({
+			issued: false,
+			keys: ["NEON_AI_GATEWAY_TOKEN"],
+			revoked: [],
+			superseded: [],
+		});
+	});
+
+	test("reports but does not revoke a credential replaced by an exact secret pull", async () => {
+		const { api, projectId } = seededFake();
+		const storageOnly = await api.createCredential(projectId, "br-main", {
+			scopes: ["storage:read", "storage:write"],
+			principalType: "user",
+			name: "neon-env main",
+		});
+
+		const result = await fetchEnvReusingSecrets(bothPolicy, {
+			api,
+			projectId,
+			branch: "main",
+			keys: ["NEON_AI_GATEWAY_TOKEN"],
+			env: { NEON_AI_GATEWAY_TOKEN: storageOnly.apiToken },
+			revokeSuperseded: false,
+		});
+
+		expect(result.credential).toEqual({
+			issued: true,
+			keys: ["NEON_AI_GATEWAY_TOKEN"],
+			revoked: [],
+			superseded: [storageOnly.tokenId],
+		});
+		expect(callsTo(api, "revokeCredential")).toBe(0);
+	});
+
 	test("does not mint a credential when only a non-secret gateway variable is selected", async () => {
 		const { api, projectId } = seededFake();
 


### PR DESCRIPTION
## Problem

`neon env pull --service` scopes a pull to service bundles. A caller that needs only `DATABASE_URL` still has to accept `DATABASE_URL_UNPOOLED` and `NEON_BRANCH`, and there is no exact-key interface.

Filtering only at file-write time is insufficient: resolution may mint branch credentials, inspect unrelated services, and treat unselected variables as managed. Exact selection has to reach the resolver and credential-reuse layer.

The matching `fetchEnv(config, { keys })` interface was exact only for inline literals. A runtime-built key list widened to its element union, so TypeScript claimed every possible key was present even when the runtime array selected only one.

## Solution

Add `-e, --env` for repeated or comma-separated environment-variable names. `--env` and `--service` form one explicit union and override `neon.ts`:

```bash
neon env pull -e DATABASE_URL
# .env.local contains only DATABASE_URL

neon env pull -s auth -e DATABASE_URL
# .env.local contains DATABASE_URL, NEON_BRANCH,
# NEON_AUTH_BASE_URL, and NEON_AUTH_JWKS_URL
```

`--env` never narrows a selected service bundle. The selection is applied to API reads, credential scopes and reuse, file writes, and stale-key pruning. A `DATABASE_URL`-only pull fetches no direct connection URI; a branch-, Auth-, storage-, or gateway-token-only pull makes no unrelated Postgres reads.

`fetchEnv` now preserves exact literal inference and safely represents dynamic selections:

```ts
const exact = await fetchEnv(config, {
  projectId,
  branch: "main",
  keys: ["DATABASE_URL"],
});
exact.postgres.databaseUrl; // string

const keys: Array<"DATABASE_URL" | "NEON_BRANCH"> = getKeys();
const selected = await fetchEnv(config, { projectId, branch: "main", keys });
selected.postgres?.databaseUrl; // string | undefined
selected.branch?.name; // string | undefined
```

Literal keys autocomplete from the services enabled by `config`; unknown and policy-disabled keys remain type errors. Widened arrays, rest tuples, and union-valued tuple positions return optional namespaces and properties. Unions of complete literal tuples retain their exact alternatives. Existing explicit-generic calls remain exact, and calls without `keys` are unchanged. Pre-bound untyped key arrays that previously fell through to the full-env overload now fail type checking instead of promising unselected values.

Selection rules:

- unknown variable names and unknown option spellings fail before a pull can silently widen; unknown selector input is redacted before the error reaches logs or analytics
- env-only pulls add only named keys; `NEON_BRANCH` must be named explicitly
- a selected service contributes its complete bundle plus `NEON_BRANCH`
- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be selected together because a newly issued storage credential changes both halves; the CLI error points to the missing key or `--service object-storage`, while `fetchEnv` rejects invalid literal lists at compile time and invalid runtime-built lists before API reads
- a base-URL-only AI Gateway selection verifies the read-only branch-credentials endpoint before writing a URL; structured unsupported-project responses fail by selector without minting a credential, while transient or ambiguous failures keep their original error
- scoped pulls do not revoke superseded branch credentials because unselected variables may still use them
- unscoped pulls still revoke the tool-issued credential they replace when the policy switches between storage and AI Gateway, even though the old feature is no longer selected

## Also in here

- Add CLI and resolver tests for exact selection, service/key unions, `neon.ts` precedence, stale-key preservation, dependency reads, credential mint/reuse/replacement, policy transitions, AI Gateway availability, secret-safe invalid input, typo-safe parsing, and strict parsing of array-valued flags.
- Add type tests for exact, dynamic, empty, rest, union-valued, whole-tuple-union, explicit-generic, and storage-credential-pair `fetchEnv` selections.
- Assert `fetchEnv` key completions through the package's public entry point with the TypeScript language service.
- Add a real-API e2e case that runs the built CLI and verifies the output file contains only `DATABASE_URL`.
- Document both interfaces. Patch changesets cover `@neon/env` and `neon`; the fixed CLI group also bumps `neonctl`.

## Verification

- `pnpm test:ci` — all workspace suites passed; CLI: 4,093 tests passed, 6 existing opt-in Testcontainers tests skipped by the default local run
- `pnpm --filter @neon/env test:ci` — 164 tests passed
- `pnpm --filter @neon/env test:types` — 45 type assertions passed
- `pnpm build`
- `pnpm lint:ci`
- `pnpm changeset status` — patch bumps: `@neon/env`, `neon`, and fixed-group `neonctl`
- packed `@neon/env` into a clean consumer, installed it normally, and compiled exact, dynamic, explicit-generic, and storage-pair selection examples with `tsc --noEmit`; invalid pairs report the missing-key rule in the TypeScript diagnostic
- built CLI accepts `-e DATABASE_URL` and `-s postgres` under strict parsing; `-e DATABSE_URL` reports the supported values; `--envs DATABASE_URL` exits before starting a pull
- [Live Neon e2e](https://github.com/neondatabase/neon-pkgs/actions/runs/31478633129/job/93738187855) on final HEAD — passed against the real API; the test deleted its project after verifying that only `DATABASE_URL` was written

## For attention

- The three unrelated opt-in psql Testcontainers suites could not start locally because this machine has no container runtime. They remain CI-gated with `CI=true`.
- Passing a pre-bound untyped `string[]` as `keys` is an intentional compile break: the old overload promised the full env even when runtime filtering removed fields. Use a policy-scoped key union for optional dynamic results.
- The synchronous `parseEnv(config, keys)` sibling still has the pre-existing dynamic-list unsoundness; it is tracked separately rather than expanding this PR.
- Exact selection can leave a replaced credential live by design. Revoking it could break an unselected storage or AI Gateway variable; the CLI reports the retained credential so it can be removed explicitly.