### PR TITLE
chore: release neon@3.2.0, neonctl@3.2.0

### DIFF
--- a/.changeset/neon-open.md
+++ b/.changeset/neon-open.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-Add `neon open` to open the project linked in `.neon` in the Neon Console.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 3.2.0
+
+### Minor Changes
+
+- 998728b: Add `neon open` to open the project linked in `.neon` in the Neon Console.
+
 ## 3.1.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.1.1",
+	"version": "3.2.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 3.2.0
+
+### Patch Changes
+
+- Updated dependencies [998728b]
+  - neon@3.2.0
+
 ## 3.1.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

`neon open` landed on main in #424 and is queued behind a pending changeset. npm still serves `neon@3.1.1` / `neonctl@3.1.1`, so the command is not installable.

## Release

- `neon`: 3.1.1 → 3.2.0
- `neonctl`: 3.1.1 → 3.2.0 (fixed-group compatibility package)

Consumes `.changeset/neon-open.md` and writes the package changelogs. No source changes.

```text
neon open
```

opens the project linked in `.neon` in the Neon Console. `--project-id` overrides the linked project.

## Verification

- `pnpm changeset version`
- `pnpm lint:ci`
- Diff is the consumed changeset, two `package.json` versions, and two changelogs

## Publish order

After merge: `neon` → `neonctl`.