### PR TITLE
chore: release @neon/env 1.0.1 and neon 3.1.1

### DIFF
--- a/.changeset/select-env-vars.md
+++ b/.changeset/select-env-vars.md
@@ -1,6 +1,0 @@
----
-"neon": patch
-"@neon/env": patch
----
-
-Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly, runtime-built lists return safely optional fields, and storage credential halves must be selected together. Pre-bound untyped key arrays that previously fell through to the full-env overload now fail type checking instead of promising unselected values.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 3.1.1
+
+### Patch Changes
+
+- 7bb17a9: Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly, runtime-built lists return safely optional fields, and storage credential halves must be selected together. Pre-bound untyped key arrays that previously fell through to the full-env overload now fail type checking instead of promising unselected values.
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.0.1
+
+### Patch Changes
+
+- 7bb17a9: Add exact environment-variable selection to `neon env pull`, and scope `fetchEnv({ keys })` work to the selected variables. Literal key lists autocomplete and narrow exactly, runtime-built lists return safely optional fields, and storage credential halves must be selected together. Pre-bound untyped key arrays that previously fell through to the full-env overload now fail type checking instead of promising unselected values.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 3.1.1
+
+### Patch Changes
+
+- Updated dependencies [7bb17a9]
+  - neon@3.1.1
+
 ## 3.1.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Release

- `@neon/env`: 1.0.0 → 1.0.1
- `neon`: 3.1.0 → 3.1.1
- `neonctl`: 3.1.0 → 3.1.1 (fixed-group compatibility package)

Consumes the exact env-variable selection changeset from #420 and writes the package changelogs.

## Verification

- `pnpm lint:ci`
- Diff contains only the consumed changeset, package versions, and changelogs

## Publish order

After merge: `@neon/env` → `neon` → `neonctl`.