### PR TITLE
Name the init CLI install step neon, not neonctl

### DIFF
--- a/.changeset/init-step-named-neon.md
+++ b/.changeset/init-step-named-neon.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+`neon init --agent` labels the CLI install step `neon`, and the README says init installs `neon` globally. `npm i -g neon` only puts `neon` on PATH.

--- a/docs/neonctl-compatibility-shim.md
+++ b/docs/neonctl-compatibility-shim.md
@@ -156,7 +156,7 @@ second reason to keep it a genuine package instead of deprecating it.
   installed `neon` and calls `neonctl` needs the `neonctl` package (which is what
   Homebrew installs) or the `neon` command.
 - The package versions stay synchronized through the Changesets fixed group.
-  `neon init` relies on this: `packages/cli/src/init/neonctl.ts` compares a globally
-  installed `neonctl --version` (which reports the `neon` implementation's version)
-  against `npm view neonctl version`, and would prompt for pointless updates if the
-  two packages could drift.
+  `neon init` probes `neon --version` first (falling back to `neonctl` so an
+  existing global install still counts), compares against `npm view neon
+  version`, and globally installs the `neon` package. The fixed group keeps a
+  Homebrew/`neonctl` install and an `npm i -g neon` install on the same version.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -673,7 +673,7 @@ $ neon init
 
 Run in a terminal it prompts you through those steps. This is what the retired `neon-init` package used to do; `npx neon init` replaces it.
 
-Two side effects worth knowing before you run it. It **installs or upgrades `neonctl` globally**, with whichever package manager invoked it — the flow drives Neon by shelling out to the CLI rather than calling the API in-process. And it **writes `.neon`** in the project directory, the same context file `neon link` and `neon checkout` use.
+Two side effects worth knowing before you run it. It **installs or upgrades `neon` globally**, with whichever package manager invoked it — the flow drives Neon by shelling out to the CLI rather than calling the API in-process. And it **writes `.neon`** in the project directory, the same context file `neon link` and `neon checkout` use.
 
 ### Agent mode
 

--- a/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
+++ b/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
@@ -770,7 +770,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -923,7 +923,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -962,7 +962,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -1798,7 +1798,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -1951,7 +1951,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -1990,7 +1990,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -2810,7 +2810,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -2963,7 +2963,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -3000,7 +3000,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -3823,7 +3823,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -3976,7 +3976,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -4015,7 +4015,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -4856,7 +4856,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -5009,7 +5009,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -5048,7 +5048,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -5889,7 +5889,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -6042,7 +6042,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -6081,7 +6081,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -6917,7 +6917,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -7070,7 +7070,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -7109,7 +7109,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -7950,7 +7950,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -8103,7 +8103,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -8142,7 +8142,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "status": "installed",
   "results": [
     {
-      "id": "neonctl",
+      "id": "neon",
       "description": "Neon CLI is up to date (v2.45.0)",
       "status": "success"
     },
@@ -8477,7 +8477,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -8639,7 +8639,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -8801,7 +8801,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -8963,7 +8963,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -9125,7 +9125,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -9287,7 +9287,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -9449,7 +9449,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > fully-config
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: configured (project). Agent skills: partially installed (project-partial) — missing skills will be auto-installed to the same scope. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -9623,7 +9623,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nNo application was detected in this directory. Ask the user if they'd like to scaffold a new project from a template (the \`template\` preference). Present ALL template options and the 'No thanks' option — do NOT auto-select even if there is only one template. If the user selects a template, the scaffolded template includes agent skills so skills installation will be skipped. If the user chooses 'none', continue with the remaining setup preferences normally. Then perform the agent checks and present the remaining preferences ONE AT A TIME.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -9788,7 +9788,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -9950,7 +9950,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -10112,7 +10112,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -10274,7 +10274,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -10436,7 +10436,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -10598,7 +10598,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -10760,7 +10760,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -10922,7 +10922,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -11084,7 +11084,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -11246,7 +11246,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -11408,7 +11408,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -11570,7 +11570,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -11732,7 +11732,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -11894,7 +11894,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -12165,7 +12165,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\n<ide-detection-instruction>\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -12319,7 +12319,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\n<ide-detection-instruction>\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -12660,7 +12660,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\n<ide-detection-instruction>\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -12814,7 +12814,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\n<ide-detection-instruction>\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -13155,7 +13155,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -13317,7 +13317,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -13664,7 +13664,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\n<ide-detection-instruction>\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -13818,7 +13818,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\n<ide-detection-instruction>\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },
@@ -14376,7 +14376,7 @@ exports[`neon init: failure output > --data without a step falls through to the 
     "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
-        "id": "neonctl",
+        "id": "neon",
         "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
         "lookFor": []
       },

--- a/packages/cli/src/init/phases/setup.test.ts
+++ b/packages/cli/src/init/phases/setup.test.ts
@@ -115,7 +115,7 @@ describe("setup phase", () => {
 
 			// Only agent-specific checks — filesystem checks are done CLI-side
 			const checkIds = result.nextAction.checks.map((c) => c.id);
-			expect(checkIds).toContain("neonctl");
+			expect(checkIds).toContain("neon");
 			expect(checkIds).toContain("mcp_server");
 			expect(checkIds).toContain("agent_type");
 			expect(checkIds).not.toContain("connection_string");
@@ -209,7 +209,7 @@ describe("setup phase", () => {
 
 		const results = result.results as { id: string; status: string }[];
 		const resultIds = results.map((r) => r.id);
-		expect(resultIds).toContain("neonctl");
+		expect(resultIds).toContain("neon");
 		expect(resultIds).toContain("install_mcp");
 		expect(resultIds).toContain("install_skills");
 		expect(resultIds).not.toContain("install_extension");
@@ -220,7 +220,7 @@ describe("setup phase", () => {
 		const args = (result.nextAction as { args: string[] }).args;
 		expect(args[0]).toBe("getting-started");
 
-		// Should have called execa for MCP only (neonctl mocked, skills via ensureSkillsUpToDate)
+		// Should have called execa for MCP only (neon CLI mocked, skills via ensureSkillsUpToDate)
 		expect(mockExeca).toHaveBeenCalledTimes(1);
 		expect(mockEnsureSkills).toHaveBeenCalled();
 

--- a/packages/cli/src/init/phases/setup.ts
+++ b/packages/cli/src/init/phases/setup.ts
@@ -221,7 +221,7 @@ async function buildBulkInspection(
 			].join("\n"),
 			checks: [
 				{
-					id: "neonctl",
+					id: "neon",
 					description:
 						"The Neon CLI will be installed or updated automatically (no action needed from the agent)",
 					lookFor: [],
@@ -502,28 +502,28 @@ async function executeBatchedInstallation(
 	switch (neonctlResult.status) {
 		case "already_current":
 			results.push({
-				id: "neonctl",
+				id: "neon",
 				description: `Neon CLI is up to date (v${neonctlResult.version})`,
 				status: "success",
 			});
 			break;
 		case "installed":
 			results.push({
-				id: "neonctl",
+				id: "neon",
 				description: `Installed Neon CLI (v${neonctlResult.version})`,
 				status: "success",
 			});
 			break;
 		case "updated":
 			results.push({
-				id: "neonctl",
+				id: "neon",
 				description: `Updated Neon CLI to v${neonctlResult.version}`,
 				status: "success",
 			});
 			break;
 		case "failed":
 			results.push({
-				id: "neonctl",
+				id: "neon",
 				description: "Failed to install Neon CLI",
 				status: "failed",
 				error: neonctlResult.error,


### PR DESCRIPTION
## Problem

#432 switched `neon init` to install and invoke the `neon` package. `npm i -g neon` only puts `neon` on PATH — it does not install a `neonctl` binary.

Two leftover names still said `neonctl`:

- `neon init --agent` labeled the CLI install check and result `id: "neonctl"`. An agent that treats that id as a command to run would call a binary that is not on PATH.
- The published README still said init "installs or upgrades `neonctl` globally".

Command strings emitted to agents were already `CI= npx -y neon`.

## Diagnosis

The install machinery in `packages/cli/src/init/neonctl.ts` already probes `neon` first, globally installs `neon`, and shells out through `npx -y neon`. The leftover was the agent protocol id and the README sentence that describes that step.

## The user-facing interface

`neon init --agent` now reports the install step as `neon`:

```json
{
  "id": "neon",
  "description": "The Neon CLI will be installed or updated automatically (no action needed from the agent)",
  "lookFor": []
}
```

The same id is used in the `results` array after install/update.

README:

```text
It **installs or upgrades `neon` globally**
```

Existing global `neonctl` installs are still counted as installed (version probe falls back to `neonctl`). Homebrew is unchanged.

## Also in here

- `docs/neonctl-compatibility-shim.md` now matches the #432 probe (`neon --version` first, `npm view neon`).
- Patch changeset so this can ship if it lands after the pending init-install release.

## Verification

- `pnpm --filter neon exec vitest run src/init/phases/setup.test.ts` — 13 passed
- `pnpm --filter neon build && pnpm --filter neon exec vitest run src/init/agent_snapshot.test.ts` — 281 passed

Not verified: a live `neon init` against a machine that only has `npm i -g neon`. The snapshot suite stubs both binaries on PATH.

## For your attention

- Internal identifiers (`ensureNeonctl`, `init/neonctl.ts`, the `neonctl` fallback probe) are unchanged. The `neonctl` compatibility package is unchanged.
- The CLI still sends `User-Agent: neonctl v<version>` on API requests.
- `@neon/config-runtime` still says "create the branch first with the neonctl CLI" in a `pushConfig` error. Out of scope here.