### PR TITLE
Retry live AI Gateway e2e once after REQUEST_LIMIT_EXCEEDED

### DIFF
--- a/packages/ai-sdk-provider/e2e/gateway-errors.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/gateway-errors.e2e.test.ts
@@ -1,7 +1,7 @@
 import { generateText } from "ai";
 import { describe, expect, it } from "vitest";
 import { neon } from "../src/index.js";
-import { MATRIX_MODELS } from "./helpers.js";
+import { MATRIX_MODELS, withRateLimitRetry } from "./helpers.js";
 
 /**
  * The Responses route answers with three different error envelopes, and only
@@ -17,11 +17,13 @@ const model = MATRIX_MODELS.openai;
 
 async function messageFor(options: Record<string, unknown>): Promise<string> {
 	try {
-		await generateText({
-			model: neon(model),
-			prompt: "Reply with exactly three words.",
-			...options,
-		} as never);
+		await withRateLimitRetry(async () => {
+			await generateText({
+				model: neon(model),
+				prompt: "Reply with exactly three words.",
+				...options,
+			} as never);
+		});
 	} catch (error) {
 		return (error as { message: string }).message;
 	}
@@ -53,11 +55,13 @@ describe(`e2e — Responses error surfacing (${model})`, () => {
 
 	it("leaves an already OpenAI-shaped error intact", async () => {
 		try {
-			await generateText({
-				model: neon("gpt-5-9-does-not-exist"),
-				prompt: "hi",
-				maxOutputTokens: 512,
-			});
+			await withRateLimitRetry(() =>
+				generateText({
+					model: neon("gpt-5-9-does-not-exist"),
+					prompt: "hi",
+					maxOutputTokens: 512,
+				}),
+			);
 			throw new Error("expected the gateway to reject this request");
 		} catch (error) {
 			expect((error as { message: string }).message).toContain(
@@ -75,12 +79,14 @@ describe(`e2e — chat-completions error surfacing (${MATRIX_MODELS.meta})`, () 
 	it("surfaces a flat Databricks rejection", async () => {
 		let message = "";
 		try {
-			await generateText({
-				model: neon(MATRIX_MODELS.meta),
-				prompt: "Reply with exactly three words.",
-				maxOutputTokens: 512,
-				temperature: 9.5,
-			});
+			await withRateLimitRetry(() =>
+				generateText({
+					model: neon(MATRIX_MODELS.meta),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+					temperature: 9.5,
+				}),
+			);
 		} catch (error) {
 			message = (error as { message: string }).message;
 		}

--- a/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/gateway-matrix.e2e.test.ts
@@ -16,6 +16,7 @@ import {
 	type MatrixFamily,
 	maxTokensFor,
 	REASONING_EFFORT_FAMILIES,
+	withRateLimitRetry,
 } from "./helpers.js";
 
 const PROMPT = "Reply with exactly three words.";
@@ -101,65 +102,89 @@ describe("e2e — Neon AI Gateway capability matrix", () => {
 	)("%s (%s)", (family, modelId) => {
 		const servesModel = served.has(modelId);
 
-		it.skipIf(!servesModel)("generateText", async () => {
-			const result = await generateText({
-				model: neon(modelId),
-				prompt: PROMPT,
-				...modelOptions(family),
-			});
-			expect(result.text.trim().length).toBeGreaterThan(0);
-			expectNoHardFailureWarnings(result.warnings);
-		});
+		it.skipIf(!servesModel)(
+			"generateText",
+			async () => {
+				const result = await withRateLimitRetry(() =>
+					generateText({
+						model: neon(modelId),
+						prompt: PROMPT,
+						...modelOptions(family),
+					}),
+				);
+				expect(result.text.trim().length).toBeGreaterThan(0);
+				expectNoHardFailureWarnings(result.warnings);
+			},
+			180_000,
+		);
 
-		it.skipIf(!servesModel)("generateText with system prompt", async () => {
-			const result = await generateText({
-				model: neon(modelId),
-				system: SYSTEM,
-				prompt: "Say hello.",
-				...modelOptions(family),
-			});
-			expect(result.text.trim().length).toBeGreaterThan(0);
-			expectNoHardFailureWarnings(result.warnings);
-		});
+		it.skipIf(!servesModel)(
+			"generateText with system prompt",
+			async () => {
+				const result = await withRateLimitRetry(() =>
+					generateText({
+						model: neon(modelId),
+						system: SYSTEM,
+						prompt: "Say hello.",
+						...modelOptions(family),
+					}),
+				);
+				expect(result.text.trim().length).toBeGreaterThan(0);
+				expectNoHardFailureWarnings(result.warnings);
+			},
+			180_000,
+		);
 
-		it.skipIf(!servesModel)("streamText", async () => {
-			const result = streamText({
-				model: neon(modelId),
-				prompt: PROMPT,
-				...modelOptions(family),
-			});
-			let text = "";
-			for await (const part of result.textStream) {
-				text += part;
-			}
-			expect(text.trim().length).toBeGreaterThan(0);
-		});
+		it.skipIf(!servesModel)(
+			"streamText",
+			async () => {
+				const text = await withRateLimitRetry(async () => {
+					const result = streamText({
+						model: neon(modelId),
+						prompt: PROMPT,
+						...modelOptions(family),
+					});
+					let collected = "";
+					for await (const part of result.textStream) {
+						collected += part;
+					}
+					return collected;
+				});
+				expect(text.trim().length).toBeGreaterThan(0);
+			},
+			180_000,
+		);
 
 		it.skipIf(!servesModel || !STRUCTURED_FAMILIES.has(family))(
 			"generateObject",
 			async () => {
-				const result = await generateObject({
-					model: neon(modelId),
-					schema: summarySchema,
-					prompt: 'Summarize "serverless postgres" in the schema.',
-					...modelOptions(family),
-				});
+				const result = await withRateLimitRetry(() =>
+					generateObject({
+						model: neon(modelId),
+						schema: summarySchema,
+						prompt: 'Summarize "serverless postgres" in the schema.',
+						...modelOptions(family),
+					}),
+				);
 				expect(result.object.topic.length).toBeGreaterThan(0);
 				expect(result.object.wordCount).toBeGreaterThan(0);
 				expectNoHardFailureWarnings(result.warnings);
 			},
+			180_000,
 		);
 
 		it.skipIf(!servesModel || !TOOL_FAMILIES.has(family))(
 			"tool calling (generateText + stepCountIs)",
 			async () => {
-				const result = await generateText({
-					model: neon(modelId),
-					prompt: "What is the temperature in Paris? Use the weather tool.",
-					tools: { weather: weatherTool },
-					stopWhen: stepCountIs(5),
-					...modelOptions(family),
-				});
+				const result = await withRateLimitRetry(() =>
+					generateText({
+						model: neon(modelId),
+						prompt: "What is the temperature in Paris? Use the weather tool.",
+						tools: { weather: weatherTool },
+						stopWhen: stepCountIs(5),
+						...modelOptions(family),
+					}),
+				);
 				expect(result.text.trim().length).toBeGreaterThan(0);
 				// A tool call plus a follow-up step, not one step that happened
 				// to answer. The follow-up is the leg that carries prior
@@ -170,6 +195,7 @@ describe("e2e — Neon AI Gateway capability matrix", () => {
 				).toBeGreaterThanOrEqual(1);
 				expect(result.steps.length).toBeGreaterThanOrEqual(2);
 			},
+			180_000,
 		);
 	});
 
@@ -180,58 +206,65 @@ describe("e2e — Neon AI Gateway capability matrix", () => {
 		it.skipIf(!served.has(MATRIX_MODELS.openai))(
 			"gets past the step that carries reasoning back",
 			async () => {
-				const result = streamText({
-					model: neon(MATRIX_MODELS.openai),
-					prompt: "What is the temperature in Paris? Use the weather tool.",
-					tools: { weather: weatherTool },
-					stopWhen: stepCountIs(5),
-					...modelOptions("openai"),
+				const { steps, text } = await withRateLimitRetry(async () => {
+					const result = streamText({
+						model: neon(MATRIX_MODELS.openai),
+						prompt: "What is the temperature in Paris? Use the weather tool.",
+						tools: { weather: weatherTool },
+						stopWhen: stepCountIs(5),
+						...modelOptions("openai"),
+					});
+					await result.consumeStream();
+					return {
+						steps: await result.steps,
+						text: await result.text,
+					};
 				});
-				await result.consumeStream();
-
-				const steps = await result.steps;
 				expect(
 					steps.flatMap((step) => step.toolCalls).length,
 				).toBeGreaterThanOrEqual(1);
 				expect(steps.length).toBeGreaterThanOrEqual(2);
-				await expect(result.text).resolves.not.toBe("");
+				expect(text).not.toBe("");
 			},
-			120_000,
+			180_000,
 		);
 	});
 
 	describe("OpenAI Responses — imageGeneration tool", () => {
 		it("streamText with neon.tools.imageGeneration returns JPEG", async () => {
-			const result = streamText({
-				model: neon(MATRIX_MODELS.openai),
-				prompt: "Generate a simple red circle on a white background.",
-				tools: {
-					image_generation: neon.tools.imageGeneration({
-						outputFormat: "jpeg",
-						quality: "low",
-						outputCompression: 30,
-						size: "1024x1024",
-					}),
-				},
-				...modelOptions("openai"),
-			});
+			const gotImage = await withRateLimitRetry(async () => {
+				const result = streamText({
+					model: neon(MATRIX_MODELS.openai),
+					prompt: "Generate a simple red circle on a white background.",
+					tools: {
+						image_generation: neon.tools.imageGeneration({
+							outputFormat: "jpeg",
+							quality: "low",
+							outputCompression: 30,
+							size: "1024x1024",
+						}),
+					},
+					...modelOptions("openai"),
+				});
 
-			let gotImage = false;
-			for await (const part of result.fullStream) {
-				if (
-					part.type === "tool-result" &&
-					part.toolName === "image_generation" &&
-					typeof part.output === "object" &&
-					part.output !== null &&
-					"result" in part.output &&
-					typeof part.output.result === "string" &&
-					part.output.result.length > 1000
-				) {
-					gotImage = true;
+				let found = false;
+				for await (const part of result.fullStream) {
+					if (
+						part.type === "tool-result" &&
+						part.toolName === "image_generation" &&
+						typeof part.output === "object" &&
+						part.output !== null &&
+						"result" in part.output &&
+						typeof part.output.result === "string" &&
+						part.output.result.length > 1000
+					) {
+						found = true;
+					}
 				}
-			}
+				return found;
+			});
 			expect(gotImage).toBe(true);
-		}, 120_000);
+		}, 180_000);
 	});
 
 	// Every one of these returns 400 if the provider forwards the parameter,
@@ -261,37 +294,41 @@ describe("e2e — Neon AI Gateway capability matrix", () => {
 			model,
 			dropped,
 		}) => {
-			const result = await generateText({
-				model: neon(model),
-				prompt: "Reply with exactly three words.",
-				maxOutputTokens: 512,
-				temperature: 0.2,
-				topP: 0.9,
-				frequencyPenalty: 0.5,
-				presencePenalty: 0.5,
-			});
+			const result = await withRateLimitRetry(() =>
+				generateText({
+					model: neon(model),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+					temperature: 0.2,
+					topP: 0.9,
+					frequencyPenalty: 0.5,
+					presencePenalty: 0.5,
+				}),
+			);
 
 			expect(result.text.trim().length).toBeGreaterThan(0);
 			const reported = (result.warnings ?? [])
 				.map((w) => ("feature" in w ? w.feature : undefined))
 				.filter(Boolean);
 			expect(new Set(reported)).toEqual(new Set(dropped));
-		}, 120_000);
+		}, 180_000);
 
 		// The older Gemini models still take penalties. If this starts
 		// failing, the restriction has spread and the id list needs widening
 		// rather than the assertion loosening.
 		it("still sends penalties to the Gemini models that accept them", async () => {
-			const result = await generateText({
-				model: neon("gemini-3-flash"),
-				prompt: "Reply with exactly three words.",
-				maxOutputTokens: 512,
-				frequencyPenalty: 0.5,
-			});
+			const result = await withRateLimitRetry(() =>
+				generateText({
+					model: neon("gemini-3-flash"),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+					frequencyPenalty: 0.5,
+				}),
+			);
 
 			expect(result.text.trim().length).toBeGreaterThan(0);
 			expect(result.warnings ?? []).toEqual([]);
-		}, 120_000);
+		}, 180_000);
 	});
 
 	// The provider used to drop reasoningEffort on Gemini and tell the caller
@@ -301,12 +338,14 @@ describe("e2e — Neon AI Gateway capability matrix", () => {
 	describe("reasoningEffort on Gemini", () => {
 		it("changes how much the model reasons", async () => {
 			const reason = async (effort: "minimal" | "high") => {
-				const result = await generateText({
-					model: neon("gemini-3-6-flash"),
-					prompt: "A farmer has 17 sheep. All but 9 run away. How many remain? Think it through.",
-					maxOutputTokens: 900,
-					providerOptions: { neon: { reasoningEffort: effort } },
-				});
+				const result = await withRateLimitRetry(() =>
+					generateText({
+						model: neon("gemini-3-6-flash"),
+						prompt: "A farmer has 17 sheep. All but 9 run away. How many remain? Think it through.",
+						maxOutputTokens: 900,
+						providerOptions: { neon: { reasoningEffort: effort } },
+					}),
+				);
 				expect(result.warnings ?? []).toEqual([]);
 				const usage = (
 					result as {
@@ -324,7 +363,7 @@ describe("e2e — Neon AI Gateway capability matrix", () => {
 			];
 			expect(minimal).toBe(0);
 			expect(high).toBeGreaterThan(0);
-		}, 180_000);
+		}, 240_000);
 	});
 
 	describe("gpt-oss harmony normalization (#308)", () => {
@@ -332,25 +371,30 @@ describe("e2e — Neon AI Gateway capability matrix", () => {
 		// array; the provider normalizes it to the OpenAI Chat Completions
 		// contract. Verify text comes through for both generate and stream.
 		it("generateText works and does not throw on the harmony shape", async () => {
-			const result = await generateText({
-				model: neon("gpt-oss-120b"),
-				prompt: "Reply with exactly three words.",
-				maxOutputTokens: 512,
-			});
+			const result = await withRateLimitRetry(() =>
+				generateText({
+					model: neon("gpt-oss-120b"),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+				}),
+			);
 			expect(result.text.trim().length).toBeGreaterThan(0);
-		});
+		}, 180_000);
 
 		it("streamText works without an invalid-JSON error flood", async () => {
-			const result = streamText({
-				model: neon("gpt-oss-120b"),
-				prompt: "Reply with exactly three words.",
-				maxOutputTokens: 512,
+			const text = await withRateLimitRetry(async () => {
+				const result = streamText({
+					model: neon("gpt-oss-120b"),
+					prompt: "Reply with exactly three words.",
+					maxOutputTokens: 512,
+				});
+				let collected = "";
+				for await (const part of result.textStream) {
+					collected += part;
+				}
+				return collected;
 			});
-			let text = "";
-			for await (const part of result.textStream) {
-				text += part;
-			}
 			expect(text.trim().length).toBeGreaterThan(0);
-		});
+		}, 180_000);
 	});
 });

--- a/packages/ai-sdk-provider/e2e/helpers.ts
+++ b/packages/ai-sdk-provider/e2e/helpers.ts
@@ -112,3 +112,31 @@ export function expectNoHardFailureWarnings(
 		expect(warning.type).not.toBe("other");
 	}
 }
+
+/**
+ * FMAPI enforces TPM over a one-minute window, so the AI SDK's immediate 429
+ * retries cannot succeed. Wait for the next window before retrying once.
+ */
+const REQUEST_LIMIT_RETRY_WAIT_MS = 60_000;
+
+function isRequestLimitExceeded(error: unknown): boolean {
+	const message = error instanceof Error ? error.message : String(error);
+	return message.includes("REQUEST_LIMIT_EXCEEDED");
+}
+
+export async function withRateLimitRetry<T>(run: () => Promise<T>): Promise<T> {
+	try {
+		return await run();
+	} catch (error) {
+		if (!isRequestLimitExceeded(error)) {
+			throw error;
+		}
+		console.warn(
+			`REQUEST_LIMIT_EXCEEDED; waiting ${REQUEST_LIMIT_RETRY_WAIT_MS / 1000}s for the TPM window before one retry`,
+		);
+		await new Promise<void>((resolve) => {
+			setTimeout(resolve, REQUEST_LIMIT_RETRY_WAIT_MS);
+		});
+		return await run();
+	}
+}

