### PR TITLE
Add neon open for linked projects

### DIFF
--- a/.changeset/neon-open.md
+++ b/.changeset/neon-open.md
@@ -1,0 +1,5 @@
+---
+"neon": minor
+---
+
+Add `neon open` to open the project linked in `.neon` in the Neon Console.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -202,12 +202,6 @@ The Neon CLI supports autocompletion, which you can configure in a few easy step
 
 `neon link` is a Vercel-style command that binds the current directory to a Neon project. It picks (or creates) an organization and a project and writes a `.neon` file (`{ "orgId", "projectId", "branch" }`) that subsequent commands run in this directory (or any sub-directory) pick up automatically.
 
-Open the linked project in the Neon Console from the same directory:
-
-```bash
-neon open
-```
-
 `link` resolves what it can and **verifies every identifier you pass** before writing, so a `.neon` is never left half-written or pointing at something that doesn't exist:
 
 - **org** is inferred from the project (so `--project-id` alone is enough); it's omitted only when the project has no organization (personal account).
@@ -357,6 +351,19 @@ How today's `set-context` uses map onto `link`:
 | a raw local write (no network)          | `neon link --no-checks --org-id <id> --project-id <id>`                    |
 
 The key difference: `link` resolves and **verifies** before writing (so you never get a half-written or stale `.neon`), whereas `set-context` writes whatever you give it verbatim. The closest like-for-like replacement for the old raw write is `link --no-checks`.
+
+### open
+
+`open` launches the linked project's page in the Neon Console. It reads the closest `.neon` file without authenticating or calling the Neon API, so it works from any sub-directory of a linked project.
+
+```bash
+neon open
+
+# Open a project without changing the linked context
+neon open --project-id polished-snowflake-12345678
+```
+
+A branch pinned in `.neon` does not change the destination. `.neon` stores the branch as a name, while the Console route requires its ID; resolving it would turn this local command into an authenticated API call.
 
 ### checkout
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -202,6 +202,12 @@ The Neon CLI supports autocompletion, which you can configure in a few easy step
 
 `neon link` is a Vercel-style command that binds the current directory to a Neon project. It picks (or creates) an organization and a project and writes a `.neon` file (`{ "orgId", "projectId", "branch" }`) that subsequent commands run in this directory (or any sub-directory) pick up automatically.
 
+Open the linked project in the Neon Console from the same directory:
+
+```bash
+neon open
+```
+
 `link` resolves what it can and **verifies every identifier you pass** before writing, so a `.neon` is never left half-written or pointing at something that doesn't exist:
 
 - **org** is inferred from the project (so `--project-id` alone is enough); it's omitted only when the project has no organization (personal account).
