### PR TITLE
Give the function-bundle size-limit test 30s so CI coverage does not time it out

### DIFF
--- a/packages/config-runtime/src/lib/function-bundle.test.ts
+++ b/packages/config-runtime/src/lib/function-bundle.test.ts
@@ -544,6 +544,7 @@ describe("buildFunctionBundle staging external package files", () => {
 		expect(names.filter((n) => n.includes("musl"))).toEqual([]);
 	});
 
+	// Under coverage, this 11 MiB ZIP has exceeded Vitest's 5s default in CI.
 	test("fails when the archive exceeds the compressed size limit, naming the largest files", async () => {
 		const source = join(dir, "uses-native.ts");
 		// A real aarch64 header, so the architecture check passes and the size limit is what
@@ -568,5 +569,5 @@ describe("buildFunctionBundle staging external package files", () => {
 
 		expect(message).toMatch(/archive is 1[01]\.\d MiB compressed/);
 		expect(message).toContain("node_modules/fake-addon/lib/huge.so.1");
-	});
+	}, 30_000);
 });


### PR DESCRIPTION
## Problem

CI's `@neon/config-runtime` unit job runs with `--coverage`. The test that rejects an archive over the 10 MiB compressed limit builds an 11 MiB ZIP of random bytes. That work has exceeded Vitest's 5s default on CI, so the job fails on a timeout. PRs that do not touch this file fail the same check.

## Diagnosis

`DEFAULT_ARCHIVE_LIMITS.maxZipBytes` is 10 MiB. The fixture fills 11 MiB with `randomFillSync` so `zipSync` at level 6 cannot compress the archive back under the limit. An aarch64 ELF header is written first so the architecture check is not what fails.

`packages/config-runtime/vitest.config.ts` does not set `testTimeout`. Vitest defaults to 5 seconds. The non-CLI unit step is `test:ci --coverage`.

On this machine the same test finished in 552ms with coverage on. 5s is enough here. The comment on the test records that the ZIP has gone past 5s on CI.

The assertions do not change. Raising `testTimeout` for the package would also let a hung test run for 30s. `packages/config/src/lib/loader.test.ts` already uses `30_000` for one coverage-slow test.

## The user-facing interface

Nothing changes for `@neon/config-runtime` callers. Archive limits are unchanged.

```ts
test(
  "fails when the archive exceeds the compressed size limit, naming the largest files",
  async () => {
    // 11 MiB of random bytes, then buildFunctionBundle(...)
  },
  30_000,
);
```

Every other test in the file keeps the 5s default.

## Verification

```
pnpm --filter @neon/config-runtime exec vitest run src/lib/function-bundle.test.ts
```

18 passed in 807ms.

Same command with `--coverage --coverage.reporter=json`: 18 passed. The size-limit test reported 552ms.

The CI timeout was not reproduced here. Filtering to that one test with `-t` fails because `uses-native.ts` is written by an earlier test in the same `describe`.

## For your attention

- 30s is headroom, not a measured CI duration.
- The 11 MiB fixture is unchanged. A smaller or compressible payload would stop exercising the compressed-limit error.
- No changeset. Users of the package do not see this.