--- a/packages/ai-sdk-provider/e2e/sdk-version-matrix.e2e.test.ts
+++ b/packages/ai-sdk-provider/e2e/sdk-version-matrix.e2e.test.ts
@@ -5,7 +5,7 @@ import {
 } from "ai-v7";
 import { beforeAll, describe, expect, it } from "vitest";
 import { neon } from "../src/index.js";
-import { assertGatewayEnv } from "./helpers.js";
+import { assertGatewayEnv, withRateLimitRetry } from "./helpers.js";
 
 const PROMPT = "Reply with exactly the single word pong.";
 const CONCURRENCY = 4;
@@ -19,22 +19,26 @@ const SDK_RUNNERS = [
 	{
 		version: "6",
 		async generate(modelId) {
-			const result = await generateTextV6({
-				model: neon(modelId),
-				prompt: PROMPT,
-				maxOutputTokens: 2048,
-			});
+			const result = await withRateLimitRetry(() =>
+				generateTextV6({
+					model: neon(modelId),
+					prompt: PROMPT,
+					maxOutputTokens: 2048,
+				}),
+			);
 			return result.text;
 		},
 	},
 	{
 		version: "7",
 		async generate(modelId) {
-			const result = await generateTextV7({
-				model: neon(modelId),
-				prompt: PROMPT,
-				maxOutputTokens: 2048,
-			});
+			const result = await withRateLimitRetry(() =>
+				generateTextV7({
+					model: neon(modelId),
+					prompt: PROMPT,
+					maxOutputTokens: 2048,
+				}),
+			);
 			return result.text;
 		},
 	},
@@ -130,34 +134,37 @@ describe("e2e — every currently enabled model on AI SDK 6 and 7", () => {
 	}
 
 	it("uses the Neon image-generation tool with AI SDK 7", async () => {
-		const result = streamTextV7({
-			model: neon("gpt-5-mini"),
-			prompt: "Generate a simple red circle on a white background.",
-			tools: {
-				image_generation: neon.tools.imageGeneration({
-					outputFormat: "jpeg",
-					quality: "low",
-					outputCompression: 30,
-					size: "1024x1024",
-				}),
-			},
-			maxOutputTokens: 2048,
-		});
+		const gotImage = await withRateLimitRetry(async () => {
+			const result = streamTextV7({
+				model: neon("gpt-5-mini"),
+				prompt: "Generate a simple red circle on a white background.",
+				tools: {
+					image_generation: neon.tools.imageGeneration({
+						outputFormat: "jpeg",
+						quality: "low",
+						outputCompression: 30,
+						size: "1024x1024",
+					}),
+				},
+				maxOutputTokens: 2048,
+			});
 
-		let gotImage = false;
-		for await (const part of result.fullStream) {
-			if (
-				part.type === "tool-result" &&
-				part.toolName === "image_generation" &&
-				typeof part.output === "object" &&
-				part.output !== null &&
-				"result" in part.output &&
-				typeof part.output.result === "string" &&
-				part.output.result.length > 1000
-			) {
-				gotImage = true;
+			let found = false;
+			for await (const part of result.fullStream) {
+				if (
+					part.type === "tool-result" &&
+					part.toolName === "image_generation" &&
+					typeof part.output === "object" &&
+					part.output !== null &&
+					"result" in part.output &&
+					typeof part.output.result === "string" &&
+					part.output.result.length > 1000
+				) {
+					found = true;
+				}
 			}
-		}
+			return found;
+		});
 		expect(gotImage).toBe(true);
-	}, 120_000);
+	}, 180_000);
 });

