### PR TITLE
Install Neon MCP through add-mcp's library

### DIFF
--- a/.changeset/init-add-mcp-sdk.md
+++ b/.changeset/init-add-mcp-sdk.md
@@ -1,0 +1,5 @@
+---
+"neon": minor
+---
+
+`neon init` installs the Neon MCP server through add-mcp's library and offers every agent add-mcp supports. Skills still use a fixed map from those agent ids; agents with no skills CLI id are skipped instead of falling back to Cursor.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -64,6 +64,7 @@
 		"@neon/config-runtime": "workspace:*",
 		"@neon/sdk": "workspace:*",
 		"@segment/analytics-node": "1.3.0",
+		"add-mcp": "2.0.0",
 		"chalk": "5.3.0",
 		"chokidar": "5.0.0",
 		"cli-table": "0.3.11",

--- a/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
+++ b/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
@@ -439,41 +439,13 @@ exports[`neon init --agent: every step, against every project shape > connected 
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -767,7 +739,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -785,7 +757,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -895,7 +867,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -948,7 +920,6 @@ exports[`neon init --agent: every step, against every project shape > connected 
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -987,7 +958,6 @@ exports[`neon init --agent: every step, against every project shape > connected 
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -1467,41 +1437,13 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -1795,7 +1737,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -1813,7 +1755,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -1923,7 +1865,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -1976,7 +1918,6 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -2015,7 +1956,6 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -2491,41 +2431,13 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -2807,7 +2719,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -2825,7 +2737,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -2935,7 +2847,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -2988,7 +2900,6 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version"
 `;
 
@@ -3025,7 +2936,6 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version"
 `;
 
@@ -3492,41 +3402,13 @@ exports[`neon init --agent: every step, against every project shape > greenfield
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -3820,7 +3702,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -3838,7 +3720,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -3948,7 +3830,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -4001,7 +3883,6 @@ exports[`neon init --agent: every step, against every project shape > greenfield
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -4040,7 +3921,6 @@ exports[`neon init --agent: every step, against every project shape > greenfield
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -4525,41 +4405,13 @@ exports[`neon init --agent: every step, against every project shape > next-prism
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -4853,7 +4705,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -4871,7 +4723,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -4981,7 +4833,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -5034,7 +4886,6 @@ exports[`neon init --agent: every step, against every project shape > next-prism
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -5073,7 +4924,6 @@ exports[`neon init --agent: every step, against every project shape > next-prism
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -5558,41 +5408,13 @@ exports[`neon init --agent: every step, against every project shape > next-prism
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -5886,7 +5708,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -5904,7 +5726,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -6014,7 +5836,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -6067,7 +5889,6 @@ exports[`neon init --agent: every step, against every project shape > next-prism
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -6106,7 +5927,6 @@ exports[`neon init --agent: every step, against every project shape > next-prism
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -6586,41 +6406,13 @@ exports[`neon init --agent: every step, against every project shape > node-app >
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -6914,7 +6706,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -6932,7 +6724,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -7042,7 +6834,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -7095,7 +6887,6 @@ exports[`neon init --agent: every step, against every project shape > node-app >
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -7134,7 +6925,6 @@ exports[`neon init --agent: every step, against every project shape > node-app >
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -7619,41 +7409,13 @@ exports[`neon init --agent: every step, against every project shape > other-data
 --- stdout ---
 {
   "phase": "tooling",
-  "status": "installing",
+  "status": "installed",
+  "path": "<home>/.cursor/mcp.json",
   "nextAction": {
-    "type": "run_command",
-    "command": "npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor",
-    "description": "Installing Neon MCP server (global scope) for cursor.",
-    "timeout": 60000,
-    "onSuccess": {
-      "type": "run_shell_command",
-      "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-    },
-    "onFailure": {
-      "other": {
-        "type": "ask_user",
-        "question": "Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-        "options": [
-          {
-            "value": "retry",
-            "label": "Try again"
-          },
-          {
-            "value": "manual",
-            "label": "I'll configure it manually"
-          }
-        ],
-        "responseMapping": {
-          "retry": {
-            "command": "neon init --agent --data '{\\"step\\":\\"mcp\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
-          },
-          "manual": {
-            "command": "neon init --agent --data '{\\"agent\\":\\"cursor\\"}'"
-          }
-        }
-      }
-    }
-  }
+    "type": "run_shell_command",
+    "command": "neon init --agent --data '{\\"step\\":\\"skills\\",\\"agent\\":\\"cursor\\",\\"install\\":true}'"
+  },
+  "message": "Installed Neon MCP server (global scope) for cursor."
 }
 --- stderr ---
 
@@ -7947,7 +7709,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -7965,7 +7727,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -8075,7 +7837,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -8128,7 +7890,6 @@ exports[`neon init --agent: every step, against every project shape > other-data
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -8167,7 +7928,6 @@ exports[`neon init --agent: every step, against every project shape > other-data
 --- subprocesses ---
 <stub>/neon --version
 <stub>/npm view neon version
-<stub>/npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a cursor
 <stub>/skills --version
 <stub>/skills add neondatabase/agent-skills --skill neon --agent cursor -y
 <stub>/skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
@@ -8474,7 +8234,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -8492,7 +8252,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -8602,7 +8362,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -8636,7 +8396,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -8654,7 +8414,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -8764,7 +8524,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -8798,7 +8558,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -8816,7 +8576,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -8926,7 +8686,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > connected �
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -8960,7 +8720,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -8978,7 +8738,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -9088,7 +8848,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -9122,7 +8882,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -9140,7 +8900,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -9250,7 +9010,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -9284,7 +9044,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -9302,7 +9062,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -9412,7 +9172,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > drizzle — 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -9446,7 +9206,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > fully-config
   "skillsScope": "project-partial",
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: configured (project). Agent skills: partially installed (project-partial) — missing skills will be auto-installed to the same scope. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: configured (project). Agent skills: partially installed (project-partial) — missing skills will be auto-installed to the same scope. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -9464,7 +9224,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > fully-config
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -9536,7 +9296,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > fully-config
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -9620,7 +9380,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nNo application was detected in this directory. Ask the user if they'd like to scaffold a new project from a template (the \`template\` preference). Present ALL template options and the 'No thanks' option — do NOT auto-select even if there is only one template. If the user selects a template, the scaffolded template includes agent skills so skills installation will be skipped. If the user chooses 'none', continue with the remaining setup preferences normally. Then perform the agent checks and present the remaining preferences ONE AT A TIME.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nNo application was detected in this directory. Ask the user if they'd like to scaffold a new project from a template (the \`template\` preference). Present ALL template options and the 'No thanks' option — do NOT auto-select even if there is only one template. If the user selects a template, the scaffolded template includes agent skills so skills installation will be skipped. If the user chooses 'none', continue with the remaining setup preferences normally. Then perform the agent checks and present the remaining preferences ONE AT A TIME.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -9638,7 +9398,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -9751,7 +9511,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -9785,7 +9545,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -9803,7 +9563,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -9913,7 +9673,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -9947,7 +9707,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -9965,7 +9725,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -10075,7 +9835,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > greenfield �
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -10109,7 +9869,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -10127,7 +9887,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -10237,7 +9997,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -10271,7 +10031,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -10289,7 +10049,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -10399,7 +10159,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -10433,7 +10193,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -10451,7 +10211,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -10561,7 +10321,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -10595,7 +10355,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -10613,7 +10373,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -10723,7 +10483,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -10757,7 +10517,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -10775,7 +10535,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -10885,7 +10645,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -10919,7 +10679,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -10937,7 +10697,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -11047,7 +10807,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > next-prisma-
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -11081,7 +10841,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -11099,7 +10859,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -11209,7 +10969,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -11243,7 +11003,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -11261,7 +11021,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -11371,7 +11131,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -11405,7 +11165,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -11423,7 +11183,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -11533,7 +11293,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > node-app —
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -11567,7 +11327,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -11585,7 +11345,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -11695,7 +11455,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -11729,7 +11489,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -11747,7 +11507,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -11857,7 +11617,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -11891,7 +11651,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -11909,7 +11669,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -12019,7 +11779,7 @@ exports[`neon init --agent: the orchestrator picks the next phase > other-databa
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -12180,7 +11940,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       }
@@ -12282,7 +12042,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -12334,7 +12094,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       }
@@ -12436,7 +12196,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -12675,7 +12435,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       }
@@ -12777,7 +12537,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -12829,7 +12589,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       }
@@ -12931,7 +12691,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -13152,7 +12912,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -13170,7 +12930,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -13280,7 +13040,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -13314,7 +13074,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -13332,7 +13092,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -13442,7 +13202,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -13679,7 +13439,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       }
@@ -13781,7 +13541,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -13833,7 +13593,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       }
@@ -13935,7 +13695,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"
@@ -14373,7 +14133,7 @@ exports[`neon init: failure output > --data without a step falls through to the 
   "skillsScope": null,
   "nextAction": {
     "type": "agent_check",
-    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
+    "instructions": "IMPORTANT: Do NOT summarize this response or ask the user for consent/confirmation before starting. Proceed IMMEDIATELY with the first userPreference question.\\n\\nPerform the agent checks listed above (MCP server status and your agent identity), then present each userPreference question to the user ONE AT A TIME, in order. Wait for the user's answer before showing the next question. Respect the \`condition\` field — only show a question if its condition is met.\\n\\nThe CLI has pre-detected the following from the filesystem: MCP server: not configured. Agent skills: not installed. Report these findings to the user before asking preferences. Only ask about scope/options for components that are NOT already configured. Do NOT ask about skills scope if skills are partially installed — they will be completed automatically.\\n\\nIMPORTANT (Cursor users): Cursor disables project-level MCP servers by default as a security measure. If the user is in Cursor and chooses project-level MCP scope, warn them that they will need to manually enable the Neon server in Cursor Settings > MCP after installation. Recommend global scope for Cursor to avoid this extra step.\\n\\nGROUPING: Preferences that share the same \`group\` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a \`group\` must be asked individually.\\n\\nThe CLI has detected the IDE as: cursor. Include this as the \\"ide\\" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.\\n\\nAfter all questions are answered, call reportBack with a single --data JSON containing: agent, ide, mcpConfigured, and all preference answers. The CLI will inspect the project and merge results automatically.",
     "checks": [
       {
         "id": "neon",
@@ -14391,7 +14151,7 @@ exports[`neon init: failure output > --data without a step falls through to the 
         "id": "agent_type",
         "description": "Identify which coding agent is running this command",
         "lookFor": [
-          "Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+          "Determine which agent you are: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor, gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed",
           "Report your own agent identifier — this is used to configure the MCP server for the correct tool"
         ]
       },
@@ -14501,7 +14261,7 @@ exports[`neon init: failure output > --data without a step falls through to the 
           }
         ],
         "default": "true",
-        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+        "context": "The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
         "condition": {
           "preferenceId": "mode",
           "equals": "customize"

--- a/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
+++ b/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
@@ -971,7 +971,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -1040,7 +1040,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -1969,7 +1969,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -2038,7 +2038,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -2947,7 +2947,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -3016,7 +3016,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -3934,7 +3934,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -4003,7 +4003,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -4937,7 +4937,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -5006,7 +5006,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -5940,7 +5940,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -6009,7 +6009,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -6938,7 +6938,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -7007,7 +7007,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -7941,7 +7941,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {
@@ -8010,7 +8010,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
   "status": "installing_skills",
   "nextAction": {
     "type": "run_command",
-    "command": "npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
+    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y",
     "description": "Installing Neon agent skills for cursor.",
     "timeout": 30000,
     "onSuccess": {

--- a/packages/cli/src/init/agents.test.ts
+++ b/packages/cli/src/init/agents.test.ts
@@ -1,0 +1,37 @@
+import { getAgentTypes } from "add-mcp";
+import { describe, expect, test } from "vitest";
+
+import {
+	getSkillsAgentName,
+	listMcpAgentIds,
+	resolveAddMcpAgentId,
+	supportsSkills,
+	tryResolveAddMcpAgentId,
+} from "./agents.js";
+
+describe("add-mcp agent ids", () => {
+	test("MCP picker is every add-mcp agent", () => {
+		expect(listMcpAgentIds()).toEqual(getAgentTypes());
+		expect(listMcpAgentIds()).toContain("windsurf");
+		expect(listMcpAgentIds()).toContain("grok-build");
+	});
+
+	test("resolves neon aliases to AgentType constants", () => {
+		expect(resolveAddMcpAgentId("claude")).toBe("claude-code");
+		expect(resolveAddMcpAgentId("grok")).toBe("grok-build");
+		expect(resolveAddMcpAgentId("copilot")).toBe("vscode");
+		expect(tryResolveAddMcpAgentId("not-an-agent")).toBeUndefined();
+	});
+
+	test("skills map is hardcoded and omits grok-build", () => {
+		expect(getSkillsAgentName("cursor")).toBe("cursor");
+		expect(getSkillsAgentName("vscode")).toBe("github-copilot");
+		expect(getSkillsAgentName("claude")).toBe("claude-code");
+		expect(getSkillsAgentName("claude-desktop")).toBe("claude-code");
+		expect(getSkillsAgentName("github-copilot-cli")).toBe("github-copilot");
+		expect(getSkillsAgentName("grok-build")).toBeUndefined();
+		expect(getSkillsAgentName("grok")).toBeUndefined();
+		expect(supportsSkills("grok-build")).toBe(false);
+		expect(supportsSkills("cursor")).toBe(true);
+	});
+});

--- a/packages/cli/src/init/agents.test.ts
+++ b/packages/cli/src/init/agents.test.ts
@@ -29,6 +29,7 @@ describe("add-mcp agent ids", () => {
 		expect(getSkillsAgentName("claude")).toBe("claude-code");
 		expect(getSkillsAgentName("claude-desktop")).toBe("claude-code");
 		expect(getSkillsAgentName("github-copilot-cli")).toBe("github-copilot");
+		expect(getSkillsAgentName("opencode")).toBe("opencode");
 		expect(getSkillsAgentName("grok-build")).toBeUndefined();
 		expect(getSkillsAgentName("grok")).toBeUndefined();
 		expect(supportsSkills("grok-build")).toBe(false);

--- a/packages/cli/src/init/agents.test.ts
+++ b/packages/cli/src/init/agents.test.ts
@@ -23,16 +23,18 @@ describe("add-mcp agent ids", () => {
 		expect(tryResolveAddMcpAgentId("not-an-agent")).toBeUndefined();
 	});
 
-	test("skills map is hardcoded and omits grok-build", () => {
+	test("skills map is hardcoded and maps grok-build to grok", () => {
 		expect(getSkillsAgentName("cursor")).toBe("cursor");
 		expect(getSkillsAgentName("vscode")).toBe("github-copilot");
 		expect(getSkillsAgentName("claude")).toBe("claude-code");
 		expect(getSkillsAgentName("claude-desktop")).toBe("claude-code");
 		expect(getSkillsAgentName("github-copilot-cli")).toBe("github-copilot");
 		expect(getSkillsAgentName("opencode")).toBe("opencode");
-		expect(getSkillsAgentName("grok-build")).toBeUndefined();
-		expect(getSkillsAgentName("grok")).toBeUndefined();
-		expect(supportsSkills("grok-build")).toBe(false);
+		expect(getSkillsAgentName("grok-build")).toBe("grok");
+		expect(getSkillsAgentName("grok")).toBe("grok");
+		expect(supportsSkills("grok-build")).toBe(true);
+		expect(getSkillsAgentName("mcporter")).toBeUndefined();
+		expect(supportsSkills("mcporter")).toBe(false);
 		expect(supportsSkills("cursor")).toBe(true);
 	});
 });

--- a/packages/cli/src/init/agents.ts
+++ b/packages/cli/src/init/agents.ts
@@ -87,6 +87,9 @@ export function resolveAddMcpAgentId(rawAgent: string): AgentType {
 }
 
 export function getSkillsAgentName(agent: string): string | undefined {
+	if (Object.hasOwn(SKILLS_AGENT_BY_TYPE, agent)) {
+		return SKILLS_AGENT_BY_TYPE[agent as AgentType];
+	}
 	const id = tryResolveAddMcpAgentId(agent);
 	if (!id) return undefined;
 	return SKILLS_AGENT_BY_TYPE[id];
@@ -101,7 +104,10 @@ export function agentPickerHint(id: AgentType): string {
 		return "Neon Local Connect extension";
 	}
 	if (id === "claude-desktop") {
-		return "Connectors in the app — remote MCP is not writable via config";
+		return supportsSkills(id)
+			? "Connectors in the app, skills"
+			: (agents[id].unsupportedTransportMessage ??
+					"Add remote servers through Connectors in the app");
 	}
 	if (supportsSkills(id)) return "MCP server, skills";
 	return "MCP server";

--- a/packages/cli/src/init/agents.ts
+++ b/packages/cli/src/init/agents.ts
@@ -51,7 +51,7 @@ const SKILLS_AGENT_BY_TYPE: { [K in AgentType]?: string } = {
 	"github-copilot-cli": "github-copilot",
 	windsurf: "windsurf",
 	zed: "zed",
-	mcporter: "mcporter",
+	"grok-build": "grok",
 };
 
 export function listMcpAgentIds(): AgentType[] {

--- a/packages/cli/src/init/agents.ts
+++ b/packages/cli/src/init/agents.ts
@@ -1,64 +1,15 @@
-import type { Editor } from "./types.js";
+import {
+	type AgentType,
+	agents,
+	detectGlobalAgents,
+	detectProjectAgents,
+	getAgentTypes,
+} from "add-mcp";
 
-export type AgentConfig = {
-	editor: Editor;
-	addMcpId: string;
-	hint: string;
-};
+export type { AgentType };
 
-/**
- * All agents that can be configured via neon-init.
- * Aligns with add-mcp's supported agents table.
- * https://github.com/neondatabase/add-mcp#supported-agents
- */
-export const ALL_CONFIGURABLE_AGENTS: AgentConfig[] = [
-	{
-		editor: "Cursor",
-		addMcpId: "cursor",
-		hint: "Neon Local Connect extension",
-	},
-	{
-		editor: "VS Code",
-		addMcpId: "vscode",
-		hint: "Neon Local Connect extension",
-	},
-	{ editor: "Claude CLI", addMcpId: "claude-code", hint: "MCP Server" },
-	{
-		editor: "Claude Desktop",
-		addMcpId: "claude-desktop",
-		hint: "MCP Server",
-	},
-	{ editor: "Codex", addMcpId: "codex", hint: "MCP Server" },
-	{ editor: "OpenCode", addMcpId: "opencode", hint: "MCP Server" },
-	{ editor: "Antigravity", addMcpId: "antigravity", hint: "MCP Server" },
-	{ editor: "Cline", addMcpId: "cline", hint: "MCP Server" },
-	{ editor: "Cline CLI", addMcpId: "cline-cli", hint: "MCP Server" },
-	{ editor: "Gemini CLI", addMcpId: "gemini-cli", hint: "MCP Server" },
-	{
-		editor: "GitHub Copilot CLI",
-		addMcpId: "github-copilot-cli",
-		hint: "MCP Server",
-	},
-	{ editor: "Goose", addMcpId: "goose", hint: "MCP Server" },
-	{ editor: "MCPorter", addMcpId: "mcporter", hint: "MCP Server" },
-	{ editor: "Zed", addMcpId: "zed", hint: "MCP Server" },
-];
-
-export function getAddMcpAgentId(editor: Editor): string {
-	const agent = ALL_CONFIGURABLE_AGENTS.find((a) => a.editor === editor);
-	if (!agent) {
-		throw new Error(`No add-mcp agent ID found for editor: ${editor}`);
-	}
-	return agent.addMcpId;
-}
-
-/**
- * Maps a raw agent identifier (as reported by agents or passed via --agent)
- * to the add-mcp compatible agent ID.
- *
- * This handles aliases like "copilot" → "vscode", "claude" → "claude-code", etc.
- */
-const AGENT_ALIAS_TO_MCP_ID: Record<string, string> = {
+// add-mcp does not export aliases, so Neon preserves CLI compatibility here.
+const AGENT_ALIASES = {
 	cursor: "cursor",
 	copilot: "vscode",
 	"github-copilot": "vscode",
@@ -72,70 +23,123 @@ const AGENT_ALIAS_TO_MCP_ID: Record<string, string> = {
 	antigravity: "antigravity",
 	cline: "cline",
 	"cline-cli": "cline-cli",
+	"cline-vscode": "cline",
 	"gemini-cli": "gemini-cli",
 	gemini: "gemini-cli",
 	goose: "goose",
 	windsurf: "windsurf",
+	codeium: "windsurf",
+	cascade: "windsurf",
 	"github-copilot-cli": "github-copilot-cli",
 	mcporter: "mcporter",
 	zed: "zed",
+	grok: "grok-build",
+	"grok-build": "grok-build",
+} as const satisfies Record<string, AgentType>;
+
+const SKILLS_AGENT_BY_TYPE: { [K in AgentType]?: string } = {
+	cursor: "cursor",
+	vscode: "github-copilot",
+	"claude-code": "claude-code",
+	"claude-desktop": "claude-code",
+	codex: "codex",
+	opencode: "opencode",
+	antigravity: "antigravity",
+	cline: "cline",
+	"cline-cli": "cline",
+	"gemini-cli": "gemini-cli",
+	goose: "goose",
+	"github-copilot-cli": "github-copilot",
+	windsurf: "windsurf",
+	zed: "zed",
+	mcporter: "mcporter",
 };
 
-export function resolveAddMcpAgentId(rawAgent: string): string {
-	const resolved = AGENT_ALIAS_TO_MCP_ID[rawAgent.toLowerCase()];
+export function listMcpAgentIds(): AgentType[] {
+	return getAgentTypes();
+}
+
+export function getAgentDisplayName(id: AgentType): string {
+	return agents[id].displayName;
+}
+
+export function agentSupportsProjectMcp(id: AgentType): boolean {
+	return Boolean(agents[id].localConfigPath);
+}
+
+export function agentSupportsHttpMcp(id: AgentType): boolean {
+	return agents[id].supportedTransports.includes("http");
+}
+
+export function tryResolveAddMcpAgentId(
+	rawAgent: string,
+): AgentType | undefined {
+	return AGENT_ALIASES[rawAgent.toLowerCase() as keyof typeof AGENT_ALIASES];
+}
+
+export function resolveAddMcpAgentId(rawAgent: string): AgentType {
+	const resolved = tryResolveAddMcpAgentId(rawAgent);
 	if (!resolved) {
 		throw new Error(
-			`Unknown agent: "${rawAgent}". Supported agents: ${Object.keys(AGENT_ALIAS_TO_MCP_ID).join(", ")}`,
+			`Unknown agent: "${rawAgent}". Supported agents: ${listMcpAgentIds().join(", ")}`,
 		);
 	}
 	return resolved;
 }
 
-/**
- * Maps a raw agent identifier to the skills CLI agent name.
- */
-export function getSkillsAgentName(agent: string): string {
-	switch (agent.toLowerCase()) {
-		case "cursor":
-			return "cursor";
-		case "copilot":
-		case "vscode":
-		case "vs-code":
-		case "github-copilot":
-			return "github-copilot";
-		case "claude":
-		case "claude-code":
-			return "claude-code";
-		case "codex":
-			return "codex";
-		case "opencode":
-			return "opencode";
-		case "antigravity":
-			return "antigravity";
-		case "cline":
-			return "cline";
-		case "gemini-cli":
-			return "gemini-cli";
-		case "goose":
-			return "goose";
-		case "claude-desktop":
-			return "claude-code";
-		case "cline-cli":
-			return "cline";
-		case "gemini":
-			return "gemini-cli";
-		case "windsurf":
-			return "windsurf";
-		case "github-copilot-cli":
-			return "github-copilot";
-		case "mcporter":
-			return "mcporter";
-		case "zed":
-			return "zed";
-		default:
-			// Fall back to "cursor" as a safe default — skills CLI uses the
-			// agent name to pick the output directory (.agents/skills, .cursor/skills, etc.)
-			// and "cursor" uses .agents/skills which works for all agents.
-			return "cursor";
+export function getSkillsAgentName(agent: string): string | undefined {
+	const id = tryResolveAddMcpAgentId(agent);
+	if (!id) return undefined;
+	return SKILLS_AGENT_BY_TYPE[id];
+}
+
+export function supportsSkills(agent: string): boolean {
+	return getSkillsAgentName(agent) !== undefined;
+}
+
+export function agentPickerHint(id: AgentType): string {
+	if (id === "cursor" || id === "vscode") {
+		return "Neon Local Connect extension";
 	}
+	if (id === "claude-desktop") {
+		return "Connectors in the app — remote MCP is not writable via config";
+	}
+	if (supportsSkills(id)) return "MCP server, skills";
+	return "MCP server";
+}
+
+export async function detectInstalledAgents(
+	cwd = process.cwd(),
+): Promise<AgentType[]> {
+	const [globalAgents, projectAgents] = await Promise.all([
+		detectGlobalAgents(),
+		Promise.resolve(detectProjectAgents(cwd)),
+	]);
+	return [...new Set([...globalAgents, ...projectAgents])];
+}
+
+export function mcpPickerOptions(): {
+	value: AgentType;
+	label: string;
+	hint: string;
+}[] {
+	return listMcpAgentIds().map((id) => ({
+		value: id,
+		label: getAgentDisplayName(id),
+		hint: agentPickerHint(id),
+	}));
+}
+
+export function skillsPickerOptions(): {
+	value: AgentType;
+	label: string;
+	hint: string;
+}[] {
+	return listMcpAgentIds()
+		.filter((id) => supportsSkills(id))
+		.map((id) => ({
+			value: id,
+			label: getAgentDisplayName(id),
+			hint: "agent skills",
+		}));
 }

--- a/packages/cli/src/init/agents.ts
+++ b/packages/cli/src/init/agents.ts
@@ -87,7 +87,7 @@ export function resolveAddMcpAgentId(rawAgent: string): AgentType {
 }
 
 export function getSkillsAgentName(agent: string): string | undefined {
-	if (Object.hasOwn(SKILLS_AGENT_BY_TYPE, agent)) {
+	if (Object.prototype.hasOwnProperty.call(SKILLS_AGENT_BY_TYPE, agent)) {
 		return SKILLS_AGENT_BY_TYPE[agent as AgentType];
 	}
 	const id = tryResolveAddMcpAgentId(agent);

--- a/packages/cli/src/init/agents.ts
+++ b/packages/cli/src/init/agents.ts
@@ -2,7 +2,6 @@ import {
 	type AgentType,
 	agents,
 	detectGlobalAgents,
-	detectProjectAgents,
 	getAgentTypes,
 } from "add-mcp";
 
@@ -108,14 +107,8 @@ export function agentPickerHint(id: AgentType): string {
 	return "MCP server";
 }
 
-export async function detectInstalledAgents(
-	cwd = process.cwd(),
-): Promise<AgentType[]> {
-	const [globalAgents, projectAgents] = await Promise.all([
-		detectGlobalAgents(),
-		Promise.resolve(detectProjectAgents(cwd)),
-	]);
-	return [...new Set([...globalAgents, ...projectAgents])];
+export async function detectInstalledAgents(): Promise<AgentType[]> {
+	return detectGlobalAgents();
 }
 
 export function mcpPickerOptions(): {

--- a/packages/cli/src/init/editors.ts
+++ b/packages/cli/src/init/editors.ts
@@ -1,16 +1,10 @@
-import { existsSync } from "node:fs";
 import { resolve } from "node:path";
-import { execa } from "execa";
-import type { Editor } from "./types.js";
+import { type AgentType, detectInstalledAgents } from "./agents.js";
 
-/**
- * Gets VS Code's global config directory based on the platform
- */
 export function getVSCodeGlobalConfigDir(homeDir: string): string | null {
 	const platform = process.platform;
 
 	if (platform === "darwin") {
-		// macOS: ~/Library/Application Support/Code/User
 		return resolve(
 			homeDir,
 			"Library",
@@ -20,11 +14,9 @@ export function getVSCodeGlobalConfigDir(homeDir: string): string | null {
 		);
 	}
 	if (platform === "linux") {
-		// Linux: ~/.config/Code/User
 		return resolve(homeDir, ".config", "Code", "User");
 	}
 	if (platform === "win32") {
-		// Windows: %APPDATA%\Code\User
 		const appData = process.env.APPDATA;
 		if (appData) {
 			return resolve(appData, "Code", "User");
@@ -34,46 +26,8 @@ export function getVSCodeGlobalConfigDir(homeDir: string): string | null {
 	return null;
 }
 
-/**
- * Checks if Claude CLI is installed
- */
-async function isClaudeCLIInstalled(): Promise<boolean> {
-	try {
-		await execa("claude", ["--version"], {
-			stdio: "ignore",
-			timeout: 5000,
-		});
-		return true;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Detects which editors are installed on the system
- */
 export async function detectAvailableEditors(
-	homeDir: string,
-): Promise<Editor[]> {
-	const editors: Editor[] = [];
-
-	// Check for Cursor (global config directory)
-	const cursorDir = resolve(homeDir, ".cursor");
-	if (existsSync(cursorDir)) {
-		editors.push("Cursor");
-	}
-
-	// Check if VS Code's global config directory exists
-	const vscodeGlobalDir = getVSCodeGlobalConfigDir(homeDir);
-	if (vscodeGlobalDir && existsSync(vscodeGlobalDir)) {
-		editors.push("VS Code");
-	}
-
-	// Check for Claude CLI by running the command
-	const claudeInstalled = await isClaudeCLIInstalled();
-	if (claudeInstalled) {
-		editors.push("Claude CLI");
-	}
-
-	return editors;
+	_homeDir?: string,
+): Promise<AgentType[]> {
+	return detectInstalledAgents();
 }

--- a/packages/cli/src/init/inspect.test.ts
+++ b/packages/cli/src/init/inspect.test.ts
@@ -128,6 +128,30 @@ describe("inspectProject", () => {
 
 		const result = await inspectProject([makeCheck("mcp_server")]);
 		expect(result.mcpConfigured).toBe(true);
+		expect(result.mcpAgents).toEqual(
+			expect.arrayContaining([{ agent: "cursor", scope: "project" }]),
+		);
+
+		process.cwd = originalCwd;
+	});
+
+	test("detects MCP server in a non-Cursor project config", async () => {
+		const originalCwd = process.cwd;
+		process.cwd = () => testDir;
+
+		mkdirSync(join(testDir, ".vscode"), { recursive: true });
+		writeFileSync(
+			join(testDir, ".vscode", "mcp.json"),
+			JSON.stringify({
+				servers: { Neon: { url: "https://mcp.neon.tech/mcp" } },
+			}),
+		);
+
+		const result = await inspectProject([makeCheck("mcp_server")]);
+		expect(result.mcpConfigured).toBe(true);
+		expect(result.mcpAgents).toEqual(
+			expect.arrayContaining([{ agent: "vscode", scope: "project" }]),
+		);
 
 		process.cwd = originalCwd;
 	});

--- a/packages/cli/src/init/inspect.ts
+++ b/packages/cli/src/init/inspect.ts
@@ -4,7 +4,9 @@
  * we examine the filesystem directly.
  */
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { resolve, sep } from "node:path";
+import { type AgentType, agents, getAgentTypes } from "add-mcp";
 import type { AgentCheck } from "./types.js";
 
 export type DetectedScope =
@@ -14,10 +16,16 @@ export type DetectedScope =
 	| "project-partial"
 	| false;
 
+export type McpAgentHit = {
+	agent: AgentType;
+	scope: "global" | "project";
+};
+
 export type InspectionResults = {
 	[key: string]: unknown;
 	mcpConfigured?: boolean;
 	mcpScope?: DetectedScope;
+	mcpAgents?: McpAgentHit[];
 	skillsInstalled?: boolean;
 	skillsScope?: DetectedScope;
 	/** True if a Neon-specific connection string (DATABASE_URL with "neon" or PGHOST with "neon") is found */
@@ -47,9 +55,10 @@ export async function inspectProject(
 	for (const check of checks) {
 		switch (check.id) {
 			case "mcp_server": {
-				const mcpScope = checkMcpServer(cwd);
-				results.mcpConfigured = mcpScope !== false;
-				results.mcpScope = mcpScope;
+				const hits = findNeonMcpAgents(cwd);
+				results.mcpAgents = hits;
+				results.mcpConfigured = hits.length > 0;
+				results.mcpScope = mcpScopeFromHits(hits);
 				break;
 			}
 			case "connection_string":
@@ -95,50 +104,80 @@ export async function inspectProject(
 // Individual check implementations
 // ---------------------------------------------------------------------------
 
-function checkMcpServer(cwd: string): DetectedScope {
-	const home = process.env.HOME || process.env.USERPROFILE || "";
-
-	// Check project-level configs first
-	const projectConfigs = [
-		resolve(cwd, ".cursor", "mcp.json"),
-		resolve(cwd, ".vscode", "settings.json"),
-	];
-	for (const configPath of projectConfigs) {
-		if (existsSync(configPath)) {
-			try {
-				const content = readFileSync(configPath, "utf-8");
-				if (
-					content.includes("neon") ||
-					content.includes("mcp.neon.tech")
-				) {
-					return "project";
-				}
-			} catch {}
-		}
-	}
-
-	// Check global configs
-	const globalConfigs = [
-		resolve(home, ".cursor", "mcp.json"),
-		// Claude Code config (add-mcp writes to settings.local.json)
-		resolve(home, ".claude", "settings.local.json"),
-		resolve(home, ".claude", "settings.json"),
-	];
-	for (const configPath of globalConfigs) {
-		if (existsSync(configPath)) {
-			try {
-				const content = readFileSync(configPath, "utf-8");
-				if (
-					content.includes("neon") ||
-					content.includes("mcp.neon.tech")
-				) {
-					return "global";
-				}
-			} catch {}
-		}
-	}
-
+function mcpScopeFromHits(hits: McpAgentHit[]): DetectedScope {
+	if (hits.some((hit) => hit.scope === "project")) return "project";
+	if (hits.some((hit) => hit.scope === "global")) return "global";
 	return false;
+}
+
+// add-mcp resolves home paths at import time, before tests replace HOME.
+function addMcpBakedHome(): string {
+	const cursorPath = agents.cursor.configPath;
+	const suffix = `${sep}.cursor${sep}mcp.json`;
+	if (cursorPath.endsWith(suffix)) {
+		return cursorPath.slice(0, -suffix.length);
+	}
+	return homedir();
+}
+
+function rebaseAddMcpHome(configPath: string): string {
+	const currentHome =
+		process.env.HOME || process.env.USERPROFILE || homedir();
+	const baked = addMcpBakedHome();
+	if (configPath.startsWith(baked)) {
+		return currentHome + configPath.slice(baked.length);
+	}
+	return configPath;
+}
+
+function agentProjectPath(id: AgentType, cwd: string): string | undefined {
+	const agent = agents[id];
+	if (agent.resolveConfigPath && agent.localConfigPath) {
+		return agent.resolveConfigPath(agent, { local: true, cwd });
+	}
+	if (agent.localConfigPath) {
+		return resolve(cwd, agent.localConfigPath);
+	}
+	return undefined;
+}
+
+function agentGlobalPath(id: AgentType, cwd: string): string {
+	const agent = agents[id];
+	if (agent.resolveConfigPath) {
+		return rebaseAddMcpHome(
+			agent.resolveConfigPath(agent, { local: false, cwd }),
+		);
+	}
+	return rebaseAddMcpHome(agent.configPath);
+}
+
+function fileHasNeonMcp(configPath: string): boolean {
+	if (!existsSync(configPath)) return false;
+	try {
+		const content = readFileSync(configPath, "utf-8");
+		if (content.toLowerCase().includes("mcp.neon.tech")) return true;
+		if (/"neon"\s*:/i.test(content)) return true;
+		if (/\[mcp_servers\.neon\]/i.test(content)) return true;
+		if (/^neon\s*=/im.test(content)) return true;
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+function findNeonMcpAgents(cwd: string): McpAgentHit[] {
+	const hits: McpAgentHit[] = [];
+	for (const id of getAgentTypes()) {
+		const projectPath = agentProjectPath(id, cwd);
+		if (projectPath && fileHasNeonMcp(projectPath)) {
+			hits.push({ agent: id, scope: "project" });
+			continue;
+		}
+		if (fileHasNeonMcp(agentGlobalPath(id, cwd))) {
+			hits.push({ agent: id, scope: "global" });
+		}
+	}
+	return hits;
 }
 
 function checkConnectionString(cwd: string): boolean {

--- a/packages/cli/src/init/install_mcp.test.ts
+++ b/packages/cli/src/init/install_mcp.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { installNeonMcpServer, NEON_MCP_URL } from "./install_mcp.js";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function tmpProject(): string {
+	const dir = mkdtempSync(join(tmpdir(), "neon-mcp-"));
+	dirs.push(dir);
+	return dir;
+}
+
+describe("installNeonMcpServer", () => {
+	test("writes the Neon HTTP server into a project Cursor config", () => {
+		const cwd = tmpProject();
+		const result = installNeonMcpServer({
+			agent: "cursor",
+			scope: "project",
+			cwd,
+		});
+
+		expect(result).toEqual({
+			ok: true,
+			path: join(cwd, ".cursor", "mcp.json"),
+		});
+
+		const written = JSON.parse(
+			readFileSync(join(cwd, ".cursor", "mcp.json"), "utf8"),
+		);
+		expect(written.mcpServers.Neon).toMatchObject({
+			url: NEON_MCP_URL,
+		});
+	});
+
+	test("writes the Neon HTTP server into a project Grok config", () => {
+		const cwd = tmpProject();
+		const result = installNeonMcpServer({
+			agent: "grok-build",
+			scope: "project",
+			cwd,
+		});
+
+		expect(result.ok).toBe(true);
+		if (!result.ok) return;
+		expect(result.path).toBe(join(cwd, ".grok", "config.toml"));
+		expect(readFileSync(result.path, "utf8")).toContain("mcp.neon.tech");
+	});
+
+	test("does not write Claude Desktop config for remote HTTP", () => {
+		const cwd = tmpProject();
+		const result = installNeonMcpServer({
+			agent: "claude-desktop",
+			scope: "global",
+			cwd,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.unsupported).toBe(true);
+		expect(result.error).toMatch(/Connectors/i);
+	});
+
+	test("does not fall back to global when the agent has no project config", () => {
+		const cwd = tmpProject();
+		const result = installNeonMcpServer({
+			agent: "windsurf",
+			scope: "project",
+			cwd,
+		});
+
+		expect(result.ok).toBe(false);
+		if (result.ok) return;
+		expect(result.unsupported).toBe(true);
+		expect(result.error).toMatch(/project-level/i);
+	});
+});

--- a/packages/cli/src/init/install_mcp.ts
+++ b/packages/cli/src/init/install_mcp.ts
@@ -1,0 +1,56 @@
+import { type AgentType, agents, upsertServer } from "add-mcp";
+
+export const NEON_MCP_URL = "https://mcp.neon.tech/mcp";
+export const NEON_MCP_NAME = "Neon";
+
+export type McpInstallScope = "global" | "project";
+
+export type NeonMcpInstallResult =
+	| { ok: true; path: string }
+	| { ok: false; unsupported: true; error: string }
+	| { ok: false; unsupported: false; error: string };
+
+export function installNeonMcpServer(options: {
+	agent: AgentType;
+	scope: McpInstallScope;
+	cwd?: string;
+}): NeonMcpInstallResult {
+	const agent = agents[options.agent];
+
+	// upsertServer will still write an HTTP entry Claude Desktop cannot load.
+	if (!agent.supportedTransports.includes("http")) {
+		return {
+			ok: false,
+			unsupported: true,
+			error:
+				agent.unsupportedTransportMessage ??
+				`${agent.displayName} does not support remote HTTP MCP servers.`,
+		};
+	}
+
+	// add-mcp errors on local+no localConfigPath; do not fall back to global.
+	if (options.scope === "project" && !agent.localConfigPath) {
+		return {
+			ok: false,
+			unsupported: true,
+			error: `${agent.displayName} does not support project-level MCP config.`,
+		};
+	}
+
+	const result = upsertServer(
+		options.agent,
+		NEON_MCP_NAME,
+		{ type: "http", url: NEON_MCP_URL },
+		{ local: options.scope === "project", cwd: options.cwd },
+	);
+
+	if (result.success) {
+		return { ok: true, path: result.path };
+	}
+
+	return {
+		ok: false,
+		unsupported: false,
+		error: result.error ?? "Failed to write Neon MCP server config",
+	};
+}

--- a/packages/cli/src/init/interactive.ts
+++ b/packages/cli/src/init/interactive.ts
@@ -15,10 +15,17 @@ import {
 	select,
 	spinner,
 } from "@clack/prompts";
-import { execa } from "execa";
 import which from "which";
 import { bold, dim, gray, italic } from "yoctocolors";
-import { ALL_CONFIGURABLE_AGENTS, getAddMcpAgentId } from "./agents.js";
+import {
+	type AgentType,
+	detectInstalledAgents,
+	getAgentDisplayName,
+	getSkillsAgentName,
+	mcpPickerOptions,
+	skillsPickerOptions,
+	tryResolveAddMcpAgentId,
+} from "./agents.js";
 import { ensureNeonctlAuth, isAuthenticated } from "./auth.js";
 import {
 	type BootstrapTemplate,
@@ -28,13 +35,9 @@ import {
 	scaffoldTemplate,
 } from "./bootstrap.js";
 import { detectAgent, detectIde } from "./detect_agent.js";
-import { detectAvailableEditors } from "./editors.js";
-import {
-	installExtension,
-	isExtensionInstalled,
-	usesExtension,
-} from "./extension.js";
+import { installExtension, isExtensionInstalled } from "./extension.js";
 import { inspectProject } from "./inspect.js";
+import { installNeonMcpServer } from "./install_mcp.js";
 import { ensureNeonctl } from "./neonctl.js";
 import { ensureSkillsUpToDate, installAgentSkills } from "./skills.js";
 import type { Editor } from "./types.js";
@@ -223,10 +226,10 @@ async function interactiveInitInner(
 		)}\n`,
 	);
 
-	const detectedAgentId = detectAgent();
-	const detectedEditor = detectedAgentId
-		? agentIdToEditor(detectedAgentId)
-		: null;
+	const detectedAgent = (() => {
+		const raw = detectAgent();
+		return raw ? tryResolveAddMcpAgentId(raw) : undefined;
+	})();
 
 	// -----------------------------------------------------------------------
 	// Step 1: Inspect what's already in place
@@ -330,7 +333,13 @@ async function interactiveInitInner(
 		writeFileSync(neonPath, `${JSON.stringify(existing, null, 2)}\n`);
 	}
 
-	const mcpAlready = inspection.mcpConfigured === true;
+	const mcpHits = inspection.mcpAgents ?? [];
+	const detectedHasMcp = detectedAgent
+		? mcpHits.some((hit) => hit.agent === detectedAgent)
+		: false;
+	const mcpAlready = detectedAgent
+		? detectedHasMcp
+		: inspection.mcpConfigured === true;
 	// If we bootstrapped, skills come from the template
 	const skillsAlready =
 		inspection.skillsInstalled === true || selectedTemplate !== null;
@@ -368,10 +377,10 @@ async function interactiveInitInner(
 		return false;
 	})();
 
-	// Check if extension is installed for the detected editor
 	let extensionAlready = false;
-	if (detectedEditor && usesExtension(detectedEditor)) {
-		extensionAlready = await isExtensionInstalled(detectedEditor);
+	const detectedIdeEditor = extensionEditorForAgent(detectedAgent);
+	if (detectedIdeEditor) {
+		extensionAlready = await isExtensionInstalled(detectedIdeEditor);
 	}
 
 	// If tooling + database are configured, check if there's anything left to do
@@ -463,35 +472,19 @@ async function interactiveInitInner(
 			return;
 		}
 
-		let selectedEditors: Editor[];
-		if (detectedEditor) {
-			selectedEditors = [detectedEditor];
+		let selectedAgents: AgentType[];
+		if (detectedAgent) {
+			selectedAgents = [detectedAgent];
 		} else {
-			const availableEditors = await detectAvailableEditors(homeDir);
-			const editorResponse = await multiselect({
-				message: "Which editor(s) would you like to configure?",
-				options: ALL_CONFIGURABLE_AGENTS.map((agent) => ({
-					value: agent.editor,
-					label: agent.editor,
-					hint: agent.hint,
-				})),
-				initialValues: availableEditors,
-				required: true,
-			});
-			if (isCancel(editorResponse)) {
+			const picked = await pickAgents(needsMcp);
+			if (!picked) {
 				outro("Setup cancelled.");
 				return;
 			}
-			selectedEditors = editorResponse as Editor[];
-			if (selectedEditors.length === 0) {
-				log.warn("No editors selected.");
-				outro("Setup cancelled.");
-				return;
-			}
+			selectedAgents = picked;
 		}
 
-		// Check extension status
-		const vscodeEditors = selectedEditors.filter(usesExtension);
+		let vscodeEditors = extensionEditorsFor(selectedAgents);
 		let extensionAlreadyInstalled = false;
 		if (vscodeEditors.length > 0) {
 			const checks = await Promise.all(
@@ -502,7 +495,7 @@ async function interactiveInitInner(
 				log.step(dim("Neon editor extension already installed ✓"));
 			}
 		}
-		const canInstallExtension =
+		let canInstallExtension =
 			vscodeEditors.length > 0 && !extensionAlreadyInstalled;
 		let doInstallExtension = false;
 
@@ -517,9 +510,11 @@ async function interactiveInitInner(
 
 		let modeResult: string;
 		while (true) {
-			const editorName = selectedEditors.join(", ");
+			const agentNames = selectedAgents
+				.map((id) => getAgentDisplayName(id))
+				.join(", ");
 			const result = await select({
-				message: `Configure ${editorName} for Neon:`,
+				message: `Configure ${agentNames} for Neon:`,
 				options: [
 					{
 						value: "defaults",
@@ -535,7 +530,7 @@ async function interactiveInitInner(
 					},
 					{
 						value: "change_editor",
-						label: "Configure a different editor",
+						label: "Configure a different agent",
 					},
 				],
 				initialValue: "defaults",
@@ -547,26 +542,15 @@ async function interactiveInitInner(
 			}
 
 			if (result === "change_editor") {
-				const availableEditors = await detectAvailableEditors(homeDir);
-				const editorResponse = await multiselect({
-					message: "Which editor(s) would you like to configure?",
-					options: ALL_CONFIGURABLE_AGENTS.map((agent) => ({
-						value: agent.editor,
-						label: agent.editor,
-						hint: agent.hint,
-					})),
-					initialValues: availableEditors,
-					required: true,
-				});
-				if (isCancel(editorResponse)) {
+				const picked = await pickAgents(needsMcp);
+				if (!picked) {
 					outro("Setup cancelled.");
 					return;
 				}
-				selectedEditors = editorResponse as Editor[];
-				if (selectedEditors.length === 0) {
-					outro("Setup cancelled.");
-					return;
-				}
+				selectedAgents = picked;
+				vscodeEditors = extensionEditorsFor(selectedAgents);
+				canInstallExtension =
+					vscodeEditors.length > 0 && !extensionAlreadyInstalled;
 				continue;
 			}
 
@@ -684,50 +668,41 @@ async function interactiveInitInner(
 				break;
 		}
 
-		// Install only what's missing
-		for (const editor of selectedEditors) {
-			if (needsMcp) {
-				const mcpAgentId = getAddMcpAgentId(editor);
-				const mcpArgs = [
-					"-y",
-					"add-mcp",
-					"https://mcp.neon.tech/mcp",
-					"-n",
-					"Neon",
-					"-y",
-					"-a",
-					mcpAgentId,
-				];
-				if (mcpScope === "global") mcpArgs.splice(5, 0, "-g");
-
+		for (const agent of selectedAgents) {
+			const label = getAgentDisplayName(agent);
+			if (needsMcp && !mcpHits.some((hit) => hit.agent === agent)) {
 				const mcpS = spinner();
-				mcpS.start(`Installing Neon MCP server for ${editor}...`);
-				try {
-					await execa("npx", mcpArgs, {
-						stdio: "pipe",
-						timeout: 60000,
-					});
+				mcpS.start(`Installing Neon MCP server for ${label}...`);
+				const installed = installNeonMcpServer({
+					agent,
+					scope: mcpScope === "project" ? "project" : "global",
+					cwd: process.cwd(),
+				});
+				if (installed.ok) {
 					mcpS.stop(
 						dim(
-							`Neon MCP server configured for ${editor} (${mcpScope}) ✓`,
+							`Neon MCP server configured for ${label} (${mcpScope}) ✓`,
 						),
 					);
-				} catch (err) {
-					const msg =
-						err instanceof Error ? err.message : "Unknown error";
-					mcpS.stop(`Failed to configure MCP server for ${editor}`);
-					log.error(msg);
+				} else if (installed.unsupported) {
+					mcpS.stop(`Could not write MCP config for ${label}`);
+					log.warn(installed.error);
+				} else {
+					mcpS.stop(`Failed to configure MCP server for ${label}`);
+					log.error(installed.error);
 				}
 			}
 
-			if (needsSkills) {
-				await installAgentSkills([editor], {
+			if (needsSkills && getSkillsAgentName(agent)) {
+				await installAgentSkills([agent], {
 					scope: skillsScope,
 					preview: options.preview,
 				});
 			}
+		}
 
-			if (doInstallExtension && usesExtension(editor)) {
+		if (doInstallExtension) {
+			for (const editor of vscodeEditors) {
 				const extS = spinner();
 				extS.start(`Installing Neon extension for ${editor}...`);
 				const extOk = await installExtension(editor);
@@ -801,22 +776,41 @@ async function interactiveInitInner(
 	outro(dim("Have feedback? Email us at feedback@neon.tech"));
 }
 
-function agentIdToEditor(agentId: string): Editor | null {
-	switch (agentId) {
-		case "cursor":
-			return "Cursor";
-		case "vscode":
-			return "VS Code";
-		case "claude-code":
-			return "Claude CLI";
-		case "windsurf":
-			// Windsurf not in Editor type yet — fall back to prompt
-			return null;
-		case "codex":
-			return "Codex";
-		case "cline":
-			return "Cline";
-		default:
-			return null;
+function extensionEditorForAgent(agent: AgentType | undefined): Editor | null {
+	if (agent === "cursor") return "Cursor";
+	if (agent === "vscode") return "VS Code";
+	const ide = detectIde();
+	if (ide === "Cursor" || ide === "VS Code") return ide;
+	return null;
+}
+
+function extensionEditorsFor(selected: AgentType[]): Editor[] {
+	const out: Editor[] = [];
+	if (selected.includes("cursor")) out.push("Cursor");
+	if (selected.includes("vscode")) out.push("VS Code");
+	const ide = detectIde();
+	if ((ide === "Cursor" || ide === "VS Code") && !out.includes(ide)) {
+		out.push(ide);
 	}
+	return out;
+}
+
+async function pickAgents(needsMcp: boolean): Promise<AgentType[] | null> {
+	const options = needsMcp ? mcpPickerOptions() : skillsPickerOptions();
+	const installed = await detectInstalledAgents();
+	const response = await multiselect({
+		message: "Which agent(s) would you like to configure?",
+		options,
+		initialValues: installed.filter((id) =>
+			options.some((option) => option.value === id),
+		),
+		required: true,
+	});
+	if (isCancel(response)) return null;
+	const selected = response as AgentType[];
+	if (selected.length === 0) {
+		log.warn("No agents selected.");
+		return null;
+	}
+	return selected;
 }

--- a/packages/cli/src/init/interactive.ts
+++ b/packages/cli/src/init/interactive.ts
@@ -39,7 +39,11 @@ import { installExtension, isExtensionInstalled } from "./extension.js";
 import { inspectProject } from "./inspect.js";
 import { installNeonMcpServer } from "./install_mcp.js";
 import { ensureNeonctl } from "./neonctl.js";
-import { ensureSkillsUpToDate, installAgentSkills } from "./skills.js";
+import {
+	ensureSkillsUpToDate,
+	installAgentSkills,
+	skillsInstalledForAgent,
+} from "./skills.js";
 import type { Editor } from "./types.js";
 
 function wordWrap(text: string, width: number): string {
@@ -337,12 +341,10 @@ async function interactiveInitInner(
 	const detectedHasMcp = detectedAgent
 		? mcpHits.some((hit) => hit.agent === detectedAgent)
 		: false;
-	const mcpAlready = detectedAgent
-		? detectedHasMcp
-		: inspection.mcpConfigured === true;
-	// If we bootstrapped, skills come from the template
+	const mcpAlready = detectedAgent ? detectedHasMcp : false;
 	const skillsAlready =
-		inspection.skillsInstalled === true || selectedTemplate !== null;
+		selectedTemplate !== null ||
+		(detectedAgent ? skillsInstalledForAgent(detectedAgent) : false);
 	const hasNeonConnection = inspection.connectionString === true;
 	const needsMcp = !mcpAlready;
 	const needsSkills = !skillsAlready;
@@ -514,8 +516,12 @@ async function interactiveInitInner(
 				hintParts.push("MCP server (global)");
 			}
 			if (
-				needsSkills &&
-				selectedAgents.some((agent) => getSkillsAgentName(agent))
+				selectedTemplate === null &&
+				selectedAgents.some(
+					(agent) =>
+						getSkillsAgentName(agent) &&
+						!skillsInstalledForAgent(agent),
+				)
 			) {
 				hintParts.push("agent skills (project)");
 			}
@@ -579,7 +585,7 @@ async function interactiveInitInner(
 							value: "global",
 							label: "Global (available in all projects)",
 						},
-						...(selectedAgents.some(agentSupportsProjectMcp)
+						...(selectedAgents.every(agentSupportsProjectMcp)
 							? [
 									{
 										value: "project",
@@ -601,8 +607,12 @@ async function interactiveInitInner(
 			}
 
 			if (
-				needsSkills &&
-				selectedAgents.some((agent) => getSkillsAgentName(agent))
+				selectedTemplate === null &&
+				selectedAgents.some(
+					(agent) =>
+						getSkillsAgentName(agent) &&
+						!skillsInstalledForAgent(agent),
+				)
 			) {
 				const skillsScopeResult = await select({
 					message: "Where should Neon agent skills be installed?",
@@ -714,7 +724,11 @@ async function interactiveInitInner(
 				}
 			}
 
-			if (needsSkills && getSkillsAgentName(agent)) {
+			if (
+				selectedTemplate === null &&
+				getSkillsAgentName(agent) &&
+				!skillsInstalledForAgent(agent)
+			) {
 				await installAgentSkills([agent], {
 					scope: skillsScope,
 					preview: options.preview,

--- a/packages/cli/src/init/interactive.ts
+++ b/packages/cli/src/init/interactive.ts
@@ -690,7 +690,11 @@ async function interactiveInitInner(
 				nctlS.stop(dim(`Updated Neon CLI to v${nctlResult.version} ✓`));
 				break;
 			case "failed":
-				nctlS.stop("Failed to install Neon CLI");
+				nctlS.stop(
+					nctlResult.action === "updating"
+						? "Failed to update Neon CLI"
+						: "Failed to install Neon CLI",
+				);
 				log.warn(
 					nctlResult.error ??
 						"The Neon CLI could not be installed automatically.",

--- a/packages/cli/src/init/interactive.ts
+++ b/packages/cli/src/init/interactive.ts
@@ -347,7 +347,11 @@ async function interactiveInitInner(
 	const skillsAlready =
 		selectedTemplate !== null ||
 		(detectedAgent
-			? skillsInstalledForAgent(detectedAgent)
+			? skillsInstalledForAgent(
+					detectedAgent,
+					process.cwd(),
+					options.preview,
+				)
 			: inspection.skillsInstalled === true);
 	const hasNeonConnection = inspection.connectionString === true;
 	const needsMcp = !mcpAlready;
@@ -524,7 +528,11 @@ async function interactiveInitInner(
 				selectedAgents.some(
 					(agent) =>
 						getSkillsAgentName(agent) &&
-						!skillsInstalledForAgent(agent),
+						!skillsInstalledForAgent(
+							agent,
+							process.cwd(),
+							options.preview,
+						),
 				)
 			) {
 				hintParts.push("agent skills (project)");
@@ -615,7 +623,11 @@ async function interactiveInitInner(
 				selectedAgents.some(
 					(agent) =>
 						getSkillsAgentName(agent) &&
-						!skillsInstalledForAgent(agent),
+						!skillsInstalledForAgent(
+							agent,
+							process.cwd(),
+							options.preview,
+						),
 				)
 			) {
 				const skillsScopeResult = await select({
@@ -741,7 +753,7 @@ async function interactiveInitInner(
 			if (
 				selectedTemplate === null &&
 				getSkillsAgentName(agent) &&
-				!skillsInstalledForAgent(agent)
+				!skillsInstalledForAgent(agent, process.cwd(), options.preview)
 			) {
 				await installAgentSkills([agent], {
 					scope: skillsScope,

--- a/packages/cli/src/init/interactive.ts
+++ b/packages/cli/src/init/interactive.ts
@@ -19,11 +19,11 @@ import which from "which";
 import { bold, dim, gray, italic } from "yoctocolors";
 import {
 	type AgentType,
+	agentSupportsProjectMcp,
 	detectInstalledAgents,
 	getAgentDisplayName,
 	getSkillsAgentName,
 	mcpPickerOptions,
-	skillsPickerOptions,
 	tryResolveAddMcpAgentId,
 } from "./agents.js";
 import { ensureNeonctlAuth, isAuthenticated } from "./auth.js";
@@ -344,7 +344,7 @@ async function interactiveInitInner(
 	const skillsAlready =
 		inspection.skillsInstalled === true || selectedTemplate !== null;
 	const hasNeonConnection = inspection.connectionString === true;
-	let needsMcp = !mcpAlready;
+	const needsMcp = !mcpAlready;
 	const needsSkills = !skillsAlready;
 	const needsInstall = needsMcp || needsSkills;
 
@@ -476,7 +476,7 @@ async function interactiveInitInner(
 		if (detectedAgent) {
 			selectedAgents = [detectedAgent];
 		} else {
-			const picked = await pickAgents(needsMcp);
+			const picked = await pickAgents();
 			if (!picked) {
 				outro("Setup cancelled.");
 				return;
@@ -499,17 +499,26 @@ async function interactiveInitInner(
 			vscodeEditors.length > 0 && !extensionAlreadyInstalled;
 		let doInstallExtension = false;
 
-		// Build hint showing only what needs installing
-		const hintParts: string[] = [];
-		if (needsMcp) hintParts.push("MCP server (global)");
-		if (needsSkills) hintParts.push("agent skills (project)");
-
 		// Installation preferences
 		let mcpScope: "global" | "project" | "none" = "global";
 		let skillsScope: "global" | "project" = "project";
 
 		let modeResult: string;
 		while (true) {
+			const hintParts: string[] = [];
+			if (
+				selectedAgents.some(
+					(agent) => !mcpHits.some((hit) => hit.agent === agent),
+				)
+			) {
+				hintParts.push("MCP server (global)");
+			}
+			if (
+				needsSkills &&
+				selectedAgents.some((agent) => getSkillsAgentName(agent))
+			) {
+				hintParts.push("agent skills (project)");
+			}
 			const agentNames = selectedAgents
 				.map((id) => getAgentDisplayName(id))
 				.join(", ");
@@ -542,7 +551,7 @@ async function interactiveInitInner(
 			}
 
 			if (result === "change_editor") {
-				const picked = await pickAgents(needsMcp);
+				const picked = await pickAgents();
 				if (!picked) {
 					outro("Setup cancelled.");
 					return;
@@ -559,7 +568,10 @@ async function interactiveInitInner(
 		}
 
 		if (modeResult === "customize") {
-			if (needsMcp) {
+			const selectedNeedMcp = selectedAgents.some(
+				(agent) => !mcpHits.some((hit) => hit.agent === agent),
+			);
+			if (selectedNeedMcp) {
 				const scopeResult = await select({
 					message: "Where should the Neon MCP server be configured?",
 					options: [
@@ -567,10 +579,14 @@ async function interactiveInitInner(
 							value: "global",
 							label: "Global (available in all projects)",
 						},
-						{
-							value: "project",
-							label: "Project-level (this project only)",
-						},
+						...(selectedAgents.some(agentSupportsProjectMcp)
+							? [
+									{
+										value: "project",
+										label: "Project-level (this project only)",
+									},
+								]
+							: []),
 						{
 							value: "none",
 							label: "Skip — do not install the MCP server",
@@ -582,10 +598,12 @@ async function interactiveInitInner(
 					return;
 				}
 				mcpScope = scopeResult as "global" | "project" | "none";
-				if (mcpScope === "none") needsMcp = false;
 			}
 
-			if (needsSkills) {
+			if (
+				needsSkills &&
+				selectedAgents.some((agent) => getSkillsAgentName(agent))
+			) {
 				const skillsScopeResult = await select({
 					message: "Where should Neon agent skills be installed?",
 					options: [
@@ -670,7 +688,10 @@ async function interactiveInitInner(
 
 		for (const agent of selectedAgents) {
 			const label = getAgentDisplayName(agent);
-			if (needsMcp && !mcpHits.some((hit) => hit.agent === agent)) {
+			if (
+				mcpScope !== "none" &&
+				!mcpHits.some((hit) => hit.agent === agent)
+			) {
 				const mcpS = spinner();
 				mcpS.start(`Installing Neon MCP server for ${label}...`);
 				const installed = installNeonMcpServer({
@@ -795,8 +816,8 @@ function extensionEditorsFor(selected: AgentType[]): Editor[] {
 	return out;
 }
 
-async function pickAgents(needsMcp: boolean): Promise<AgentType[] | null> {
-	const options = needsMcp ? mcpPickerOptions() : skillsPickerOptions();
+async function pickAgents(): Promise<AgentType[] | null> {
+	const options = mcpPickerOptions();
 	const installed = await detectInstalledAgents();
 	const response = await multiselect({
 		message: "Which agent(s) would you like to configure?",

--- a/packages/cli/src/init/interactive.ts
+++ b/packages/cli/src/init/interactive.ts
@@ -668,7 +668,13 @@ async function interactiveInitInner(
 		// Ensure the Neon CLI is installed and up to date
 		const nctlS = spinner();
 		nctlS.start("Checking Neon CLI...");
-		const nctlResult = await ensureNeonctl();
+		const nctlResult = await ensureNeonctl((phase) => {
+			nctlS.message(
+				phase === "installing"
+					? "Installing Neon CLI..."
+					: "Updating Neon CLI...",
+			);
+		});
 		switch (nctlResult.status) {
 			case "already_current":
 				nctlS.stop(

--- a/packages/cli/src/init/interactive.ts
+++ b/packages/cli/src/init/interactive.ts
@@ -341,10 +341,14 @@ async function interactiveInitInner(
 	const detectedHasMcp = detectedAgent
 		? mcpHits.some((hit) => hit.agent === detectedAgent)
 		: false;
-	const mcpAlready = detectedAgent ? detectedHasMcp : false;
+	const mcpAlready = detectedAgent
+		? detectedHasMcp
+		: inspection.mcpConfigured === true;
 	const skillsAlready =
 		selectedTemplate !== null ||
-		(detectedAgent ? skillsInstalledForAgent(detectedAgent) : false);
+		(detectedAgent
+			? skillsInstalledForAgent(detectedAgent)
+			: inspection.skillsInstalled === true);
 	const hasNeonConnection = inspection.connectionString === true;
 	const needsMcp = !mcpAlready;
 	const needsSkills = !skillsAlready;

--- a/packages/cli/src/init/neonctl.ts
+++ b/packages/cli/src/init/neonctl.ts
@@ -180,7 +180,7 @@ export async function ensureNeonctl(
 			status: "failed",
 			action,
 			error:
-				"Could not install the Neon CLI: this machine has no package manager that can perform a global install. " +
+				`Could not ${action === "updating" ? "update" : "install"} the Neon CLI: this machine has no package manager that can perform a global install. ` +
 				"npm, pnpm and bun are not on PATH (yarn Berry has no global install). " +
 				"Install npm, pnpm or bun, then run this again.",
 		};

--- a/packages/cli/src/init/neonctl.ts
+++ b/packages/cli/src/init/neonctl.ts
@@ -112,6 +112,7 @@ export type EnsureNeonctlResult = {
 	status: "already_current" | "installed" | "updated" | "failed";
 	version?: string;
 	error?: string;
+	action?: "installing" | "updating";
 };
 
 /**
@@ -171,11 +172,13 @@ export async function ensureNeonctl(
 
 	const pm = resolveInvokingPackageManager();
 	const install = globalInstallCommand(pm, "neon");
+	const action = check.installed ? "updating" : "installing";
 	if (!install) {
 		// The next step is installing a package manager, not falling back to
 		// npx: npx ships with npm, so it is missing in exactly this case.
 		return {
 			status: "failed",
+			action,
 			error:
 				"Could not install the Neon CLI: this machine has no package manager that can perform a global install. " +
 				"npm, pnpm and bun are not on PATH (yarn Berry has no global install). " +
@@ -183,7 +186,7 @@ export async function ensureNeonctl(
 		};
 	}
 	const { command, args } = install;
-	onProgress?.(check.installed ? "updating" : "installing");
+	onProgress?.(action);
 
 	try {
 		await execa(command, args, { stdio: "pipe", timeout: 60000 });
@@ -197,6 +200,7 @@ export async function ensureNeonctl(
 	} catch (err) {
 		return {
 			status: "failed",
+			action,
 			error: err instanceof Error ? err.message : "Unknown error",
 		};
 	}

--- a/packages/cli/src/init/neonctl.ts
+++ b/packages/cli/src/init/neonctl.ts
@@ -148,7 +148,9 @@ function isLocalDevSymlink(): boolean {
  * Ensures neonctl is globally installed and up to date.
  * Uses the same package manager that invoked the init command.
  */
-export async function ensureNeonctl(): Promise<EnsureNeonctlResult> {
+export async function ensureNeonctl(
+	onProgress?: (phase: "installing" | "updating") => void,
+): Promise<EnsureNeonctlResult> {
 	// Skip install for local dev symlinks to avoid permission errors
 	if (isLocalDevSymlink()) {
 		const version = await getNeonCliVersion();
@@ -181,6 +183,7 @@ export async function ensureNeonctl(): Promise<EnsureNeonctlResult> {
 		};
 	}
 	const { command, args } = install;
+	onProgress?.(check.installed ? "updating" : "installing");
 
 	try {
 		await execa(command, args, { stdio: "pipe", timeout: 60000 });

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -93,6 +93,8 @@ function mockToolingInstalled(extraFiles: Record<string, string> = {}) {
 		"package.json": APP_PKG_JSON,
 		".cursor/mcp.json":
 			'{"mcpServers":{"Neon":{"url":"https://mcp.neon.tech/mcp"}}}',
+		".mcp.json":
+			'{"mcpServers":{"Neon":{"url":"https://mcp.neon.tech/mcp"}}}',
 		// skills directory exists and contains neon-postgres skill with SKILL.md
 		".cursor/skills/neon-postgres/SKILL.md": "",
 		...extraFiles,
@@ -259,6 +261,29 @@ describe("v2 orchestrator", () => {
 		const result = await orchestrate({ agent: "claude" });
 
 		expect(result.phase).toBe("neon_auth");
+	});
+
+	test("enters setup when the requested agent has no MCP even if another agent does", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockToolingInstalled();
+
+		const result = await orchestrate({ agent: "grok-build" });
+
+		expect(result.phase).toBe("setup");
+		expect(result.status).toBe("pending");
+	});
+
+	test("skips skills for grok-build once that agent has MCP", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockAppExists({
+			".grok/config.toml":
+				'[mcp_servers.Neon]\nurl = "https://mcp.neon.tech/mcp"\n',
+		});
+
+		const result = await orchestrate({ agent: "grok-build" });
+
+		expect(result.phase).toBe("setup");
+		expect(result.status).toBe("getting_started");
 	});
 
 	test("enters setup even with DATABASE_URL if MCP not configured", async () => {

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -95,8 +95,9 @@ function mockToolingInstalled(extraFiles: Record<string, string> = {}) {
 			'{"mcpServers":{"Neon":{"url":"https://mcp.neon.tech/mcp"}}}',
 		".mcp.json":
 			'{"mcpServers":{"Neon":{"url":"https://mcp.neon.tech/mcp"}}}',
-		// skills directory exists and contains neon-postgres skill with SKILL.md
+		".cursor/skills/neon/SKILL.md": "",
 		".cursor/skills/neon-postgres/SKILL.md": "",
+		".claude/skills/neon/SKILL.md": "",
 		".claude/skills/neon-postgres/SKILL.md": "",
 		...extraFiles,
 	};
@@ -260,6 +261,7 @@ describe("v2 orchestrator", () => {
 		mockAppExists({
 			".grok/config.toml":
 				'[mcp_servers.Neon]\nurl = "https://mcp.neon.tech/mcp"\n',
+			".grok/skills/neon/SKILL.md": "",
 			".grok/skills/neon-postgres/SKILL.md": "",
 			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb\nNEON_AUTH_TOKEN=abc",
 			".neon": '{"projectId":"proj-123"}',

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -97,6 +97,7 @@ function mockToolingInstalled(extraFiles: Record<string, string> = {}) {
 			'{"mcpServers":{"Neon":{"url":"https://mcp.neon.tech/mcp"}}}',
 		// skills directory exists and contains neon-postgres skill with SKILL.md
 		".cursor/skills/neon-postgres/SKILL.md": "",
+		".claude/skills/neon-postgres/SKILL.md": "",
 		...extraFiles,
 	};
 	mockFs(files);
@@ -283,6 +284,20 @@ describe("v2 orchestrator", () => {
 		const result = await orchestrate({ agent: "claude" });
 
 		expect(result.phase).toBe("neon_auth");
+	});
+
+	test("enters setup when the requested agent has no skills even if another agent does", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockAppExists({
+			".mcp.json":
+				'{"mcpServers":{"Neon":{"url":"https://mcp.neon.tech/mcp"}}}',
+			".cursor/skills/neon-postgres/SKILL.md": "",
+		});
+
+		const result = await orchestrate({ agent: "claude" });
+
+		expect(result.phase).toBe("setup");
+		expect(result.status).toBe("pending");
 	});
 
 	test("enters setup when the requested agent has no MCP even if another agent does", async () => {

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -238,11 +238,12 @@ describe("v2 orchestrator", () => {
 		}
 	});
 
-	test("complete message for grok-build does not claim skills", async () => {
+	test("complete message for grok-build includes skills", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 		mockAppExists({
 			".grok/config.toml":
 				'[mcp_servers.Neon]\nurl = "https://mcp.neon.tech/mcp"\n',
+			".grok/skills/neon-postgres/SKILL.md": "",
 			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb\nNEON_AUTH_TOKEN=abc",
 			".neon": '{"projectId":"proj-123"}',
 		});
@@ -255,7 +256,7 @@ describe("v2 orchestrator", () => {
 		expect(result.nextAction.type).toBe("complete");
 		if (result.nextAction.type === "complete") {
 			expect(result.nextAction.message).toContain("MCP server");
-			expect(result.nextAction.message).not.toContain("skills");
+			expect(result.nextAction.message).toContain("skills");
 		}
 	});
 
@@ -311,7 +312,7 @@ describe("v2 orchestrator", () => {
 		expect(result.status).toBe("pending");
 	});
 
-	test("skips skills for grok-build once that agent has MCP", async () => {
+	test("enters setup when grok-build has MCP but no skills", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 		mockAppExists({
 			".grok/config.toml":
@@ -321,7 +322,8 @@ describe("v2 orchestrator", () => {
 		const result = await orchestrate({ agent: "grok-build" });
 
 		expect(result.phase).toBe("setup");
-		expect(result.status).toBe("getting_started");
+		expect(result.status).toBe("pending");
+		expect(result.skillsInstalled).toBe(false);
 	});
 
 	test("enters setup even with DATABASE_URL if MCP not configured", async () => {

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -233,6 +233,28 @@ describe("v2 orchestrator", () => {
 		expect(result.nextAction.type).toBe("complete");
 		if (result.nextAction.type === "complete") {
 			expect(result.nextAction.message).toContain("complete");
+			expect(result.nextAction.message).toContain("skills");
+		}
+	});
+
+	test("complete message for grok-build does not claim skills", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockAppExists({
+			".grok/config.toml":
+				'[mcp_servers.Neon]\nurl = "https://mcp.neon.tech/mcp"\n',
+			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb\nNEON_AUTH_TOKEN=abc",
+			".neon": '{"projectId":"proj-123"}',
+		});
+
+		const result = await orchestrate({
+			agent: "grok-build",
+			skipMigrations: true,
+		});
+
+		expect(result.nextAction.type).toBe("complete");
+		if (result.nextAction.type === "complete") {
+			expect(result.nextAction.message).toContain("MCP server");
+			expect(result.nextAction.message).not.toContain("skills");
 		}
 	});
 

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -298,6 +298,7 @@ describe("v2 orchestrator", () => {
 
 		expect(result.phase).toBe("setup");
 		expect(result.status).toBe("pending");
+		expect(result.skillsInstalled).toBe(false);
 	});
 
 	test("enters setup when the requested agent has no MCP even if another agent does", async () => {

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -206,6 +206,32 @@ describe("v2 orchestrator", () => {
 		expect(result.phase).toBe("migrations");
 	});
 
+	test("enters setup on --preview when another agent has preview skills but this one does not", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockAppExists({
+			".grok/config.toml":
+				'[mcp_servers.Neon]\nurl = "https://mcp.neon.tech/mcp"\n',
+			".grok/skills/neon/SKILL.md": "",
+			".grok/skills/neon-postgres/SKILL.md": "",
+			".cursor/skills/neon/SKILL.md": "",
+			".cursor/skills/neon-postgres/SKILL.md": "",
+			".cursor/skills/neon-object-storage/SKILL.md": "",
+			".cursor/skills/neon-functions/SKILL.md": "",
+			".cursor/skills/neon-ai-gateway/SKILL.md": "",
+			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb",
+			".neon": '{"projectId":"proj-123"}',
+		});
+
+		const result = await orchestrate({
+			agent: "grok-build",
+			preview: true,
+		});
+
+		expect(result.phase).toBe("setup");
+		expect(result.status).toBe("pending");
+		expect(result.skillsInstalled).toBe(false);
+	});
+
 	test("enters setup on --preview when base skills exist but preview skills do not", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 		mockToolingInstalled({

--- a/packages/cli/src/init/orchestrate.test.ts
+++ b/packages/cli/src/init/orchestrate.test.ts
@@ -205,6 +205,23 @@ describe("v2 orchestrator", () => {
 		expect(result.phase).toBe("migrations");
 	});
 
+	test("enters setup on --preview when base skills exist but preview skills do not", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockToolingInstalled({
+			".cursor/skills/neon/SKILL.md": "",
+			".claude/skills/neon/SKILL.md": "",
+			".env": "DATABASE_URL=postgres://user:pass@ep-foo.us-east-2.aws.neon.tech/neondb",
+			".neon": '{"projectId":"proj-123"}',
+		});
+
+		const result = await orchestrate({ agent: "cursor", preview: true });
+
+		expect(result.phase).toBe("setup");
+		expect(result.status).toBe("pending");
+		expect(result.skillsInstalled).toBe(false);
+		expect(result.skillsScope).toBe("project-partial");
+	});
+
 	test("skips neon_auth when features are empty", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 		mockToolingInstalled({

--- a/packages/cli/src/init/orchestrate.ts
+++ b/packages/cli/src/init/orchestrate.ts
@@ -122,7 +122,9 @@ export async function orchestrate(
 				? mcpForThisAgent
 				: (inspection.mcpConfigured ?? null),
 			mcpScope: inspection.mcpScope || undefined,
-			skillsInstalled: skillsInstalled ?? null,
+			skillsInstalled: requestedAgent
+				? skillsReady
+				: (skillsInstalled ?? null),
 			skillsScope: inspection.skillsScope || undefined,
 		});
 	}

--- a/packages/cli/src/init/orchestrate.ts
+++ b/packages/cli/src/init/orchestrate.ts
@@ -104,7 +104,8 @@ export async function orchestrate(
 		requestedAgent && !supportsSkills(requestedAgent)
 			? true
 			: requestedAgent
-				? skillsInstalledForAgent(requestedAgent, cwd)
+				? skillsInstalledForAgent(requestedAgent, cwd) &&
+					(!options.preview || skillsInstalled === true)
 				: skillsInstalled === true;
 	const toolingInstalled = mcpForThisAgent && skillsReady;
 	const hasNeonConnection = inspection.connectionString === true;

--- a/packages/cli/src/init/orchestrate.ts
+++ b/packages/cli/src/init/orchestrate.ts
@@ -9,7 +9,11 @@ import { handleMigrationsPhase } from "./phases/migrations.js";
 import { handleNeonAuthPhase } from "./phases/neon_auth.js";
 import { handleSetupPhase } from "./phases/setup.js";
 import { resolveNeonContext } from "./resolve_context.js";
-import { skillsInstalledForAgent } from "./skills.js";
+import {
+	getSkillList,
+	missingSkillsForAgent,
+	skillsInstalledForAgent,
+} from "./skills.js";
 import type { PhaseResponse } from "./types.js";
 
 export type OrchestratorOptions = {
@@ -60,10 +64,31 @@ export async function orchestrate(
 	// Only detect empty projects when --preview is enabled
 	const hasApp = options.preview ? inspection.hasApp === true : true;
 
+	const requestedAgent = options.agent
+		? tryResolveAddMcpAgentId(options.agent)
+		: undefined;
+
 	// When preview is enabled, check that all preview skills are installed too
 	let skillsInstalled = inspection.skillsInstalled;
-	if (options.preview && skillsInstalled && inspection.skillsScope) {
-		const { getSkillList } = await import("./skills.js");
+	if (options.preview && requestedAgent && supportsSkills(requestedAgent)) {
+		const missing = missingSkillsForAgent(requestedAgent, {
+			cwd,
+			preview: true,
+		});
+		const required = getSkillList(true);
+		if (missing.length > 0) {
+			skillsInstalled = false;
+			if (missing.length < required.length) {
+				const baseScope =
+					inspection.skillsScope &&
+					!String(inspection.skillsScope).includes("partial")
+						? inspection.skillsScope
+						: "project";
+				inspection.skillsScope =
+					`${baseScope}-partial` as typeof inspection.skillsScope;
+			}
+		}
+	} else if (options.preview && skillsInstalled && inspection.skillsScope) {
 		const previewSkills = getSkillList(true);
 		const { existsSync: exists } = await import("node:fs");
 		const { resolve: resolvePath } = await import("node:path");
@@ -92,9 +117,6 @@ export async function orchestrate(
 		}
 	}
 
-	const requestedAgent = options.agent
-		? tryResolveAddMcpAgentId(options.agent)
-		: undefined;
 	const mcpForThisAgent = requestedAgent
 		? (inspection.mcpAgents ?? []).some(
 				(hit) => hit.agent === requestedAgent,
@@ -104,8 +126,7 @@ export async function orchestrate(
 		requestedAgent && !supportsSkills(requestedAgent)
 			? true
 			: requestedAgent
-				? skillsInstalledForAgent(requestedAgent, cwd) &&
-					(!options.preview || skillsInstalled === true)
+				? skillsInstalledForAgent(requestedAgent, cwd, options.preview)
 				: skillsInstalled === true;
 	const toolingInstalled = mcpForThisAgent && skillsReady;
 	const hasNeonConnection = inspection.connectionString === true;

--- a/packages/cli/src/init/orchestrate.ts
+++ b/packages/cli/src/init/orchestrate.ts
@@ -195,7 +195,9 @@ export async function orchestrate(
 		nextAction: {
 			type: "complete",
 			message:
-				"Neon setup is complete. Your database is configured and your agent has the Neon MCP server and skills available.",
+				requestedAgent && !supportsSkills(requestedAgent)
+					? "Neon setup is complete. Your database is configured and your agent has the Neon MCP server available."
+					: "Neon setup is complete. Your database is configured and your agent has the Neon MCP server and skills available.",
 		},
 	};
 }

--- a/packages/cli/src/init/orchestrate.ts
+++ b/packages/cli/src/init/orchestrate.ts
@@ -9,6 +9,7 @@ import { handleMigrationsPhase } from "./phases/migrations.js";
 import { handleNeonAuthPhase } from "./phases/neon_auth.js";
 import { handleSetupPhase } from "./phases/setup.js";
 import { resolveNeonContext } from "./resolve_context.js";
+import { skillsInstalledForAgent } from "./skills.js";
 import type { PhaseResponse } from "./types.js";
 
 export type OrchestratorOptions = {
@@ -102,7 +103,9 @@ export async function orchestrate(
 	const skillsReady =
 		requestedAgent && !supportsSkills(requestedAgent)
 			? true
-			: skillsInstalled === true;
+			: requestedAgent
+				? skillsInstalledForAgent(requestedAgent, cwd)
+				: skillsInstalled === true;
 	const toolingInstalled = mcpForThisAgent && skillsReady;
 	const hasNeonConnection = inspection.connectionString === true;
 

--- a/packages/cli/src/init/orchestrate.ts
+++ b/packages/cli/src/init/orchestrate.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { supportsSkills, tryResolveAddMcpAgentId } from "./agents.js";
 import { isAuthenticated } from "./auth.js";
 import { inspectProject } from "./inspect.js";
 import { handleAuthPhase } from "./phases/auth.js";
@@ -90,7 +91,19 @@ export async function orchestrate(
 		}
 	}
 
-	const toolingInstalled = inspection.mcpConfigured && skillsInstalled;
+	const requestedAgent = options.agent
+		? tryResolveAddMcpAgentId(options.agent)
+		: undefined;
+	const mcpForThisAgent = requestedAgent
+		? (inspection.mcpAgents ?? []).some(
+				(hit) => hit.agent === requestedAgent,
+			)
+		: inspection.mcpConfigured === true;
+	const skillsReady =
+		requestedAgent && !supportsSkills(requestedAgent)
+			? true
+			: skillsInstalled === true;
+	const toolingInstalled = mcpForThisAgent && skillsReady;
 	const hasNeonConnection = inspection.connectionString === true;
 
 	// Phase 3a: No app or tooling not installed → setup flow
@@ -102,7 +115,9 @@ export async function orchestrate(
 			agent: options.agent,
 			preview: options.preview,
 			hasApp,
-			mcpConfigured: inspection.mcpConfigured ?? null,
+			mcpConfigured: requestedAgent
+				? mcpForThisAgent
+				: (inspection.mcpConfigured ?? null),
 			mcpScope: inspection.mcpScope || undefined,
 			skillsInstalled: skillsInstalled ?? null,
 			skillsScope: inspection.skillsScope || undefined,

--- a/packages/cli/src/init/phases/mcp.test.ts
+++ b/packages/cli/src/init/phases/mcp.test.ts
@@ -108,11 +108,27 @@ describe("handleMcpPhase", () => {
 		}
 	});
 
-	test("--install skips skills when the agent has no skills target", async () => {
+	test("--install chains grok-build to skills", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 
 		const result = await handleMcpPhase({
 			agent: "grok-build",
+			install: true,
+		});
+
+		expect(result.status).toBe("installed");
+		expect(result.nextAction.type).toBe("run_neon_init");
+		if (result.nextAction.type === "run_neon_init") {
+			expect(result.nextAction.args).toContain("skills");
+			expect(result.nextAction.args).toContain("--install");
+		}
+	});
+
+	test("--install skips skills when the agent has no skills target", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+
+		const result = await handleMcpPhase({
+			agent: "mcporter",
 			install: true,
 		});
 

--- a/packages/cli/src/init/phases/mcp.test.ts
+++ b/packages/cli/src/init/phases/mcp.test.ts
@@ -54,6 +54,22 @@ describe("handleMcpPhase", () => {
 		}
 	});
 
+	test("omits project scope when the agent has no project MCP path", async () => {
+		const result = await handleMcpPhase({
+			agent: "windsurf",
+			mcpConfigured: false,
+		});
+
+		expect(result.nextAction.type).toBe("ask_user");
+		if (result.nextAction.type === "ask_user") {
+			const values = result.nextAction.options.map((option) =>
+				typeof option === "string" ? option : option.value,
+			);
+			expect(values).toContain("defaults");
+			expect(values).not.toContain("project_scope");
+		}
+	});
+
 	test("asks user to install when mcp-configured is false", async () => {
 		const result = await handleMcpPhase({
 			agent: "claude",

--- a/packages/cli/src/init/phases/mcp.test.ts
+++ b/packages/cli/src/init/phases/mcp.test.ts
@@ -4,6 +4,14 @@ vi.mock("../auth.js", () => ({
 	isAuthenticated: vi.fn(),
 }));
 
+const mockInstallMcp = vi.fn().mockReturnValue({
+	ok: true,
+	path: "/tmp/mcp.json",
+});
+vi.mock("../install_mcp.js", () => ({
+	installNeonMcpServer: (...args: unknown[]) => mockInstallMcp(...args),
+}));
+
 import { isAuthenticated } from "../auth.js";
 import { handleMcpPhase } from "./mcp.js";
 
@@ -12,6 +20,10 @@ const mockIsAuthenticated = vi.mocked(isAuthenticated);
 describe("handleMcpPhase", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		mockInstallMcp.mockReturnValue({
+			ok: true,
+			path: "/tmp/mcp.json",
+		});
 	});
 
 	test("asks agent to detect MCP by default", async () => {
@@ -58,7 +70,7 @@ describe("handleMcpPhase", () => {
 		}
 	});
 
-	test("--install returns run_command when authenticated", async () => {
+	test("--install writes MCP in-process and chains to skills", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 
 		const result = await handleMcpPhase({
@@ -66,14 +78,32 @@ describe("handleMcpPhase", () => {
 			install: true,
 		});
 
-		expect(result.status).toBe("installing");
-		expect(result.nextAction.type).toBe("run_command");
-		if (result.nextAction.type === "run_command") {
-			expect(result.nextAction.command).toContain("add-mcp");
-			expect(result.nextAction.command).toContain("mcp.neon.tech");
-			// After install, should chain to skills, not loop back to MCP
-			expect(result.nextAction.onSuccess.args).toContain("skills");
-			expect(result.nextAction.onSuccess.args).toContain("--install");
+		expect(result.status).toBe("installed");
+		expect(mockInstallMcp).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agent: "claude-code",
+				scope: "global",
+			}),
+		);
+		expect(result.nextAction.type).toBe("run_neon_init");
+		if (result.nextAction.type === "run_neon_init") {
+			expect(result.nextAction.args).toContain("skills");
+			expect(result.nextAction.args).toContain("--install");
+		}
+	});
+
+	test("--install skips skills when the agent has no skills target", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+
+		const result = await handleMcpPhase({
+			agent: "grok-build",
+			install: true,
+		});
+
+		expect(result.status).toBe("installed");
+		expect(result.nextAction.type).toBe("run_neon_init");
+		if (result.nextAction.type === "run_neon_init") {
+			expect(result.nextAction.args).not.toContain("skills");
 		}
 	});
 

--- a/packages/cli/src/init/phases/mcp.test.ts
+++ b/packages/cli/src/init/phases/mcp.test.ts
@@ -114,6 +114,27 @@ describe("handleMcpPhase", () => {
 		}
 	});
 
+	test("--install with project scope does not offer global when HTTP is also unsupported", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockInstallMcp.mockReturnValue({
+			ok: false,
+			unsupported: true,
+			error: "Claude Desktop only supports local (stdio) servers via its config file. Add remote servers through Settings → Connectors in the app instead.",
+		});
+
+		const result = await handleMcpPhase({
+			agent: "claude-desktop",
+			install: true,
+			scope: "project",
+		});
+
+		expect(result.status).toBe("unsupported");
+		expect(result.nextAction.type).toBe("run_neon_init");
+		if (result.nextAction.type === "run_neon_init") {
+			expect(result.nextAction.args).toContain("skills");
+		}
+	});
+
 	test("--install writes MCP in-process and chains to skills", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 

--- a/packages/cli/src/init/phases/mcp.test.ts
+++ b/packages/cli/src/init/phases/mcp.test.ts
@@ -86,6 +86,34 @@ describe("handleMcpPhase", () => {
 		}
 	});
 
+	test("--install with project scope offers global when the agent cannot write it", async () => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockInstallMcp.mockReturnValue({
+			ok: false,
+			unsupported: true,
+			error: "Windsurf does not support project-level MCP config.",
+		});
+
+		const result = await handleMcpPhase({
+			agent: "windsurf",
+			install: true,
+			scope: "project",
+		});
+
+		expect(result.status).toBe("unsupported");
+		expect(result.nextAction.type).toBe("ask_user");
+		if (result.nextAction.type === "ask_user") {
+			expect(result.nextAction.question).toContain("globally");
+			expect(result.nextAction.responseMapping).toHaveProperty("global");
+			expect(result.nextAction.responseMapping).toHaveProperty("skip");
+			const global = result.nextAction.responseMapping.global;
+			if ("args" in global) {
+				expect(global.args).toContain("--install");
+				expect(global.args).not.toContain("project");
+			}
+		}
+	});
+
 	test("--install writes MCP in-process and chains to skills", async () => {
 		mockIsAuthenticated.mockResolvedValue(true);
 

--- a/packages/cli/src/init/phases/mcp.ts
+++ b/packages/cli/src/init/phases/mcp.ts
@@ -1,15 +1,28 @@
-import { resolveAddMcpAgentId } from "../agents.js";
+import { getSkillsAgentName, resolveAddMcpAgentId } from "../agents.js";
 import { isAuthenticated } from "../auth.js";
-import type { Editor, PhaseResponse } from "../types.js";
+import { installNeonMcpServer } from "../install_mcp.js";
+import type { PhaseResponse } from "../types.js";
 
 export type McpPhaseOptions = {
 	agent?: string;
-	editor?: Editor;
+	editor?: string;
 	status?: boolean;
 	install?: boolean;
 	scope?: "global" | "project";
 	mcpConfigured?: boolean | null;
 };
+
+function skillsFollowUp(agent: string | undefined): string[] {
+	if (agent && !getSkillsAgentName(agent)) {
+		return agent ? ["--agent", agent, "--json"] : ["--json"];
+	}
+	return [
+		"skills",
+		"--json",
+		...(agent ? ["--agent", agent] : []),
+		"--install",
+	];
+}
 
 export async function handleMcpPhase(
 	options: McpPhaseOptions,
@@ -18,7 +31,6 @@ export async function handleMcpPhase(
 		? ["--agent", options.agent, "--json"]
 		: ["--json"];
 
-	// --status: just report what we know
 	if (options.status) {
 		return {
 			phase: "tooling",
@@ -49,7 +61,6 @@ export async function handleMcpPhase(
 		};
 	}
 
-	// --install: proceed with installation
 	if (options.install) {
 		const authed = await isAuthenticated();
 		if (!authed) {
@@ -63,99 +74,97 @@ export async function handleMcpPhase(
 			};
 		}
 
-		// Build the add-mcp command
 		const scope = options.scope ?? "global";
 		const mcpAgentId = resolveAddMcpAgentId(options.agent ?? "claude-code");
+		const installed = installNeonMcpServer({
+			agent: mcpAgentId,
+			scope,
+			cwd: process.cwd(),
+		});
+
+		if (!installed.ok) {
+			if (installed.unsupported) {
+				return {
+					phase: "tooling",
+					status: "unsupported",
+					error: installed.error,
+					nextAction: {
+						type: "run_neon_init",
+						args: skillsFollowUp(options.agent),
+					},
+				};
+			}
+			return {
+				phase: "tooling",
+				status: "failed",
+				error: installed.error,
+				nextAction: {
+					type: "ask_user",
+					question:
+						"Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
+					options: [
+						{ value: "retry", label: "Try again" },
+						{
+							value: "manual",
+							label: "I'll configure it manually",
+						},
+					],
+					responseMapping: {
+						retry: {
+							args: [
+								"mcp",
+								"--json",
+								...(options.agent
+									? ["--agent", options.agent]
+									: []),
+								"--install",
+								...(scope === "project"
+									? ["--scope", "project"]
+									: []),
+							],
+						},
+						manual: {
+							args: agentArgs,
+						},
+					},
+				},
+			};
+		}
+
 		const isCursor =
 			mcpAgentId === "cursor" ||
 			options.agent?.toLowerCase() === "cursor";
 		const isClaudeCode =
 			mcpAgentId === "claude-code" ||
 			options.agent?.toLowerCase() === "claude-code";
-		const installCmd = [
-			"npx -y add-mcp https://mcp.neon.tech/mcp",
-			scope === "global" ? "-g" : "",
-			"-n Neon",
-			"-y",
-			`-a ${mcpAgentId}`,
-		]
-			.filter(Boolean)
-			.join(" ");
-
 		let enableNote = "";
 		if (isCursor && scope === "project") {
 			enableNote =
-				' Note: Cursor disables project-level MCP servers by default — after installation, open Cursor Settings > MCP and toggle the "Neon" server on.';
+				' Cursor disables project-level MCP servers by default — open Cursor Settings > MCP and toggle the "Neon" server on.';
 		} else if (isClaudeCode) {
 			enableNote =
-				' Note: Claude Code requires approval for newly added MCP servers. When prompted, approve the "Neon" server to enable it.';
+				' Claude Code requires approval for newly added MCP servers. When prompted, approve the "Neon" server to enable it.';
 		}
 
 		return {
 			phase: "tooling",
-			status: "installing",
+			status: "installed",
+			path: installed.path,
 			nextAction: {
-				type: "run_command",
-				command: installCmd,
-				description: `Installing Neon MCP server (${scope} scope) for ${mcpAgentId}.${enableNote}`,
-				timeout: 60000,
-				onSuccess: {
-					type: "run_neon_init",
-					args: [
-						"skills",
-						"--json",
-						...(options.agent ? ["--agent", options.agent] : []),
-						"--install",
-					],
-				},
-				onFailure: {
-					other: {
-						type: "ask_user",
-						question:
-							"Failed to install the Neon MCP server automatically. Would you like to try again or configure it manually?",
-						options: [
-							{ value: "retry", label: "Try again" },
-							{
-								value: "manual",
-								label: "I'll configure it manually",
-							},
-						],
-						responseMapping: {
-							retry: {
-								args: [
-									"mcp",
-									"--json",
-									...(options.agent
-										? ["--agent", options.agent]
-										: []),
-									"--install",
-								],
-							},
-							manual: {
-								args: agentArgs,
-							},
-						},
-					},
-				},
+				type: "run_neon_init",
+				args: skillsFollowUp(options.agent),
 			},
+			message: `Installed Neon MCP server (${scope} scope) for ${mcpAgentId}.${enableNote}`,
 		};
 	}
 
-	// Agent reported detection result via --mcp-configured
 	if (options.mcpConfigured === true) {
-		// MCP is done — chain to skills installation (not back to orchestrator,
-		// which would re-check MCP and loop since skills aren't installed yet).
 		return {
 			phase: "tooling",
 			status: "mcp_configured",
 			nextAction: {
 				type: "run_neon_init",
-				args: [
-					"skills",
-					"--json",
-					...(options.agent ? ["--agent", options.agent] : []),
-					"--install",
-				],
+				args: skillsFollowUp(options.agent),
 			},
 		};
 	}
@@ -209,21 +218,13 @@ export async function handleMcpPhase(
 						],
 					},
 					skip: {
-						args: [
-							"skills",
-							"--json",
-							...(options.agent
-								? ["--agent", options.agent]
-								: []),
-							"--install",
-						],
+						args: skillsFollowUp(options.agent),
 					},
 				},
 			},
 		};
 	}
 
-	// Default: ask the agent to check
 	return {
 		phase: "tooling",
 		status: "detection_needed",

--- a/packages/cli/src/init/phases/mcp.ts
+++ b/packages/cli/src/init/phases/mcp.ts
@@ -1,4 +1,5 @@
 import {
+	agentSupportsHttpMcp,
 	agentSupportsProjectMcp,
 	getAgentDisplayName,
 	getSkillsAgentName,
@@ -92,7 +93,8 @@ export async function handleMcpPhase(
 			if (installed.unsupported) {
 				if (
 					scope === "project" &&
-					!agentSupportsProjectMcp(mcpAgentId)
+					!agentSupportsProjectMcp(mcpAgentId) &&
+					agentSupportsHttpMcp(mcpAgentId)
 				) {
 					return {
 						phase: "tooling",

--- a/packages/cli/src/init/phases/mcp.ts
+++ b/packages/cli/src/init/phases/mcp.ts
@@ -1,4 +1,9 @@
-import { getSkillsAgentName, resolveAddMcpAgentId } from "../agents.js";
+import {
+	agentSupportsProjectMcp,
+	getSkillsAgentName,
+	resolveAddMcpAgentId,
+	tryResolveAddMcpAgentId,
+} from "../agents.js";
 import { isAuthenticated } from "../auth.js";
 import { installNeonMcpServer } from "../install_mcp.js";
 import type { PhaseResponse } from "../types.js";
@@ -182,10 +187,20 @@ export async function handleMcpPhase(
 						value: "defaults",
 						label: "Yes, install with default settings",
 					},
-					{
-						value: "project_scope",
-						label: "Yes, install for this project only",
-					},
+					...(() => {
+						const known = options.agent
+							? tryResolveAddMcpAgentId(options.agent)
+							: undefined;
+						if (known && !agentSupportsProjectMcp(known)) {
+							return [];
+						}
+						return [
+							{
+								value: "project_scope",
+								label: "Yes, install for this project only",
+							},
+						];
+					})(),
 					{ value: "skip", label: "Skip for now" },
 				],
 				context:

--- a/packages/cli/src/init/phases/mcp.ts
+++ b/packages/cli/src/init/phases/mcp.ts
@@ -1,5 +1,6 @@
 import {
 	agentSupportsProjectMcp,
+	getAgentDisplayName,
 	getSkillsAgentName,
 	resolveAddMcpAgentId,
 	tryResolveAddMcpAgentId,
@@ -89,6 +90,45 @@ export async function handleMcpPhase(
 
 		if (!installed.ok) {
 			if (installed.unsupported) {
+				if (
+					scope === "project" &&
+					!agentSupportsProjectMcp(mcpAgentId)
+				) {
+					return {
+						phase: "tooling",
+						status: "unsupported",
+						error: installed.error,
+						nextAction: {
+							type: "ask_user",
+							question: `${getAgentDisplayName(mcpAgentId)} does not support project-level MCP. Install the Neon MCP server globally instead?`,
+							options: [
+								{
+									value: "global",
+									label: "Install globally",
+								},
+								{
+									value: "skip",
+									label: "Skip MCP install",
+								},
+							],
+							responseMapping: {
+								global: {
+									args: [
+										"mcp",
+										"--json",
+										...(options.agent
+											? ["--agent", options.agent]
+											: []),
+										"--install",
+									],
+								},
+								skip: {
+									args: skillsFollowUp(options.agent),
+								},
+							},
+						},
+					};
+				}
 				return {
 					phase: "tooling",
 					status: "unsupported",

--- a/packages/cli/src/init/phases/setup.test.ts
+++ b/packages/cli/src/init/phases/setup.test.ts
@@ -462,6 +462,51 @@ describe("setup phase", () => {
 		);
 	});
 
+	test("omits project MCP scope when the agent has no project config", async () => {
+		const result = await handleSetupPhase({ agent: "windsurf" });
+
+		expect(result.nextAction.type).toBe("agent_check");
+		if (result.nextAction.type === "agent_check") {
+			const mcpScopePref = result.nextAction.userPreferences?.find(
+				(p) => p.id === "mcpScope",
+			);
+			const values = (mcpScopePref?.options ?? []).map((option) =>
+				typeof option === "string" ? option : option.value,
+			);
+			expect(values).toContain("global");
+			expect(values).not.toContain("project");
+		}
+	});
+
+	test("project-scope MCP for an agent without project config is not success", async () => {
+		mockInstallMcp.mockReturnValue({
+			ok: false,
+			unsupported: true,
+			error: "Windsurf does not support project-level MCP config.",
+		});
+
+		const result = await handleSetupPhase({
+			agent: "windsurf",
+			mcpConfigured: false,
+			connectionString: false,
+			framework: "none",
+			orm: "none",
+			isVscodeIde: false,
+			mode: "customize",
+			mcpScope: "project",
+		});
+
+		expect(result.status).toBe("partial");
+		const results = result.results as {
+			id: string;
+			status: string;
+			error?: string;
+		}[];
+		expect(results.find((r) => r.id === "install_mcp")?.status).toBe(
+			"failed",
+		);
+	});
+
 	test("reports partial status when some installs fail", async () => {
 		mockExeca.mockResolvedValueOnce({ stdout: "", stderr: "" }); // MCP succeeds
 		// Skills fails

--- a/packages/cli/src/init/phases/setup.test.ts
+++ b/packages/cli/src/init/phases/setup.test.ts
@@ -14,6 +14,14 @@ vi.mock("execa", () => ({
 	execa: (...args: unknown[]) => mockExeca(...args),
 }));
 
+const mockInstallMcp = vi.fn().mockReturnValue({
+	ok: true,
+	path: "/tmp/mcp.json",
+});
+vi.mock("../install_mcp.js", () => ({
+	installNeonMcpServer: (...args: unknown[]) => mockInstallMcp(...args),
+}));
+
 vi.mock("../inspect.js", () => ({
 	inspectProject: vi.fn().mockResolvedValue({
 		connectionString: false,
@@ -85,6 +93,10 @@ describe("setup phase", () => {
 			version: "2.23.1",
 		});
 		mockExeca.mockReset().mockResolvedValue({ stdout: "", stderr: "" });
+		mockInstallMcp.mockReset().mockReturnValue({
+			ok: true,
+			path: "/tmp/mcp.json",
+		});
 		mockEnsureSkills.mockReset().mockResolvedValue(true);
 		mockFindEditorCommand.mockReset().mockResolvedValue("/usr/bin/cursor");
 		mockFetch.mockReset().mockResolvedValue({
@@ -220,15 +232,18 @@ describe("setup phase", () => {
 		const args = (result.nextAction as { args: string[] }).args;
 		expect(args[0]).toBe("getting-started");
 
-		// Should have called execa for MCP only (neon CLI mocked, skills via ensureSkillsUpToDate)
-		expect(mockExeca).toHaveBeenCalledTimes(1);
 		expect(mockEnsureSkills).toHaveBeenCalled();
-
-		// MCP call should use -g for global scope
-		const mcpCall = mockExeca.mock.calls[0];
-		expect(mcpCall[0]).toBe("npx");
-		expect(mcpCall[1]).toContain("-g");
-		expect(mcpCall[1]).toContain("add-mcp");
+		expect(mockInstallMcp).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agent: "vscode",
+				scope: "global",
+			}),
+		);
+		expect(
+			mockExeca.mock.calls.some((call) =>
+				String(call[1] ?? "").includes("add-mcp"),
+			),
+		).toBe(false);
 	});
 
 	test("defaults mode skips MCP when already configured", async () => {
@@ -402,11 +417,11 @@ describe("setup phase", () => {
 		// Extension should NOT be installed since installExtension=false
 		expect(resultIds).not.toContain("install_extension");
 
-		// MCP should be project scope (no -g flag)
-		const mcpCall = mockExeca.mock.calls.find((call) =>
-			call[1]?.includes("add-mcp"),
+		expect(mockInstallMcp).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope: "project",
+			}),
 		);
-		expect(mcpCall?.[1]).not.toContain("-g");
 	});
 
 	test("--data with customize mode goes straight to execution", async () => {
@@ -440,11 +455,11 @@ describe("setup phase", () => {
 		expect(result.phase).toBe("setup");
 		expect(result.status).toBe("installed");
 
-		// MCP call should not include -g for project scope
-		const mcpCall = mockExeca.mock.calls.find((call) =>
-			call[1]?.includes("add-mcp"),
+		expect(mockInstallMcp).toHaveBeenCalledWith(
+			expect.objectContaining({
+				scope: "project",
+			}),
 		);
-		expect(mcpCall?.[1]).not.toContain("-g");
 	});
 
 	test("reports partial status when some installs fail", async () => {

--- a/packages/cli/src/init/phases/setup.test.ts
+++ b/packages/cli/src/init/phases/setup.test.ts
@@ -112,6 +112,19 @@ describe("setup phase", () => {
 			body: "mock-stream",
 		});
 	});
+	test("reportBack omits project mcpScope when the agent cannot write it", async () => {
+		const result = await handleSetupPhase({ agent: "windsurf" });
+
+		expect(result.nextAction.type).toBe("agent_check");
+		if (result.nextAction.type === "agent_check") {
+			const dataPlaceholder = result.nextAction.reportBack.args.find(
+				(a: string) => a.includes("json:"),
+			);
+			expect(dataPlaceholder).toContain("mcpScope?: 'global'|'none'");
+			expect(dataPlaceholder).not.toContain("'project'");
+		}
+	});
+
 	test("returns inspection checks with phased userPreferences and instructions", async () => {
 		const result = await handleSetupPhase({ agent: "claude" });
 

--- a/packages/cli/src/init/phases/setup.ts
+++ b/packages/cli/src/init/phases/setup.ts
@@ -3,9 +3,12 @@ import { unlink } from "node:fs/promises";
 import { resolve } from "node:path";
 import { execa } from "execa";
 import {
+	agentSupportsProjectMcp,
 	getSkillsAgentName,
 	listMcpAgentIds,
 	resolveAddMcpAgentId,
+	supportsSkills,
+	tryResolveAddMcpAgentId,
 } from "../agents.js";
 import {
 	FALLBACK_TEMPLATES,
@@ -296,7 +299,9 @@ async function buildBulkInspection(
 					).includes("partial");
 					const needsMcpChoice = !options.mcpConfigured;
 					const needsSkillsChoice =
-						!options.skillsInstalled && !isPartialSkills;
+						!options.skillsInstalled &&
+						!isPartialSkills &&
+						!(options.agent && !supportsSkills(options.agent));
 					const hasCustomizableOptions =
 						needsMcpChoice || needsSkillsChoice;
 					if (!hasCustomizableOptions) return [];
@@ -332,10 +337,20 @@ async function buildBulkInspection(
 							value: "global",
 							label: "Global (available in all projects)",
 						},
-						{
-							value: "project",
-							label: "Project-level (scoped to this project only)",
-						},
+						...(() => {
+							const known = options.agent
+								? tryResolveAddMcpAgentId(options.agent)
+								: undefined;
+							if (known && !agentSupportsProjectMcp(known)) {
+								return [];
+							}
+							return [
+								{
+									value: "project",
+									label: "Project-level (scoped to this project only)",
+								},
+							];
+						})(),
 						{
 							value: "none",
 							label: "Skip — do not install the MCP server",
@@ -348,7 +363,8 @@ async function buildBulkInspection(
 				// Show skills scope when skills aren't detected and no partial install exists.
 				// Partial installations are auto-completed to the same scope silently.
 				...(!options.skillsInstalled &&
-				!String(options.skillsScope ?? "").includes("partial")
+				!String(options.skillsScope ?? "").includes("partial") &&
+				!(options.agent && !supportsSkills(options.agent))
 					? [
 							{
 								id: "skillsScope",
@@ -589,11 +605,15 @@ async function executeBatchedInstallation(
 				});
 			}
 		} else if (installed.unsupported) {
+			const projectUnsupported =
+				mcpScope === "project" && !agentSupportsProjectMcp(mcpAgentId);
 			results.push({
 				id: "install_mcp",
 				description: installed.error,
-				status: "success",
-				manualAction: true,
+				status: projectUnsupported ? "failed" : "success",
+				...(projectUnsupported
+					? { error: installed.error }
+					: { manualAction: true }),
 			});
 		} else {
 			results.push({

--- a/packages/cli/src/init/phases/setup.ts
+++ b/packages/cli/src/init/phases/setup.ts
@@ -2,7 +2,11 @@ import { writeFileSync } from "node:fs";
 import { unlink } from "node:fs/promises";
 import { resolve } from "node:path";
 import { execa } from "execa";
-import { resolveAddMcpAgentId } from "../agents.js";
+import {
+	getSkillsAgentName,
+	listMcpAgentIds,
+	resolveAddMcpAgentId,
+} from "../agents.js";
 import {
 	FALLBACK_TEMPLATES,
 	fetchTemplates,
@@ -17,6 +21,7 @@ import {
 } from "../detect_agent.js";
 import { findEditorCommand } from "../extension.js";
 import { inspectProject } from "../inspect.js";
+import { installNeonMcpServer } from "../install_mcp.js";
 import { ensureNeonctl } from "../neonctl.js";
 import { ensureSkillsUpToDate } from "../skills.js";
 import type { Editor, PhaseResponse } from "../types.js";
@@ -212,7 +217,7 @@ async function buildBulkInspection(
 				"GROUPING: Preferences that share the same `group` field should be presented together in a single message (e.g. list all customize options at once and let the user answer them together). Preferences without a `group` must be asked individually.",
 				"",
 				detectedIde
-					? `The CLI has detected the IDE as: ${detectedIde.toLowerCase()}. Include this as the "ide" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor/VS Code/Windsurf, the extension IS applicable even if you are Claude Code.`
+					? `The CLI has detected the IDE as: ${detectedIde.toLowerCase()}. Include this as the "ide" field in your reportBack data. IMPORTANT: The IDE and the agent are different — you may be Claude Code (agent) running inside Cursor (IDE). The extension installs into the IDE, so if the IDE is Cursor or VS Code, the extension IS applicable even if you are Claude Code.`
 					: installedEditors.length > 0
 						? `No IDE detected, but the following editors are installed: ${installedEditors.join(", ")}. The "installedEditors" field in this response lists them. If the user wants the extension installed, ask which editor to install it for and include that as the "ide" field in your reportBack data. If not, set "ide" to "none".`
 						: `No IDE or supported editors detected. Set "ide" to "none" in your reportBack data.`,
@@ -239,7 +244,7 @@ async function buildBulkInspection(
 					description:
 						"Identify which coding agent is running this command",
 					lookFor: [
-						"Determine which agent you are: cursor, claude-code, copilot, vscode, windsurf, codex, cline, gemini-cli, goose, opencode, or antigravity",
+						`Determine which agent you are: ${listMcpAgentIds().join(", ")}`,
 						"Report your own agent identifier — this is used to configure the MCP server for the correct tool",
 					],
 				},
@@ -382,7 +387,7 @@ async function buildBulkInspection(
 					],
 					default: "true",
 					context:
-						"The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code-based IDEs (VS Code, Cursor, Windsurf). SKIP this question if the user is NOT in a VS Code-based IDE, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
+						"The extension installs into the IDE, NOT the agent. If the CLI detected the IDE (see detectedIde field), use that — e.g. Claude Code running inside Cursor means the IDE is Cursor and the extension IS applicable. Only applicable for VS Code and Cursor. SKIP this question if the user is NOT in VS Code or Cursor, or if the extension_installed check found it is already installed. Set installExtension to false in reportBack if skipped.",
 					condition: { preferenceId: "mode", equals: "customize" },
 					group: "customize",
 				},
@@ -550,28 +555,18 @@ async function executeBatchedInstallation(
 			status: "success",
 		});
 	} else {
-		const mcpArgs = [
-			"-y",
-			"add-mcp",
-			"https://mcp.neon.tech/mcp",
-			...(mcpScope === "global" ? ["-g"] : []),
-			"-n",
-			"Neon",
-			"-y",
-			"-a",
-			mcpAgentId,
-		];
-		try {
-			await execa("npx", mcpArgs, { stdio: "pipe", timeout: 60000 });
+		const installed = installNeonMcpServer({
+			agent: mcpAgentId,
+			scope: mcpScope === "project" ? "project" : "global",
+			cwd: process.cwd(),
+		});
+		if (installed.ok) {
 			results.push({
 				id: "install_mcp",
 				description: `Installed Neon MCP server (${mcpScope} scope)`,
 				status: "success",
 			});
 
-			// Some editors disable newly added MCP servers by default.
-			// Cursor: project-level servers are always disabled initially.
-			// Claude Code: newly added servers require user approval.
 			const isClaudeCode =
 				mcpAgentId === "claude-code" ||
 				options.agent?.toLowerCase() === "claude-code";
@@ -593,21 +588,35 @@ async function executeBatchedInstallation(
 					manualAction: true,
 				});
 			}
-		} catch (err) {
+		} else if (installed.unsupported) {
+			results.push({
+				id: "install_mcp",
+				description: installed.error,
+				status: "success",
+				manualAction: true,
+			});
+		} else {
 			results.push({
 				id: "install_mcp",
 				description: "Failed to install Neon MCP server",
 				status: "failed",
-				error: err instanceof Error ? err.message : "Unknown error",
+				error: installed.error,
 			});
 		}
 	}
 
 	// Step 3: Install/update skills (skip when bootstrapping — templates bundle skills)
+	const skillsAgent = getSkillsAgentName(agentId);
 	if (isBootstrap) {
 		results.push({
 			id: "install_skills",
 			description: "Neon agent skills included in template",
+			status: "success",
+		});
+	} else if (!skillsAgent) {
+		results.push({
+			id: "skip_skills",
+			description: "No Neon agent skills target for this agent",
 			status: "success",
 		});
 	} else {
@@ -626,13 +635,11 @@ async function executeBatchedInstallation(
 				status: "success",
 			});
 		} else {
-			// Build the install commands for the agent to run directly
-			// (sandboxed environments may block child process writes)
 			const { getSkillList } = await import("../skills.js");
 			const skillList = getSkillList(options.preview);
 			const cmds = skillList.map(
 				(s) =>
-					`skills add neondatabase/agent-skills --skill ${s} --agent ${agentId}${skillsScope === "global" ? " -g" : ""} -y`,
+					`skills add neondatabase/agent-skills --skill ${s} --agent ${skillsAgent}${skillsScope === "global" ? " -g" : ""} -y`,
 			);
 			results.push({
 				id: "install_skills",
@@ -750,12 +757,7 @@ async function mergeCliInspection(
 function isVscodeBasedIde(options: SetupPhaseOptions): boolean {
 	if (options.ide) {
 		const ide = options.ide.toLowerCase();
-		return (
-			ide === "cursor" ||
-			ide === "vscode" ||
-			ide === "vs-code" ||
-			ide === "windsurf"
-		);
+		return ide === "cursor" || ide === "vscode" || ide === "vs-code";
 	}
 	return options.isVscodeIde === true;
 }

--- a/packages/cli/src/init/phases/setup.ts
+++ b/packages/cli/src/init/phases/setup.ts
@@ -432,8 +432,15 @@ async function buildBulkInspection(
 						const modeField = hasModeQuestion
 							? ", mode: string"
 							: "";
+						const knownAgent = options.agent
+							? tryResolveAddMcpAgentId(options.agent)
+							: undefined;
+						const mcpScopeUnion =
+							knownAgent && !agentSupportsProjectMcp(knownAgent)
+								? "'global'|'none'"
+								: "'global'|'project'|'none'";
 						const mcpField = hasModeQuestion
-							? ", mcpScope?: 'global'|'project'|'none'"
+							? `, mcpScope?: ${mcpScopeUnion}`
 							: "";
 						const skillsField = needsSkillsChoice
 							? ", skillsScope?: string"

--- a/packages/cli/src/init/phases/skills.ts
+++ b/packages/cli/src/init/phases/skills.ts
@@ -1,10 +1,10 @@
 import { getSkillsAgentName } from "../agents.js";
 import { SKILL_REFERENCE_URLS } from "../skills.js";
-import type { Editor, PhaseResponse } from "../types.js";
+import type { PhaseResponse } from "../types.js";
 
 export type SkillsPhaseOptions = {
 	agent?: string;
-	editor?: Editor;
+	editor?: string;
 	status?: boolean;
 	install?: boolean;
 	update?: boolean;
@@ -19,6 +19,17 @@ export async function handleSkillsPhase(
 	const skillsAgent = options.agent
 		? getSkillsAgentName(options.agent)
 		: "claude-code";
+
+	if (options.agent && !skillsAgent) {
+		return {
+			phase: "tooling",
+			status: "skipped",
+			nextAction: {
+				type: "run_neon_init",
+				args: agentArgs,
+			},
+		};
+	}
 
 	// --status: ask agent to check
 	if (options.status) {
@@ -53,7 +64,7 @@ export async function handleSkillsPhase(
 
 	// --install or --update: run the skills CLI
 	if (options.install || options.update) {
-		const installCmd = `npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent ${skillsAgent} -y`;
+		const installCmd = `npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent ${skillsAgent ?? "claude-code"} -y`;
 		return {
 			phase: "tooling",
 			status: "installing_skills",

--- a/packages/cli/src/init/phases/skills.ts
+++ b/packages/cli/src/init/phases/skills.ts
@@ -1,5 +1,5 @@
 import { getSkillsAgentName } from "../agents.js";
-import { SKILL_REFERENCE_URLS } from "../skills.js";
+import { getSkillList, SKILL_REFERENCE_URLS } from "../skills.js";
 import type { PhaseResponse } from "../types.js";
 
 export type SkillsPhaseOptions = {
@@ -64,7 +64,12 @@ export async function handleSkillsPhase(
 
 	// --install or --update: run the skills CLI
 	if (options.install || options.update) {
-		const installCmd = `npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent ${skillsAgent ?? "claude-code"} -y`;
+		const installCmd = getSkillList()
+			.map(
+				(skill) =>
+					`npx -y skills add neondatabase/agent-skills --skill ${skill} --agent ${skillsAgent ?? "claude-code"} -y`,
+			)
+			.join(" && ");
 		return {
 			phase: "tooling",
 			status: "installing_skills",

--- a/packages/cli/src/init/phases/status.test.ts
+++ b/packages/cli/src/init/phases/status.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("../auth.js", () => ({
+	isAuthenticated: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../inspect.js", () => ({
+	inspectProject: vi.fn(),
+}));
+
+import { isAuthenticated } from "../auth.js";
+import { inspectProject } from "../inspect.js";
+import { handleStatusPhase } from "./status.js";
+
+const mockIsAuthenticated = vi.mocked(isAuthenticated);
+const mockInspect = vi.mocked(inspectProject);
+
+describe("handleStatusPhase", () => {
+	beforeEach(() => {
+		mockIsAuthenticated.mockResolvedValue(true);
+		mockInspect.mockResolvedValue({
+			databaseUrl: true,
+			mcpConfigured: true,
+			skillsInstalled: false,
+			migrationTool: "none",
+			migrationDir: "none",
+		});
+	});
+
+	test("recommends skills when the agent has a skills target", async () => {
+		const result = await handleStatusPhase({ agent: "cursor" });
+		expect(
+			result.recommendations.some((r) =>
+				r.message.includes("agent skills"),
+			),
+		).toBe(true);
+	});
+
+	test("does not recommend skills for grok-build", async () => {
+		const result = await handleStatusPhase({ agent: "grok-build" });
+		expect(
+			result.recommendations.some((r) =>
+				r.message.includes("agent skills"),
+			),
+		).toBe(false);
+	});
+});

--- a/packages/cli/src/init/phases/status.test.ts
+++ b/packages/cli/src/init/phases/status.test.ts
@@ -36,8 +36,8 @@ describe("handleStatusPhase", () => {
 		).toBe(true);
 	});
 
-	test("does not recommend skills for grok-build", async () => {
-		const result = await handleStatusPhase({ agent: "grok-build" });
+	test("does not recommend skills for mcporter", async () => {
+		const result = await handleStatusPhase({ agent: "mcporter" });
 		expect(
 			result.recommendations.some((r) =>
 				r.message.includes("agent skills"),

--- a/packages/cli/src/init/phases/status.ts
+++ b/packages/cli/src/init/phases/status.ts
@@ -1,3 +1,4 @@
+import { supportsSkills, tryResolveAddMcpAgentId } from "../agents.js";
 import { isAuthenticated } from "../auth.js";
 import { inspectProject } from "../inspect.js";
 import type { StatusResponse } from "../types.js";
@@ -7,7 +8,7 @@ export type StatusOptions = {
 };
 
 export async function handleStatusPhase(
-	_options: StatusOptions,
+	options: StatusOptions,
 ): Promise<StatusResponse> {
 	const authed = await isAuthenticated();
 
@@ -45,7 +46,10 @@ export async function handleStatusPhase(
 		});
 	}
 
-	if (!skillsInstalled) {
+	const statusAgent = options.agent
+		? tryResolveAddMcpAgentId(options.agent)
+		: undefined;
+	if (!skillsInstalled && (!statusAgent || supportsSkills(statusAgent))) {
 		recommendations.push({
 			priority: "medium",
 			message: "Neon agent skills not detected in this project",

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -7,8 +7,10 @@ import {
 	globalInstallCommand,
 	resolveInvokingPackageManager,
 } from "../utils/package_manager.js";
-import { getSkillsAgentName as getSkillsAgentNameFromId } from "./agents.js";
-import type { Editor } from "./types.js";
+import {
+	type AgentType,
+	getSkillsAgentName as getSkillsAgentNameFromId,
+} from "./agents.js";
 
 /**
  * Ensures the `skills` CLI is globally installed so npx doesn't need
@@ -68,42 +70,6 @@ export const SKILL_REFERENCE_URLS: Record<string, string> = {
 	neonJs: `${SKILL_BASE_URL}/neon-js.md`,
 };
 
-/**
- * Maps Editor display names to the skills CLI agent name.
- */
-function editorToSkillsAgent(editor: Editor): string {
-	switch (editor) {
-		case "Cursor":
-			return "cursor";
-		case "VS Code":
-		case "GitHub Copilot CLI":
-			return "github-copilot";
-		case "Claude CLI":
-			return "claude-code";
-		case "Codex":
-			return "codex";
-		case "OpenCode":
-			return "opencode";
-		case "Antigravity":
-			return "antigravity";
-		case "Cline":
-		case "Cline CLI":
-			return "cline";
-		case "Gemini CLI":
-			return "gemini-cli";
-		case "Goose":
-			return "goose";
-		case "Claude Desktop":
-			return "claude-code";
-		case "MCPorter":
-			return "mcporter";
-		case "Zed":
-			return "zed";
-		default:
-			return "";
-	}
-}
-
 export type InstallSkillsOptions = {
 	json?: boolean;
 	scope?: "global" | "project";
@@ -114,16 +80,16 @@ export type InstallSkillsOptions = {
  * Installs Neon agent skills using Vercel's skills CLI.
  */
 export async function installAgentSkills(
-	selectedEditors: Editor[],
+	selectedAgents: AgentType[],
 	options?: InstallSkillsOptions,
 ): Promise<boolean> {
 	const quiet = options?.json === true;
 
-	const editorsWithSkills = selectedEditors.filter(
-		(e) => editorToSkillsAgent(e) !== "",
+	const agentsWithSkills = selectedAgents.filter(
+		(id) => getSkillsAgentNameFromId(id) !== undefined,
 	);
 
-	if (editorsWithSkills.length === 0) {
+	if (agentsWithSkills.length === 0) {
 		return true;
 	}
 
@@ -135,8 +101,9 @@ export async function installAgentSkills(
 	await ensureSkillsCli();
 	const skills = getSkillList(options?.preview);
 
-	for (const editor of editorsWithSkills) {
-		const agentName = editorToSkillsAgent(editor);
+	for (const agent of agentsWithSkills) {
+		const agentName = getSkillsAgentNameFromId(agent);
+		if (!agentName) continue;
 
 		// Install one skill at a time — the skills CLI has a bug with multiple
 		// --skill flags where it creates directories but doesn't copy all SKILL.md files.
@@ -162,7 +129,7 @@ export async function installAgentSkills(
 			} catch (error) {
 				if (!quiet)
 					log.error(
-						`Failed to install skill ${skill} for ${editor}: ${error instanceof Error ? error.message : "Unknown error"}`,
+						`Failed to install skill ${skill} for ${agent}: ${error instanceof Error ? error.message : "Unknown error"}`,
 					);
 				anyFailed = true;
 			}
@@ -237,6 +204,7 @@ function skillsAreFresh(agent: string, requiredSkills: string[]): boolean {
 
 	// Check global: ALL required skills must exist in agent-specific dirs
 	const agentName = getSkillsAgentNameFromId(agent);
+	if (!agentName) return false;
 	const globalDirs = GLOBAL_SKILLS_DIRS[agentName] ?? [];
 	for (const dir of globalDirs) {
 		const allExist = requiredSkills.every((skill) =>
@@ -269,11 +237,13 @@ export async function ensureSkillsUpToDate(
 	preview?: boolean,
 ): Promise<boolean> {
 	const resolvedAgent = agent || "cursor";
+	const agentName = getSkillsAgentNameFromId(resolvedAgent);
+	if (!agentName) return true;
+
 	const skills = getSkillList(preview);
 	if (skillsAreFresh(resolvedAgent, skills)) return true;
 
 	await ensureSkillsCli();
-	const agentName = getSkillsAgentNameFromId(resolvedAgent);
 	let allOk = true;
 
 	// Only install skills that don't already have SKILL.md on disk.

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -234,11 +234,14 @@ export function missingSkillsForAgent(
 export function skillsInstalledForAgent(
 	agent: AgentType,
 	cwd = process.cwd(),
+	preview = false,
 ): boolean {
 	if (!getSkillsAgentNameFromId(agent)) return true;
 	return (
-		missingSkillsForAgent(agent, { cwd, scope: "project" }).length === 0 ||
-		missingSkillsForAgent(agent, { cwd, scope: "global" }).length === 0
+		missingSkillsForAgent(agent, { cwd, scope: "project", preview })
+			.length === 0 ||
+		missingSkillsForAgent(agent, { cwd, scope: "global", preview })
+			.length === 0
 	);
 }
 

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -184,9 +184,50 @@ const PROJECT_SKILLS_DIRS: Record<string, string[]> = {
 	grok: [".grok/skills", ".agents/skills"],
 };
 
-function dirsHaveNeonSkill(dirs: string[]): boolean {
-	return BASE_SKILLS.some((skill) =>
-		dirs.some((dir) => existsSync(resolve(dir, skill, "SKILL.md"))),
+function skillDirsForAgent(
+	skillsId: string,
+	scope: "global" | "project",
+	cwd: string,
+	home: string,
+): string[] {
+	if (scope === "global") {
+		return [
+			...new Set([
+				...(GLOBAL_SKILLS_DIRS[skillsId] ?? []),
+				resolve(home, ".agents", "skills"),
+			]),
+		];
+	}
+	return [
+		...new Set(
+			[...(PROJECT_SKILLS_DIRS[skillsId] ?? []), ".agents/skills"].map(
+				(dir) => resolve(cwd, dir),
+			),
+		),
+	];
+}
+
+export function missingSkillsForAgent(
+	agent: string,
+	options: {
+		cwd?: string;
+		scope?: "global" | "project";
+		preview?: boolean;
+	} = {},
+): string[] {
+	const skillsId = getSkillsAgentNameFromId(agent);
+	if (!skillsId) return [];
+	const cwd = options.cwd ?? process.cwd();
+	const home = process.env.HOME || process.env.USERPROFILE || "";
+	const dirs = skillDirsForAgent(
+		skillsId,
+		options.scope ?? "project",
+		cwd,
+		home,
+	);
+	return getSkillList(options.preview).filter(
+		(skill) =>
+			!dirs.some((dir) => existsSync(resolve(dir, skill, "SKILL.md"))),
 	);
 }
 
@@ -194,19 +235,11 @@ export function skillsInstalledForAgent(
 	agent: AgentType,
 	cwd = process.cwd(),
 ): boolean {
-	const skillsId = getSkillsAgentNameFromId(agent);
-	if (!skillsId) return true;
-	const home = process.env.HOME || process.env.USERPROFILE || "";
-	const projectDirs = [
-		...(PROJECT_SKILLS_DIRS[skillsId] ?? []),
-		".agents/skills",
-	].map((dir) => resolve(cwd, dir));
-	if (dirsHaveNeonSkill([...new Set(projectDirs)])) return true;
-	const globalDirs = [
-		...(GLOBAL_SKILLS_DIRS[skillsId] ?? []),
-		resolve(home, ".agents", "skills"),
-	];
-	return dirsHaveNeonSkill([...new Set(globalDirs)]);
+	if (!getSkillsAgentNameFromId(agent)) return true;
+	return (
+		missingSkillsForAgent(agent, { cwd, scope: "project" }).length === 0 ||
+		missingSkillsForAgent(agent, { cwd, scope: "global" }).length === 0
+	);
 }
 
 /**
@@ -285,27 +318,10 @@ export async function ensureSkillsUpToDate(
 
 	// Only install skills that don't already have SKILL.md on disk.
 	// Re-installing existing skills can trigger sandbox permission prompts.
-	const home = process.env.HOME || process.env.USERPROFILE || "";
-	const cwd = process.cwd();
-	const checkDirs =
-		scope === "global"
-			? [
-					resolve(home, ".cursor", "skills"),
-					resolve(home, ".claude", "skills"),
-					resolve(home, ".agents", "skills"),
-				]
-			: [
-					resolve(cwd, ".cursor", "skills"),
-					resolve(cwd, ".claude", "skills"),
-					resolve(cwd, ".agents", "skills"),
-				];
-
-	const missingSkills = skills.filter(
-		(skill) =>
-			!checkDirs.some((dir) =>
-				existsSync(resolve(dir, skill, "SKILL.md")),
-			),
-	);
+	const missingSkills = missingSkillsForAgent(resolvedAgent, {
+		scope: scope ?? "project",
+		preview,
+	});
 
 	if (missingSkills.length === 0) return true;
 

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -194,11 +194,17 @@ export function skillsInstalledForAgent(
 ): boolean {
 	const skillsId = getSkillsAgentNameFromId(agent);
 	if (!skillsId) return true;
-	const projectDirs = (PROJECT_SKILLS_DIRS[skillsId] ?? []).map((dir) =>
-		resolve(cwd, dir),
-	);
-	if (dirsHaveNeonSkill(projectDirs)) return true;
-	return dirsHaveNeonSkill(GLOBAL_SKILLS_DIRS[skillsId] ?? []);
+	const home = process.env.HOME || process.env.USERPROFILE || "";
+	const projectDirs = [
+		...(PROJECT_SKILLS_DIRS[skillsId] ?? []),
+		".agents/skills",
+	].map((dir) => resolve(cwd, dir));
+	if (dirsHaveNeonSkill([...new Set(projectDirs)])) return true;
+	const globalDirs = [
+		...(GLOBAL_SKILLS_DIRS[skillsId] ?? []),
+		resolve(home, ".agents", "skills"),
+	];
+	return dirsHaveNeonSkill([...new Set(globalDirs)]);
 }
 
 /**

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -171,6 +171,7 @@ const GLOBAL_SKILLS_DIRS: Record<string, string[]> = (() => {
 		"github-copilot": [resolve(home, ".vscode", "skills"), agentsDir],
 		codex: [resolve(home, ".codex", "skills"), agentsDir],
 		cline: [resolve(home, ".cline", "skills"), agentsDir],
+		grok: [resolve(home, ".grok", "skills"), agentsDir],
 	};
 })();
 
@@ -180,6 +181,7 @@ const PROJECT_SKILLS_DIRS: Record<string, string[]> = {
 	"github-copilot": [".vscode/skills", ".agents/skills"],
 	codex: [".codex/skills", ".agents/skills"],
 	cline: [".cline/skills", ".agents/skills"],
+	grok: [".grok/skills", ".agents/skills"],
 };
 
 function dirsHaveNeonSkill(dirs: string[]): boolean {

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -208,20 +208,22 @@ export function skillsInstalledForAgent(
 function skillsAreFresh(agent: string, requiredSkills: string[]): boolean {
 	const now = Date.now();
 	const cwd = process.cwd();
-	const projectSkillDirs = [".agents", ".cursor", ".claude"];
+	const skillsId = getSkillsAgentNameFromId(agent);
+	const projectDirs =
+		(skillsId ? PROJECT_SKILLS_DIRS[skillsId] : undefined)?.map((dir) =>
+			resolve(cwd, dir),
+		) ?? [];
 
 	// Check project-level: ALL required skills must exist on disk
 	// and skills-lock.json must be recent
 	const lockPath = resolve(cwd, "skills-lock.json");
-	if (existsSync(lockPath)) {
+	if (existsSync(lockPath) && projectDirs.length > 0) {
 		try {
 			const mtime = statSync(lockPath).mtimeMs;
 			if (now - mtime < SKILLS_FRESHNESS_MS) {
 				const allExist = requiredSkills.every((skill) =>
-					projectSkillDirs.some((dir) =>
-						existsSync(
-							resolve(cwd, dir, "skills", skill, "SKILL.md"),
-						),
+					projectDirs.some((dir) =>
+						existsSync(resolve(dir, skill, "SKILL.md")),
 					),
 				);
 				if (allExist) return true;

--- a/packages/cli/src/init/skills.ts
+++ b/packages/cli/src/init/skills.ts
@@ -174,6 +174,33 @@ const GLOBAL_SKILLS_DIRS: Record<string, string[]> = (() => {
 	};
 })();
 
+const PROJECT_SKILLS_DIRS: Record<string, string[]> = {
+	cursor: [".cursor/skills", ".agents/skills"],
+	"claude-code": [".claude/skills", ".agents/skills"],
+	"github-copilot": [".vscode/skills", ".agents/skills"],
+	codex: [".codex/skills", ".agents/skills"],
+	cline: [".cline/skills", ".agents/skills"],
+};
+
+function dirsHaveNeonSkill(dirs: string[]): boolean {
+	return BASE_SKILLS.some((skill) =>
+		dirs.some((dir) => existsSync(resolve(dir, skill, "SKILL.md"))),
+	);
+}
+
+export function skillsInstalledForAgent(
+	agent: AgentType,
+	cwd = process.cwd(),
+): boolean {
+	const skillsId = getSkillsAgentNameFromId(agent);
+	if (!skillsId) return true;
+	const projectDirs = (PROJECT_SKILLS_DIRS[skillsId] ?? []).map((dir) =>
+		resolve(cwd, dir),
+	);
+	if (dirsHaveNeonSkill(projectDirs)) return true;
+	return dirsHaveNeonSkill(GLOBAL_SKILLS_DIRS[skillsId] ?? []);
+}
+
 /**
  * Checks whether skills were recently updated (within the freshness window).
  * Checks both project-level (skills-lock.json mtime) and global (skills dir mtime).

--- a/packages/cli/src/init/skills_installed.test.ts
+++ b/packages/cli/src/init/skills_installed.test.ts
@@ -28,4 +28,18 @@ describe("skillsInstalledForAgent", () => {
 		expect(skillsInstalledForAgent("windsurf", cwd)).toBe(true);
 		expect(skillsInstalledForAgent("zed", cwd)).toBe(true);
 	});
+
+	test("treats .grok/skills as installed for grok-build", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
+		dirs.push(cwd);
+		mkdirSync(join(cwd, ".grok", "skills", "neon-postgres"), {
+			recursive: true,
+		});
+		writeFileSync(
+			join(cwd, ".grok", "skills", "neon-postgres", "SKILL.md"),
+			"",
+		);
+
+		expect(skillsInstalledForAgent("grok-build", cwd)).toBe(true);
+	});
 });

--- a/packages/cli/src/init/skills_installed.test.ts
+++ b/packages/cli/src/init/skills_installed.test.ts
@@ -1,0 +1,31 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { skillsInstalledForAgent } from "./skills.js";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+describe("skillsInstalledForAgent", () => {
+	test("treats .agents/skills as installed for agents without a dedicated dir", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
+		dirs.push(cwd);
+		mkdirSync(join(cwd, ".agents", "skills", "neon-postgres"), {
+			recursive: true,
+		});
+		writeFileSync(
+			join(cwd, ".agents", "skills", "neon-postgres", "SKILL.md"),
+			"",
+		);
+
+		expect(skillsInstalledForAgent("windsurf", cwd)).toBe(true);
+		expect(skillsInstalledForAgent("zed", cwd)).toBe(true);
+	});
+});

--- a/packages/cli/src/init/skills_installed.test.ts
+++ b/packages/cli/src/init/skills_installed.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
-import { skillsInstalledForAgent } from "./skills.js";
+import { missingSkillsForAgent, skillsInstalledForAgent } from "./skills.js";
 
 const dirs: string[] = [];
 
@@ -13,17 +13,18 @@ afterEach(() => {
 	}
 });
 
+function writeSkills(cwd: string, root: string, names: string[]) {
+	for (const name of names) {
+		mkdirSync(join(cwd, root, name), { recursive: true });
+		writeFileSync(join(cwd, root, name, "SKILL.md"), "");
+	}
+}
+
 describe("skillsInstalledForAgent", () => {
 	test("treats .agents/skills as installed for agents without a dedicated dir", () => {
 		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
 		dirs.push(cwd);
-		mkdirSync(join(cwd, ".agents", "skills", "neon-postgres"), {
-			recursive: true,
-		});
-		writeFileSync(
-			join(cwd, ".agents", "skills", "neon-postgres", "SKILL.md"),
-			"",
-		);
+		writeSkills(cwd, ".agents/skills", ["neon", "neon-postgres"]);
 
 		expect(skillsInstalledForAgent("windsurf", cwd)).toBe(true);
 		expect(skillsInstalledForAgent("zed", cwd)).toBe(true);
@@ -32,14 +33,42 @@ describe("skillsInstalledForAgent", () => {
 	test("treats .grok/skills as installed for grok-build", () => {
 		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
 		dirs.push(cwd);
-		mkdirSync(join(cwd, ".grok", "skills", "neon-postgres"), {
-			recursive: true,
-		});
-		writeFileSync(
-			join(cwd, ".grok", "skills", "neon-postgres", "SKILL.md"),
-			"",
-		);
+		writeSkills(cwd, ".grok/skills", ["neon", "neon-postgres"]);
 
 		expect(skillsInstalledForAgent("grok-build", cwd)).toBe(true);
+	});
+
+	test("does not treat a single base skill as installed", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
+		dirs.push(cwd);
+		writeSkills(cwd, ".cursor/skills", ["neon-postgres"]);
+
+		expect(skillsInstalledForAgent("cursor", cwd)).toBe(false);
+	});
+});
+
+describe("missingSkillsForAgent", () => {
+	test("does not treat another agent's files as present", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
+		dirs.push(cwd);
+		writeSkills(cwd, ".cursor/skills", ["neon", "neon-postgres"]);
+
+		expect(
+			missingSkillsForAgent("grok-build", { cwd, scope: "project" }),
+		).toEqual(["neon", "neon-postgres"]);
+	});
+
+	test("lists preview skills that are not on disk for that agent", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
+		dirs.push(cwd);
+		writeSkills(cwd, ".cursor/skills", ["neon", "neon-postgres"]);
+
+		expect(
+			missingSkillsForAgent("cursor", {
+				cwd,
+				scope: "project",
+				preview: true,
+			}),
+		).toEqual(["neon-object-storage", "neon-functions", "neon-ai-gateway"]);
 	});
 });

--- a/packages/cli/src/init/skills_installed.test.ts
+++ b/packages/cli/src/init/skills_installed.test.ts
@@ -38,6 +38,15 @@ describe("skillsInstalledForAgent", () => {
 		expect(skillsInstalledForAgent("grok-build", cwd)).toBe(true);
 	});
 
+	test("does not treat preview as installed when only base skills exist", () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
+		dirs.push(cwd);
+		writeSkills(cwd, ".cursor/skills", ["neon", "neon-postgres"]);
+
+		expect(skillsInstalledForAgent("cursor", cwd, true)).toBe(false);
+		expect(skillsInstalledForAgent("cursor", cwd)).toBe(true);
+	});
+
 	test("does not treat a single base skill as installed", () => {
 		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-"));
 		dirs.push(cwd);

--- a/packages/cli/src/init/types.ts
+++ b/packages/cli/src/init/types.ts
@@ -1,18 +1,4 @@
-export type Editor =
-	| "Cursor"
-	| "VS Code"
-	| "Claude CLI"
-	| "Claude Desktop"
-	| "Codex"
-	| "OpenCode"
-	| "Antigravity"
-	| "Cline"
-	| "Cline CLI"
-	| "Gemini CLI"
-	| "GitHub Copilot CLI"
-	| "Goose"
-	| "MCPorter"
-	| "Zed";
+export type Editor = "Cursor" | "VS Code";
 
 // ---------------------------------------------------------------------------
 // Agent-driven state machine protocol

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@segment/analytics-node':
         specifier: 1.3.0
         version: 1.3.0
+      add-mcp:
+        specifier: 2.0.0
+        version: 2.0.0
       chalk:
         specifier: 5.3.0
         version: 5.3.0
@@ -1015,11 +1018,17 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
+  '@clack/core@0.4.1':
+    resolution: {integrity: sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==}
+
   '@clack/core@0.4.2':
     resolution: {integrity: sha512-NYQfcEy8MWIxrT5Fj8nIVchfRFA26yYKJcvBS7WlUIlw2OmQOY9DhGGXMovyI5J5PpxrCPGkgUi207EBrjpBvg==}
 
   '@clack/prompts@0.10.1':
     resolution: {integrity: sha512-Q0T02vx8ZM9XSv9/Yde0jTmmBQufZhPJfYAg2XrrrxWWaZgq1rr8nU8Hv710BQ1dhoP8rtY7YUdpGej2Qza/cw==}
+
+  '@clack/prompts@0.9.1':
+    resolution: {integrity: sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1424,6 +1433,9 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       hono: ^4
+
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
 
   '@inquirer/external-editor@1.0.1':
     resolution: {integrity: sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==}
@@ -2257,6 +2269,11 @@ packages:
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  add-mcp@2.0.0:
+    resolution: {integrity: sha512-UvMKmPPzE+9WgzghCkOTP2e1rKBZBWZ2XzUwR0Q/6Y8EOUPiVLL+44v8zNKaUoxEyFNIU+CETSrGBz7DWFjxig==}
+    engines: {node: '>=18'}
     hasBin: true
 
   agent-base@6.0.2:
@@ -3606,6 +3623,9 @@ packages:
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
@@ -5727,6 +5747,11 @@ snapshots:
       human-id: 4.1.1
       prettier: 2.8.8
 
+  '@clack/core@0.4.1':
+    dependencies:
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
   '@clack/core@0.4.2':
     dependencies:
       picocolors: 1.1.1
@@ -5735,6 +5760,12 @@ snapshots:
   '@clack/prompts@0.10.1':
     dependencies:
       '@clack/core': 0.4.2
+      picocolors: 1.1.1
+      sisteransi: 1.0.5
+
+  '@clack/prompts@0.9.1':
+    dependencies:
+      '@clack/core': 0.4.1
       picocolors: 1.1.1
       sisteransi: 1.0.5
 
@@ -6014,6 +6045,8 @@ snapshots:
   '@hono/node-server@2.1.0(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
+
+  '@iarna/toml@2.2.5': {}
 
   '@inquirer/external-editor@1.0.1(@types/node@24.3.1)':
     dependencies:
@@ -6844,6 +6877,15 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  add-mcp@2.0.0:
+    dependencies:
+      '@clack/prompts': 0.9.1
+      '@iarna/toml': 2.2.5
+      chalk: 5.4.1
+      commander: 13.1.0
+      js-yaml: 4.1.1
+      jsonc-parser: 3.3.1
 
   agent-base@6.0.2:
     dependencies:
@@ -8242,6 +8284,8 @@ snapshots:
   json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
+
+  jsonc-parser@3.3.1: {}
 
   jsonfile@4.0.0:
     optionalDependencies:


### PR DESCRIPTION
## Problem

`neon init` installed the Neon MCP server by telling the agent to run add-mcp as a subprocess:

```
npx -y add-mcp https://mcp.neon.tech/mcp -g -n Neon -y -a claude-code
```

That command writes even when the agent cannot load the result. Claude Desktop only loads local stdio from its config file; an HTTP `Neon` entry is unused. Windsurf has no project MCP path, so `--scope project` has nowhere to write.

The skills step installed only `neon-postgres`. Setup treated another agent's MCP or skills as done for this one. `--preview` used the same shared cursor/claude/agents directories, so one agent's preview set hid another agent's missing files.

## Diagnosis

add-mcp 2.0.0 exports the agent table and `upsertServer`. `supportedTransports` and `localConfigPath` are already on each agent. Init can refuse in-process and return a structured result instead of asking the agent to run a CLI that will write anyway.

Skills CLI ids are not in add-mcp. The map from add-mcp id to `skills --agent` stays hardcoded. An agent with no entry is skipped, not rewritten to Cursor.

Inspect now walks every add-mcp agent path and records who actually has Neon. Orchestrate only skips setup when this agent has MCP and this agent's full skill set.

## Interface

`neon init` and `neon init --agent` keep the same flags. MCP is written in-process through add-mcp. Skills still go through the skills CLI.

```ts
upsertServer(
  agent,
  "Neon",
  { type: "http", url: "https://mcp.neon.tech/mcp" },
  { local: scope === "project", cwd },
);
```

`neon init mcp --json --agent claude --install` no longer returns `status: "installing"` and a `run_command` for `npx add-mcp`. It writes, then:

```json
{
  "phase": "tooling",
  "status": "installed",
  "path": "~/.claude.json",
  "message": "Installed Neon MCP server (global scope) for claude-code.",
  "nextAction": {
    "type": "run_neon_init",
    "args": ["skills", "--json", "--agent", "claude", "--install"]
  }
}
```

Cursor project scope still writes `.cursor/mcp.json`:

```json
{
  "mcpServers": {
    "Neon": { "url": "https://mcp.neon.tech/mcp" }
  }
}
```

The picker is every add-mcp agent: `antigravity`, `cline`, `cline-cli`, `claude-code`, `claude-desktop`, `codex`, `cursor`, `gemini-cli`, `goose`, `github-copilot-cli`, `grok-build`, `mcporter`, `opencode`, `vscode`, `windsurf`, `zed`.

### Windsurf `--scope project`

Windsurf has HTTP and no `localConfigPath`. Customize and the install prompt omit project. `--scope project` is still accepted and refused:

```
neon init mcp --json --agent windsurf --install --scope project
```

```json
{
  "phase": "tooling",
  "status": "unsupported",
  "error": "Windsurf does not support project-level MCP config.",
  "nextAction": {
    "type": "ask_user",
    "question": "Windsurf does not support project-level MCP. Install the Neon MCP server globally instead?",
    "options": [
      { "value": "global", "label": "Install globally" },
      { "value": "skip", "label": "Skip MCP install" }
    ],
    "responseMapping": {
      "global": {
        "args": ["mcp", "--json", "--agent", "windsurf", "--install"]
      },
      "skip": {
        "args": ["skills", "--json", "--agent", "windsurf", "--install"]
      }
    }
  }
}
```

`global` re-invokes `mcp --install` without `--scope` (global is the default). Nothing is written on the project attempt.

### Claude Desktop, project or global

Claude Desktop is stdio-only. There is no HTTP write and no "Install globally" question, because global cannot write HTTP either.

```
neon init mcp --json --agent claude-desktop --install
neon init mcp --json --agent claude-desktop --install --scope project
```

```json
{
  "phase": "tooling",
  "status": "unsupported",
  "error": "Claude Desktop only supports local (stdio) servers via its config file. Add remote servers through Settings → Connectors in the app instead.",
  "nextAction": {
    "type": "run_neon_init",
    "args": ["skills", "--json", "--agent", "claude-desktop", "--install"]
  }
}
```

### Skills

The skills step installs `neon` and `neon-postgres`. One skill per `skills add` call:

```
neon init skills --json --agent cursor --install
```

```json
{
  "phase": "tooling",
  "status": "installing_skills",
  "nextAction": {
    "type": "run_command",
    "command": "npx -y skills add neondatabase/agent-skills --skill neon --agent cursor -y && npx -y skills add neondatabase/agent-skills --skill neon-postgres --agent cursor -y"
  }
}
```

`--preview` adds `neon-object-storage`, `neon-functions`, and `neon-ai-gateway` in setup and interactive, for that agent only. The skills step does not take `--preview`.

| add-mcp id | `skills --agent` |
|---|---|
| `cursor` | `cursor` |
| `vscode` | `github-copilot` |
| `claude-code` | `claude-code` |
| `claude-desktop` | `claude-code` |
| `codex` | `codex` |
| `opencode` | `opencode` |
| `antigravity` | `antigravity` |
| `cline` | `cline` |
| `cline-cli` | `cline` |
| `gemini-cli` | `gemini-cli` |
| `goose` | `goose` |
| `github-copilot-cli` | `github-copilot` |
| `windsurf` | `windsurf` |
| `zed` | `zed` |
| `grok-build` | `grok` |
| `mcporter` | none (skills skipped) |

### Per-agent MCP and skills

```
# .cursor/mcp.json already has Neon, and Cursor has neon + neon-postgres
neon init --agent grok-build --json
# setup, pending — Grok has neither

neon init --agent grok-build --preview --json
# setup, pending if Grok is missing preview skills, even when Cursor has all five
```

`mcporter` MCP success chains to `--agent mcporter --json`, not `skills --install`.

## Also in here

- `neon` 3.4.0 depends on `add-mcp@2.0.0`. Changeset is a neon minor.
- Inspect finds Neon MCP in each add-mcp path (JSON and TOML), not only Cursor/Claude files.
- Neon CLI install failure copy says "update" when the binary was already present.
- `Object.hasOwn` is gone so init typechecks on ES2020.

## Verification

`pnpm exec vitest run` on the init files this branch adds or changes: 8 files, 70 tests, pass.

- Cursor and Grok project writes; Claude Desktop HTTP refuse; Windsurf project refuse with no global fallback
- Windsurf `--scope project` → `unsupported` + Install globally / Skip; Claude Desktop → `unsupported` + skills, no global option
- Another agent's MCP, base skills, or preview skills do not skip setup
- Preview is not installed when only `neon` and `neon-postgres` exist for that agent
- `mcporter` has no skills target; grok-build maps to `grok`
- Setup omits project MCP for Windsurf; a project-scope attempt is `failed`, not success

Not run here: `agent_snapshot` (needs a CLI build), a live Windsurf or Claude Desktop app, or `skills add` against the network.

## For your attention

- Interactive `neon init` never offers project MCP for Windsurf, so it never asks "Install globally?". That question is the agent `mcp --install --scope project` path.
- Setup's batched install treats Claude Desktop's HTTP refuse as `success` with `manualAction: true` and the Connectors text. The mcp phase returns `unsupported`.
- Agents still holding the old `npx add-mcp ...` `nextAction` will run a write this branch no longer asks for.
