### PR TITLE
Add `neon claim` for temporary projects without an account

### DIFF
--- a/.changeset/calm-bears-claim.md
+++ b/.changeset/calm-bears-claim.md
@@ -3,6 +3,6 @@
 "@neon/config": patch
 ---
 
-Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`, and `delete` drops a local record after the identity assertion expires.
+Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`. `list` prints `state` so an expired assertion is visible without running `status`, and `delete` drops a local record after the identity assertion expires.
 
 Recognize Claimable Neon capability errors in Config-as-Code so unavailable pre-claim services keep their actionable claim guidance instead of being reported as API-key failures.

--- a/.changeset/calm-bears-claim.md
+++ b/.changeset/calm-bears-claim.md
@@ -1,0 +1,8 @@
+---
+"neon": minor
+"@neon/config": patch
+---
+
+Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account.
+
+Recognize Claimable Neon capability errors in Config-as-Code so unavailable pre-claim services keep their actionable claim guidance instead of being reported as API-key failures.

--- a/.changeset/calm-bears-claim.md
+++ b/.changeset/calm-bears-claim.md
@@ -3,6 +3,6 @@
 "@neon/config": patch
 ---
 
-Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`. `list` prints `state` so an expired assertion is visible without running `status`, and `delete` drops a local record after the identity assertion expires.
+Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`. `list` prints `state` from the assertion clock and the project expiry, and `delete` drops a local record after the identity assertion expires. `create` prints CLI service names and `project_expires_at`.
 
 Recognize Claimable Neon capability errors in Config-as-Code so unavailable pre-claim services keep their actionable claim guidance instead of being reported as API-key failures.

--- a/.changeset/calm-bears-claim.md
+++ b/.changeset/calm-bears-claim.md
@@ -3,6 +3,6 @@
 "@neon/config": patch
 ---
 
-Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account.
+Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`, and `delete` drops a local record after the identity assertion expires.
 
 Recognize Claimable Neon capability errors in Config-as-Code so unavailable pre-claim services keep their actionable claim guidance instead of being reported as API-key failures.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -108,7 +108,8 @@ neon claim delete <project-id> --yes
 
 `status`, `accept`, and `delete` take an optional project id from `claim list`, so a
 project stays manageable after its original directory is gone. `list` prints `state`
-(`unclaimed` or `expired`) and `project_expires_at`. `delete` also drops a
+(`unclaimed` or `expired`) from the identity assertion clock and the project
+expiry, plus `project_expires_at`. `delete` also drops a
 local record whose identity assertion has expired or been revoked.
 
 `neon claimable` is an alias for `neon claim`. For local service development, set

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -102,12 +102,13 @@ neon env pull --service postgres --service auth --service data-api
 
 neon claim accept                 # create a claim code and open the transfer URL
 neon claim delete --yes           # permanently delete an unclaimed project
-neon claim list                   # projects whose assertions are saved locally
+neon claim list                   # local records, including expired
 neon claim delete <project-id> --yes
 ```
 
 `status`, `accept`, and `delete` take an optional project id from `claim list`, so a
-project stays manageable after its original directory is gone. `delete` also drops a
+project stays manageable after its original directory is gone. `list` prints `state`
+(`unclaimed` or `expired`) and `project_expires_at`. `delete` also drops a
 local record whose identity assertion has expired or been revoked.
 
 `neon claimable` is an alias for `neon claim`. For local service development, set

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -96,14 +96,19 @@ allowed before claim.
 ```bash
 neon claim status                 # lifecycle and transfer status
 neon projects get <project-id>    # regular CLI command, same agent token
-neon psql -- -c "select now()"
+neon psql --role-name neondb_owner -- -c "select now()"
 neon config plan
 neon env pull --service postgres --service auth --service data-api
 
 neon claim accept                 # create a claim code and open the transfer URL
 neon claim delete --yes           # permanently delete an unclaimed project
 neon claim list                   # projects whose assertions are saved locally
+neon claim delete <project-id> --yes
 ```
+
+`status`, `accept`, and `delete` take an optional project id from `claim list`, so a
+project stays manageable after its original directory is gone. `delete` also drops a
+local record whose identity assertion has expired or been revoked.
 
 `neon claimable` is an alias for `neon claim`. For local service development, set
 `CLAIMABLE_NEON_HOST=http://localhost:8787`; non-local origins must use HTTPS.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -64,6 +64,50 @@ neon projects list --api-key <neon_api_key>
 
 For information about obtaining an Neon API key, see [Authentication](https://neon.com/docs/reference/api/get-started), in the _Neon API Reference_.
 
+## Create a project without an account
+
+`neon claim create` provisions a temporary Claimable Neon project for an agent without
+requiring a Neon account or opening a browser:
+
+```bash
+# Lakebase Postgres is always included
+neon claim create
+
+# Request Managed Better Auth and the Data API too
+neon claim create --service auth --service data-api
+```
+
+When the current directory has a `neon.ts`, `claim create` also requests every service
+declared there. Explicit `--service` values are added to that set. Object Storage, Functions,
+and the AI Gateway are sent to the service so demand is recorded, but are reported as
+unavailable until the project is claimed; the CLI does not silently remove them.
+
+The command writes:
+
+- a `.neon` context that identifies the project and Claimable Neon service;
+- an owner-only identity assertion under the CLI config directory;
+- `DATABASE_URL` and any granted Auth or Data API variables to `.env` or `.env.local
+  (disable this with `--no-env-pull`).
+
+Subsequent project commands automatically exchange the assertion for a short-lived agent
+token. The allowlisted pre-claim surface includes project inspection, `connection-string`,
+`psql`, `env pull`, and `neon.ts` status, plan, and apply operations for granted services.
+
+```bash
+neon claim status                 # lifecycle and transfer status
+neon projects get <project-id>    # regular CLI command, same agent token
+neon psql -- -c "select now()"
+neon config plan
+neon env pull --service postgres --service auth --service data-api
+
+neon claim accept                 # open the human transfer ceremony
+neon claim delete --yes           # permanently delete an unclaimed project
+neon claim list                   # projects whose assertions are saved locally
+```
+
+`neon claimable` is an alias for `neon claim`. For local service development, set
+`CLAIMABLE_NEON_HOST=http://localhost:8787`; non-local origins must use HTTPS.
+
 ## Project and branch creation
 
 Choose the PostgreSQL version when creating a project:
@@ -1145,6 +1189,7 @@ Id   Name      Project         Created At            Last Used At          Last 
 | Command                                                                    | Subcommands                                                                                                  | Description                        |
 | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------- |
 | [auth](https://neon.com/docs/reference/cli-auth)                           |                                                                                                              | Authenticate                       |
+| claim (`claimable`)                                                        | `create`, `status`, `accept`, `list`, `delete`                                                               | Manage claimable projects          |
 | profile                                                                    | `list`, `create`, `rotate-key`, `remove`                                                                     | Manage named sets of credentials   |
 | api-keys                                                                   | `list`, `create`, `revoke`                                                                                   | Manage API keys                    |
 | [projects](https://neon.com/docs/reference/cli-projects)                   | `list`, `create`, `update`, `delete`, `get`                                                                  | Manage projects                    |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -86,12 +86,12 @@ The command writes:
 
 - a `.neon` context that identifies the project and Claimable Neon service;
 - an owner-only identity assertion under the CLI config directory;
-- `DATABASE_URL` and any granted Auth or Data API variables to `.env` or `.env.local
+- `DATABASE_URL` and any granted Auth or Data API variables to `.env` or `.env.local`
   (disable this with `--no-env-pull`).
 
 Subsequent project commands automatically exchange the assertion for a short-lived agent
-token. The allowlisted pre-claim surface includes project inspection, `connection-string`,
-`psql`, `env pull`, and `neon.ts` status, plan, and apply operations for granted services.
+token and send API calls to Claimable Neon. The service decides which operations are
+allowed before claim.
 
 ```bash
 neon claim status                 # lifecycle and transfer status
@@ -100,7 +100,7 @@ neon psql -- -c "select now()"
 neon config plan
 neon env pull --service postgres --service auth --service data-api
 
-neon claim accept                 # open the human transfer ceremony
+neon claim accept                 # create a claim code and open the transfer URL
 neon claim delete --yes           # permanently delete an unclaimed project
 neon claim list                   # projects whose assertions are saved locally
 ```

--- a/packages/cli/e2e/claim.e2e.test.ts
+++ b/packages/cli/e2e/claim.e2e.test.ts
@@ -1,0 +1,157 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect } from "vitest";
+import { e2eTest, runCli } from "./helpers.js";
+
+type CreatedClaim = {
+	project_id: string;
+	branch_id: string;
+	state: string;
+};
+
+type ClaimStatus = {
+	project_id: string;
+	state: string;
+	reconciled: boolean;
+};
+
+type BareProject = {
+	id: string;
+};
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.shift()?.();
+});
+
+const isolatedDirs = (): {
+	configDir: string;
+	contextFile: string;
+	cwd: string;
+} => {
+	const root = mkdtempSync(join(tmpdir(), "neon-claim-e2e-"));
+	cleanups.push(() => rmSync(root, { recursive: true, force: true }));
+	const configDir = join(root, "config");
+	mkdirSync(configDir);
+	return {
+		configDir,
+		contextFile: join(root, ".neon"),
+		cwd: join(root, "workspace"),
+	};
+};
+
+const anonymous = {
+	apiKey: null,
+	env: {
+		NEON_API_KEY: undefined,
+		NEON_PROFILE: undefined,
+	},
+} as const;
+
+const claimHostArgs = (): string[] => {
+	const host = process.env.CLAIMABLE_NEON_HOST;
+	return host ? ["--claimable-host", host] : [];
+};
+
+const runAnonymousJson = async <T>(
+	args: string[],
+	dirs: { configDir: string; contextFile: string; cwd?: string },
+): Promise<T> => {
+	const result = await runCli(args, {
+		...anonymous,
+		configDir: dirs.configDir,
+		contextFile: dirs.contextFile,
+		...(dirs.cwd ? { cwd: dirs.cwd } : {}),
+	});
+	if (result.code !== 0) {
+		throw new Error(
+			`neon ${args.join(" ")} exited ${result.code}\n${result.stderr || result.stdout}`,
+		);
+	}
+	try {
+		return JSON.parse(result.stdout) as T;
+	} catch {
+		throw new Error(
+			`neon ${args.join(" ")} did not print JSON:\n${result.stdout}`,
+		);
+	}
+};
+
+describe.sequential("e2e — neon claim against live Claimable Neon", () => {
+	e2eTest(
+		"creates, uses through ensureAuth, reports status, and deletes by project id",
+		async () => {
+			const createdIn = isolatedDirs();
+			mkdirSync(createdIn.cwd);
+			let projectId: string | undefined;
+			try {
+				const created = await runAnonymousJson<CreatedClaim>(
+					["claim", "create", "--no-env-pull", ...claimHostArgs()],
+					createdIn,
+				);
+				projectId = created.project_id;
+				expect(created.state).toBe("unclaimed");
+
+				const fetched = await runAnonymousJson<BareProject>(
+					["projects", "get", created.project_id],
+					createdIn,
+				);
+				expect(fetched.id).toBe(created.project_id);
+
+				const liveStatus = await runAnonymousJson<ClaimStatus>(
+					["claim", "status", ...claimHostArgs()],
+					createdIn,
+				);
+				expect(liveStatus).toMatchObject({
+					project_id: created.project_id,
+					reconciled: false,
+				});
+				expect(liveStatus.state).not.toBe("expired");
+
+				const orphaned = isolatedDirs();
+				const deleted = await runAnonymousJson<{
+					project_id: string;
+					state: string;
+				}>(
+					[
+						"claim",
+						"delete",
+						created.project_id,
+						"--yes",
+						...claimHostArgs(),
+					],
+					{ ...orphaned, configDir: createdIn.configDir },
+				);
+				expect(deleted).toEqual({
+					project_id: created.project_id,
+					state: "deleted",
+				});
+				projectId = undefined;
+
+				const listed = await runAnonymousJson<unknown[]>(
+					["claim", "list"],
+					{ ...orphaned, configDir: createdIn.configDir },
+				);
+				expect(listed).toEqual([]);
+			} finally {
+				if (projectId !== undefined) {
+					await runCli(
+						[
+							"claim",
+							"delete",
+							projectId,
+							"--yes",
+							...claimHostArgs(),
+						],
+						{
+							...anonymous,
+							configDir: createdIn.configDir,
+							contextFile: createdIn.contextFile,
+						},
+					);
+				}
+			}
+		},
+	);
+});

--- a/packages/cli/e2e/claim.e2e.test.ts
+++ b/packages/cli/e2e/claim.e2e.test.ts
@@ -33,11 +33,13 @@ const isolatedDirs = (): {
 	const root = mkdtempSync(join(tmpdir(), "neon-claim-e2e-"));
 	cleanups.push(() => rmSync(root, { recursive: true, force: true }));
 	const configDir = join(root, "config");
+	const cwd = join(root, "workspace");
 	mkdirSync(configDir);
+	mkdirSync(cwd);
 	return {
 		configDir,
 		contextFile: join(root, ".neon"),
-		cwd: join(root, "workspace"),
+		cwd,
 	};
 };
 
@@ -83,7 +85,6 @@ describe.sequential("e2e — neon claim against live Claimable Neon", () => {
 		"creates, uses through ensureAuth, reports status, and deletes by project id",
 		async () => {
 			const createdIn = isolatedDirs();
-			mkdirSync(createdIn.cwd);
 			let projectId: string | undefined;
 			try {
 				const created = await runAnonymousJson<CreatedClaim>(

--- a/packages/cli/src/api.ts
+++ b/packages/cli/src/api.ts
@@ -127,6 +127,13 @@ export function messageFromBody(body: unknown): string | undefined {
 		const message = body.message;
 		if (typeof message === "string") return message;
 	}
+	if (body && typeof body === "object" && "error" in body) {
+		const error = body.error;
+		if (error && typeof error === "object" && "message" in error) {
+			const message = error.message;
+			if (typeof message === "string") return message;
+		}
+	}
 	return undefined;
 }
 
@@ -135,6 +142,13 @@ export function codeFromBody(body: unknown): string | undefined {
 	if (body && typeof body === "object" && "code" in body) {
 		const code = body.code;
 		if (typeof code === "string") return code;
+	}
+	if (body && typeof body === "object" && "error" in body) {
+		const error = body.error;
+		if (error && typeof error === "object" && "code" in error) {
+			const code = error.code;
+			if (typeof code === "string") return code;
+		}
 	}
 	return undefined;
 }

--- a/packages/cli/src/auth_context.ts
+++ b/packages/cli/src/auth_context.ts
@@ -5,7 +5,11 @@ import { isOwnedCredentialPath } from "./config.js";
  * The 401 handler runs outside yargs, so it needs the exact authentication source
  * to avoid clearing DEFAULT after a named-profile failure.
  */
-export type AuthSource = "api-key" | "profile-api-key" | "stored-credentials";
+export type AuthSource =
+	| "api-key"
+	| "profile-api-key"
+	| "stored-credentials"
+	| "claimable";
 
 export type AuthContext = {
 	source: AuthSource;
@@ -78,6 +82,10 @@ export const authFailureMessage = (context: AuthContext | null): string => {
 	if (context?.source === "profile-api-key") {
 		// Not `rotate-key`: a rejected key cannot authenticate to mint its own replacement.
 		return `Authentication failed: the Neon API rejected profile "${profile}"'s API key${where}. Replace it with \`neon profile create ${profile} --mint\`, or store another with \`neon profile create ${profile} --api-key -\`.`;
+	}
+
+	if (context?.source === "claimable") {
+		return `Authentication failed: Claimable Neon rejected the linked project's short-lived access token${where}. Retry the command to exchange the saved identity assertion again; if it still fails, run \`neon claim status\`.`;
 	}
 
 	// Reached only when the session was not ours to clear, i.e. an adopted credentials file.

--- a/packages/cli/src/claimable/api.test.ts
+++ b/packages/cli/src/claimable/api.test.ts
@@ -32,10 +32,6 @@ describe("Claimable Neon response validation", () => {
 					{ capability: "postgres", granted: true },
 					{ capability: "data_api", granted: true },
 				],
-				claim: {
-					start_url:
-						"https://claimable.neon.tech/claim?registration_id=reg-test",
-				},
 				ignored_by_cli: "not projected",
 			}),
 		).toEqual({
@@ -52,8 +48,6 @@ describe("Claimable Neon response validation", () => {
 				{ capability: "postgres", granted: true },
 				{ capability: "data_api", granted: true },
 			],
-			claimStartUrl:
-				"https://claimable.neon.tech/claim?registration_id=reg-test",
 		});
 	});
 

--- a/packages/cli/src/claimable/api.test.ts
+++ b/packages/cli/src/claimable/api.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import { codeFromBody, messageFromBody } from "../api.js";
+import {
+	ClaimableServiceError,
+	parseClaimCodeResponse,
+	parseClaimStatusResponse,
+	parseCredentialsResponse,
+	parseRegistrationResponse,
+	parseTokenResponse,
+} from "./api.js";
+
+describe("Claimable Neon response validation", () => {
+	it("accepts the registration contract without exposing extra fields", () => {
+		expect(
+			parseRegistrationResponse({
+				registration_id: "reg-test",
+				identity_assertion: "signed-assertion",
+				assertion_expires: 1786718400,
+				scopes: ["postgres.read", "postgres.write", "data_api.read"],
+				project: {
+					id: "project-test",
+					branch_id: "br-test",
+					expires_at: "2026-08-14T12:00:00.000Z",
+				},
+				capabilities: [
+					{ capability: "postgres", granted: true },
+					{ capability: "data_api", granted: true },
+				],
+				claim: {
+					start_url:
+						"https://claimable.neon.tech/claim?registration_id=reg-test",
+				},
+				ignored_by_cli: "not projected",
+			}),
+		).toEqual({
+			registrationId: "reg-test",
+			identityAssertion: "signed-assertion",
+			assertionExpires: 1786718400,
+			scopes: ["postgres.read", "postgres.write", "data_api.read"],
+			project: {
+				id: "project-test",
+				branchId: "br-test",
+				expiresAt: "2026-08-14T12:00:00.000Z",
+			},
+			capabilities: [
+				{ capability: "postgres", granted: true },
+				{ capability: "data_api", granted: true },
+			],
+			claimStartUrl:
+				"https://claimable.neon.tech/claim?registration_id=reg-test",
+		});
+	});
+
+	it("accepts token, credentials, and claim ceremony responses", () => {
+		expect(
+			parseTokenResponse({
+				access_token: "short-lived-token",
+				token_type: "Bearer",
+				expires_in: 900,
+				scope: "postgres.read postgres.write",
+			}),
+		).toEqual({
+			accessToken: "short-lived-token",
+			expiresIn: 900,
+			scope: "postgres.read postgres.write",
+		});
+		expect(
+			parseTokenResponse({
+				access_token: "claim-status-token",
+				token_type: "Bearer",
+				expires_in: 900,
+				scope: "",
+			}),
+		).toEqual({
+			accessToken: "claim-status-token",
+			expiresIn: 900,
+			scope: "",
+		});
+
+		expect(
+			parseCredentialsResponse({
+				project_id: "project-test",
+				branch_id: "br-test",
+				database_url: "postgresql://user:secret@example.test/neondb",
+				services: {
+					data_api: { url: "https://data.example.test" },
+					auth: {
+						base_url: "https://auth.example.test",
+						jwks_url:
+							"https://auth.example.test/.well-known/jwks.json",
+					},
+				},
+				expires_at: "2026-08-14T12:00:00.000Z",
+			}),
+		).toEqual({
+			projectId: "project-test",
+			branchId: "br-test",
+			databaseUrl: "postgresql://user:secret@example.test/neondb",
+			services: {
+				dataApi: { url: "https://data.example.test" },
+				auth: {
+					baseUrl: "https://auth.example.test",
+					jwksUrl: "https://auth.example.test/.well-known/jwks.json",
+				},
+			},
+			expiresAt: "2026-08-14T12:00:00.000Z",
+		});
+
+		expect(
+			parseClaimCodeResponse({
+				user_code: "ABCD-2345",
+				verification_uri: "https://claimable.neon.tech/claim",
+				verification_uri_complete:
+					"https://claimable.neon.tech/claim?user_code=ABCD-2345",
+				expires_in: 900,
+				interval: 5,
+			}),
+		).toEqual({
+			userCode: "ABCD-2345",
+			verificationUri: "https://claimable.neon.tech/claim",
+			verificationUriComplete:
+				"https://claimable.neon.tech/claim?user_code=ABCD-2345",
+			expiresIn: 900,
+			interval: 5,
+		});
+
+		expect(
+			parseClaimStatusResponse({
+				state: "accepted",
+				expires_at: "2026-08-11T13:10:00.000Z",
+				reconciled: false,
+			}),
+		).toEqual({
+			state: "accepted",
+			expiresAt: "2026-08-11T13:10:00.000Z",
+			reconciled: false,
+		});
+	});
+
+	it("refuses malformed upstream responses at the boundary", () => {
+		expect(() =>
+			parseRegistrationResponse({
+				registration_id: "reg-test",
+				identity_assertion: "signed-assertion",
+			}),
+		).toThrow("registering an anonymous identity");
+
+		expect(() =>
+			parseTokenResponse({
+				access_token: "short-lived-token",
+				token_type: "Basic",
+			}),
+		).toThrow("exchanging the identity assertion");
+	});
+});
+
+describe("ClaimableServiceError", () => {
+	it("keeps actionable metadata without placing response data in the message", () => {
+		const error = new ClaimableServiceError(
+			403,
+			{
+				code: "insufficient_scope",
+				message: "This token cannot delete the project.",
+				retryable: false,
+				requestId: "request-test",
+			},
+			{ secret: "must-not-appear" },
+		);
+
+		expect(error.message).toBe("This token cannot delete the project.");
+		expect(error.code).toBe("insufficient_scope");
+		expect(error.retryable).toBe(false);
+		expect(error.requestId).toBe("request-test");
+		expect(error.message).not.toContain("must-not-appear");
+	});
+});
+
+describe("proxied Neon API errors", () => {
+	it("reads Claimable Neon's nested error envelope", () => {
+		const body = {
+			error: {
+				code: "capability_requires_claim",
+				message: "Claim this project before deploying functions.",
+			},
+		};
+
+		expect(codeFromBody(body)).toBe("capability_requires_claim");
+		expect(messageFromBody(body)).toBe(
+			"Claim this project before deploying functions.",
+		);
+	});
+});