--- a/packages/ai-sdk-provider/e2e/with-rate-limit-retry.test.ts
+++ b/packages/ai-sdk-provider/e2e/with-rate-limit-retry.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withRateLimitRetry } from "./helpers.js";
+
+describe("withRateLimitRetry", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.spyOn(console, "warn").mockImplementation(() => {});
+	});
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("returns the first success", async () => {
+		await expect(withRateLimitRetry(async () => 1)).resolves.toBe(1);
+	});
+
+	it("rethrows a non-quota error immediately", async () => {
+		await expect(
+			withRateLimitRetry(async () => {
+				throw new Error("not a quota error");
+			}),
+		).rejects.toThrow("not a quota error");
+	});
+
+	it("retries once after REQUEST_LIMIT_EXCEEDED and a 60s wait", async () => {
+		let calls = 0;
+		const pending = withRateLimitRetry(async () => {
+			calls += 1;
+			if (calls === 1) {
+				throw new Error(
+					"Failed after 3 attempts. Last error: REQUEST_LIMIT_EXCEEDED: Exceeded workspace input tokens per minute rate limit",
+				);
+			}
+			return "ok";
+		});
+		await vi.advanceTimersByTimeAsync(60_000);
+		await expect(pending).resolves.toBe("ok");
+		expect(calls).toBe(2);
+	});
+
+	it("does not retry a second REQUEST_LIMIT_EXCEEDED", async () => {
+		const pending = withRateLimitRetry(async () => {
+			throw new Error("REQUEST_LIMIT_EXCEEDED");
+		});
+		const assertion = expect(pending).rejects.toThrow(
+			"REQUEST_LIMIT_EXCEEDED",
+		);
+		await vi.advanceTimersByTimeAsync(60_000);
+		await assertion;
+	});
+});


