### PR TITLE
chore: release neon@3.3.0, neonctl@3.3.0, @neon/env@1.1.0, @neon/tools@0.1.0

### DIFF
--- a/.changeset/cli-credential-keyring.md
+++ b/.changeset/cli-credential-keyring.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"@neon/env": minor
----
-
-Opt-in OS keyring storage for a CLI profile via a `"keyring"` pointer in `profiles.json`. `neon profile create` no longer takes `--force`: creating an existing name replaces it and revokes the credential it held.

--- a/.changeset/green-agents-build.md
+++ b/.changeset/green-agents-build.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": minor
----
-
-Add generated, type-safe agent tools for every Neon Management API operation, with adapters for MCP, Eve, and Mastra. Tools authenticate with a Bearer credential: a Neon API key or a Neon OAuth access token.

--- a/.changeset/lucky-tools-addons.md
+++ b/.changeset/lucky-tools-addons.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": minor
----
-
-Add optional description overrides, an execute hook for host tracking, and project/branch path injection on generated tools.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 3.3.0
+
+### Minor Changes
+
+- 0b37ad5: Opt-in OS keyring storage for a CLI profile via a `"keyring"` pointer in `profiles.json`. `neon profile create` no longer takes `--force`: creating an existing name replaces it and revokes the credential it held.
+
 ## 3.2.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.2.2",
+	"version": "3.3.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.1.0
+
+### Minor Changes
+
+- 0b37ad5: Opt-in OS keyring storage for a CLI profile via a `"keyring"` pointer in `profiles.json`. `neon profile create` no longer takes `--force`: creating an existing name replaces it and revokes the credential it held.
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 3.3.0
+
+### Patch Changes
+
+- Updated dependencies [0b37ad5]
+  - neon@3.3.0
+
 ## 3.2.2
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @neon/tools
+
+## 0.1.0
+
+### Minor Changes
+
+- 2bb6dcf: Add generated, type-safe agent tools for every Neon Management API operation, with adapters for MCP, Eve, and Mastra. Tools authenticate with a Bearer credential: a Neon API key or a Neon OAuth access token.
+- 2bb6dcf: Add optional description overrides, an execute hook for host tracking, and project/branch path injection on generated tools.

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.0.0",
+	"version": "0.1.0",
 	"description": "Generated agent tools for every Neon Management API operation, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Problem

#430 and #422 are on main. A CLI profile can store its credential in the OS keyring via a `"keyring"` pointer in `profiles.json`. `@neon/tools` adds generated, type-safe agent tools for every Neon Management API operation. npm still serves `neon@3.2.2` / `neonctl@3.2.2` / `@neon/env@1.0.1`. `@neon/tools` is `0.0.0`.

## Release

- `@neon/env`: 1.0.1 → 1.1.0
- `@neon/tools`: 0.0.0 → 0.1.0
- `neon`: 3.2.2 → 3.3.0
- `neonctl`: 3.2.2 → 3.3.0 (fixed-group compatibility package)

Consumes `.changeset/cli-credential-keyring.md`, `.changeset/green-agents-build.md`, and `.changeset/lucky-tools-addons.md` and writes the package changelogs. No source changes.

```text
neon profile create work --keyring
```

`profiles.json` records a `"keyring"` pointer. `neon profile create` no longer takes `--force`: creating an existing name replaces it and revokes the credential it held.

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
  apiKey,
  operations: ["listProjects", "createProject"],
});
```

Tools authenticate with a Bearer credential: a Neon API key or a Neon OAuth access token. Adapters exist for MCP, Eve, and Mastra. The same constructor takes optional description overrides, an execute hook for host tracking, and project/branch path injection.

`neonctl` is the dependency bump to `neon@3.3.0`.

## Verification

- `pnpm changeset version`
- `pnpm lint:ci`
- Diff is the three consumed changesets, four `package.json` versions, and four changelogs

## Publish order

After merge: `@neon/env` → `@neon/tools` → `neon` → `neonctl`.