--- a/packages/cli/src/claimable/api.test.ts
+++ b/packages/cli/src/claimable/api.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
+import { afterEach, describe, expect, it } from "vitest";
 import { codeFromBody, messageFromBody } from "../api.js";
 import {
+	ClaimableClient,
 	ClaimableServiceError,
 	parseClaimCodeResponse,
 	parseClaimStatusResponse,
@@ -188,5 +194,107 @@ describe("proxied Neon API errors", () => {
 		expect(messageFromBody(body)).toBe(
 			"Claim this project before deploying functions.",
 		);
+	});
+});
+
+const listen = async (
+	handler: (req: IncomingMessage, res: ServerResponse) => void,
+) => {
+	const server = createServer(handler);
+	await new Promise<void>((resolve) => {
+		server.listen(0, "localhost", resolve);
+	});
+	const address = server.address();
+	if (address === null || typeof address === "string") {
+		throw new Error("test server did not bind a port");
+	}
+	return {
+		origin: `http://localhost:${address.port}`,
+		close: () =>
+			new Promise<void>((resolve, reject) => {
+				server.close((error) => (error ? reject(error) : resolve()));
+			}),
+	};
+};
+
+describe("ClaimableClient resource paths", () => {
+	const seen: { method?: string; url?: string }[] = [];
+	let close: (() => Promise<void>) | undefined;
+
+	afterEach(async () => {
+		seen.length = 0;
+		await close?.();
+		close = undefined;
+	});
+
+	it("calls /v1/projects/{id} for credentials, claim, and delete", async () => {
+		const projectId = "quiet-fog-12345678";
+		const server = await listen((req, res) => {
+			seen.push({ method: req.method, url: req.url });
+			if (req.url === `/v1/projects/${projectId}/credentials`) {
+				res.writeHead(200, { "content-type": "application/json" });
+				res.end(
+					JSON.stringify({
+						project_id: projectId,
+						branch_id: "br-test",
+						database_url:
+							"postgresql://user:secret@example.test/neondb",
+						services: {},
+						expires_at: "2026-08-14T12:00:00.000Z",
+					}),
+				);
+				return;
+			}
+			if (req.url === `/v1/projects/${projectId}/claim`) {
+				res.writeHead(200, { "content-type": "application/json" });
+				res.end(
+					JSON.stringify(
+						req.method === "POST"
+							? {
+									user_code: "ABCD-2345",
+									verification_uri: "http://127.0.0.1/claim",
+									verification_uri_complete:
+										"http://127.0.0.1/claim?user_code=ABCD-2345",
+									expires_in: 900,
+									interval: 5,
+								}
+							: {
+									state: "pending",
+									expires_at: "2026-08-14T12:00:00.000Z",
+									reconciled: false,
+								},
+					),
+				);
+				return;
+			}
+			if (
+				req.method === "DELETE" &&
+				req.url === `/v1/projects/${projectId}`
+			) {
+				res.writeHead(204);
+				res.end();
+				return;
+			}
+			res.writeHead(404, { "content-type": "application/json" });
+			res.end(
+				JSON.stringify({
+					error: { code: "not_found", message: req.url },
+				}),
+			);
+		});
+		close = server.close;
+		const client = new ClaimableClient(server.origin);
+
+		await client.credentials(projectId, "access-token");
+		await client.createClaim(projectId, "access-token");
+		await client.claimStatus(projectId, "access-token");
+		await client.deleteProject(projectId, "access-token");
+
+		expect(seen).toEqual([
+			{ method: "GET", url: `/v1/projects/${projectId}/credentials` },
+			{ method: "POST", url: `/v1/projects/${projectId}/claim` },
+			{ method: "GET", url: `/v1/projects/${projectId}/claim` },
+			{ method: "DELETE", url: `/v1/projects/${projectId}` },
+		]);
 	});
 });

--- a/packages/cli/src/claimable/api.ts
+++ b/packages/cli/src/claimable/api.ts
@@ -31,7 +31,6 @@ export type Registration = {
 		expiresAt: string;
 	};
 	capabilities: CapabilityDecision[];