### PR DESCRIPTION
## Problem

The live AI Gateway e2e suite fails when a model returns `REQUEST_LIMIT_EXCEEDED`. That is the tokens-per-minute quota. The suite fails for a quota window, not for a provider regression.

## Diagnosis

The AI SDK already retries that 429 three times. Those retries run inside the same minute.

The quota is a one-minute window. Immediate retries cannot succeed. The test then fails with the SDK's "Failed after 3 attempts" wrapper.

`streamText` returns before the stream is read. A 429 on a later chunk is the same miss, so the retry has to rerun the request and the consumption.

A 60s sleep in the published provider would change caller latency on every quota 429. The retry stays in the e2e helper.

## The user-facing interface

`withRateLimitRetry` is in `packages/ai-sdk-provider/e2e/helpers.ts`. It is not part of the published package. Published `@neon/ai-sdk-provider` behavior does not change.

```ts
export async function withRateLimitRetry<T>(run: () => Promise<T>): Promise<T> {
	try {
		return await run();
	} catch (error) {
		if (!isRequestLimitExceeded(error)) {
			throw error;
		}
		console.warn(
			`REQUEST_LIMIT_EXCEEDED; waiting ${REQUEST_LIMIT_RETRY_WAIT_MS / 1000}s for the TPM window before one retry`,
		);
		await new Promise<void>((resolve) => {
			setTimeout(resolve, REQUEST_LIMIT_RETRY_WAIT_MS);
		});
		return await run();
	}
}
```