@@ -1044,6 +1050,7 @@ API keys in org-7
 | checkout                                                                   |                                                                                                              | Pin a branch in `.neon`            |
 | diff                                                                       |                                                                                                              | Git-style schema diff vs a branch  |
 | [link](https://neon.com/docs/reference/cli-link)                           |                                                                                                              | Link a directory to a project      |
+| open                                                                       |                                                                                                              | Open the linked project in Console |
 | config                                                                     | `init`, `status`, `plan`, `apply`                                                                            | Drive a branch from `neon.ts`      |
 | deploy                                                                     |                                                                                                              | Alias for `config apply`           |
 | bootstrap                                                                  |                                                                                                              | Scaffold a project from a template |

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -316,6 +316,11 @@ export const ensureAuth = async (
 		return;
 	}
 
+	// `open` only reads the linked project from `.neon` and launches its Console URL.
+	if (props._[0] === "open") {
+		return;
+	}
+
 	// `dev` runs a function locally. It injects the selected branch's env vars
 	// when credentials happen to be available, but must never trigger an
 	// interactive login: use an API key or existing stored credentials if

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -20,6 +20,7 @@ import * as ipAllow from "./ip_allow.js";
 import * as link from "./link.js";
 import * as logs from "./logs.js";
 import * as neonAuth from "./neon_auth.js";
+import * as open from "./open.js";
 import * as operations from "./operations.js";
 import * as orgs from "./orgs.js";
 import * as profile from "./profile.js";
@@ -55,6 +56,7 @@ export default [
 	setContext,
 	checkout,
 	link,
+	open,
 	init,
 	dataApi,
 	functions,

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import { projectConsoleUrl } from "./open.js";
+
+const workspaces: string[] = [];
+
+afterEach(() => {
+	for (const workspace of workspaces.splice(0)) {
+		rmSync(workspace, { recursive: true, force: true });
+	}
+});
+
+describe("open", () => {
+	test("builds the Console URL for the linked project", () => {
+		expect(projectConsoleUrl("quiet-frog-12345678")).toBe(
+			"https://console.neon.tech/app/projects/quiet-frog-12345678",
+		);
+	});
+
+	test("encodes a project id before placing it in the URL", () => {
+		expect(projectConsoleUrl("project/with spaces")).toBe(
+			"https://console.neon.tech/app/projects/project%2Fwith%20spaces",
+		);
+	});
+
+	test("bare open reaches the handler without authenticating", () => {
+		const workspace = mkdtempSync(join(tmpdir(), "neon-open-"));
+		workspaces.push(workspace);
+
+		const result = spawnSync(
+			process.execPath,
+			[
+				resolve(process.cwd(), "dist/cli.js"),
+				"--config-dir",
+				join(workspace, "config"),
+				"--context-file",
+				join(workspace, ".neon"),
+				"--no-analytics",
+				"open",
+			],
+			{
+				encoding: "utf8",
+				env: {
+					...process.env,
+					CI: "1",
+					NEON_API_KEY: "",
+					NEON_PROFILE: "",
+				},
+			},
+		);
+
+		expect(result.status).toBe(1);
+		expect(result.stdout).toBe("");
+		expect(result.stderr).toContain("No Neon project linked");
+		expect(result.stderr).toContain("`neon link`");
+		expect(result.stderr).not.toContain(
+			"Cannot run interactive auth in CI",
+		);
+	});
+});

--- a/packages/cli/src/commands/open.test.ts
+++ b/packages/cli/src/commands/open.test.ts
@@ -13,6 +13,33 @@ afterEach(() => {
 	}
 });
 
+const runCli = (args: string[]) => {
+	const workspace = mkdtempSync(join(tmpdir(), "neon-open-"));
+	workspaces.push(workspace);
+
+	return spawnSync(
+		process.execPath,
+		[
+			resolve(process.cwd(), "dist/cli.js"),
+			"--config-dir",
+			join(workspace, "config"),
+			"--context-file",
+			join(workspace, ".neon"),
+			"--no-analytics",
+			...args,
+		],
+		{
+			encoding: "utf8",
+			env: {
+				...process.env,
+				CI: "1",
+				NEON_API_KEY: "",
+				NEON_PROFILE: "",
+			},
+		},
+	);
+};
+
 describe("open", () => {
 	test("builds the Console URL for the linked project", () => {
 		expect(projectConsoleUrl("quiet-frog-12345678")).toBe(
@@ -27,30 +54,7 @@ describe("open", () => {
 	});
 
 	test("bare open reaches the handler without authenticating", () => {
-		const workspace = mkdtempSync(join(tmpdir(), "neon-open-"));
-		workspaces.push(workspace);
-
-		const result = spawnSync(
-			process.execPath,
-			[
-				resolve(process.cwd(), "dist/cli.js"),
-				"--config-dir",
-				join(workspace, "config"),
-				"--context-file",
-				join(workspace, ".neon"),
-				"--no-analytics",
-				"open",
-			],
-			{
-				encoding: "utf8",
-				env: {
-					...process.env,
-					CI: "1",
-					NEON_API_KEY: "",
-					NEON_PROFILE: "",
-				},
-			},
-		);
+		const result = runCli(["open"]);
 
 		expect(result.status).toBe(1);
 		expect(result.stdout).toBe("");
@@ -58,6 +62,16 @@ describe("open", () => {
 		expect(result.stderr).toContain("`neon link`");
 		expect(result.stderr).not.toContain(
 			"Cannot run interactive auth in CI",
+		);
+	});
+
+	test("documents the explicit project override", () => {
+		const result = runCli(["open", "--help"]);
+
+		expect(result.status).toBe(0);
+		expect(result.stderr).toContain("--project-id");
+		expect(result.stderr).toContain(
+			"defaults to the project linked in .neon",
 		);
 	});
 });

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -9,10 +9,16 @@ type OpenProps = CommonProps & {
 };
 
 export const command = "open";
-export const describe = "Open the current project in the Neon Console";
+export const describe = "Open the linked project in the Neon Console";
 
 export const builder = (argv: yargs.Argv) =>
-	argv.usage("$0 open").example("$0 open", describe);
+	argv
+		.usage("$0 open [options]")
+		.option("project-id", {
+			describe: "Project ID (defaults to the project linked in .neon)",
+			type: "string",
+		})
+		.example("$0 open", describe);
 
 export const projectConsoleUrl = (projectId: string): string =>
 	`https://console.neon.tech/app/projects/${encodeURIComponent(projectId)}`;

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,0 +1,41 @@
+import openBrowser from "open";
+import type yargs from "yargs";
+import { log } from "../log.js";
+import type { CommonProps } from "../types.js";
+import { getCliName } from "../utils/cli_name.js";
+
+type OpenProps = CommonProps & {
+	projectId?: string;
+};
+
+export const command = "open";
+export const describe = "Open the current project in the Neon Console";
+
+export const builder = (argv: yargs.Argv) =>
+	argv.usage("$0 open").example("$0 open", describe);
+
+export const projectConsoleUrl = (projectId: string): string =>
+	`https://console.neon.tech/app/projects/${encodeURIComponent(projectId)}`;
+
+export const handler = async (props: OpenProps) => {
+	if (!props.projectId) {
+		throw new Error(
+			`No Neon project linked. Run \`${getCliName()} link\` to link this directory to a project.`,
+		);
+	}
+
+	const url = projectConsoleUrl(props.projectId);
+	log.info("Opening %s in your browser.", url);
+
+	const subprocess = await openBrowser(url);
+	await new Promise<void>((resolve, reject) => {
+		subprocess.once("spawn", resolve);
+		subprocess.once("error", (error) => {
+			reject(
+				new Error(
+					`Failed to open the Neon Console in your browser. Open ${url} manually. ${error.message}`,
+				),
+			);
+		});
+	});
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -52,6 +52,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
 	"link",
 
+	"open",
+
 	"init",
 
 	"dev",


### PR DESCRIPTION
## Problem

`neon link` records the current project in `.neon`, but there is no CLI path from that local context to the same project in the Neon Console. Opening it requires leaving the terminal and locating the project again.

## Solution

Add a local, top-level `neon open` command. By default it reads the nearest `.neon` and opens that project's stable Console URL in the default browser. `--project-id` opens an explicit project without changing the linked context. Neither path authenticates or calls the Neon API.

An unlinked directory with no explicit project fails with the command needed to establish context.

## Interface

```console
$ neon open
INFO: Opening https://console.neon.tech/app/projects/<project-id> in your browser.

$ neon open --project-id <project-id>
INFO: Opening https://console.neon.tech/app/projects/<project-id> in your browser.
```

Without a linked or explicit project:

```console
$ neon open
ERROR: No Neon project linked. Run `neon link` to link this directory to a project.
```

The command is project-scoped. `.neon` stores a pinned branch as a name, while the Console branch route requires an ID; honoring the pin would require the authenticated API lookup this local command avoids.

## Also in here

- Document `neon open` beside the other linked-context commands and in the CLI command inventory.
- Add a minor changeset for the `neon` / `neonctl` fixed release group.

## Verification

- `pnpm lint:ci`
- `pnpm --filter neon test:ci` — 149 test files passed, 4,097 tests passed
- `pnpm --filter neonctl test:ci` — 4 tests passed
- `pnpm --filter neon build`
- `pnpm --filter neon exec vitest run src/commands/open.test.ts` — 4 tests passed after the final interface refinements
- Ran the built command from a nested directory under a real linked project; it resolved the parent `.neon` and opened the expected Console project URL.
- Verified the unlinked path reaches the command handler without triggering interactive auth.