-	claimStartUrl: string;
 };
 
 export type ClaimableAccessToken = {
@@ -195,7 +194,6 @@ export const parseRegistrationResponse = (value: unknown): Registration => {
 	const action = "registering an anonymous identity";
 	const response = record(value, action);
 	const project = record(response.project, action);
-	const claim = record(response.claim, action);
 	const capabilities = response.capabilities;
 	if (!Array.isArray(capabilities)) throw invalidResponse(action);
 	return {
@@ -211,7 +209,6 @@ export const parseRegistrationResponse = (value: unknown): Registration => {
 		capabilities: capabilities.map((item) =>
 			parseCapabilityDecision(item, action),
 		),
-		claimStartUrl: stringField(claim, "start_url", action),
 	};
 };
 

--- a/packages/cli/src/claimable/api.ts
+++ b/packages/cli/src/claimable/api.ts
@@ -261,7 +261,7 @@ export const parseCredentialsResponse = (
 };
 
 export const parseClaimCodeResponse = (value: unknown): ClaimCode => {
-	const action = "starting the claim ceremony";
+	const action = "creating a claim code";
 	const response = record(value, action);
 	return {
 		userCode: stringField(response, "user_code", action),

--- a/packages/cli/src/claimable/api.ts
+++ b/packages/cli/src/claimable/api.ts
@@ -400,7 +400,7 @@ export class ClaimableClient {
 	): Promise<ClaimableCredentials> {
 		return parseCredentialsResponse(
 			await this.request(
-				`/v1/databases/${encodeURIComponent(projectId)}/credentials`,
+				`/v1/projects/${encodeURIComponent(projectId)}/credentials`,
 				{ accessToken },
 			),
 		);
@@ -412,7 +412,7 @@ export class ClaimableClient {
 	): Promise<ClaimCode> {
 		return parseClaimCodeResponse(
 			await this.request(
-				`/v1/databases/${encodeURIComponent(projectId)}/claim`,
+				`/v1/projects/${encodeURIComponent(projectId)}/claim`,
 				{ method: "POST", accessToken },
 			),
 		);
@@ -424,14 +424,14 @@ export class ClaimableClient {
 	): Promise<ClaimStatus> {
 		return parseClaimStatusResponse(
 			await this.request(
-				`/v1/databases/${encodeURIComponent(projectId)}/claim`,
+				`/v1/projects/${encodeURIComponent(projectId)}/claim`,
 				{ accessToken },
 			),
 		);
 	}
 
 	async deleteProject(projectId: string, accessToken: string): Promise<void> {
-		await this.request(`/v1/databases/${encodeURIComponent(projectId)}`, {
+		await this.request(`/v1/projects/${encodeURIComponent(projectId)}`, {
 			method: "DELETE",
 			accessToken,
 		});

--- a/packages/cli/src/claimable/api.ts
+++ b/packages/cli/src/claimable/api.ts
@@ -1,0 +1,489 @@
+const REQUEST_TIMEOUT_MS = 60_000;
+const JWT_BEARER_GRANT = "urn:ietf:params:oauth:grant-type:jwt-bearer";
+
+export const DEFAULT_CLAIMABLE_ORIGIN = "https://claimable.neon.tech";
+
+export type ClaimableCapability =
+	| "postgres"
+	| "data_api"
+	| "auth"
+	| "storage"
+	| "functions"
+	| "ai_gateway";
+
+export type CapabilityDecision =
+	| { capability: string; granted: true }
+	| {
+			capability: string;
+			granted: false;
+			reason: string;
+			message: string;
+	  };
+
+export type Registration = {
+	registrationId: string;
+	identityAssertion: string;
+	assertionExpires: number;
+	scopes: string[];
+	project: {
+		id: string;
+		branchId: string;
+		expiresAt: string;
+	};
+	capabilities: CapabilityDecision[];
+	claimStartUrl: string;
+};
+
+export type ClaimableAccessToken = {
+	accessToken: string;
+	expiresIn: number;
+	scope: string;
+};
+
+export type ClaimableCredentials = {
+	projectId: string;
+	branchId: string;
+	databaseUrl: string;
+	expiresAt: string;
+	services: {
+		auth?: {
+			baseUrl: string;
+			jwksUrl: string;
+		};
+		dataApi?: { url: string };
+	};
+};
+
+export type ClaimCode = {
+	userCode: string;
+	verificationUri: string;
+	verificationUriComplete: string;
+	expiresIn: number;
+	interval: number;
+};
+
+export type ClaimStatus = {
+	state: string;
+	expiresAt: string;
+	reconciled: boolean;
+};
+
+type ClaimableErrorMetadata = {
+	code: string;
+	message: string;
+	retryable: boolean;
+	requestId?: string;
+};
+
+export class ClaimableServiceError extends Error {
+	readonly status: number;
+	readonly code: string;
+	readonly retryable: boolean;
+	readonly requestId?: string;
+	readonly details: unknown;
+
+	constructor(
+		status: number,
+		metadata: ClaimableErrorMetadata,
+		details?: unknown,
+	) {
+		super(metadata.message);
+		this.name = "ClaimableServiceError";
+		this.status = status;
+		this.code = metadata.code;
+		this.retryable = metadata.retryable;
+		this.requestId = metadata.requestId;
+		this.details = details;
+	}
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const record = (value: unknown, action: string): Record<string, unknown> => {
+	if (!isRecord(value)) {
+		throw invalidResponse(action);
+	}
+	return value;
+};
+
+const stringField = (
+	value: Record<string, unknown>,
+	key: string,
+	action: string,
+): string => {
+	const field = value[key];
+	if (typeof field !== "string" || field.length === 0) {
+		throw invalidResponse(action);
+	}
+	return field;
+};
+
+const stringFieldAllowEmpty = (
+	value: Record<string, unknown>,
+	key: string,
+	action: string,
+): string => {
+	const field = value[key];
+	if (typeof field !== "string") {
+		throw invalidResponse(action);
+	}
+	return field;
+};
+
+const numberField = (
+	value: Record<string, unknown>,
+	key: string,
+	action: string,
+): number => {
+	const field = value[key];
+	if (typeof field !== "number" || !Number.isFinite(field) || field <= 0) {
+		throw invalidResponse(action);
+	}
+	return field;
+};
+
+const booleanField = (
+	value: Record<string, unknown>,
+	key: string,
+	action: string,
+): boolean => {
+	const field = value[key];
+	if (typeof field !== "boolean") {
+		throw invalidResponse(action);
+	}
+	return field;
+};
+
+const stringArrayField = (
+	value: Record<string, unknown>,
+	key: string,
+	action: string,
+): string[] => {
+	const field = value[key];
+	if (
+		!Array.isArray(field) ||
+		!field.every((item) => typeof item === "string" && item.length > 0)
+	) {
+		throw invalidResponse(action);
+	}
+	return field;
+};
+
+const invalidResponse = (action: string): Error =>
+	new Error(
+		`Claimable Neon returned an invalid response while ${action}. The response was not used.`,
+	);
+
+const parseCapabilityDecision = (
+	value: unknown,
+	action: string,
+): CapabilityDecision => {
+	const decision = record(value, action);
+	const capability = stringField(decision, "capability", action);
+	const granted = booleanField(decision, "granted", action);
+	if (granted) return { capability, granted: true };
+	return {
+		capability,
+		granted: false,
+		reason: stringField(decision, "reason", action),
+		message: stringField(decision, "message", action),
+	};
+};
+
+export const parseRegistrationResponse = (value: unknown): Registration => {
+	const action = "registering an anonymous identity";
+	const response = record(value, action);
+	const project = record(response.project, action);
+	const claim = record(response.claim, action);
+	const capabilities = response.capabilities;
+	if (!Array.isArray(capabilities)) throw invalidResponse(action);
+	return {
+		registrationId: stringField(response, "registration_id", action),
+		identityAssertion: stringField(response, "identity_assertion", action),
+		assertionExpires: numberField(response, "assertion_expires", action),
+		scopes: stringArrayField(response, "scopes", action),
+		project: {
+			id: stringField(project, "id", action),
+			branchId: stringField(project, "branch_id", action),
+			expiresAt: stringField(project, "expires_at", action),
+		},
+		capabilities: capabilities.map((item) =>
+			parseCapabilityDecision(item, action),
+		),
+		claimStartUrl: stringField(claim, "start_url", action),
+	};
+};
+
+export const parseTokenResponse = (value: unknown): ClaimableAccessToken => {
+	const action = "exchanging the identity assertion";
+	const response = record(value, action);
+	if (response.token_type !== "Bearer") throw invalidResponse(action);
+	return {
+		accessToken: stringField(response, "access_token", action),
+		expiresIn: numberField(response, "expires_in", action),
+		scope: stringFieldAllowEmpty(response, "scope", action),
+	};
+};
+
+export const parseCredentialsResponse = (
+	value: unknown,
+): ClaimableCredentials => {
+	const action = "fetching project credentials";
+	const response = record(value, action);
+	const services = record(response.services, action);
+	const authValue = services.auth;
+	const dataApiValue = services.data_api;
+	const auth =
+		authValue === undefined
+			? undefined
+			: (() => {
+					const parsed = record(authValue, action);
+					return {
+						baseUrl: stringField(parsed, "base_url", action),
+						jwksUrl: stringField(parsed, "jwks_url", action),
+					};
+				})();
+	const dataApi =
+		dataApiValue === undefined
+			? undefined
+			: (() => {
+					const parsed = record(dataApiValue, action);
+					return { url: stringField(parsed, "url", action) };
+				})();
+	return {
+		projectId: stringField(response, "project_id", action),
+		branchId: stringField(response, "branch_id", action),
+		databaseUrl: stringField(response, "database_url", action),
+		expiresAt: stringField(response, "expires_at", action),
+		services: {
+			...(auth === undefined ? {} : { auth }),
+			...(dataApi === undefined ? {} : { dataApi }),
+		},
+	};
+};
+
+export const parseClaimCodeResponse = (value: unknown): ClaimCode => {
+	const action = "starting the claim ceremony";
+	const response = record(value, action);
+	return {
+		userCode: stringField(response, "user_code", action),
+		verificationUri: stringField(response, "verification_uri", action),
+		verificationUriComplete: stringField(
+			response,
+			"verification_uri_complete",
+			action,
+		),
+		expiresIn: numberField(response, "expires_in", action),
+		interval: numberField(response, "interval", action),
+	};
+};
+
+export const parseClaimStatusResponse = (value: unknown): ClaimStatus => {
+	const action = "fetching claim status";
+	const response = record(value, action);
+	return {
+		state: stringField(response, "state", action),
+		expiresAt: stringField(response, "expires_at", action),
+		reconciled: booleanField(response, "reconciled", action),
+	};
+};
+
+const normalizeOrigin = (origin: string): string => {
+	let url: URL;
+	try {
+		url = new URL(origin);
+	} catch {
+		throw new Error(`Invalid Claimable Neon origin "${origin}".`);
+	}
+	if (
+		url.username ||
+		url.password ||
+		url.search ||
+		url.hash ||
+		url.pathname !== "/"
+	) {
+		throw new Error(
+			`Claimable Neon origin must contain only a scheme and host, got "${origin}".`,
+		);
+	}
+	if (url.protocol !== "https:" && url.hostname !== "localhost") {
+		throw new Error(
+			"Claimable Neon requires HTTPS except when testing against localhost.",
+		);
+	}
+	return url.origin;
+};
+
+const parseErrorMetadata = (
+	status: number,
+	statusText: string,
+	payload: unknown,
+): ClaimableErrorMetadata => {
+	if (!isRecord(payload) || !isRecord(payload.error)) {
+		return {
+			code: "unknown_error",
+			message: `Claimable Neon returned HTTP ${status} ${statusText}.`,
+			retryable: status === 429 || status >= 500,
+		};
+	}
+	const error = payload.error;
+	return {
+		code:
+			typeof error.code === "string" && error.code.length > 0
+				? error.code
+				: "unknown_error",
+		message:
+			typeof error.message === "string" && error.message.length > 0
+				? error.message
+				: `Claimable Neon returned HTTP ${status} ${statusText}.`,
+		retryable:
+			typeof error.retryable === "boolean"
+				? error.retryable
+				: status === 429 || status >= 500,
+		requestId:
+			typeof error.request_id === "string" ? error.request_id : undefined,
+	};
+};
+
+const readJson = async (response: Response): Promise<unknown> => {
+	const text = await response.text();
+	if (text.trim() === "") return undefined;
+	try {
+		return JSON.parse(text);
+	} catch {
+		throw new Error(
+			`Claimable Neon returned non-JSON content with HTTP ${response.status}.`,
+		);
+	}
+};
+
+export class ClaimableClient {
+	readonly origin: string;
+
+	constructor(origin = DEFAULT_CLAIMABLE_ORIGIN) {
+		this.origin = normalizeOrigin(origin);
+	}
+
+	async register(input: {
+		capabilities: readonly ClaimableCapability[];
+		source: string;
+	}): Promise<Registration> {
+		return parseRegistrationResponse(
+			await this.request("/v1/agent/identity", {
+				method: "POST",
+				json: {
+					type: "anonymous",
+					capabilities: input.capabilities,
+					source: input.source,
+				},
+			}),
+		);
+	}
+
+	async exchange(identityAssertion: string): Promise<ClaimableAccessToken> {
+		return parseTokenResponse(
+			await this.request("/v1/oauth2/token", {
+				method: "POST",
+				form: new URLSearchParams({
+					grant_type: JWT_BEARER_GRANT,
+					assertion: identityAssertion,
+					resource: `${this.origin}/`,
+				}),
+			}),
+		);
+	}
+
+	async credentials(
+		projectId: string,
+		accessToken: string,
+	): Promise<ClaimableCredentials> {
+		return parseCredentialsResponse(
+			await this.request(
+				`/v1/databases/${encodeURIComponent(projectId)}/credentials`,
+				{ accessToken },
+			),
+		);
+	}
+
+	async createClaim(
+		projectId: string,
+		accessToken: string,
+	): Promise<ClaimCode> {
+		return parseClaimCodeResponse(
+			await this.request(
+				`/v1/databases/${encodeURIComponent(projectId)}/claim`,
+				{ method: "POST", accessToken },
+			),
+		);
+	}
+
+	async claimStatus(
+		projectId: string,
+		accessToken: string,
+	): Promise<ClaimStatus> {
+		return parseClaimStatusResponse(
+			await this.request(
+				`/v1/databases/${encodeURIComponent(projectId)}/claim`,
+				{ accessToken },
+			),
+		);
+	}
+
+	async deleteProject(projectId: string, accessToken: string): Promise<void> {
+		await this.request(`/v1/databases/${encodeURIComponent(projectId)}`, {
+			method: "DELETE",
+			accessToken,
+		});
+	}
+
+	private async request(
+		path: string,
+		options: {
+			method?: "GET" | "POST" | "DELETE";
+			accessToken?: string;
+			json?: unknown;
+			form?: URLSearchParams;
+		} = {},
+	): Promise<unknown> {
+		const headers = new Headers({ accept: "application/json" });
+		if (options.accessToken) {
+			headers.set("authorization", `Bearer ${options.accessToken}`);
+		}
+		let body: string | undefined;
+		if (options.json !== undefined) {
+			headers.set("content-type", "application/json");
+			body = JSON.stringify(options.json);
+		} else if (options.form !== undefined) {
+			headers.set("content-type", "application/x-www-form-urlencoded");
+			body = options.form.toString();
+		}
+
+		let response: Response;
+		try {
+			response = await fetch(new URL(path, `${this.origin}/`), {
+				method: options.method ?? "GET",
+				headers,
+				body,
+				signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+			});
+		} catch {
+			throw new Error(
+				`Could not reach Claimable Neon at ${this.origin}. Check the connection and retry.`,
+			);
+		}
+		const payload = await readJson(response);
+		if (!response.ok) {
+			throw new ClaimableServiceError(
+				response.status,
+				parseErrorMetadata(
+					response.status,
+					response.statusText,
+					payload,
+				),
+				payload,
+			);
+		}
+		return payload;
+	}
+}

--- a/packages/cli/src/claimable/state.test.ts
+++ b/packages/cli/src/claimable/state.test.ts
@@ -1,0 +1,188 @@
+import {
+	chmodSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	claimableCredentialsPath,
+	listClaimableCredentials,
+	readClaimableCredentials,
+	removeClaimableCredentials,
+	resolveClaimableContext,
+	shouldUseClaimableCredentials,
+	writeClaimableCredentials,
+} from "./state.js";
+
+const temporaryDirectories: string[] = [];
+
+const temporaryDirectory = (): string => {
+	const directory = mkdtempSync(join(tmpdir(), "neon-claimable-state-"));
+	temporaryDirectories.push(directory);
+	return directory;
+};
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+const credentials = {
+	version: 1,
+	origin: "https://claimable.neon.tech",
+	registrationId: "reg_test",
+	projectId: "project-test",
+	branchId: "br-test",
+	identityAssertion: "signed-identity-assertion",
+	expiresAt: "2026-08-14T12:00:00.000Z",
+} as const;
+
+describe("claimable credentials", () => {
+	it("writes an owner-only secret file and reads it back", () => {
+		const configDir = temporaryDirectory();
+
+		writeClaimableCredentials(configDir, credentials);
+
+		const path = claimableCredentialsPath(configDir, credentials.projectId);
+		expect(statSync(path).mode & 0o777).toBe(0o600);
+		expect(
+			readClaimableCredentials(configDir, credentials.projectId),
+		).toEqual(credentials);
+	});
+
+	it("repairs permissive file permissions on replacement", () => {
+		const configDir = temporaryDirectory();
+		writeClaimableCredentials(configDir, credentials);
+		const path = claimableCredentialsPath(configDir, credentials.projectId);
+		chmodSync(path, 0o644);
+
+		writeClaimableCredentials(configDir, credentials);
+
+		expect(statSync(path).mode & 0o777).toBe(0o600);
+		expect(readFileSync(path, "utf8")).not.toContain("undefined");
+	});
+
+	it("lists and removes only Claimable Neon credential files", () => {
+		const configDir = temporaryDirectory();
+		writeClaimableCredentials(configDir, credentials);
+		writeClaimableCredentials(configDir, {
+			...credentials,
+			projectId: "another-project",
+		});
+
+		expect(
+			listClaimableCredentials(configDir).map((item) => item.projectId),
+		).toEqual(["another-project", "project-test"]);
+
+		removeClaimableCredentials(configDir, "project-test");
+		expect(readClaimableCredentials(configDir, "project-test")).toBeNull();
+		expect(listClaimableCredentials(configDir)).toHaveLength(1);
+	});
+
+	it("rejects project ids that could escape the config directory", () => {
+		const configDir = temporaryDirectory();
+
+		expect(() =>
+			claimableCredentialsPath(configDir, "../credentials"),
+		).toThrow("Invalid Claimable Neon project ID");
+	});
+});
+
+describe("claimable context", () => {
+	it("resolves a versioned marker with a matching project", () => {
+		expect(
+			resolveClaimableContext({
+				projectId: "project-test",
+				branch: "br-test",
+				claimable: {
+					version: 1,
+					origin: "https://claimable.neon.tech",
+				},
+			}),
+		).toEqual({
+			projectId: "project-test",
+			branch: "br-test",
+			origin: "https://claimable.neon.tech",
+		});
+	});
+
+	it("returns null for an ordinary Neon context", () => {
+		expect(
+			resolveClaimableContext({
+				orgId: "org-test",
+				projectId: "project-test",
+				branch: "main",
+			}),
+		).toBeNull();
+	});
+
+	it("refuses a malformed marker rather than falling back to account auth", () => {
+		expect(() =>
+			resolveClaimableContext(
+				JSON.parse(
+					'{"projectId":"project-test","claimable":{"version":2,"origin":"https://claimable.neon.tech"}}',
+				),
+			),
+		).toThrow("Unsupported Claimable Neon context version");
+	});
+});
+
+describe("claimable credential selection", () => {
+	const noInputs = {
+		apiKeyFlag: "",
+		apiKeyEnv: "",
+		profileEnv: "",
+	};
+
+	it("uses the linked claimable project when no account credential was selected", () => {
+		expect(
+			shouldUseClaimableCredentials(noInputs, undefined, {
+				projectId: "project-test",
+				claimable: {
+					version: 1,
+					origin: "https://claimable.neon.tech",
+				},
+			}),
+		).toBe(true);
+	});
+
+	it("lets every explicit or ambient account selection override the local marker", () => {
+		const context = {
+			projectId: "project-test",
+			claimable: {
+				version: 1,
+				origin: "https://claimable.neon.tech",
+			},
+		} as const;
+
+		expect(
+			shouldUseClaimableCredentials(
+				{ ...noInputs, apiKeyFlag: "napi_explicit" },
+				undefined,
+				context,
+			),
+		).toBe(false);
+		expect(
+			shouldUseClaimableCredentials(
+				{ ...noInputs, apiKeyEnv: "napi_ambient" },
+				undefined,
+				context,
+			),
+		).toBe(false);
+		expect(
+			shouldUseClaimableCredentials(
+				{ ...noInputs, profileEnv: "work" },
+				undefined,
+				context,
+			),
+		).toBe(false);
+		expect(shouldUseClaimableCredentials(noInputs, "work", context)).toBe(
+			false,
+		);
+	});
+});

--- a/packages/cli/src/claimable/state.test.ts
+++ b/packages/cli/src/claimable/state.test.ts
@@ -43,6 +43,16 @@ const credentials = {
 } as const;
 
 describe("claimable credentials", () => {
+	it("creates the config directory when it does not exist", () => {
+		const configDir = join(temporaryDirectory(), "missing", "neon");
+
+		writeClaimableCredentials(configDir, credentials);
+
+		expect(
+			readClaimableCredentials(configDir, credentials.projectId),
+		).toEqual(credentials);
+	});
+
 	it("writes an owner-only secret file and reads it back", () => {
 		const configDir = temporaryDirectory();
 

--- a/packages/cli/src/claimable/state.test.ts
+++ b/packages/cli/src/claimable/state.test.ts
@@ -147,6 +147,8 @@ describe("claimable credential selection", () => {
 		apiKeyFlag: "",
 		apiKeyEnv: "",
 		profileEnv: "",
+		profileFlag: "",
+		configDir: "",
 	};
 
 	it("uses the linked claimable project when no account credential was selected", () => {

--- a/packages/cli/src/claimable/state.test.ts
+++ b/packages/cli/src/claimable/state.test.ts
@@ -4,11 +4,13 @@ import {
 	readFileSync,
 	rmSync,
 	statSync,
+	writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+	assertionHasExpired,
 	claimableCredentialsPath,
 	listClaimableCredentials,
 	readClaimableCredentials,
@@ -100,6 +102,50 @@ describe("claimable credentials", () => {
 		expect(() =>
 			claimableCredentialsPath(configDir, "../credentials"),
 		).toThrow("Invalid Claimable Neon project ID");
+	});
+
+	it("reads credentials that omit assertionExpires", () => {
+		const configDir = temporaryDirectory();
+		writeClaimableCredentials(configDir, credentials);
+
+		expect(
+			assertionHasExpired(
+				readClaimableCredentials(configDir, credentials.projectId) ??
+					credentials,
+			),
+		).toBe(false);
+	});
+
+	it("treats a stored assertionExpires in the past as expired", () => {
+		expect(
+			assertionHasExpired(
+				{ ...credentials, assertionExpires: 1 },
+				1_700_000_000_000,
+			),
+		).toBe(true);
+		expect(
+			assertionHasExpired(
+				{ ...credentials, assertionExpires: 2_000_000_000 },
+				1_700_000_000_000,
+			),
+		).toBe(false);
+	});
+
+	it("rejects a stored assertionExpires that is not a unix timestamp", () => {
+		const configDir = temporaryDirectory();
+		writeClaimableCredentials(configDir, {
+			...credentials,
+			assertionExpires: 1_800_000_000,
+		});
+		const path = claimableCredentialsPath(configDir, credentials.projectId);
+		writeFileSync(
+			path,
+			JSON.stringify({ ...credentials, assertionExpires: 0 }),
+		);
+
+		expect(() =>
+			readClaimableCredentials(configDir, credentials.projectId),
+		).toThrow("valid Claimable Neon credential");
 	});
 });
 

--- a/packages/cli/src/claimable/state.ts
+++ b/packages/cli/src/claimable/state.ts
@@ -1,4 +1,10 @@
-import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	unlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 import type { CredentialInputs } from "@neon-internals/cli-core/auth_selection";
 import { writeSecretFile } from "@neon-internals/cli-core/secure_file";
@@ -87,6 +93,7 @@ export const writeClaimableCredentials = (
 	configDir: string,
 	credentials: StoredClaimableCredentials,
 ): void => {
+	mkdirSync(configDir, { recursive: true });
 	const path = claimableCredentialsPath(configDir, credentials.projectId);
 	writeSecretFile(path, JSON.stringify(credentials));
 };

--- a/packages/cli/src/claimable/state.ts
+++ b/packages/cli/src/claimable/state.ts
@@ -159,7 +159,7 @@ export const resolveClaimableContext = (
 	if (marker === undefined) return null;
 	if (!isRecord(marker)) {
 		throw new Error(
-			'The linked .neon file has an invalid "claimable" marker. Run `neon link` to replace it.',
+			'The linked .neon file has an invalid "claimable" marker. Delete the claimable field from .neon, or delete .neon.',
 		);
 	}
 	if (marker.version !== 1) {
@@ -169,7 +169,7 @@ export const resolveClaimableContext = (
 	}
 	if (!nonEmptyString(marker.origin) || !nonEmptyString(context.projectId)) {
 		throw new Error(
-			'The linked .neon file has an incomplete "claimable" marker. Run `neon link` to replace it.',
+			'The linked .neon file has an incomplete "claimable" marker. Delete the claimable field from .neon, or delete .neon.',
 		);
 	}
 	assertProjectId(context.projectId);

--- a/packages/cli/src/claimable/state.ts
+++ b/packages/cli/src/claimable/state.ts
@@ -1,0 +1,192 @@
+import { existsSync, readdirSync, readFileSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import type { CredentialInputs } from "@neon-internals/cli-core/auth_selection";
+import { writeSecretFile } from "@neon-internals/cli-core/secure_file";
+import type { Context } from "../context.js";
+
+const FILE_PREFIX = "claimable-credential.";
+const FILE_SUFFIX = ".json";
+const PROJECT_ID = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/u;
+
+export type StoredClaimableCredentials = {
+	version: 1;
+	origin: string;
+	registrationId: string;
+	projectId: string;
+	branchId: string;
+	identityAssertion: string;
+	expiresAt: string;
+};
+
+export type ResolvedClaimableContext = {
+	origin: string;
+	projectId: string;
+	branch?: string;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+	typeof value === "object" && value !== null && !Array.isArray(value);
+
+const nonEmptyString = (value: unknown): value is string =>
+	typeof value === "string" && value.trim().length > 0;
+
+const assertProjectId = (projectId: string): void => {
+	if (!PROJECT_ID.test(projectId)) {
+		throw new Error(`Invalid Claimable Neon project ID "${projectId}".`);
+	}
+};
+
+export const claimableCredentialsPath = (
+	configDir: string,
+	projectId: string,
+): string => {
+	assertProjectId(projectId);
+	return join(configDir, `${FILE_PREFIX}${projectId}${FILE_SUFFIX}`);
+};
+
+const parseStoredCredentials = (
+	value: unknown,
+	path: string,
+	expectedProjectId?: string,
+): StoredClaimableCredentials => {
+	if (
+		!isRecord(value) ||
+		value.version !== 1 ||
+		!nonEmptyString(value.origin) ||
+		!nonEmptyString(value.registrationId) ||
+		!nonEmptyString(value.projectId) ||
+		!nonEmptyString(value.branchId) ||
+		!nonEmptyString(value.identityAssertion) ||
+		!nonEmptyString(value.expiresAt)
+	) {
+		throw new Error(
+			`${path} does not contain a valid Claimable Neon credential. Delete it and run \`neon claim create\` again.`,
+		);
+	}
+	assertProjectId(value.projectId);
+	if (
+		expectedProjectId !== undefined &&
+		value.projectId !== expectedProjectId
+	) {
+		throw new Error(
+			`${path} belongs to a different Claimable Neon project. Delete it and run \`neon claim create\` again.`,
+		);
+	}
+	return {
+		version: 1,
+		origin: value.origin,
+		registrationId: value.registrationId,
+		projectId: value.projectId,
+		branchId: value.branchId,
+		identityAssertion: value.identityAssertion,
+		expiresAt: value.expiresAt,
+	};
+};
+
+export const writeClaimableCredentials = (
+	configDir: string,
+	credentials: StoredClaimableCredentials,
+): void => {
+	const path = claimableCredentialsPath(configDir, credentials.projectId);
+	writeSecretFile(path, JSON.stringify(credentials));
+};
+
+export const readClaimableCredentials = (
+	configDir: string,
+	projectId: string,
+): StoredClaimableCredentials | null => {
+	const path = claimableCredentialsPath(configDir, projectId);
+	if (!existsSync(path)) return null;
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(readFileSync(path, "utf8"));
+	} catch {
+		throw new Error(
+			`${path} is not valid JSON, so the Claimable Neon credential cannot be read. Delete it and run \`neon claim create\` again.`,
+		);
+	}
+	return parseStoredCredentials(parsed, path, projectId);
+};
+
+export const listClaimableCredentials = (
+	configDir: string,
+): StoredClaimableCredentials[] => {
+	if (!existsSync(configDir)) return [];
+	return readdirSync(configDir)
+		.filter(
+			(name) =>
+				name.startsWith(FILE_PREFIX) && name.endsWith(FILE_SUFFIX),
+		)
+		.sort()
+		.map((name) => {
+			const path = join(configDir, name);
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(readFileSync(path, "utf8"));
+			} catch {
+				throw new Error(
+					`${path} is not valid JSON, so the Claimable Neon credential cannot be listed. Delete it and run \`neon claim create\` again.`,
+				);
+			}
+			return parseStoredCredentials(parsed, path);
+		})
+		.sort((left, right) => left.projectId.localeCompare(right.projectId));
+};
+
+export const removeClaimableCredentials = (
+	configDir: string,
+	projectId: string,
+): void => {
+	const path = claimableCredentialsPath(configDir, projectId);
+	try {
+		unlinkSync(path);
+	} catch (error) {
+		if (
+			isRecord(error) &&
+			typeof error.code === "string" &&
+			error.code === "ENOENT"
+		) {
+			return;
+		}
+		throw error;
+	}
+};
+
+export const resolveClaimableContext = (
+	context: Context,
+): ResolvedClaimableContext | null => {
+	const marker: unknown = context.claimable;
+	if (marker === undefined) return null;
+	if (!isRecord(marker)) {
+		throw new Error(
+			'The linked .neon file has an invalid "claimable" marker. Run `neon link` to replace it.',
+		);
+	}
+	if (marker.version !== 1) {
+		throw new Error(
+			`Unsupported Claimable Neon context version in .neon. Update the Neon CLI before using this project.`,
+		);
+	}
+	if (!nonEmptyString(marker.origin) || !nonEmptyString(context.projectId)) {
+		throw new Error(
+			'The linked .neon file has an incomplete "claimable" marker. Run `neon link` to replace it.',
+		);
+	}
+	assertProjectId(context.projectId);
+	return {
+		origin: marker.origin,
+		projectId: context.projectId,
+		...(nonEmptyString(context.branch) ? { branch: context.branch } : {}),
+	};
+};
+
+export const shouldUseClaimableCredentials = (
+	inputs: CredentialInputs,
+	profileFlag: string | undefined,
+	context: Context,
+): boolean =>
+	inputs.apiKeyFlag.trim() === "" &&
+	inputs.apiKeyEnv.trim() === "" &&
+	inputs.profileEnv.trim() === "" &&
+	(profileFlag === undefined || profileFlag.trim() === "") &&
+	resolveClaimableContext(context) !== null;

--- a/packages/cli/src/claimable/state.ts
+++ b/packages/cli/src/claimable/state.ts
@@ -22,6 +22,7 @@ export type StoredClaimableCredentials = {
 	branchId: string;
 	identityAssertion: string;
 	expiresAt: string;
+	assertionExpires?: number;
 };
 
 export type ResolvedClaimableContext = {
@@ -78,6 +79,7 @@ const parseStoredCredentials = (
 			`${path} belongs to a different Claimable Neon project. Delete it and run \`neon claim create\` again.`,
 		);
 	}
+	const assertionExpires = optionalUnixSeconds(value.assertionExpires, path);
 	return {
 		version: 1,
 		origin: value.origin,
@@ -86,8 +88,29 @@ const parseStoredCredentials = (
 		branchId: value.branchId,
 		identityAssertion: value.identityAssertion,
 		expiresAt: value.expiresAt,
+		...(assertionExpires === undefined ? {} : { assertionExpires }),
 	};
 };
+
+const optionalUnixSeconds = (
+	value: unknown,
+	path: string,
+): number | undefined => {
+	if (value === undefined) return undefined;
+	if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+		throw new Error(
+			`${path} does not contain a valid Claimable Neon credential. Delete it and run \`neon claim create\` again.`,
+		);
+	}
+	return value;
+};
+
+export const assertionHasExpired = (
+	credentials: StoredClaimableCredentials,
+	now = Date.now(),
+): boolean =>
+	credentials.assertionExpires !== undefined &&
+	credentials.assertionExpires * 1000 <= now;
 
 export const writeClaimableCredentials = (
 	configDir: string,

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -37,6 +37,7 @@ import { auth, refreshToken } from "../auth.js";
 import { setAuthContext } from "../auth_context.js";
 import { ClaimableClient, ClaimableServiceError } from "../claimable/api.js";
 import {
+	assertionHasExpired,
 	claimableCredentialsPath,
 	readClaimableCredentials,
 	resolveClaimableContext,
@@ -506,6 +507,11 @@ export const ensureAuth = async (
 		if (stored === null) {
 			throw new Error(
 				`The linked project is claimable, but its identity assertion is missing from ${path}. Run \`neon claim create\` in a new directory, or \`neon link\` after claiming the project.`,
+			);
+		}
+		if (assertionHasExpired(stored)) {
+			throw new Error(
+				`The identity assertion for ${linked.projectId} has expired. Run \`neon claim delete ${linked.projectId} --yes\` to drop the local record.`,
 			);
 		}
 		const client = new ClaimableClient(stored.origin);

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -545,6 +545,12 @@ export const ensureAuth = async (
 		return;
 	}
 
+	if (localContext.claimable !== undefined) {
+		log.warning(
+			"This directory is linked to a claimable project, but NEON_API_KEY or NEON_PROFILE is set. This command will use that account credential instead of the unclaimed project. Unset them to keep using the unclaimed project.",
+		);
+	}
+
 	// Throws when `--api-key` and `--profile` are both passed.
 	const selection = selectCredential({
 		...inputs,

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -35,13 +35,24 @@ import type { NeonApiClient } from "../api.js";
 import { getApiClient } from "../api.js";
 import { auth, refreshToken } from "../auth.js";
 import { setAuthContext } from "../auth_context.js";
+import { ClaimableClient } from "../claimable/api.js";
 import {
+	claimableCredentialsPath,
+	readClaimableCredentials,
+	resolveClaimableContext,
+	shouldUseClaimableCredentials,
+} from "../claimable/state.js";
+import { credentialsPath as defaultCredentialsPath } from "../config.js";
+import {
+	currentContextFile,
+	isClaimCommand,
 	isConfigInit,
 	isCurrentBranchProbe,
 	isMcpCommand,
 	isMcpOauth,
 	isProfileCommand,
 	isSkillsCommand,
+	readContextFile,
 } from "../context.js";
 import { storeFor } from "../credential_io.js";
 import { isCi } from "../env.js";
@@ -65,6 +76,7 @@ type AuthProps = {
 	allowUnsafeTls?: boolean;
 	profile?: string;
 	keyring?: boolean;
+	contextFile?: string | ((cwd?: string) => string);
 };
 
 export const locationForAuth = (
@@ -436,6 +448,12 @@ export const ensureAuth = async (
 		return;
 	}
 
+	// `claim` owns its assertion exchange and can create the project before a context exists.
+	// Account auth here would open a browser before the command ever reaches Claimable Neon.
+	if (isClaimCommand(props)) {
+		return;
+	}
+
 	// `dev` runs a function locally. It injects the selected branch's env vars
 	// when credentials happen to be available, but must never trigger an
 	// interactive login: use an API key or existing stored credentials if
@@ -466,9 +484,59 @@ export const ensureAuth = async (
 		return;
 	}
 
+	const inputs = credentialInputs();
+	const contextFile =
+		typeof props.contextFile === "function"
+			? props.contextFile()
+			: (props.contextFile ?? currentContextFile());
+	const localContext = readContextFile(contextFile);
+	if (shouldUseClaimableCredentials(inputs, props.profile, localContext)) {
+		const linked = resolveClaimableContext(localContext);
+		if (linked === null) {
+			throw new Error(
+				"The linked Claimable Neon context could not be resolved.",
+			);
+		}
+		const stored = readClaimableCredentials(
+			props.configDir,
+			linked.projectId,
+		);
+		const path = claimableCredentialsPath(
+			props.configDir,
+			linked.projectId,
+		);
+		if (stored === null) {
+			throw new Error(
+				`The linked project is claimable, but its identity assertion is missing from ${path}. Run \`neon claim create\` in a new directory, or \`neon link\` after claiming the project.`,
+			);
+		}
+		const client = new ClaimableClient(stored.origin);
+		if (client.origin !== new ClaimableClient(linked.origin).origin) {
+			throw new Error(
+				`The linked .neon file and ${path} name different Claimable Neon services. Run \`neon link\` to replace the local context.`,
+			);
+		}
+		const token = await client.exchange(stored.identityAssertion);
+		props.apiKey = token.accessToken;
+		props.apiHost = `${client.origin}/v1`;
+		props.apiClient = getApiClient({
+			apiKey: token.accessToken,
+			apiHost: props.apiHost,
+		});
+		setAuthContext({
+			source: "claimable",
+			configDir: props.configDir,
+			credentialsPath: path,
+		});
+		log.debug(
+			"Using the linked Claimable Neon project's short-lived access token",
+		);
+		return;
+	}
+
 	// Throws when `--api-key` and `--profile` are both passed.
 	const selection = selectCredential({
-		...credentialInputs(),
+		...inputs,
 		profileFlag: props.profile,
 	});
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -35,7 +35,7 @@ import type { NeonApiClient } from "../api.js";
 import { getApiClient } from "../api.js";
 import { auth, refreshToken } from "../auth.js";
 import { setAuthContext } from "../auth_context.js";
-import { ClaimableClient } from "../claimable/api.js";
+import { ClaimableClient, ClaimableServiceError } from "../claimable/api.js";
 import {
 	claimableCredentialsPath,
 	readClaimableCredentials,
@@ -511,10 +511,23 @@ export const ensureAuth = async (
 		const client = new ClaimableClient(stored.origin);
 		if (client.origin !== new ClaimableClient(linked.origin).origin) {
 			throw new Error(
-				`The linked .neon file and ${path} name different Claimable Neon services. Run \`neon link\` to replace the local context.`,
+				`The linked .neon file and ${path} name different Claimable Neon services. Delete .neon or the assertion file and run \`neon claim create\` in a new directory.`,
 			);
 		}
-		const token = await client.exchange(stored.identityAssertion);
+		let token;
+		try {
+			token = await client.exchange(stored.identityAssertion);
+		} catch (error) {
+			if (
+				error instanceof ClaimableServiceError &&
+				error.code === "project_claimed"
+			) {
+				throw new Error(
+					"This project was claimed. Run `neon claim status` to drop the local assertion, then `neon auth` or `neon link`.",
+				);
+			}
+			throw error;
+		}
 		props.apiKey = token.accessToken;
 		props.apiHost = `${client.origin}/v1`;
 		props.apiClient = getApiClient({

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -447,8 +447,7 @@ export const ensureAuth = async (
 		return;
 	}
 
-	// `claim` owns its assertion exchange and can create the project before a context exists.
-	// Account auth here would open a browser before the command ever reaches Claimable Neon.
+	// Claim commands exchange their own assertion, so account auth must not open first.
 	if (isClaimCommand(props)) {
 		return;
 	}

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -42,7 +42,6 @@ import {
 	resolveClaimableContext,
 	shouldUseClaimableCredentials,
 } from "../claimable/state.js";
-import { credentialsPath as defaultCredentialsPath } from "../config.js";
 import {
 	currentContextFile,
 	isClaimCommand,

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -8,7 +8,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import strip from "strip-ansi";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
-import { writeClaimableCredentials } from "../claimable/state.js";
+import {
+	readClaimableCredentials,
+	writeClaimableCredentials,
+} from "../claimable/state.js";
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
@@ -29,7 +32,12 @@ beforeAll(async () => {
 	});
 });
 
-type Run = { code: number | null; stdout: string; stderr: string };
+type Run = {
+	code: number | null;
+	stdout: string;
+	stderr: string;
+	configDir: string;
+};
 
 const makeWorkspace = (): { configDir: string; contextFile: string } => {
 	const dir = mkdtempSync(join(tmpdir(), "neon-claim-cli-"));
@@ -78,7 +86,12 @@ const runCli = (
 		});
 		cp.on("error", rej);
 		cp.on("close", (code) =>
-			res({ code, stdout: strip(stdout), stderr: strip(stderr) }),
+			res({
+				code,
+				stdout: strip(stdout),
+				stderr: strip(stderr),
+				configDir,
+			}),
 		);
 	});
 };
@@ -122,6 +135,86 @@ describe("claim create with explicit credential flags", () => {
 		expect(stderr).toContain(
 			"Claimable Neon does not use a Neon account credential. Remove --api-key or --profile.",
 		);
+		expect(reachedClaimableService(stderr)).toBe(false);
+	});
+});
+
+const expiredCredentials = {
+	version: 1 as const,
+	origin: "https://claimable.neon.tech",
+	registrationId: "reg_expired",
+	projectId: "quiet-fog-12345678",
+	branchId: "br-quiet-fog-12345678",
+	identityAssertion: "expired-assertion",
+	expiresAt: "2026-08-24T12:00:00.000Z",
+	assertionExpires: 1,
+};
+
+describe("claim status and delete after the assertion expires", () => {
+	test("status reports expired without contacting the service", async () => {
+		const { code, stdout, stderr } = await runCli(
+			[
+				"claim",
+				"status",
+				expiredCredentials.projectId,
+				"--output",
+				"json",
+			],
+			{},
+			({ configDir }) => {
+				writeClaimableCredentials(configDir, expiredCredentials);
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+		expect(JSON.parse(stdout)).toMatchObject({
+			project_id: expiredCredentials.projectId,
+			state: "expired",
+			reconciled: false,
+		});
+		expect(reachedClaimableService(stderr)).toBe(false);
+	});
+
+	test("delete drops a listed project that has no .neon", async () => {
+		const { code, stdout, stderr, configDir } = await runCli(
+			[
+				"claim",
+				"delete",
+				expiredCredentials.projectId,
+				"--yes",
+				"--output",
+				"json",
+			],
+			{},
+			({ configDir }) => {
+				writeClaimableCredentials(configDir, expiredCredentials);
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+		expect(JSON.parse(stdout)).toEqual({
+			project_id: expiredCredentials.projectId,
+			state: "cleared",
+		});
+		expect(reachedClaimableService(stderr)).toBe(false);
+		expect(
+			readClaimableCredentials(configDir, expiredCredentials.projectId),
+		).toBeNull();
+	});
+
+	test("accept refuses an expired assertion without contacting the service", async () => {
+		const { code, stderr } = await runCli(
+			["claim", "accept", expiredCredentials.projectId, "--no-open"],
+			{},
+			({ configDir }) => {
+				writeClaimableCredentials(configDir, expiredCredentials);
+			},
+		);
+
+		expect(code).toBe(1);
+		expect(stderr).toContain("has expired");
 		expect(reachedClaimableService(stderr)).toBe(false);
 	});
 });

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -1,7 +1,4 @@
-/**
- * These tests cannot use `testCliCommand` because it always passes `--api-key`,
- * which `claim` rejects.
- */
+/** `testCliCommand` always passes `--api-key`, which `claim` rejects. */
 
 import { fork } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import strip from "strip-ansi";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
+import { writeClaimableCredentials } from "../claimable/state.js";
 
 const cleanups: Array<() => void> = [];
 afterEach(() => {
@@ -42,8 +43,15 @@ const makeWorkspace = (): { configDir: string; contextFile: string } => {
 	return { configDir, contextFile: join(dir, ".neon") };
 };
 
-const runCli = (args: string[], env: NodeJS.ProcessEnv = {}): Promise<Run> => {
+const BOX = /[┌┐└┘├┤┬┴┼─│]/;
+
+const runCli = (
+	args: string[],
+	env: NodeJS.ProcessEnv = {},
+	setup?: (workspace: { configDir: string; contextFile: string }) => void,
+): Promise<Run> => {
 	const { configDir, contextFile } = makeWorkspace();
+	setup?.({ configDir, contextFile });
 	return new Promise((res, rej) => {
 		const cp = fork(
 			join(process.cwd(), "./dist/cli.js"),
@@ -118,5 +126,53 @@ describe("claim create with explicit credential flags", () => {
 			"Claimable Neon does not use a Neon account credential. Remove --api-key or --profile.",
 		);
 		expect(reachedClaimableService(stderr)).toBe(false);
+	});
+});
+
+describe("claim list table output", () => {
+	test("empty list is a message, not a box table", async () => {
+		const { code, stdout, stderr } = await runCli(["claim", "list"]);
+
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).not.toMatch(BOX);
+		expect(stdout).toContain(
+			"No Claimable Neon projects are saved on this machine.",
+		);
+	});
+
+	test("prints every column at full width without boxes", async () => {
+		const projectId = "wandering-haze-25754674";
+		const branchId = "br-main-branch-123456";
+		const origin = "https://claimable.neon.tech";
+		const expiresAt = "2026-08-24T12:00:00.000Z";
+		const { code, stdout, stderr } = await runCli(
+			["claim", "list"],
+			{},
+			({ configDir }) => {
+				writeClaimableCredentials(configDir, {
+					version: 1,
+					origin,
+					registrationId: "reg_test",
+					projectId,
+					branchId,
+					identityAssertion: "assertion",
+					expiresAt,
+				});
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).not.toMatch(BOX);
+		expect(stdout).toContain("Project Id");
+		expect(stdout).toContain("Branch Id");
+		expect(stdout).toContain("Expires At");
+		expect(stdout).toContain("Origin");
+		expect(stdout).toContain(projectId);
+		expect(stdout).toContain(branchId);
+		expect(stdout).toContain(expiresAt);
+		expect(stdout).toContain(origin);
+		expect(stdout.trimEnd().split("\n")).toHaveLength(2);
 	});
 });

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -235,7 +235,7 @@ describe("claim list table output", () => {
 		const projectId = "wandering-haze-25754674";
 		const branchId = "br-main-branch-123456";
 		const origin = "https://claimable.neon.tech";
-		const expiresAt = "2026-08-24T12:00:00.000Z";
+		const expiresAt = "2027-08-24T12:00:00.000Z";
 		const { code, stdout, stderr } = await runCli(
 			["claim", "list"],
 			{},
@@ -266,6 +266,32 @@ describe("claim list table output", () => {
 		expect(stdout).toContain(expiresAt);
 		expect(stdout).toContain(origin);
 		expect(stdout.trimEnd().split("\n")).toHaveLength(2);
+	});
+
+	test("marks a past project expiry as expired even when the assertion is live", async () => {
+		const projectId = "wandering-haze-25754674";
+		const { code, stdout, stderr } = await runCli(
+			["claim", "list"],
+			{},
+			({ configDir }) => {
+				writeClaimableCredentials(configDir, {
+					version: 1,
+					origin: "https://claimable.neon.tech",
+					registrationId: "reg_test",
+					projectId,
+					branchId: "br-main-branch-123456",
+					identityAssertion: "assertion",
+					expiresAt: "2026-08-24T12:00:00.000Z",
+					assertionExpires: 4_000_000_000,
+				});
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).toContain("expired");
+		expect(stdout).not.toContain("unclaimed");
+		expect(stdout).toContain(projectId);
 	});
 
 	test("marks a locally expired assertion as expired", async () => {

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -257,12 +257,40 @@ describe("claim list table output", () => {
 		expect(stdout).not.toMatch(BOX);
 		expect(stdout).toContain("Project Id");
 		expect(stdout).toContain("Branch Id");
-		expect(stdout).toContain("Expires At");
+		expect(stdout).toContain("State");
+		expect(stdout).toContain("Project Expires At");
 		expect(stdout).toContain("Origin");
+		expect(stdout).toContain("unclaimed");
 		expect(stdout).toContain(projectId);
 		expect(stdout).toContain(branchId);
 		expect(stdout).toContain(expiresAt);
 		expect(stdout).toContain(origin);
 		expect(stdout.trimEnd().split("\n")).toHaveLength(2);
+	});
+
+	test("marks a locally expired assertion as expired", async () => {
+		const projectId = "wandering-haze-25754674";
+		const { code, stdout, stderr } = await runCli(
+			["claim", "list"],
+			{},
+			({ configDir }) => {
+				writeClaimableCredentials(configDir, {
+					version: 1,
+					origin: "https://claimable.neon.tech",
+					registrationId: "reg_test",
+					projectId,
+					branchId: "br-main-branch-123456",
+					identityAssertion: "assertion",
+					expiresAt: "2026-08-24T12:00:00.000Z",
+					assertionExpires: 1_700_000_000,
+				});
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+		expect(stdout).toContain("expired");
+		expect(stdout).not.toContain("unclaimed");
+		expect(stdout).toContain(projectId);
 	});
 });

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -1,0 +1,122 @@
+/**
+ * These tests cannot use `testCliCommand` because it always passes `--api-key`,
+ * which `claim` rejects.
+ */
+
+import { fork } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import strip from "strip-ansi";
+import { afterEach, beforeAll, describe, expect, test } from "vitest";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+	while (cleanups.length > 0) cleanups.shift()?.();
+});
+
+let unreachableOrigin = "";
+beforeAll(async () => {
+	unreachableOrigin = await new Promise<string>((res, rej) => {
+		const probe = createServer();
+		probe.on("error", rej);
+		probe.listen(0, "localhost", () => {
+			const { port } = probe.address() as AddressInfo;
+			probe.close((err) =>
+				err ? rej(err) : res(`http://localhost:${port}`),
+			);
+		});
+	});
+});
+
+type Run = { code: number | null; stdout: string; stderr: string };
+
+const makeWorkspace = (): { configDir: string; contextFile: string } => {
+	const dir = mkdtempSync(join(tmpdir(), "neon-claim-cli-"));
+	cleanups.push(() => rmSync(dir, { recursive: true, force: true }));
+	writeFileSync(join(dir, ".git"), "gitdir: test");
+	const configDir = join(dir, "config");
+	mkdirSync(configDir);
+	return { configDir, contextFile: join(dir, ".neon") };
+};
+
+const runCli = (args: string[], env: NodeJS.ProcessEnv = {}): Promise<Run> => {
+	const { configDir, contextFile } = makeWorkspace();
+	return new Promise((res, rej) => {
+		const cp = fork(
+			join(process.cwd(), "./dist/cli.js"),
+			[
+				"--no-analytics",
+				"--config-dir",
+				configDir,
+				"--context-file",
+				contextFile,
+				"--claimable-host",
+				unreachableOrigin,
+				...args,
+			],
+			{
+				stdio: "pipe",
+				env: { PATH: process.env.PATH ?? "", HOME: tmpdir(), ...env },
+			},
+		);
+		cp.stdin?.end();
+		let stdout = "";
+		let stderr = "";
+		cp.stdout?.on("data", (d: Buffer) => {
+			stdout += d.toString();
+		});
+		cp.stderr?.on("data", (d: Buffer) => {
+			stderr += d.toString();
+		});
+		cp.on("error", rej);
+		cp.on("close", (code) =>
+			res({ code, stdout: strip(stdout), stderr: strip(stderr) }),
+		);
+	});
+};
+
+const reachedClaimableService = (stderr: string) =>
+	stderr.includes(`Could not reach Claimable Neon at ${unreachableOrigin}`);
+
+describe("claim create with ambient credentials", () => {
+	test.each([
+		{ NEON_API_KEY: "napi_ambient" },
+		{ NEON_PROFILE: "work" },
+		{ NEON_API_KEY: "napi_ambient", NEON_PROFILE: "work" },
+	])("creates without warning or throwing when %o is set", async (env) => {
+		const { code, stderr } = await runCli(
+			["claim", "create", "--no-env-pull"],
+			env,
+		);
+
+		expect(code).toBe(1);
+		expect(reachedClaimableService(stderr)).toBe(true);
+		expect(stderr).not.toContain("Unset");
+		expect(stderr).not.toContain("NEON_API_KEY or NEON_PROFILE is set");
+		expect(stderr).not.toContain("does not use a Neon account credential");
+	});
+});
+
+describe("claim create with explicit credential flags", () => {
+	test.each([
+		["--api-key", "napi_flag"],
+		["--profile", "work"],
+	] as const)("%s still fails before contacting Claimable Neon", async (flag, value) => {
+		const { code, stderr } = await runCli([
+			flag,
+			value,
+			"claim",
+			"create",
+			"--no-env-pull",
+		]);
+
+		expect(code).toBe(1);
+		expect(stderr).toContain(
+			"Claimable Neon does not use a Neon account credential. Remove --api-key or --profile.",
+		);
+		expect(reachedClaimableService(stderr)).toBe(false);
+	});
+});

--- a/packages/cli/src/commands/claim.test.ts
+++ b/packages/cli/src/commands/claim.test.ts
@@ -82,7 +82,7 @@ describe("claim create table fields", () => {
 				project_id: "quiet-fog-12345678",
 				branch_id: "br-quiet-fog-12345678",
 				state: "unclaimed",
-				expires_at: "2026-08-24T12:00:00.000Z",
+				project_expires_at: "2026-08-24T12:00:00.000Z",
 				granted_capabilities: ["postgres"],
 				denied_capabilities: [],
 				env_file: "/tmp/.env.local",

--- a/packages/cli/src/commands/claim.test.ts
+++ b/packages/cli/src/commands/claim.test.ts
@@ -1,8 +1,14 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import stripAnsi from "strip-ansi";
 import { afterEach, describe, expect, it } from "vitest";
-import { claimableCapabilities, findNeonConfig } from "./claim.js";
+import { formatHumanChunk } from "../human_table.js";
+import {
+	claimableCapabilities,
+	claimCreateFields,
+	findNeonConfig,
+} from "./claim.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -65,5 +71,37 @@ describe("claimable neon.ts discovery", () => {
 		mkdirSync(nested, { recursive: true });
 
 		expect(findNeonConfig(nested)).toBeUndefined();
+	});
+});
+
+describe("claim create table fields", () => {
+	it("omits Denied Capabilities when nothing is denied", () => {
+		expect(claimCreateFields([])).not.toContain("denied_capabilities");
+		const out = formatHumanChunk({
+			data: {
+				project_id: "quiet-fog-12345678",
+				branch_id: "br-quiet-fog-12345678",
+				state: "unclaimed",
+				expires_at: "2026-08-24T12:00:00.000Z",
+				granted_capabilities: ["postgres"],
+				denied_capabilities: [],
+				env_file: "/tmp/.env.local",
+			},
+			fields: claimCreateFields([]),
+			colorTitle: false,
+		});
+		expect(stripAnsi(out)).not.toContain("Denied");
+		expect(stripAnsi(out)).toContain("Granted Capabilities");
+	});
+
+	it("keeps Denied Capabilities when a capability is denied", () => {
+		const denied = [
+			{
+				capability: "functions",
+				message:
+					"functions is unavailable until the project is claimed",
+			},
+		];
+		expect(claimCreateFields(denied)).toContain("denied_capabilities");
 	});
 });

--- a/packages/cli/src/commands/claim.test.ts
+++ b/packages/cli/src/commands/claim.test.ts
@@ -1,0 +1,69 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { claimableCapabilities, findNeonConfig } from "./claim.js";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+	for (const directory of temporaryDirectories.splice(0)) {
+		rmSync(directory, { recursive: true, force: true });
+	}
+});
+
+describe("claimable service requests", () => {
+	it("always requests Postgres and maps the shared CLI service vocabulary", () => {
+		expect(claimableCapabilities([])).toEqual(["postgres"]);
+		expect(
+			claimableCapabilities([
+				"auth",
+				"data-api",
+				"functions",
+				"object-storage",
+				"ai-gateway",
+			]),
+		).toEqual([
+			"postgres",
+			"data_api",
+			"auth",
+			"storage",
+			"functions",
+			"ai_gateway",
+		]);
+	});
+
+	it("does not suppress services that require claiming", () => {
+		expect(
+			claimableCapabilities([
+				"object-storage",
+				"functions",
+				"ai-gateway",
+			]),
+		).toEqual(["postgres", "storage", "functions", "ai_gateway"]);
+	});
+});
+
+describe("claimable neon.ts discovery", () => {
+	it("finds the closest config while walking to the repository root", () => {
+		const root = mkdtempSync(join(tmpdir(), "neon-claim-config-"));
+		temporaryDirectories.push(root);
+		writeFileSync(join(root, ".git"), "gitdir: test");
+		const config = join(root, "neon.ts");
+		writeFileSync(config, "export default {};");
+		const nested = join(root, "packages", "app");
+		mkdirSync(nested, { recursive: true });
+
+		expect(findNeonConfig(nested)).toBe(config);
+	});
+
+	it("does not escape a repository that has no config", () => {
+		const root = mkdtempSync(join(tmpdir(), "neon-claim-config-"));
+		temporaryDirectories.push(root);
+		writeFileSync(join(root, ".git"), "gitdir: test");
+		const nested = join(root, "packages", "app");
+		mkdirSync(nested, { recursive: true });
+
+		expect(findNeonConfig(nested)).toBeUndefined();
+	});
+});

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -13,6 +13,7 @@ import {
 	DEFAULT_CLAIMABLE_ORIGIN,
 } from "../claimable/api.js";
 import {
+	assertionHasExpired,
 	listClaimableCredentials,
 	readClaimableCredentials,
 	removeClaimableCredentials,
@@ -49,6 +50,7 @@ type ClaimProps = {
 	claimableHost: string;
 	profile?: string;
 	apiKey: string;
+	projectId?: string;
 };
 
 type CreateProps = ClaimProps & {
@@ -242,16 +244,29 @@ export const builder = (argv: yargs.Argv) =>
 			},
 		)
 		.command(
-			"status",
-			"Show the linked claimable project's lifecycle and claim status",
-			(y) => y.strict().check(noPassthrough("claim status")),
+			"status [project-id]",
+			"Show a claimable project's lifecycle and claim status",
+			(y) =>
+				y
+					.positional("project-id", {
+						describe:
+							"Project from `neon claim list`. Defaults to the project linked in this directory",
+						type: "string",
+					})
+					.strict()
+					.check(noPassthrough("claim status")),
 			async (args) => await status(args as unknown as ClaimProps),
 		)
 		.command(
-			"accept",
+			"accept [project-id]",
 			"Create a claim code and open the URL where a human signs in and takes the project",
 			(y) =>
 				y
+					.positional("project-id", {
+						describe:
+							"Project from `neon claim list`. Defaults to the project linked in this directory",
+						type: "string",
+					})
 					.option("open", {
 						describe: "Open the verification URL in a browser",
 						type: "boolean",
@@ -268,10 +283,15 @@ export const builder = (argv: yargs.Argv) =>
 			async (args) => list(args as unknown as ClaimProps),
 		)
 		.command(
-			"delete",
-			"Permanently delete the linked unclaimed project",
+			"delete [project-id]",
+			"Permanently delete an unclaimed project, or drop a local record that can no longer reach the service",
 			(y) =>
 				y
+					.positional("project-id", {
+						describe:
+							"Project from `neon claim list`. Defaults to the project linked in this directory",
+						type: "string",
+					})
 					.option("yes", {
 						alias: "y",
 						describe: "Skip the confirmation prompt",
@@ -297,38 +317,67 @@ const rejectExplicitAccountCredential = (props: ClaimProps): void => {
 	}
 };
 
-const linkedCredentials = (
+const resolveTarget = (
 	props: ClaimProps,
 ): {
-	context: ReturnType<typeof readContextFile>;
-	linked: NonNullable<ReturnType<typeof resolveClaimableContext>>;
+	projectId: string;
 	credentials: StoredClaimableCredentials;
 	client: ClaimableClient;
+	contextMatches: boolean;
 } => {
 	rejectExplicitAccountCredential(props);
+	const requested = props.projectId?.trim();
 	const context = readContextFile(props.contextFile);
 	const linked = resolveClaimableContext(context);
-	if (linked === null) {
+	const projectId = requested || linked?.projectId;
+	if (projectId === undefined) {
 		throw new Error(
-			"This directory is not linked to a claimable project. Run `neon claim create` first.",
+			"This directory is not linked to a claimable project. Pass a project id from `neon claim list`, or run `neon claim create` first.",
 		);
 	}
-	const credentials = readClaimableCredentials(
-		props.configDir,
-		linked.projectId,
-	);
+	const credentials = readClaimableCredentials(props.configDir, projectId);
 	if (credentials === null) {
 		throw new Error(
-			`The identity assertion for ${linked.projectId} is missing. The project cannot be managed from this machine; claim it through its existing verification URL or run \`neon link\` after it is claimed.`,
+			`The identity assertion for ${projectId} is missing. The project cannot be managed from this machine; claim it through its existing verification URL or run \`neon link\` after it is claimed.`,
 		);
 	}
 	const client = new ClaimableClient(credentials.origin);
-	if (client.origin !== new ClaimableClient(linked.origin).origin) {
+	const contextMatches = linked?.projectId === projectId;
+	if (
+		contextMatches &&
+		linked !== null &&
+		client.origin !== new ClaimableClient(linked.origin).origin
+	) {
 		throw new Error(
 			"The .neon context and saved identity assertion name different Claimable Neon services. Delete .neon or the assertion file and run `neon claim create` in a new directory.",
 		);
 	}
-	return { context, linked, credentials, client };
+	return { projectId, credentials, client, contextMatches };
+};
+
+const requireLiveIdentity = (credentials: StoredClaimableCredentials): void => {
+	if (assertionHasExpired(credentials)) {
+		throw new Error(
+			`The identity assertion for ${credentials.projectId} has expired. Run \`neon claim delete ${credentials.projectId} --yes\` to drop the local record.`,
+		);
+	}
+};
+
+const isUnusableIdentity = (error: unknown): error is ClaimableServiceError =>
+	error instanceof ClaimableServiceError &&
+	(error.code === "invalid_grant" ||
+		error.code === "project_expired" ||
+		error.code === "not_found");
+
+const clearLocalRecord = (
+	props: ClaimProps,
+	projectId: string,
+	contextMatches: boolean,
+): void => {
+	removeClaimableCredentials(props.configDir, projectId);
+	if (contextMatches && existsSync(props.contextFile)) {
+		applyContext(props.contextFile, {});
+	}
 };
 
 const create = async (props: CreateProps): Promise<void> => {
@@ -360,6 +409,7 @@ const create = async (props: CreateProps): Promise<void> => {
 		branchId: registration.project.branchId,
 		identityAssertion: registration.identityAssertion,
 		expiresAt: registration.project.expiresAt,
+		assertionExpires: registration.assertionExpires,
 	};
 	let localStateWritten = false;
 	let contextWritten = false;
@@ -500,7 +550,27 @@ const create = async (props: CreateProps): Promise<void> => {
 };
 
 const status = async (props: ClaimProps): Promise<void> => {
-	const { linked, credentials, client } = linkedCredentials(props);
+	const { projectId, credentials, client, contextMatches } =
+		resolveTarget(props);
+	if (assertionHasExpired(credentials)) {
+		writer(props).end(
+			{
+				project_id: projectId,
+				state: "expired",
+				reconciled: false,
+				project_expires_at: credentials.expiresAt,
+			},
+			{
+				fields: [
+					"project_id",
+					"state",
+					"reconciled",
+					"project_expires_at",
+				],
+			},
+		);
+		return;
+	}
 	try {
 		const token = await client.exchange(credentials.identityAssertion);
 		let claimState = "unclaimed";
@@ -508,7 +578,7 @@ const status = async (props: ClaimProps): Promise<void> => {
 		let claimExpiresAt: string | undefined;
 		try {
 			const claim = await client.claimStatus(
-				linked.projectId,
+				projectId,
 				token.accessToken,
 			);
 			claimState = claim.state;
@@ -523,11 +593,11 @@ const status = async (props: ClaimProps): Promise<void> => {
 			}
 		}
 		if (reconciled) {
-			finishClaimedContext(props);
+			finishClaimedContext(props, projectId, contextMatches);
 		}
 		writer(props).end(
 			{
-				project_id: linked.projectId,
+				project_id: projectId,
 				state: claimState,
 				reconciled,
 				project_expires_at: credentials.expiresAt,
@@ -548,14 +618,33 @@ const status = async (props: ClaimProps): Promise<void> => {
 			error instanceof ClaimableServiceError &&
 			error.code === "project_claimed"
 		) {
-			finishClaimedContext(props);
+			finishClaimedContext(props, projectId, contextMatches);
 			writer(props).end(
 				{
-					project_id: linked.projectId,
+					project_id: projectId,
 					state: "claimed",
 					reconciled: true,
 				},
 				{ fields: ["project_id", "state", "reconciled"] },
+			);
+			return;
+		}
+		if (isUnusableIdentity(error)) {
+			writer(props).end(
+				{
+					project_id: projectId,
+					state: "expired",
+					reconciled: false,
+					project_expires_at: credentials.expiresAt,
+				},
+				{
+					fields: [
+						"project_id",
+						"state",
+						"reconciled",
+						"project_expires_at",
+					],
+				},
 			);
 			return;
 		}
@@ -564,13 +653,14 @@ const status = async (props: ClaimProps): Promise<void> => {
 };
 
 const accept = async (props: AcceptProps): Promise<void> => {
-	const { linked, credentials, client } = linkedCredentials(props);
+	const { projectId, credentials, client } = resolveTarget(props);
+	requireLiveIdentity(credentials);
 	const token = await client.exchange(credentials.identityAssertion);
-	const claim = await client.createClaim(linked.projectId, token.accessToken);
+	const claim = await client.createClaim(projectId, token.accessToken);
 
 	writer(props).end(
 		{
-			project_id: linked.projectId,
+			project_id: projectId,
 			user_code: claim.userCode,
 			verification_url: claim.verificationUriComplete,
 			expires_in_seconds: claim.expiresIn,
@@ -615,7 +705,8 @@ const list = (props: ClaimProps): void => {
 };
 
 const deleteProject = async (props: DeleteProps): Promise<void> => {
-	const { linked, credentials, client } = linkedCredentials(props);
+	const { projectId, credentials, client, contextMatches } =
+		resolveTarget(props);
 	if (!props.yes) {
 		if (isCi() || !process.stdin.isTTY) {
 			throw new Error(
@@ -625,7 +716,7 @@ const deleteProject = async (props: DeleteProps): Promise<void> => {
 		const { proceed } = await prompts({
 			type: "confirm",
 			name: "proceed",
-			message: `Permanently delete ${linked.projectId}?`,
+			message: `Permanently delete ${projectId}?`,
 			initial: false,
 		});
 		if (!proceed) {
@@ -633,26 +724,50 @@ const deleteProject = async (props: DeleteProps): Promise<void> => {
 			return;
 		}
 	}
-	const token = await client.exchange(credentials.identityAssertion);
-	await client.deleteProject(linked.projectId, token.accessToken);
-	removeClaimableCredentials(props.configDir, linked.projectId);
-	if (existsSync(props.contextFile)) {
-		applyContext(props.contextFile, {});
+	if (assertionHasExpired(credentials)) {
+		clearLocalRecord(props, projectId, contextMatches);
+		writer(props).end(
+			{ project_id: projectId, state: "cleared" },
+			{ fields: ["project_id", "state"] },
+		);
+		return;
 	}
+	try {
+		const token = await client.exchange(credentials.identityAssertion);
+		await client.deleteProject(projectId, token.accessToken);
+	} catch (error) {
+		if (!isUnusableIdentity(error)) {
+			throw error;
+		}
+		clearLocalRecord(props, projectId, contextMatches);
+		writer(props).end(
+			{ project_id: projectId, state: "cleared" },
+			{ fields: ["project_id", "state"] },
+		);
+		return;
+	}
+	clearLocalRecord(props, projectId, contextMatches);
 	writer(props).end(
-		{ project_id: linked.projectId, state: "deleted" },
+		{ project_id: projectId, state: "deleted" },
 		{ fields: ["project_id", "state"] },
 	);
 };
 
-const finishClaimedContext = (props: ClaimProps): void => {
-	const context = readContextFile(props.contextFile);
-	if (!context.projectId) return;
-	removeClaimableCredentials(props.configDir, context.projectId);
-	applyContext(props.contextFile, {
-		projectId: context.projectId,
-		...(contextBranch(context) ? { branch: contextBranch(context) } : {}),
-	});
+const finishClaimedContext = (
+	props: ClaimProps,
+	projectId: string,
+	contextMatches: boolean,
+): void => {
+	removeClaimableCredentials(props.configDir, projectId);
+	if (contextMatches && existsSync(props.contextFile)) {
+		const context = readContextFile(props.contextFile);
+		applyContext(props.contextFile, {
+			projectId: context.projectId,
+			...(contextBranch(context)
+				? { branch: contextBranch(context) }
+				: {}),
+		});
+	}
 	log.info(
 		"Dropped the local identity assertion. The next command needs `neon auth` or `neon link`.",
 	);

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -147,6 +147,13 @@ const removeFileIfPresent = (path: string): void => {
 const failureMessage = (error: unknown): string =>
 	error instanceof Error ? error.message : String(error);
 
+export const CLAIM_LIST_FIELDS = [
+	"project_id",
+	"branch_id",
+	"expires_at",
+	"origin",
+] as const;
+
 export const command = "claim";
 export const aliases = ["claimable"];
 export const describe = "Create and claim temporary Neon projects";
@@ -424,7 +431,7 @@ const create = async (props: CreateProps): Promise<void> => {
 								(decision) =>
 									`${decision.capability}: ${decision.message}`,
 							)
-							.join("\n"),
+							.join(", "),
 				},
 			},
 		);
@@ -593,7 +600,7 @@ const list = (props: ClaimProps): void => {
 		origin: item.origin,
 	}));
 	writer(props).end(projects, {
-		fields: ["project_id", "branch_id", "expires_at", "origin"],
+		fields: CLAIM_LIST_FIELDS,
 		emptyMessage: "No Claimable Neon projects are saved on this machine.",
 	});
 };

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -225,7 +225,7 @@ export const builder = (argv: yargs.Argv) =>
 		)
 		.command(
 			"accept",
-			"Start the browser ceremony that transfers the project to your Neon account",
+			"Create a claim code and open the URL where a human signs in and takes the project",
 			(y) =>
 				y
 					.option("open", {
@@ -301,7 +301,7 @@ const linkedCredentials = (
 	const client = new ClaimableClient(credentials.origin);
 	if (client.origin !== new ClaimableClient(linked.origin).origin) {
 		throw new Error(
-			"The .neon context and saved identity assertion name different Claimable Neon services. Run `neon link` to replace the local context.",
+			"The .neon context and saved identity assertion name different Claimable Neon services. Delete .neon or the assertion file and run `neon claim create` in a new directory.",
 		);
 	}
 	return { context, linked, credentials, client };
@@ -561,7 +561,12 @@ const accept = async (props: AcceptProps): Promise<void> => {
 	);
 
 	if (props.open && !isCi()) {
-		await open(claim.verificationUriComplete);
+		open(claim.verificationUriComplete).catch(() => {
+			log.info(
+				"Could not open a browser. Open %s",
+				claim.verificationUriComplete,
+			);
+		});
 	} else if (props.open) {
 		log.info(
 			"Browser opening is disabled in CI. Open %s",
@@ -623,4 +628,7 @@ const finishClaimedContext = (props: ClaimProps): void => {
 		projectId: context.projectId,
 		...(contextBranch(context) ? { branch: contextBranch(context) } : {}),
 	});
+	log.info(
+		"Dropped the local identity assertion. The next command needs `neon auth` or `neon link`.",
+	);
 };

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -309,6 +309,12 @@ const linkedCredentials = (
 
 const create = async (props: CreateProps): Promise<void> => {
 	rejectExplicitAccountCredential(props);
+	const ambient = credentialInputs();
+	if (ambient.apiKeyEnv.trim() !== "" || ambient.profileEnv.trim() !== "") {
+		log.warning(
+			"NEON_API_KEY or NEON_PROFILE is set. Later commands will use that account credential instead of this claimable project. Unset them to keep using the unclaimed project.",
+		);
+	}
 	const existing = readContextFile(props.contextFile);
 	if (existing.projectId || existing.orgId || existing.claimable) {
 		throw new Error(
@@ -417,6 +423,15 @@ const create = async (props: CreateProps): Promise<void> => {
 					"denied_capabilities",
 					"env_file",
 				],
+				renderColumns: {
+					denied_capabilities: (row) =>
+						row.denied_capabilities
+							.map(
+								(decision) =>
+									`${decision.capability} (${decision.reason})`,
+							)
+							.join("\n"),
+				},
 			},
 		);
 	} catch (error) {

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -154,6 +154,23 @@ export const CLAIM_LIST_FIELDS = [
 	"origin",
 ] as const;
 
+export const CLAIM_CREATE_FIELDS = [
+	"project_id",
+	"branch_id",
+	"state",
+	"expires_at",
+	"granted_capabilities",
+	"denied_capabilities",
+	"env_file",
+] as const;
+
+export const claimCreateFields = (
+	denied: readonly unknown[],
+): (typeof CLAIM_CREATE_FIELDS)[number][] =>
+	CLAIM_CREATE_FIELDS.filter(
+		(field) => field !== "denied_capabilities" || denied.length > 0,
+	);
+
 export const command = "claim";
 export const aliases = ["claimable"];
 export const describe = "Create and claim temporary Neon projects";
@@ -415,15 +432,7 @@ const create = async (props: CreateProps): Promise<void> => {
 				...(envFile ? { env_file: envFile } : {}),
 			},
 			{
-				fields: [
-					"project_id",
-					"branch_id",
-					"state",
-					"expires_at",
-					"granted_capabilities",
-					"denied_capabilities",
-					"env_file",
-				],
+				fields: claimCreateFields(denied),
 				renderColumns: {
 					denied_capabilities: (row) =>
 						row.denied_capabilities

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -100,7 +100,7 @@ const SERVICE_FOR_CAPABILITY: Readonly<
 };
 
 const isClaimableCapability = (value: string): value is ClaimableCapability =>
-	Object.hasOwn(SERVICE_FOR_CAPABILITY, value);
+	value in SERVICE_FOR_CAPABILITY;
 
 const cliServiceName = (capability: string): string =>
 	isClaimableCapability(capability)

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -88,6 +88,25 @@ const CAPABILITY_ORDER: readonly ClaimableCapability[] = [
 	"ai_gateway",
 ];
 
+const SERVICE_FOR_CAPABILITY: Readonly<
+	Record<ClaimableCapability, NeonService>
+> = {
+	postgres: "postgres",
+	auth: "auth",
+	data_api: "data-api",
+	functions: "functions",
+	storage: "object-storage",
+	ai_gateway: "ai-gateway",
+};
+
+const isClaimableCapability = (value: string): value is ClaimableCapability =>
+	Object.hasOwn(SERVICE_FOR_CAPABILITY, value);
+
+const cliServiceName = (capability: string): string =>
+	isClaimableCapability(capability)
+		? SERVICE_FOR_CAPABILITY[capability]
+		: capability;
+
 export const claimableCapabilities = (
 	services: readonly NeonService[],
 ): ClaimableCapability[] => {
@@ -161,7 +180,7 @@ export const CLAIM_CREATE_FIELDS = [
 	"project_id",
 	"branch_id",
 	"state",
-	"expires_at",
+	"project_expires_at",
 	"granted_capabilities",
 	"denied_capabilities",
 	"env_file",
@@ -464,11 +483,11 @@ const create = async (props: CreateProps): Promise<void> => {
 
 		const granted = registration.capabilities
 			.filter((decision) => decision.granted)
-			.map((decision) => decision.capability);
+			.map((decision) => cliServiceName(decision.capability));
 		const denied = registration.capabilities
 			.filter((decision) => !decision.granted)
 			.map((decision) => ({
-				capability: decision.capability,
+				capability: cliServiceName(decision.capability),
 				reason: decision.reason,
 				message: decision.message,
 			}));
@@ -477,7 +496,7 @@ const create = async (props: CreateProps): Promise<void> => {
 				project_id: registration.project.id,
 				branch_id: registration.project.branchId,
 				state: "unclaimed",
-				expires_at: registration.project.expiresAt,
+				project_expires_at: registration.project.expiresAt,
 				granted_capabilities: granted,
 				denied_capabilities: denied,
 				...(envFile ? { env_file: envFile } : {}),
@@ -693,13 +712,21 @@ const accept = async (props: AcceptProps): Promise<void> => {
 
 const list = (props: ClaimProps): void => {
 	rejectExplicitAccountCredential(props);
-	const projects = listClaimableCredentials(props.configDir).map((item) => ({
-		project_id: item.projectId,
-		branch_id: item.branchId,
-		state: assertionHasExpired(item) ? "expired" : "unclaimed",
-		project_expires_at: item.expiresAt,
-		origin: item.origin,
-	}));
+	const projects = listClaimableCredentials(props.configDir).map((item) => {
+		const projectMs = Date.parse(item.expiresAt);
+		const projectExpired =
+			Number.isFinite(projectMs) && projectMs <= Date.now();
+		return {
+			project_id: item.projectId,
+			branch_id: item.branchId,
+			state:
+				assertionHasExpired(item) || projectExpired
+					? "expired"
+					: "unclaimed",
+			project_expires_at: item.expiresAt,
+			origin: item.origin,
+		};
+	});
 	writer(props).end(projects, {
 		fields: CLAIM_LIST_FIELDS,
 		emptyMessage: "No Claimable Neon projects are saved on this machine.",

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -1,0 +1,629 @@
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { loadConfigFromFile } from "@neon/config-runtime";
+import { credentialInputs } from "@neon-internals/cli-core/auth_selection";
+import open from "open";
+import prompts from "prompts";
+import type yargs from "yargs";
+import {
+	type ClaimableCapability,
+	ClaimableClient,
+	ClaimableServiceError,
+	DEFAULT_CLAIMABLE_ORIGIN,
+} from "../claimable/api.js";
+import {
+	listClaimableCredentials,
+	readClaimableCredentials,
+	removeClaimableCredentials,
+	resolveClaimableContext,
+	type StoredClaimableCredentials,
+	writeClaimableCredentials,
+} from "../claimable/state.js";
+import { declaredNeonServices } from "../config_services.js";
+import {
+	applyContext,
+	contextBranch,
+	ensureGitignored,
+	readContextFile,
+} from "../context.js";
+import { isCi } from "../env.js";
+import { mergeEnvFile, resolveEnvFilePath } from "../env_file.js";
+import { log } from "../log.js";
+import {
+	deprecatedServiceMessage,
+	NEON_SERVICES,
+	type NeonService,
+	parseServices,
+	servicesFlagValue,
+	servicesOption,
+} from "../neon_services.js";
+import { noPassthrough } from "../utils/flags.js";
+import { writer } from "../writer.js";
+
+type ClaimProps = {
+	_: (string | number)[];
+	output: "yaml" | "json" | "table";
+	configDir: string;
+	contextFile: string;
+	claimableHost: string;
+	profile?: string;
+	apiKey: string;
+};
+
+type CreateProps = ClaimProps & {
+	services?: readonly NeonService[];
+	config?: string;
+	file?: string;
+	envPull: boolean;
+};
+
+type AcceptProps = ClaimProps & {
+	open: boolean;
+};
+
+type DeleteProps = ClaimProps & {
+	yes: boolean;
+};
+
+const CAPABILITY_FOR_SERVICE: Readonly<
+	Record<NeonService, ClaimableCapability>
+> = {
+	postgres: "postgres",
+	auth: "auth",
+	"data-api": "data_api",
+	functions: "functions",
+	"object-storage": "storage",
+	"ai-gateway": "ai_gateway",
+};
+
+const CAPABILITY_ORDER: readonly ClaimableCapability[] = [
+	"postgres",
+	"data_api",
+	"auth",
+	"storage",
+	"functions",
+	"ai_gateway",
+];
+
+export const claimableCapabilities = (
+	services: readonly NeonService[],
+): ClaimableCapability[] => {
+	const requested = new Set<ClaimableCapability>(["postgres"]);
+	for (const service of services) {
+		requested.add(CAPABILITY_FOR_SERVICE[service]);
+	}
+	return CAPABILITY_ORDER.filter((capability) => requested.has(capability));
+};
+
+const CONFIG_FILENAMES = [
+	"neon.ts",
+	"neon.mts",
+	"neon.js",
+	"neon.mjs",
+] as const;
+
+export const findNeonConfig = (cwd = process.cwd()): string | undefined => {
+	let current = resolve(cwd);
+	const stop = resolve(homedir());
+	while (true) {
+		for (const name of CONFIG_FILENAMES) {
+			const candidate = join(current, name);
+			if (existsSync(candidate)) return candidate;
+		}
+		if (existsSync(join(current, ".git")) || current === stop)
+			return undefined;
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+};
+
+const servicesFromConfig = async (
+	explicitPath: string | undefined,
+): Promise<NeonService[]> => {
+	const path = explicitPath ?? findNeonConfig();
+	if (!path) return [];
+	const { config } = await loadConfigFromFile({ path });
+	return declaredNeonServices(config);
+};
+
+const removeFileIfPresent = (path: string): void => {
+	try {
+		unlinkSync(path);
+	} catch (error) {
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			"code" in error &&
+			error.code === "ENOENT"
+		) {
+			return;
+		}
+		throw error;
+	}
+};
+
+const failureMessage = (error: unknown): string =>
+	error instanceof Error ? error.message : String(error);
+
+export const command = "claim";
+export const aliases = ["claimable"];
+export const describe = "Create and claim temporary Neon projects";
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 claim <sub-command> [options]")
+		.option("claimable-host", {
+			describe: "Claimable Neon service origin",
+			type: "string",
+			default:
+				process.env.CLAIMABLE_NEON_HOST ?? DEFAULT_CLAIMABLE_ORIGIN,
+			hidden: true,
+		})
+		.command(
+			"create",
+			"Create a temporary Neon project without an account",
+			(y) =>
+				y
+					.option(
+						"service",
+						servicesOption({
+							key: "service",
+							allowed: NEON_SERVICES,
+							describe:
+								"Services to request for the claimable project",
+							also: "Postgres is always included. Services unavailable before claim are recorded and reported.",
+						}),
+					)
+					.option("file", {
+						describe:
+							"Target dotenv file. Defaults to an existing .env, otherwise .env.local",
+						type: "string",
+					})
+					.option("config", {
+						describe:
+							"Path to neon.ts. Defaults to walking up from the current directory",
+						type: "string",
+					})
+					.option("env-pull", {
+						describe:
+							"Write the provisioned DATABASE_URL and service URLs to a dotenv file",
+						type: "boolean",
+						default: true,
+					})
+					.strict()
+					.check(noPassthrough("claim create")),
+			async (args) => {
+				const rawServices = servicesFlagValue(args.service);
+				const services = rawServices
+					? parseServices(rawServices, {
+							allowed: NEON_SERVICES,
+							flag: "--service",
+							onDeprecated: (used, canonical) =>
+								log.warning(
+									deprecatedServiceMessage(used, canonical),
+								),
+						})
+					: [];
+				const configuredServices = await servicesFromConfig(
+					typeof args.config === "string" ? args.config : undefined,
+				);
+				await create({
+					...(args as unknown as CreateProps),
+					services: [
+						...new Set([...services, ...configuredServices]),
+					],
+				});
+			},
+		)
+		.command(
+			"status",
+			"Show the linked claimable project's lifecycle and claim status",
+			(y) => y.strict().check(noPassthrough("claim status")),
+			async (args) => await status(args as unknown as ClaimProps),
+		)
+		.command(
+			"accept",
+			"Start the browser ceremony that transfers the project to your Neon account",
+			(y) =>
+				y
+					.option("open", {
+						describe: "Open the verification URL in a browser",
+						type: "boolean",
+						default: true,
+					})
+					.strict()
+					.check(noPassthrough("claim accept")),
+			async (args) => await accept(args as unknown as AcceptProps),
+		)
+		.command(
+			"list",
+			"List claimable projects saved on this machine",
+			(y) => y.strict().check(noPassthrough("claim list")),
+			async (args) => list(args as unknown as ClaimProps),
+		)
+		.command(
+			"delete",
+			"Permanently delete the linked unclaimed project",
+			(y) =>
+				y
+					.option("yes", {
+						alias: "y",
+						describe: "Skip the confirmation prompt",
+						type: "boolean",
+						default: false,
+					})
+					.strict()
+					.check(noPassthrough("claim delete")),
+			async (args) => await deleteProject(args as unknown as DeleteProps),
+		)
+		.demandCommand(1, "Run `neon claim --help` to see the subcommands.");
+
+export const handler = (_args: yargs.Arguments) => {
+	/* subcommands only */
+};
+
+const rejectExplicitAccountCredential = (props: ClaimProps): void => {
+	const inputs = credentialInputs();
+	if (inputs.apiKeyFlag.trim() !== "" || props.profile?.trim()) {
+		throw new Error(
+			"Claimable Neon does not use a Neon account credential. Remove --api-key or --profile.",
+		);
+	}
+};
+
+const linkedCredentials = (
+	props: ClaimProps,
+): {
+	context: ReturnType<typeof readContextFile>;
+	linked: NonNullable<ReturnType<typeof resolveClaimableContext>>;
+	credentials: StoredClaimableCredentials;
+	client: ClaimableClient;
+} => {
+	rejectExplicitAccountCredential(props);
+	const context = readContextFile(props.contextFile);
+	const linked = resolveClaimableContext(context);
+	if (linked === null) {
+		throw new Error(
+			"This directory is not linked to a claimable project. Run `neon claim create` first.",
+		);
+	}
+	const credentials = readClaimableCredentials(
+		props.configDir,
+		linked.projectId,
+	);
+	if (credentials === null) {
+		throw new Error(
+			`The identity assertion for ${linked.projectId} is missing. The project cannot be managed from this machine; claim it through its existing verification URL or run \`neon link\` after it is claimed.`,
+		);
+	}
+	const client = new ClaimableClient(credentials.origin);
+	if (client.origin !== new ClaimableClient(linked.origin).origin) {
+		throw new Error(
+			"The .neon context and saved identity assertion name different Claimable Neon services. Run `neon link` to replace the local context.",
+		);
+	}
+	return { context, linked, credentials, client };
+};
+
+const create = async (props: CreateProps): Promise<void> => {
+	rejectExplicitAccountCredential(props);
+	const existing = readContextFile(props.contextFile);
+	if (existing.projectId || existing.orgId || existing.claimable) {
+		throw new Error(
+			`${props.contextFile} already links this directory to a Neon project. Run \`neon claim create\` from an unlinked directory.`,
+		);
+	}
+	const contextFileExisted = existsSync(props.contextFile);
+	const envFile = props.envPull
+		? resolveEnvFilePath(process.cwd(), props.file)
+		: undefined;
+	const envFileExisted = envFile ? existsSync(envFile) : false;
+	const previousEnv =
+		envFileExisted && envFile ? readFileSync(envFile) : undefined;
+
+	const client = new ClaimableClient(props.claimableHost);
+	const registration = await client.register({
+		capabilities: claimableCapabilities(props.services ?? []),
+		source: "neon_cli",
+	});
+	const stored: StoredClaimableCredentials = {
+		version: 1,
+		origin: client.origin,
+		registrationId: registration.registrationId,
+		projectId: registration.project.id,
+		branchId: registration.project.branchId,
+		identityAssertion: registration.identityAssertion,
+		expiresAt: registration.project.expiresAt,
+	};
+	let localStateWritten = false;
+	let contextWritten = false;
+	let envWriteAttempted = false;
+	let accessToken: string | undefined;
+	try {
+		// Persist the durable assertion before any later network call. If cleanup itself fails,
+		// the user still has enough state to retry `neon claim delete`.
+		writeClaimableCredentials(props.configDir, stored);
+		localStateWritten = true;
+		applyContext(props.contextFile, {
+			projectId: registration.project.id,
+			branch: registration.project.branchId,
+			claimable: { version: 1, origin: client.origin },
+		});
+		contextWritten = true;
+
+		const token = await client.exchange(registration.identityAssertion);
+		accessToken = token.accessToken;
+		const credentials = await client.credentials(
+			registration.project.id,
+			token.accessToken,
+		);
+		if (
+			credentials.projectId !== registration.project.id ||
+			credentials.branchId !== registration.project.branchId
+		) {
+			throw new Error(
+				"Claimable Neon returned credentials for a different project. The project was not kept.",
+			);
+		}
+
+		if (envFile) {
+			const env = {
+				DATABASE_URL: credentials.databaseUrl,
+				...(credentials.services.dataApi
+					? { NEON_DATA_API_URL: credentials.services.dataApi.url }
+					: {}),
+				...(credentials.services.auth
+					? {
+							NEON_AUTH_BASE_URL:
+								credentials.services.auth.baseUrl,
+							NEON_AUTH_JWKS_URL:
+								credentials.services.auth.jwksUrl,
+						}
+					: {}),
+			};
+			envWriteAttempted = true;
+			mergeEnvFile(envFile, env);
+			ensureGitignored(envFile);
+		}
+
+		const granted = registration.capabilities
+			.filter((decision) => decision.granted)
+			.map((decision) => decision.capability);
+		const denied = registration.capabilities
+			.filter((decision) => !decision.granted)
+			.map((decision) => ({
+				capability: decision.capability,
+				reason: decision.reason,
+				message: decision.message,
+			}));
+		writer(props).end(
+			{
+				project_id: registration.project.id,
+				branch_id: registration.project.branchId,
+				state: "unclaimed",
+				expires_at: registration.project.expiresAt,
+				granted_capabilities: granted,
+				denied_capabilities: denied,
+				claim_url: registration.claimStartUrl,
+				...(envFile ? { env_file: envFile } : {}),
+			},
+			{
+				fields: [
+					"project_id",
+					"branch_id",
+					"state",
+					"expires_at",
+					"granted_capabilities",
+					"denied_capabilities",
+					"claim_url",
+					"env_file",
+				],
+			},
+		);
+	} catch (error) {
+		let remoteDeleted = false;
+		try {
+			const cleanupToken =
+				accessToken ??
+				(await client.exchange(registration.identityAssertion))
+					.accessToken;
+			await client.deleteProject(registration.project.id, cleanupToken);
+			remoteDeleted = true;
+		} catch (cleanupError) {
+			log.error(
+				"Claimable project %s could not be cleaned up after create failed: %s",
+				registration.project.id,
+				failureMessage(cleanupError),
+			);
+			if (localStateWritten && contextWritten) {
+				log.error(
+					"Retry cleanup with `neon claim delete --yes` from this directory.",
+				);
+			}
+		}
+
+		if (remoteDeleted) {
+			try {
+				if (localStateWritten) {
+					removeClaimableCredentials(
+						props.configDir,
+						registration.project.id,
+					);
+				}
+				if (contextWritten) {
+					if (contextFileExisted) {
+						applyContext(props.contextFile, existing);
+					} else {
+						removeFileIfPresent(props.contextFile);
+					}
+				}
+				if (envWriteAttempted && envFile) {
+					if (envFileExisted && previousEnv) {
+						writeFileSync(envFile, previousEnv);
+					} else {
+						removeFileIfPresent(envFile);
+					}
+				}
+			} catch (rollbackError) {
+				log.error(
+					"Project cleanup succeeded, but local rollback failed: %s",
+					failureMessage(rollbackError),
+				);
+			}
+		}
+		throw error;
+	}
+};
+
+const status = async (props: ClaimProps): Promise<void> => {
+	const { linked, credentials, client } = linkedCredentials(props);
+	try {
+		const token = await client.exchange(credentials.identityAssertion);
+		let claimState = "unclaimed";
+		let reconciled = false;
+		let claimExpiresAt: string | undefined;
+		try {
+			const claim = await client.claimStatus(
+				linked.projectId,
+				token.accessToken,
+			);
+			claimState = claim.state;
+			reconciled = claim.reconciled;
+			claimExpiresAt = claim.expiresAt;
+		} catch (error) {
+			if (
+				!(error instanceof ClaimableServiceError) ||
+				error.code !== "not_found"
+			) {
+				throw error;
+			}
+		}
+		if (reconciled) {
+			finishClaimedContext(props);
+		}
+		writer(props).end(
+			{
+				project_id: linked.projectId,
+				state: claimState,
+				reconciled,
+				project_expires_at: credentials.expiresAt,
+				...(claimExpiresAt ? { claim_expires_at: claimExpiresAt } : {}),
+			},
+			{
+				fields: [
+					"project_id",
+					"state",
+					"reconciled",
+					"project_expires_at",
+					"claim_expires_at",
+				],
+			},
+		);
+	} catch (error) {
+		if (
+			error instanceof ClaimableServiceError &&
+			error.code === "project_claimed"
+		) {
+			finishClaimedContext(props);
+			writer(props).end(
+				{
+					project_id: linked.projectId,
+					state: "claimed",
+					reconciled: true,
+				},
+				{ fields: ["project_id", "state", "reconciled"] },
+			);
+			return;
+		}
+		throw error;
+	}
+};
+
+const accept = async (props: AcceptProps): Promise<void> => {
+	const { linked, credentials, client } = linkedCredentials(props);
+	const token = await client.exchange(credentials.identityAssertion);
+	const claim = await client.createClaim(linked.projectId, token.accessToken);
+
+	writer(props).end(
+		{
+			project_id: linked.projectId,
+			user_code: claim.userCode,
+			verification_url: claim.verificationUriComplete,
+			expires_in_seconds: claim.expiresIn,
+		},
+		{
+			fields: [
+				"project_id",
+				"user_code",
+				"verification_url",
+				"expires_in_seconds",
+			],
+		},
+	);
+
+	if (props.open && !isCi()) {
+		await open(claim.verificationUriComplete);
+	} else if (props.open) {
+		log.info(
+			"Browser opening is disabled in CI. Open %s",
+			claim.verificationUriComplete,
+		);
+	}
+};
+
+const list = (props: ClaimProps): void => {
+	rejectExplicitAccountCredential(props);
+	const projects = listClaimableCredentials(props.configDir).map((item) => ({
+		project_id: item.projectId,
+		branch_id: item.branchId,
+		expires_at: item.expiresAt,
+		origin: item.origin,
+	}));
+	writer(props).end(projects, {
+		fields: ["project_id", "branch_id", "expires_at", "origin"],
+		emptyMessage: "No Claimable Neon projects are saved on this machine.",
+	});
+};
+
+const deleteProject = async (props: DeleteProps): Promise<void> => {
+	const { linked, credentials, client } = linkedCredentials(props);
+	if (!props.yes) {
+		if (isCi() || !process.stdin.isTTY) {
+			throw new Error(
+				"Deleting a claimable project requires confirmation. Re-run interactively or pass --yes.",
+			);
+		}
+		const { proceed } = await prompts({
+			type: "confirm",
+			name: "proceed",
+			message: `Permanently delete ${linked.projectId}?`,
+			initial: false,
+		});
+		if (!proceed) {
+			log.info("Claimable project was not deleted.");
+			return;
+		}
+	}
+	const token = await client.exchange(credentials.identityAssertion);
+	await client.deleteProject(linked.projectId, token.accessToken);
+	removeClaimableCredentials(props.configDir, linked.projectId);
+	if (existsSync(props.contextFile)) {
+		applyContext(props.contextFile, {});
+	}
+	writer(props).end(
+		{ project_id: linked.projectId, state: "deleted" },
+		{ fields: ["project_id", "state"] },
+	);
+};
+
+const finishClaimedContext = (props: ClaimProps): void => {
+	const context = readContextFile(props.contextFile);
+	if (!context.projectId) return;
+	removeClaimableCredentials(props.configDir, context.projectId);
+	applyContext(props.contextFile, {
+		projectId: context.projectId,
+		...(contextBranch(context) ? { branch: contextBranch(context) } : {}),
+	});
+};

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -152,7 +152,8 @@ const failureMessage = (error: unknown): string =>
 export const CLAIM_LIST_FIELDS = [
 	"project_id",
 	"branch_id",
-	"expires_at",
+	"state",
+	"project_expires_at",
 	"origin",
 ] as const;
 
@@ -695,7 +696,8 @@ const list = (props: ClaimProps): void => {
 	const projects = listClaimableCredentials(props.configDir).map((item) => ({
 		project_id: item.projectId,
 		branch_id: item.branchId,
-		expires_at: item.expiresAt,
+		state: assertionHasExpired(item) ? "expired" : "unclaimed",
+		project_expires_at: item.expiresAt,
 		origin: item.origin,
 	}));
 	writer(props).end(projects, {

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -309,12 +309,6 @@ const linkedCredentials = (
 
 const create = async (props: CreateProps): Promise<void> => {
 	rejectExplicitAccountCredential(props);
-	const ambient = credentialInputs();
-	if (ambient.apiKeyEnv.trim() !== "" || ambient.profileEnv.trim() !== "") {
-		log.warning(
-			"NEON_API_KEY or NEON_PROFILE is set. Later commands will use that account credential instead of this claimable project. Unset them to keep using the unclaimed project.",
-		);
-	}
 	const existing = readContextFile(props.contextFile);
 	if (existing.projectId || existing.orgId || existing.claimable) {
 		throw new Error(

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -428,7 +428,7 @@ const create = async (props: CreateProps): Promise<void> => {
 						row.denied_capabilities
 							.map(
 								(decision) =>
-									`${decision.capability} (${decision.reason})`,
+									`${decision.capability}: ${decision.message}`,
 							)
 							.join("\n"),
 				},

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -261,7 +261,7 @@ export const builder = (argv: yargs.Argv) =>
 		.demandCommand(1, "Run `neon claim --help` to see the subcommands.");
 
 export const handler = (_args: yargs.Arguments) => {
-	/* subcommands only */
+	/* Yargs requires a handler for command groups. */
 };
 
 const rejectExplicitAccountCredential = (props: ClaimProps): void => {
@@ -342,8 +342,7 @@ const create = async (props: CreateProps): Promise<void> => {
 	let envWriteAttempted = false;
 	let accessToken: string | undefined;
 	try {
-		// Persist the durable assertion before any later network call. If cleanup itself fails,
-		// the user still has enough state to retry `neon claim delete`.
+		// Save the assertion first so failed cleanup can still be retried.
 		writeClaimableCredentials(props.configDir, stored);
 		localStateWritten = true;
 		applyContext(props.contextFile, {

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -405,7 +405,6 @@ const create = async (props: CreateProps): Promise<void> => {
 				expires_at: registration.project.expiresAt,
 				granted_capabilities: granted,
 				denied_capabilities: denied,
-				claim_url: registration.claimStartUrl,
 				...(envFile ? { env_file: envFile } : {}),
 			},
 			{
@@ -416,7 +415,6 @@ const create = async (props: CreateProps): Promise<void> => {
 					"expires_at",
 					"granted_capabilities",
 					"denied_capabilities",
-					"claim_url",
 					"env_file",
 				],
 			},

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -24,6 +24,7 @@ import chalk from "chalk";
 import type yargs from "yargs";
 import { getApiClient, type NeonApiClient } from "../api.js";
 import { type NeonConfigView, toNeonConfigView } from "../config_format.js";
+import { declaredNeonServices } from "../config_services.js";
 import {
 	CONFIG_INIT_NONE_MEANS,
 	CONFIG_INIT_SERVICES,
@@ -748,20 +749,6 @@ export const applyCmd = async (props: ConfigProps): Promise<void> => {
 type ReportMode = "plan" | "apply";
 
 /**
- * A static service toggle (`auth` / `dataApi` / `preview.aiGateway`) is "on" unless
- * explicitly disabled: `true` / `{}` / `{ enabled: true }` enable it; `false` /
- * `{ enabled: false }` / absent leave it off. Mirrors the runtime's `isServiceEnabled`
- * (which isn't exported), kept tiny and pure so it can be read straight off the policy.
- */
-const isToggleEnabled = (
-	toggle: boolean | { enabled?: boolean } | undefined,
-): boolean => {
-	if (toggle === undefined) return false;
-	if (typeof toggle === "boolean") return toggle;
-	return toggle.enabled !== false;
-};
-
-/**
  * Human-readable list of the services a `neon.ts` policy utilizes on the branch, shown under
  * the plan/apply table. Postgres is always present (every branch has it); the rest are listed
  * only when the policy declares them. This deliberately surfaces services that produce **no**
@@ -771,17 +758,18 @@ const isToggleEnabled = (
  * lives in the per-branch closure), so reading it straight off `config` is accurate.
  */
 const utilizedServices = (config: Config): string[] => {
-	const services = ["Postgres"];
-	if (isToggleEnabled(config.auth)) services.push("Neon Auth");
-	if (isToggleEnabled(config.dataApi)) services.push("Data API");
-	if (Object.keys(config.preview?.buckets ?? {}).length > 0) {
-		services.push("Object Storage");
-	}
-	if (Object.keys(config.preview?.functions ?? {}).length > 0) {
-		services.push("Functions");
-	}
-	if (isToggleEnabled(config.preview?.aiGateway)) services.push("AI Gateway");
-	return services;
+	const labels: Record<NeonService, string> = {
+		postgres: "Postgres",
+		auth: "Neon Auth",
+		"data-api": "Data API",
+		"object-storage": "Object Storage",
+		functions: "Functions",
+		"ai-gateway": "AI Gateway",
+	};
+	return [
+		labels.postgres,
+		...declaredNeonServices(config).map((service) => labels[service]),
+	];
 };
 
 /**

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -5,6 +5,7 @@ import * as bootstrap from "./bootstrap.js";
 import * as branches from "./branches.js";
 import * as bucket from "./bucket.js";
 import * as checkout from "./checkout.js";
+import * as claim from "./claim.js";
 import * as config from "./config.js";
 import * as cs from "./connection_string.js";
 import * as dataApi from "./data_api.js";
@@ -59,6 +60,7 @@ export default [
 	checkout,
 	link,
 	open,
+	claim,
 	init,
 	mcp,
 	skills,

--- a/packages/cli/src/config_services.test.ts
+++ b/packages/cli/src/config_services.test.ts
@@ -1,0 +1,45 @@
+import { defineConfig } from "@neon/config-runtime";
+import { describe, expect, it } from "vitest";
+import { declaredNeonServices } from "./config_services.js";
+
+describe("declaredNeonServices", () => {
+	it("maps every static neon.ts service without adding Postgres", () => {
+		const config = defineConfig({
+			auth: true,
+			dataApi: { enabled: true },
+			preview: {
+				buckets: {
+					assets: { access: "private" },
+				},
+				functions: {
+					api: { name: "API", source: "./api.ts" },
+				},
+				aiGateway: true,
+			},
+			branch: () => ({}),
+		});
+
+		expect(declaredNeonServices(config)).toEqual([
+			"auth",
+			"data-api",
+			"object-storage",
+			"functions",
+			"ai-gateway",
+		]);
+	});
+
+	it("omits explicitly disabled toggles and empty preview maps", () => {
+		const config = defineConfig({
+			auth: false,
+			dataApi: { enabled: false },
+			preview: {
+				buckets: {},
+				functions: {},
+				aiGateway: { enabled: false },
+			},
+			branch: () => ({}),
+		});
+
+		expect(declaredNeonServices(config)).toEqual([]);
+	});
+});

--- a/packages/cli/src/config_services.ts
+++ b/packages/cli/src/config_services.ts
@@ -1,10 +1,6 @@
 import type { Config } from "@neon/config-runtime";
 import type { NeonService } from "./neon_services.js";
 
-/**
- * A static service toggle is on unless explicitly disabled: `true`, `{}`, and
- * `{ enabled: true }` enable it; `false`, `{ enabled: false }`, and absence leave it off.
- */
 const isToggleEnabled = (
 	toggle: boolean | { enabled?: boolean } | undefined,
 ): boolean => {
@@ -13,12 +9,7 @@ const isToggleEnabled = (
 	return toggle.enabled !== false;
 };
 
-/**
- * Static services declared by a neon.ts policy.
- *
- * Postgres is omitted because every Neon project has it. Callers that construct a
- * Claimable Neon capability request add Postgres unconditionally.
- */
+/** Postgres is omitted because every project includes it. */
 export const declaredNeonServices = (config: Config): NeonService[] => {
 	const services: NeonService[] = [];
 	if (isToggleEnabled(config.auth)) services.push("auth");

--- a/packages/cli/src/config_services.ts
+++ b/packages/cli/src/config_services.ts
@@ -1,0 +1,36 @@
+import type { Config } from "@neon/config-runtime";
+import type { NeonService } from "./neon_services.js";
+
+/**
+ * A static service toggle is on unless explicitly disabled: `true`, `{}`, and
+ * `{ enabled: true }` enable it; `false`, `{ enabled: false }`, and absence leave it off.
+ */
+const isToggleEnabled = (
+	toggle: boolean | { enabled?: boolean } | undefined,
+): boolean => {
+	if (toggle === undefined) return false;
+	if (typeof toggle === "boolean") return toggle;
+	return toggle.enabled !== false;
+};
+
+/**
+ * Static services declared by a neon.ts policy.
+ *
+ * Postgres is omitted because every Neon project has it. Callers that construct a
+ * Claimable Neon capability request add Postgres unconditionally.
+ */
+export const declaredNeonServices = (config: Config): NeonService[] => {
+	const services: NeonService[] = [];
+	if (isToggleEnabled(config.auth)) services.push("auth");
+	if (isToggleEnabled(config.dataApi)) services.push("data-api");
+	if (Object.keys(config.preview?.buckets ?? {}).length > 0) {
+		services.push("object-storage");
+	}
+	if (Object.keys(config.preview?.functions ?? {}).length > 0) {
+		services.push("functions");
+	}
+	if (isToggleEnabled(config.preview?.aiGateway)) {
+		services.push("ai-gateway");
+	}
+	return services;
+};

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -7,7 +7,7 @@ import { log } from "./log.js";
 
 export type ClaimableContext = {
 	version: 1;
-	/** Claimable Neon authorization-server origin, without the `/v1` API prefix. */
+	/** Omits the `/v1` API prefix. */
 	origin: string;
 };
 
@@ -26,10 +26,6 @@ export type Context = {
 	 * dropped the next time the context is written.
 	 */
 	branchId?: string;
-	/**
-	 * The assertion stays outside `.neon` so repository context never contains the owner
-	 * credential.
-	 */
 	claimable?: ClaimableContext;
 };
 

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -27,9 +27,8 @@ export type Context = {
 	 */
 	branchId?: string;
 	/**
-	 * Present while this project is owned by Claimable Neon. The durable identity assertion
-	 * stays in the owner-only CLI config directory; `.neon` carries only the public issuer
-	 * needed to find it.
+	 * The assertion stays outside `.neon` so repository context never contains the owner
+	 * credential.
 	 */
 	claimable?: ClaimableContext;
 };
@@ -95,10 +94,6 @@ export const isConfigInit = (args: {
 export const isProfileCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "profile" || args._[0] === "profiles";
 
-/**
- * `claim` / `claimable` talks to the Claimable Neon authorization service and manages its
- * own durable assertion. It must never trigger account authentication first.
- */
 export const isClaimCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "claim" || args._[0] === "claimable";
 
@@ -246,8 +241,7 @@ export const enrichFromContext = (
 	if (isSkillsCommand(args)) {
 		return;
 	}
-	// Claim commands resolve their own project and assertion. Letting `.neon` populate their
-	// arguments would make `claim list` accidentally target whichever directory it runs from.
+	// Claim commands bypass enrichment so `claim list` never targets the current directory.
 	if (isClaimCommand(args)) {
 		return;
 	}

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -5,6 +5,12 @@ import type yargs from "yargs";
 
 import { log } from "./log.js";
 
+export type ClaimableContext = {
+	version: 1;
+	/** Claimable Neon authorization-server origin, without the `/v1` API prefix. */
+	origin: string;
+};
+
 export type Context = {
 	orgId?: string;
 	projectId?: string;
@@ -20,6 +26,12 @@ export type Context = {
 	 * dropped the next time the context is written.
 	 */
 	branchId?: string;
+	/**
+	 * Present while this project is owned by Claimable Neon. The durable identity assertion
+	 * stays in the owner-only CLI config directory; `.neon` carries only the public issuer
+	 * needed to find it.
+	 */
+	claimable?: ClaimableContext;
 };
 
 /**
@@ -82,6 +94,13 @@ export const isConfigInit = (args: {
  */
 export const isProfileCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "profile" || args._[0] === "profiles";
+
+/**
+ * `claim` / `claimable` talks to the Claimable Neon authorization service and manages its
+ * own durable assertion. It must never trigger account authentication first.
+ */
+export const isClaimCommand = (args: { _: (string | number)[] }): boolean =>
+	args._[0] === "claim" || args._[0] === "claimable";
 
 /**
  * `neon api-keys …`, under either spelling. Exempts the group from context enrichment: how
@@ -225,6 +244,11 @@ export const enrichFromContext = (
 		return;
 	}
 	if (isSkillsCommand(args)) {
+		return;
+	}
+	// Claim commands resolve their own project and assertion. Letting `.neon` populate their
+	// arguments would make `claim list` accidentally target whichever directory it runs from.
+	if (isClaimCommand(args)) {
 		return;
 	}
 	const context = readContextFile(args.contextFile);

--- a/packages/cli/src/list_tables.test.ts
+++ b/packages/cli/src/list_tables.test.ts
@@ -1,6 +1,7 @@
 import stripAnsi from "strip-ansi";
 import { describe, expect, it } from "vitest";
 import { BRANCH_FIELDS } from "./commands/branches.js";
+import { CLAIM_LIST_FIELDS } from "./commands/claim.js";
 import {
 	PROJECT_FIELDS,
 	RECOVERABLE_PROJECT_FIELDS,
@@ -136,6 +137,32 @@ describe("list field order", () => {
 		for (const field of PROJECT_FIELDS) {
 			expect(header).toContain(titleCase(field));
 		}
+	});
+
+	it("prints claim list as full-width columns without boxes", () => {
+		const origin = "https://claimable.neon.tech";
+		const out = formatHumanChunk({
+			data: [
+				{
+					project_id: PROJECT_ID,
+					branch_id: BRANCH_ID,
+					expires_at: TIMESTAMP,
+					origin,
+				},
+			],
+			fields: CLAIM_LIST_FIELDS,
+			width: 40,
+			colorTitle: false,
+		});
+		expect(out).not.toMatch(BOX);
+		const header = headerOf(out);
+		for (const field of CLAIM_LIST_FIELDS) {
+			expect(header).toContain(titleCase(field));
+		}
+		expect(header.indexOf("Expires At")).toBeGreaterThan(-1);
+		expect(stripAnsi(out)).toContain(PROJECT_ID);
+		expect(stripAnsi(out)).toContain(origin);
+		expect(stripAnsi(out).trimEnd().split("\n")).toHaveLength(2);
 	});
 });
 

--- a/packages/cli/src/list_tables.test.ts
+++ b/packages/cli/src/list_tables.test.ts
@@ -146,7 +146,8 @@ describe("list field order", () => {
 				{
 					project_id: PROJECT_ID,
 					branch_id: BRANCH_ID,
-					expires_at: TIMESTAMP,
+					state: "unclaimed",
+					project_expires_at: TIMESTAMP,
 					origin,
 				},
 			],
@@ -159,7 +160,7 @@ describe("list field order", () => {
 		for (const field of CLAIM_LIST_FIELDS) {
 			expect(header).toContain(titleCase(field));
 		}
-		expect(header.indexOf("Expires At")).toBeGreaterThan(-1);
+		expect(header.indexOf("Project Expires At")).toBeGreaterThan(-1);
 		expect(stripAnsi(out)).toContain(PROJECT_ID);
 		expect(stripAnsi(out)).toContain(origin);
 		expect(stripAnsi(out).trimEnd().split("\n")).toHaveLength(2);

--- a/packages/config/src/lib/wrap-neon-error.test.ts
+++ b/packages/config/src/lib/wrap-neon-error.test.ts
@@ -66,8 +66,12 @@ describe("wrapNeonError — HTTP status mapping", () => {
 		);
 		const p = err as PlatformError;
 		expect(p.code).toBe(ErrorCode.FeatureUnavailable);
+		expect(p.message).toContain(
+			"this capability requires a claimed project",
+		);
 		expect(p.message).toContain("functions requires a claimed project");
 		expect(p.message).toContain("npx neon claim accept");
+		expect(p.message).toContain("npx neon auth");
 		expect(p.message).toContain("req-claimable");
 		expect(p.message).not.toContain("API key");
 		expect(p.details.requestId).toBe("req-claimable");

--- a/packages/config/src/lib/wrap-neon-error.test.ts
+++ b/packages/config/src/lib/wrap-neon-error.test.ts
@@ -71,6 +71,7 @@ describe("wrapNeonError — HTTP status mapping", () => {
 		);
 		expect(p.message).toContain("functions requires a claimed project");
 		expect(p.message).toContain("npx neon claim accept");
+		expect(p.message).toContain("npx neon claim status");
 		expect(p.message).toContain("npx neon auth");
 		expect(p.message).toContain("req-claimable");
 		expect(p.message).not.toContain("API key");

--- a/packages/config/src/lib/wrap-neon-error.test.ts
+++ b/packages/config/src/lib/wrap-neon-error.test.ts
@@ -4,7 +4,7 @@ import { wrapNeonError } from "./wrap-neon-error.js";
 
 function axiosLike(
 	status: number,
-	body?: { message?: string; code?: string; request_id?: string },
+	body?: object,
 ): { response: { status: number; data?: object } } {
 	const err: { response: { status: number; data?: object } } = {
 		response: { status },
@@ -50,6 +50,26 @@ describe("wrapNeonError — HTTP status mapping", () => {
 		expect(p.message).toContain(
 			"Project-scoped keys can only operate on their own project",
 		);
+	});
+
+	test("maps a nested Claimable Neon capability error without API-key advice", () => {
+		const err = wrapNeonError(
+			axiosLike(403, {
+				error: {
+					code: "capability_requires_claim",
+					message: "functions requires a claimed project",
+					request_id: "req-claimable",
+				},
+			}),
+			CTX,
+		);
+		const p = err as PlatformError;
+		expect(p.code).toBe(ErrorCode.FeatureUnavailable);
+		expect(p.message).toContain("functions requires a claimed project");
+		expect(p.message).toContain("Claim the project");
+		expect(p.message).not.toContain("API key");
+		expect(p.details.requestId).toBe("req-claimable");
+		expect(p.details.neonCode).toBe("capability_requires_claim");
 	});
 
 	test("404 → NotFound + verifies project id when present", () => {

--- a/packages/config/src/lib/wrap-neon-error.test.ts
+++ b/packages/config/src/lib/wrap-neon-error.test.ts
@@ -1,3 +1,4 @@
+import { NeonApiError } from "@neon/sdk";
 import { describe, expect, test } from "vitest";
 import { ErrorCode, PlatformError } from "./errors.js";
 import { wrapNeonError } from "./wrap-neon-error.js";
@@ -70,6 +71,53 @@ describe("wrapNeonError — HTTP status mapping", () => {
 		expect(p.message).not.toContain("API key");
 		expect(p.details.requestId).toBe("req-claimable");
 		expect(p.details.neonCode).toBe("capability_requires_claim");
+	});
+
+	test("maps a generated-SDK NeonApiError whose nested envelope is in body", () => {
+		const sdkError = new NeonApiError(
+			"Neon API request failed with status 403.",
+			{
+				status: 403,
+				body: {
+					error: {
+						code: "capability_requires_claim",
+						message: "functions requires a claimed project",
+						request_id: "req-sdk",
+					},
+				},
+			},
+		);
+		const err = wrapNeonError(sdkError, CTX);
+		const p = err as PlatformError;
+		expect(p.code).toBe(ErrorCode.FeatureUnavailable);
+		expect(p.message).toContain("functions requires a claimed project");
+		expect(p.message).not.toContain("API key");
+		expect(p.details.requestId).toBe("req-sdk");
+		expect(p.details.neonCode).toBe("capability_requires_claim");
+	});
+
+	test("maps an unwrap-shaped NeonApiError stuffed into response.data", () => {
+		const sdkError = new NeonApiError(
+			"Neon API request failed with status 403.",
+			{
+				status: 403,
+				body: {
+					error: {
+						code: "capability_requires_claim",
+						message: "functions requires a claimed project",
+						request_id: "req-unwrap",
+					},
+				},
+			},
+		);
+		const err = wrapNeonError(
+			{ response: { status: 403, data: sdkError } },
+			CTX,
+		);
+		const p = err as PlatformError;
+		expect(p.code).toBe(ErrorCode.FeatureUnavailable);
+		expect(p.message).not.toContain("API key");
+		expect(p.details.requestId).toBe("req-unwrap");
 	});
 
 	test("404 → NotFound + verifies project id when present", () => {

--- a/packages/config/src/lib/wrap-neon-error.test.ts
+++ b/packages/config/src/lib/wrap-neon-error.test.ts
@@ -67,7 +67,8 @@ describe("wrapNeonError — HTTP status mapping", () => {
 		const p = err as PlatformError;
 		expect(p.code).toBe(ErrorCode.FeatureUnavailable);
 		expect(p.message).toContain("functions requires a claimed project");
-		expect(p.message).toContain("Claim the project");
+		expect(p.message).toContain("npx neon claim accept");
+		expect(p.message).toContain("req-claimable");
 		expect(p.message).not.toContain("API key");
 		expect(p.details.requestId).toBe("req-claimable");
 		expect(p.details.neonCode).toBe("capability_requires_claim");

--- a/packages/config/src/lib/wrap-neon-error.ts
+++ b/packages/config/src/lib/wrap-neon-error.ts
@@ -49,6 +49,17 @@ export function wrapNeonError(
 		: "";
 	const apiSummaryWithRequestId = `${apiSummary}${requestIdSuffix}.`;
 
+	if (httpInfo.neonCode === "capability_requires_claim") {
+		return new PlatformError(
+			ErrorCode.FeatureUnavailable,
+			[
+				`${context.op} failed: ${httpInfo.neonMessage ?? "This capability requires a claimed project."}`,
+				"Claim the project before enabling this service.",
+			].join(" "),
+			{ cause: err, details: httpDetails(context, httpInfo) },
+		);
+	}
+
 	switch (httpInfo.status) {
 		case 401:
 			return new PlatformError(
@@ -151,12 +162,20 @@ function extractHttpInfo(err: unknown): HttpInfo | null {
 	const out: HttpInfo = { status };
 	if (data !== null && typeof data === "object") {
 		const dataObj = data as Record<string, unknown>;
-		if (typeof dataObj.message === "string" && dataObj.message !== "")
-			out.neonMessage = dataObj.message;
-		if (typeof dataObj.code === "string" && dataObj.code !== "")
-			out.neonCode = dataObj.code;
-		if (typeof dataObj.request_id === "string" && dataObj.request_id !== "")
-			out.requestId = dataObj.request_id;
+		const nested = dataObj.error;
+		const errorObj =
+			nested !== null && typeof nested === "object"
+				? (nested as Record<string, unknown>)
+				: dataObj;
+		if (typeof errorObj.message === "string" && errorObj.message !== "")
+			out.neonMessage = errorObj.message;
+		if (typeof errorObj.code === "string" && errorObj.code !== "")
+			out.neonCode = errorObj.code;
+		if (
+			typeof errorObj.request_id === "string" &&
+			errorObj.request_id !== ""
+		)
+			out.requestId = errorObj.request_id;
 	}
 	return out;
 }

--- a/packages/config/src/lib/wrap-neon-error.ts
+++ b/packages/config/src/lib/wrap-neon-error.ts
@@ -54,9 +54,9 @@ export function wrapNeonError(
 		return new PlatformError(
 			ErrorCode.FeatureUnavailable,
 			[
-				`${context.op} failed: ${httpInfo.neonMessage ?? "This capability requires a claimed project."}`,
-				"Run `npx neon claim accept` before enabling this service.",
+				`${context.op} failed: this capability requires a claimed project.`,
 				apiSummaryWithRequestId,
+				"Run `npx neon claim accept`, complete the sign-in, then `npx neon auth` or `npx neon link` and re-run.",
 			].join(" "),
 			{ cause: err, details: httpDetails(context, httpInfo) },
 		);

--- a/packages/config/src/lib/wrap-neon-error.ts
+++ b/packages/config/src/lib/wrap-neon-error.ts
@@ -55,7 +55,8 @@ export function wrapNeonError(
 			ErrorCode.FeatureUnavailable,
 			[
 				`${context.op} failed: ${httpInfo.neonMessage ?? "This capability requires a claimed project."}`,
-				"Claim the project before enabling this service.",
+				"Run `npx neon claim accept` before enabling this service.",
+				apiSummaryWithRequestId,
 			].join(" "),
 			{ cause: err, details: httpDetails(context, httpInfo) },
 		);

--- a/packages/config/src/lib/wrap-neon-error.ts
+++ b/packages/config/src/lib/wrap-neon-error.ts
@@ -1,3 +1,4 @@
+import { NeonApiError } from "@neon/sdk";
 import { ErrorCode, PlatformError } from "./errors.js";
 
 /**
@@ -152,31 +153,45 @@ interface HttpInfo {
 	requestId?: string;
 }
 
+function takeErrorFields(payload: unknown, out: HttpInfo): void {
+	if (payload === null || typeof payload !== "object") return;
+	const dataObj = payload as Record<string, unknown>;
+	const nested = dataObj.error;
+	const errorObj =
+		nested !== null && typeof nested === "object"
+			? (nested as Record<string, unknown>)
+			: dataObj;
+	if (typeof errorObj.message === "string" && errorObj.message !== "")
+		out.neonMessage = errorObj.message;
+	if (typeof errorObj.code === "string" && errorObj.code !== "")
+		out.neonCode = errorObj.code;
+	if (typeof errorObj.request_id === "string" && errorObj.request_id !== "")
+		out.requestId = errorObj.request_id;
+}
+
+function fromNeonApiError(err: NeonApiError): HttpInfo {
+	const out: HttpInfo = { status: err.status };
+	takeErrorFields(err.body, out);
+	if (out.neonCode === undefined && err.code !== undefined)
+		out.neonCode = err.code;
+	if (out.neonMessage === undefined && err.message !== "")
+		out.neonMessage = err.message;
+	if (out.requestId === undefined && err.requestId !== undefined)
+		out.requestId = err.requestId;
+	return out;
+}
+
 function extractHttpInfo(err: unknown): HttpInfo | null {
+	if (err instanceof NeonApiError) return fromNeonApiError(err);
 	if (err === null || typeof err !== "object") return null;
 	const response = (err as { response?: unknown }).response;
 	if (response === null || typeof response !== "object") return null;
 	const status = (response as { status?: unknown }).status;
 	if (typeof status !== "number") return null;
 	const data = (response as { data?: unknown }).data;
+	if (data instanceof NeonApiError) return fromNeonApiError(data);
 	const out: HttpInfo = { status };
-	if (data !== null && typeof data === "object") {
-		const dataObj = data as Record<string, unknown>;
-		const nested = dataObj.error;
-		const errorObj =
-			nested !== null && typeof nested === "object"
-				? (nested as Record<string, unknown>)
-				: dataObj;
-		if (typeof errorObj.message === "string" && errorObj.message !== "")
-			out.neonMessage = errorObj.message;
-		if (typeof errorObj.code === "string" && errorObj.code !== "")
-			out.neonCode = errorObj.code;
-		if (
-			typeof errorObj.request_id === "string" &&
-			errorObj.request_id !== ""
-		)
-			out.requestId = errorObj.request_id;
-	}
+	takeErrorFields(data, out);
 	return out;
 }
 

--- a/packages/config/src/lib/wrap-neon-error.ts
+++ b/packages/config/src/lib/wrap-neon-error.ts
@@ -56,7 +56,7 @@ export function wrapNeonError(
 			[
 				`${context.op} failed: this capability requires a claimed project.`,
 				apiSummaryWithRequestId,
-				"Run `npx neon claim accept`, complete the sign-in, then `npx neon auth` or `npx neon link` and re-run.",
+				"Run `npx neon claim accept`, complete the sign-in, then `npx neon claim status` to drop the local assertion, then `npx neon auth` or `npx neon link` and re-run.",
 			].join(" "),
 			{ cause: err, details: httpDetails(context, httpInfo) },
 		);


### PR DESCRIPTION
## The problem

Every path into the Neon CLI starts with a Neon account. `neon auth` opens a browser, `--api-key` and `--profile` want a key you already minted. An agent that lands in an empty directory on a machine with no Neon credential has nothing to connect to, and the human is the one who has to go and sign up before any code can run against a database.

Claimable Neon (`https://claimable.neon.tech`) hands out temporary projects to an anonymous caller and lets a human take ownership later. The CLI had no way to talk to it, so an agent that wanted a database still had to stop and ask.

## What this adds

`neon claim`, with `neon claimable` as an alias, and five subcommands: `create`, `status`, `accept`, `list`, `delete`.

`claim create` registers an anonymous identity with Claimable Neon, gets a project back, saves a signed identity assertion on this machine and links the directory. From there the rest of the CLI works against that project: when a directory carries the claimable marker and no account credential is in play, the CLI exchanges the assertion for a short-lived bearer token and points the API host at the Claimable Neon origin.

The identity assertion is the only secret that lands on disk. Access tokens are exchanged per command and expire in minutes.

## Creating a project

```bash
# Lakebase Postgres is always requested
neon claim create

# Ask for more, on top of whatever the local neon.ts declares
neon claim create --service auth --service data-api
```

Output, from the built CLI in this worktree against a local stub of the Claimable Neon endpoints:

```
Project Id            wandering-haze-25754674
Branch Id             br-quiet-sky-12345678
State                 unclaimed
Project Expires At    2026-08-26T19:58:00.000Z
Granted Capabilities  postgres, data-api
Denied Capabilities   object-storage: Object Storage is available after the project is claimed., ai-gateway: The AI Gateway is available after the project is claimed.
Env File              /private/tmp/claimcreate.iyi5/ws/.env.local
```

The capability names printed here are the CLI's own service names (`data-api`, `object-storage`, `ai-gateway`), the same vocabulary `--service`, `status` and `list` use, so nobody has to learn the service's `data_api` / `storage` / `ai_gateway` spelling. `Denied Capabilities` is dropped from the table when nothing is denied.

Services that a `neon.ts` in scope declares are added to the request automatically. Services the platform cannot grant before a claim are still sent, so demand is recorded, and they come back denied with a reason rather than being silently dropped from the request.

Three things land on disk:

```
.neon           projectId, branch and a { "claimable": { "version": 1, "origin": ... } } marker
.env.local      DATABASE_URL plus any granted Auth or Data API variables (--no-env-pull skips this)
<config-dir>/claimable-credential.<project-id>.json    mode 0600
```

The dotenv target follows the existing rule: an existing `.env` if there is one, otherwise `.env.local`, and `--file` overrides. The file is added to `.gitignore` the same way `neon env pull` does it.

`.env.local` from the run above:

```
DATABASE_URL="postgresql://neondb_owner:demo@ep-quiet-sky-12345678-pooler.us-east-2.aws.neon.tech/neondb?sslmode=require"
NEON_DATA_API_URL=https://app-quiet-sky-12345678.dpl.myneon.app
```

`create` refuses to run in a directory that is already linked:

```
ERROR: /tmp/claimdel.1mB2/ws/.neon already links this directory to a Neon project. Run `neon claim create` from an unlinked directory.
```

## Using, claiming and cleaning up

```bash
neon claim status                 # lifecycle and transfer state
neon projects get <project-id>    # ordinary CLI command, same short-lived token
neon claim accept                 # claim code plus the URL where a human signs in
neon claim list                   # every record saved on this machine
neon claim delete --yes           # permanently delete an unclaimed project
```

`status`, `accept` and `delete` take an optional project id, so a project stays manageable after the directory it was created in is gone:

```bash
neon claim delete wandering-haze-25754674 --yes
```

Real output for each, same stub service:

```
$ neon claim status
Project Id          wandering-haze-25754674
State               pending
Reconciled          false
Project Expires At  2026-08-26T19:58:00.000Z
Claim Expires At    2026-08-25T20:13:00.000Z

$ neon claim accept --no-open
Project Id          wandering-haze-25754674
User Code           QJTM-4XFD
Verification Url    https://claimable.neon.tech/claim?code=QJTM-4XFD
Expires In Seconds  900

$ neon claim delete --yes
Project Id  wandering-haze-25754674
State       deleted
```

`accept` opens the verification URL in a browser by default. `--no-open` prints it instead, and CI never opens a browser.

`list` is a full-width writer table like `neon projects list`, with no box drawing:

```
$ neon claim list
Project Id               Branch Id              State      Project Expires At        Origin
wandering-haze-25754674  br-quiet-sky-12345678  unclaimed  2027-08-24T12:00:00.000Z  https://claimable.neon.tech
```

`state` is `expired` when either clock has run out, the identity assertion's or the project's. Both are read locally, so `list` never has to reach the service:

```
$ neon claim list
Project Id               Branch Id              State    Project Expires At        Origin
wandering-haze-25754674  br-quiet-sky-12345678  expired  2026-08-24T12:00:00.000Z  https://claimable.neon.tech
```

An empty list prints a sentence: `No Claimable Neon projects are saved on this machine.`

`delete` has two outcomes. `deleted` means the project was removed from the service. `cleared` means the assertion had expired or the service no longer accepts it, so only the local record and the `.neon` link were dropped. Either way the directory is unlinked afterwards.

Once a human completes the claim, `status` sees `reconciled`, deletes the local assertion and leaves the `.neon` project link in place, with a note that the next command needs `neon auth` or `neon link`. That is a one-way step on this machine: the anonymous identity is gone and the project now belongs to an account.

## What decides which credential is used

An account credential always wins. The claimable assertion is used only when `--api-key`, `--profile`, `NEON_API_KEY` and `NEON_PROFILE` are all absent. When one of them is set in a claimable directory, the command runs against the account and warns:

```
This directory is linked to a claimable project, but NEON_API_KEY or NEON_PROFILE is set. This command will use that account credential instead of the unclaimed project. Unset them to keep using the unclaimed project.
```

The `claim` subcommands themselves reject `--api-key` and `--profile` before any network call, because there is no account credential involved in registering or claiming. Ambient `NEON_API_KEY` and `NEON_PROFILE` are tolerated there, so an agent on a machine that already has a working Neon login is never told to unset it.

Nothing changes for anyone who is not in a claimable directory. `ensureAuth` reaches the new branch only after the existing checks, and only when the `.neon` file carries the marker.

## Error handling and rollback

Claimable Neon returns errors as `{ "error": { "code", "message", "request_id" } }`, one level deeper than the Neon API's flat body. Three places learned to read that shape:

- `codeFromBody` and `messageFromBody` in the CLI, so a proxied error keeps its code.
- `wrapNeonError` in `@neon/config`, which also now recognizes a `NeonApiError` directly rather than only an axios-shaped `response.data`.
- `capability_requires_claim` maps to `FeatureUnavailable` with the claim path spelled out, instead of the generic 403 that tells you to check your API key.

Every response from the service is validated at the boundary and projected to known fields. A malformed body raises `Claimable Neon returned an invalid response while <action>. The response was not used.` rather than being half-consumed. An origin has to be a scheme and a host with nothing else on it, and HTTPS unless the host is `localhost`.

`create` is transactional. If anything after registration fails, it deletes the project it just created and restores `.neon` and the dotenv file to what they were. If that remote delete also fails, it says so and names the retry: `neon claim delete --yes`.

## Also in here

- `declaredNeonServices` is pulled out of `commands/config.ts` into `config_services.ts`, so `claim create` and `config plan` agree on which services a `neon.ts` declares. `config plan` output is unchanged; the toggle logic moved as-is.
- `claim` is exempt from `.neon` context enrichment, so `claim list` enumerates the machine rather than the current directory.
- README gets a section on creating a project without an account, and a row in the command table.
- `list_tables.test.ts` gains a case pinning `claim list` to the full-width columns.
- Changeset: `neon` minor, `@neon/config` patch.

## Verification

`packages/cli` was built with `pnpm exec tsdown` first, because the CLI-level tests and the output above spawn `dist/cli.js`. Then:

```
$ pnpm exec vitest run src/claimable src/commands/claim.test.ts src/commands/claim.cli.test.ts \
    src/config_services.test.ts src/list_tables.test.ts
Test Files  6 passed (6)
     Tests  70 passed (70)

$ cd packages/config && pnpm exec vitest run src/lib/wrap-neon-error.test.ts
Test Files  1 passed (1)
     Tests  17 passed (17)
```

Behaviours covered:

- Postgres is always requested, and every `--service` value maps to the service's capability name.
- Capabilities that need a claim are still sent, and come back reported.
- `neon.ts` discovery walks up to the repository root and stops there.
- The assertion file is written 0600, permissive modes are repaired on rewrite, and a project id that could escape the config directory is rejected.
- A stored assertion expiry in the past reads as expired; a missing one reads as live.
- A malformed or future-versioned `claimable` marker throws instead of falling back to account auth.
- Every explicit and ambient account credential turns the claimable path off.
- `claim status`, `claim delete` and `claim accept` handle an expired assertion without contacting the service, spawning the real built binary against an origin with nothing listening on it.
- `claim create` fails before the network when `--api-key` or `--profile` is passed, and does not warn when only ambient credentials are set.
- `claim list` prints every column at full width, marks a past project expiry and a past assertion expiry as expired and prints a message when empty.
- The client calls `/v1/projects/{id}/credentials`, `/v1/projects/{id}/claim` and `DELETE /v1/projects/{id}`, asserted against a real HTTP server.
- `wrapNeonError` maps the nested capability error from three shapes: an axios-like body, a `NeonApiError` and a `NeonApiError` stuffed into `response.data`.

The command output shown above was produced by running `packages/cli/dist/cli.js` in this worktree against a local HTTP stub of the Claimable Neon endpoints. The flow, formatting and files written are the CLI's; the project id, URLs and timestamps come from the stub.

**Not run: `packages/cli/e2e/claim.e2e.test.ts` against the live service.** The e2e suite's setup file calls the harness orphan sweep, which needs `NEON_API_KEY`. That test covers the part no local run can: create against the real service, `neon projects get` through the exchanged token, `claim status` and delete by project id from a directory that never had the `.neon`. It needs one green run before merge.

## For your attention

- **The live contract is unverified here.** Response parsing is pinned to the shapes in `claimable/api.ts`, and every one of them is a guess about the service until the e2e run happens. A field rename on the service side surfaces as `Claimable Neon returned an invalid response`, which is the right failure but still a failure.
- **`--claimable-host` is hidden, and `CLAIMABLE_NEON_HOST` overrides the default origin.** Both exist for pointing at a local service during development. Non-localhost origins are forced to HTTPS.
- **Deleting `.neon` by hand strands the assertion file.** `claim list` still shows the project and `claim delete <project-id> --yes` still removes it, so the recovery path exists, but nothing sweeps the config directory on its own.
- **`status` dropping the assertion after a claim is irreversible on that machine.** If the human claims the project and the agent still needs it, the way back is `neon auth` or `neon link` against the now-owned project.
- **`create` writes the dotenv file before the table prints.** On a rollback the previous contents are restored byte for byte, and the file is removed if it did not exist, but an editor holding the old buffer will not know.
- **Denied capabilities are informational.** The CLI reports what the service refused and carries on with a project that has fewer services than asked for, rather than failing the create. An agent that needs Object Storage has to read the output.
