### PR TITLE
chore: release neon@3.2.1, neonctl@3.2.1

### DIFF
--- a/.changeset/init-install-neon-not-neonctl.md
+++ b/.changeset/init-install-neon-not-neonctl.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-`neon init` now detects and installs the `neon` CLI instead of the retired `neonctl` alias. Version probing checks `neon` first (falling back to `neonctl` so an existing global install still counts as installed), the update check reads `npm view neon`, and auth/context lookups shell out to `neon`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 3.2.1
+
+### Patch Changes
+
+- ad7cf9a: `neon init` now detects and installs the `neon` CLI instead of the retired `neonctl` alias. Version probing checks `neon` first (falling back to `neonctl` so an existing global install still counts as installed), the update check reads `npm view neon`, and auth/context lookups shell out to `neon`.
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.2.0",
+	"version": "3.2.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 3.2.1
+
+### Patch Changes
+
+- Updated dependencies [ad7cf9a]
+  - neon@3.2.1
+
 ## 3.2.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

`neon init` still installed the retired `neonctl` package (#432). That is on main and queued behind a pending changeset. npm still serves `neon@3.2.0` / `neonctl@3.2.0`.

## Release

- `neon`: 3.2.0 → 3.2.1
- `neonctl`: 3.2.0 → 3.2.1 (fixed-group compatibility package)

Consumes `.changeset/init-install-neon-not-neonctl.md` and writes the package changelogs. No source changes.

```text
npm i -g neon
neon init
```

`neon init` now detects and installs the `neon` CLI. Version probing checks `neon` first (falling back to `neonctl` so an existing global install still counts), the update check reads `npm view neon`, and auth/context lookups shell out to `neon`.

## Verification

- `pnpm changeset version`
- `pnpm lint:ci`
- Diff is the consumed changeset, two `package.json` versions, and two changelogs

## Publish order

After merge: `neon` → `neonctl`.