### PR TITLE
chore: release neon@3.4.0, neonctl@3.4.0

### DIFF
--- a/.changeset/quiet-moons-inspect.md
+++ b/.changeset/quiet-moons-inspect.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-`neon inspect db` without `--database-name` now runs each database-scoped check against every database the API lists for the branch and adds a `database` column, including on a branch that has only one database. That column is new on the default invocation. Compute-wide checks still run once and keep their previous columns. Pass `--database-name` to keep the previous columns on a database-scoped check. `locks` and `long-running-queries` also report only the database you name with the flag; they previously listed sessions from every database, and `locks` printed an empty or wrong relation name for those foreign rows.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 3.4.0
+
+### Minor Changes
+
+- 5abe208: `neon inspect db` without `--database-name` now runs each database-scoped check against every database the API lists for the branch and adds a `database` column, including on a branch that has only one database. That column is new on the default invocation. Compute-wide checks still run once and keep their previous columns. Pass `--database-name` to keep the previous columns on a database-scoped check. `locks` and `long-running-queries` also report only the database you name with the flag; they previously listed sessions from every database, and `locks` printed an empty or wrong relation name for those foreign rows.
+
 ## 3.3.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.3.0",
+	"version": "3.4.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 3.4.0
+
+### Patch Changes
+
+- Updated dependencies [5abe208]
+  - neon@3.4.0
+
 ## 3.3.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

`neon@3.3.0` and `neonctl@3.3.0` are what npm serves. The inspect-every-database change is already on `main` (`5abe208`, #406) and is not in those tarballs.

```
$ npm view neon version
3.3.0
$ npm view neonctl version
3.3.0
```

`3.4.0` is unpublished.

## Diagnosis

`5abe208` landed after the 3.3.0 release. A release in this repo is a version bump and changelog commit. `pnpm changeset version` consumed the pending minor changeset on `neon`. `neon` and `neonctl` are a Changesets fixed group, so both become 3.4.0.

No source in this PR. The command already behaves this way on `main`.

## The user-facing interface

```
neon inspect db
neon inspect db --database-name mydb
```

`packages/cli/CHANGELOG.md` for 3.4.0:

```
## 3.4.0

### Minor Changes

- 5abe208: `neon inspect db` without `--database-name` now runs each database-scoped check against every database the API lists for the branch and adds a `database` column, including on a branch that has only one database. That column is new on the default invocation. Compute-wide checks still run once and keep their previous columns. Pass `--database-name` to keep the previous columns on a database-scoped check. `locks` and `long-running-queries` also report only the database you name with the flag; they previously listed sessions from every database, and `locks` printed an empty or wrong relation name for those foreign rows.
```

`packages/neonctl/CHANGELOG.md` for 3.4.0:

```
## 3.4.0

### Patch Changes

- Updated dependencies [5abe208]
  - neon@3.4.0
```

Callers that already pass `--database-name` keep the previous columns. `neonctl` stays a compatibility wrapper; it has no inspect implementation.

## Also in here

`.changeset/quiet-moons-inspect.md` is deleted because it was consumed. `packages/cli` and `packages/neonctl` `package.json` versions are 3.4.0. No other package is versioned.

## Verification

`git diff origin/main...HEAD` at `bffb237` is five files, 15 insertions, 7 deletions. No `src/` or test changes.

`npm view neon version` and `npm view neonctl version` both returned `3.3.0`. The `3.4.0` time key is absent.

Did not re-run inspect tests. This diff does not change that code.

Did not publish.

## For your attention

- Merge does not put 3.4.0 on npm. Publish is a separate manual workflow after merge.
- `neonctl` is versioned only because it is fixed to `neon`. It has no inspect implementation.