### PR TITLE
chore: release neon@3.2.2, neonctl@3.2.2

### DIFF
--- a/.changeset/init-step-named-neon.md
+++ b/.changeset/init-step-named-neon.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-`neon init --agent` labels the CLI install step `neon`, and the README says init installs `neon` globally. `npm i -g neon` only puts `neon` on PATH.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 3.2.2
+
+### Patch Changes
+
+- e8715cd: `neon init --agent` labels the CLI install step `neon`, and the README says init installs `neon` globally. `npm i -g neon` only puts `neon` on PATH.
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 3.2.2
+
+### Patch Changes
+
+- Updated dependencies [e8715cd]
+  - neon@3.2.2
+
 ## 3.2.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

#435 is on main. `neon init --agent` now labels the CLI install step `neon`, and the README says init installs `neon` globally. npm still serves `neon@3.2.1` / `neonctl@3.2.1`.

## Release

- `neon`: 3.2.1 → 3.2.2
- `neonctl`: 3.2.1 → 3.2.2 (fixed-group compatibility package)

Consumes `.changeset/init-step-named-neon.md` and writes the package changelogs. No source changes.

```text
npm i -g neon
neon init --agent
```

The install check in agent output is now `id: "neon"`. `npm i -g neon` only puts `neon` on PATH.

## Verification

- `pnpm changeset version`
- `pnpm lint:ci`
- Diff is the consumed changeset, two `package.json` versions, and two changelogs

## Publish order

After merge: `neon` → `neonctl`.