`isRequestLimitExceeded` is `message.includes("REQUEST_LIMIT_EXCEEDED")`. Other errors are rethrown. A second quota miss is not retried. The wait is 60 seconds.

## Usage examples

```ts
const result = await withRateLimitRetry(() =>
	generateText({
		model: neon(modelId),
		prompt: PROMPT,
		...modelOptions(family),
	}),
);
```

```ts
const text = await withRateLimitRetry(async () => {
	const result = streamText({
		model: neon(modelId),
		prompt: PROMPT,
		...modelOptions(family),
	});
	let collected = "";
	for await (const part of result.textStream) {
		collected += part;
	}
	return collected;
});
```

## Also in here

Wrapped live cases raise their timeout to 180s so the wait plus two attempts fits. The Gemini `reasoningEffort` case makes two sequential calls and goes to 240s. The SDK 6/7 all-models case stays at 600s.

`gateway-errors.e2e.test.ts` uses the helper so a quota 429 is not treated as the error under test. It keeps the suite default of 120s.

`e2e/with-rate-limit-retry.test.ts` is a network-free unit test. The default vitest config already runs `e2e/*.test.ts` files that are not `*.e2e.test.ts`.

## Verification

`packages/ai-sdk-provider` on this branch, base `origin/main` (`849e3aa`):

```
npm test -- --run
```

102 tests passed. The new helper cases:

- first success returns
- a non-quota error is rethrown with no wait
- `REQUEST_LIMIT_EXCEEDED` waits 60s and retries once
- a second `REQUEST_LIMIT_EXCEEDED` is not retried

Not verified: `npm run test:e2e` against a live gateway. That wait is real time.

## For your attention

- One retry only. A quota that lasts through the next minute still fails the test.
- Match is the substring `REQUEST_LIMIT_EXCEEDED`, including inside the SDK's "Failed after 3 attempts" message.
- `gateway-errors.e2e.test.ts` can still hit the 120s suite timeout if the first attempt is slow and then waits 60s.
- Each hit adds about 60s of wall time. The e2e pool is a single fork, so waits do not overlap across files.