### PR TITLE
Point neon init doc links at canonical neon.com/docs pages

### DIFF
--- a/.changeset/init-canonical-doc-urls.md
+++ b/.changeset/init-canonical-doc-urls.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+Point `neon init`'s doc hints at canonical `neon.com/docs` pages instead of the retired skill-reference URLs, and rename the `skillReferences` field to `docReferences`.

--- a/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
+++ b/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
@@ -292,7 +292,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -345,7 +345,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -408,7 +408,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -691,7 +691,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -718,7 +718,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -1015,15 +1015,15 @@ exports[`neon init --agent: every step, against every project shape > connected 
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -1084,15 +1084,15 @@ exports[`neon init --agent: every step, against every project shape > connected 
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -1320,7 +1320,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -1373,7 +1373,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -1436,7 +1436,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -1719,7 +1719,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -1746,7 +1746,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -2043,15 +2043,15 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -2112,15 +2112,15 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -2348,7 +2348,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -2401,7 +2401,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -2462,7 +2462,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -2735,7 +2735,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -2760,7 +2760,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -3051,15 +3051,15 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -3120,15 +3120,15 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -3345,7 +3345,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -3398,7 +3398,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -3461,7 +3461,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -3744,7 +3744,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -3771,7 +3771,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -4068,15 +4068,15 @@ exports[`neon init --agent: every step, against every project shape > greenfield
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -4137,15 +4137,15 @@ exports[`neon init --agent: every step, against every project shape > greenfield
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -4378,7 +4378,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -4431,7 +4431,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -4494,7 +4494,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -4777,7 +4777,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -4804,7 +4804,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -5101,15 +5101,15 @@ exports[`neon init --agent: every step, against every project shape > next-prism
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -5170,15 +5170,15 @@ exports[`neon init --agent: every step, against every project shape > next-prism
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -5411,7 +5411,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -5464,7 +5464,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -5527,7 +5527,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -5810,7 +5810,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -5837,7 +5837,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -6134,15 +6134,15 @@ exports[`neon init --agent: every step, against every project shape > next-prism
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -6203,15 +6203,15 @@ exports[`neon init --agent: every step, against every project shape > next-prism
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -6439,7 +6439,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -6492,7 +6492,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -6555,7 +6555,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -6838,7 +6838,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -6865,7 +6865,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -7162,15 +7162,15 @@ exports[`neon init --agent: every step, against every project shape > node-app >
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -7231,15 +7231,15 @@ exports[`neon init --agent: every step, against every project shape > node-app >
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -7472,7 +7472,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   },
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
+    "prerequisite": "https://neon.com/docs/connect/choose-connection.md",
     "steps": [
       {
         "id": "get_connection_string",
@@ -7525,7 +7525,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -7588,7 +7588,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "run_migrations",
@@ -7871,7 +7871,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
         "label": "No, skip for now"
       }
     ],
-    "context": "Full documentation: https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "context": "Full documentation: https://neon.com/docs/auth/overview.md",
     "responseMapping": {
       "yes": {
         "command": "neon init --agent --data '{\\"step\\":\\"neon-auth\\",\\"agent\\":\\"cursor\\",\\"setup\\":true}'"
@@ -7898,7 +7898,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "status": "in_progress",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
+    "prerequisite": "https://neon.com/docs/auth/overview.md",
     "steps": [
       {
         "id": "provision",
@@ -8195,15 +8195,15 @@ exports[`neon init --agent: every step, against every project shape > other-data
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -8264,15 +8264,15 @@ exports[`neon init --agent: every step, against every project shape > other-data
       }
     }
   },
-  "skillReferences": {
-    "gettingStarted": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
-    "connectionMethods": "https://neon.com/docs/ai/skills/neon-postgres/references/connection-methods.md",
-    "neonAuth": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-auth.md",
-    "serverlessDriver": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-serverless.md",
-    "neonCli": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-cli.md",
-    "devtools": "https://neon.com/docs/ai/skills/neon-postgres/references/devtools.md",
-    "branching": "https://neon.com/docs/ai/skills/neon-postgres/references/branching.md",
-    "neonJs": "https://neon.com/docs/ai/skills/neon-postgres/references/neon-js.md"
+  "docReferences": {
+    "gettingStarted": "https://neon.com/docs/get-started/backend-overview.md",
+    "connectionMethods": "https://neon.com/docs/connect/choose-connection.md",
+    "neonAuth": "https://neon.com/docs/auth/overview.md",
+    "serverlessDriver": "https://neon.com/docs/serverless/serverless-driver.md",
+    "neonCli": "https://neon.com/docs/cli/install.md",
+    "devtools": "https://neon.com/docs/reference/api.md",
+    "branching": "https://neon.com/docs/introduction/branching.md",
+    "neonJs": "https://neon.com/docs/reference/javascript-sdk.md"
   }
 }
 --- stderr ---
@@ -8332,7 +8332,7 @@ exports[`neon init --agent: nested and string-encoded --data payloads > JSON-enc
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -8400,7 +8400,7 @@ exports[`neon init --agent: nested and string-encoded --data payloads > nested o
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -12064,7 +12064,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -12559,7 +12559,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -13054,7 +13054,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",
@@ -13565,7 +13565,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
   "status": "getting_started",
   "nextAction": {
     "type": "agent_action",
-    "prerequisite": "https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+    "prerequisite": "https://neon.com/docs/get-started/backend-overview.md",
     "steps": [
       {
         "id": "select_org",

--- a/packages/cli/src/init/phases/db.test.ts
+++ b/packages/cli/src/init/phases/db.test.ts
@@ -75,7 +75,7 @@ describe("handleDbPhase", () => {
 			expect(result.nextAction.steps).toHaveLength(3);
 			expect(result.nextAction.steps[0].command).toContain("proj-xyz");
 			expect(result.nextAction.prerequisite).toContain(
-				"connection-methods",
+				"choose-connection",
 			);
 		}
 	});

--- a/packages/cli/src/init/phases/db.ts
+++ b/packages/cli/src/init/phases/db.ts
@@ -1,5 +1,5 @@
 import { neonctlCmd } from "../neonctl.js";
-import { SKILL_REFERENCE_URLS } from "../skills.js";
+import { DOC_REFERENCE_URLS } from "../skills.js";
 import type { PhaseResponse } from "../types.js";
 
 /**
@@ -65,7 +65,7 @@ export async function handleDbPhase(
 			project: { id: options.projectId },
 			nextAction: {
 				type: "agent_action",
-				prerequisite: SKILL_REFERENCE_URLS.connectionMethods,
+				prerequisite: DOC_REFERENCE_URLS.connectionMethods,
 				steps: [
 					{
 						id: "get_connection_string",

--- a/packages/cli/src/init/phases/getting_started.test.ts
+++ b/packages/cli/src/init/phases/getting_started.test.ts
@@ -33,7 +33,7 @@ describe("getting-started phase", () => {
 
 		if (result.nextAction.type === "agent_action") {
 			expect(result.nextAction.prerequisite).toContain(
-				"getting-started.md",
+				"backend-overview.md",
 			);
 			expect(result.nextAction.onComplete.type).toBe("run_neon_init");
 		}

--- a/packages/cli/src/init/phases/getting_started.ts
+++ b/packages/cli/src/init/phases/getting_started.ts
@@ -6,7 +6,7 @@ import {
 	resolvePackageManager,
 } from "../../utils/package_manager.js";
 import { neonctlCmd } from "../neonctl.js";
-import { ensureSkillsUpToDate, SKILL_REFERENCE_URLS } from "../skills.js";
+import { DOC_REFERENCE_URLS, ensureSkillsUpToDate } from "../skills.js";
 import type { PhaseResponse } from "../types.js";
 
 export type GettingStartedPhaseOptions = {
@@ -264,7 +264,7 @@ export async function handleGettingStartedPhase(
 		status: "getting_started",
 		nextAction: {
 			type: "agent_action",
-			prerequisite: SKILL_REFERENCE_URLS.gettingStarted,
+			prerequisite: DOC_REFERENCE_URLS.gettingStarted,
 			steps,
 			onComplete: buildOnComplete(options),
 		},

--- a/packages/cli/src/init/phases/neon_auth.ts
+++ b/packages/cli/src/init/phases/neon_auth.ts
@@ -1,5 +1,5 @@
 import { neonctlCmd } from "../neonctl.js";
-import { ensureSkillsUpToDate, SKILL_REFERENCE_URLS } from "../skills.js";
+import { DOC_REFERENCE_URLS, ensureSkillsUpToDate } from "../skills.js";
 import type { PhaseResponse } from "../types.js";
 
 export type NeonAuthPhaseOptions = {
@@ -36,7 +36,7 @@ export async function handleNeonAuthPhase(
 					{ value: "yes", label: "Yes, set up Neon Auth" },
 					{ value: "no", label: "No, skip for now" },
 				],
-				context: `Full documentation: ${SKILL_REFERENCE_URLS.neonAuth}`,
+				context: `Full documentation: ${DOC_REFERENCE_URLS.neonAuth}`,
 				responseMapping: {
 					yes: {
 						args: [
@@ -72,7 +72,7 @@ export async function handleNeonAuthPhase(
 			status: "in_progress",
 			nextAction: {
 				type: "agent_action",
-				prerequisite: SKILL_REFERENCE_URLS.neonAuth,
+				prerequisite: DOC_REFERENCE_URLS.neonAuth,
 				steps: [
 					{
 						id: "provision",

--- a/packages/cli/src/init/phases/skills.ts
+++ b/packages/cli/src/init/phases/skills.ts
@@ -1,5 +1,5 @@
 import { getSkillsAgentName } from "../agents.js";
-import { SKILL_REFERENCE_URLS } from "../skills.js";
+import { DOC_REFERENCE_URLS } from "../skills.js";
 import type { Editor, PhaseResponse } from "../types.js";
 
 export type SkillsPhaseOptions = {
@@ -73,7 +73,7 @@ export async function handleSkillsPhase(
 					},
 				},
 			},
-			skillReferences: SKILL_REFERENCE_URLS,
+			docReferences: DOC_REFERENCE_URLS,
 		};
 	}
 

--- a/packages/cli/src/init/skills.test.ts
+++ b/packages/cli/src/init/skills.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { SKILL_REFERENCE_URLS } from "./skills.js";
+import { DOC_REFERENCE_URLS } from "./skills.js";
 
-describe("SKILL_REFERENCE_URLS", () => {
+describe("DOC_REFERENCE_URLS", () => {
 	test("contains gettingStarted URL", () => {
-		expect(SKILL_REFERENCE_URLS.gettingStarted).toBe(
-			"https://neon.com/docs/ai/skills/neon-postgres/references/getting-started.md",
+		expect(DOC_REFERENCE_URLS.gettingStarted).toBe(
+			"https://neon.com/docs/get-started/backend-overview.md",
 		);
 	});
 
@@ -20,13 +20,13 @@ describe("SKILL_REFERENCE_URLS", () => {
 			"neonJs",
 		];
 		for (const key of expectedKeys) {
-			expect(SKILL_REFERENCE_URLS).toHaveProperty(key);
-			expect(SKILL_REFERENCE_URLS[key]).toMatch(/^https:\/\/neon\.com\//);
+			expect(DOC_REFERENCE_URLS).toHaveProperty(key);
+			expect(DOC_REFERENCE_URLS[key]).toMatch(/^https:\/\/neon\.com\//);
 		}
 	});
 
 	test("all URLs end with .md", () => {
-		for (const url of Object.values(SKILL_REFERENCE_URLS)) {
+		for (const url of Object.values(DOC_REFERENCE_URLS)) {
 			expect(url).toMatch(/\.md$/);
 		}
 	});

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -54,18 +54,21 @@ export function getSkillList(preview?: boolean): string[] {
 	return preview ? [...BASE_SKILLS, ...PREVIEW_SKILLS] : BASE_SKILLS;
 }
 
-const SKILL_BASE_URL =
-	"https://neon.com/docs/ai/skills/neon-postgres/references";
+// Canonical docs URLs surfaced to agents as `prerequisite`/`context` hints. The
+// old `/docs/ai/skills/neon-postgres/references/*.md` skill files were retired
+// and now redirect here, so we point at the canonical pages directly rather than
+// rely on the redirect hop.
+const DOCS_BASE_URL = "https://neon.com/docs";
 
-export const SKILL_REFERENCE_URLS: Record<string, string> = {
-	gettingStarted: `${SKILL_BASE_URL}/getting-started.md`,
-	connectionMethods: `${SKILL_BASE_URL}/connection-methods.md`,
-	neonAuth: `${SKILL_BASE_URL}/neon-auth.md`,
-	serverlessDriver: `${SKILL_BASE_URL}/neon-serverless.md`,
-	neonCli: `${SKILL_BASE_URL}/neon-cli.md`,
-	devtools: `${SKILL_BASE_URL}/devtools.md`,
-	branching: `${SKILL_BASE_URL}/branching.md`,
-	neonJs: `${SKILL_BASE_URL}/neon-js.md`,
+export const DOC_REFERENCE_URLS: Record<string, string> = {
+	gettingStarted: `${DOCS_BASE_URL}/get-started/backend-overview.md`,
+	connectionMethods: `${DOCS_BASE_URL}/connect/choose-connection.md`,
+	neonAuth: `${DOCS_BASE_URL}/auth/overview.md`,
+	serverlessDriver: `${DOCS_BASE_URL}/serverless/serverless-driver.md`,
+	neonCli: `${DOCS_BASE_URL}/cli/install.md`,
+	devtools: `${DOCS_BASE_URL}/reference/api.md`,
+	branching: `${DOCS_BASE_URL}/introduction/branching.md`,
+	neonJs: `${DOCS_BASE_URL}/reference/javascript-sdk.md`,
 };
 
 /**


### PR DESCRIPTION
## Overview

`neon init` surfaced documentation hints (the `prerequisite` and `context` fields agents follow) using the old `/docs/ai/skills/neon-postgres/references/*.md` skill files. Those pages were retired and now only redirect, so this points them at the canonical docs directly: getting started, connection methods, Neon Auth, the serverless driver, the CLI, branching, and the JS SDK.

It also renames the map and its emitted field from `skillReferences` to `docReferences`. These are documentation links, not the agent skill files installed by the skills CLI, so the old name implied a connection that does not exist. The emitted-field rename is a small change to the agent protocol output.

Verified all eight new URLs resolve (200) and the old ones 308-redirect onto live pages, so this removes a redirect hop.

Split out of #431 so the doc-link update is easy to review on its own.

This pull request and its description were written by Isaac.