### PR TITLE
chore: release neon@3.5.0

### DIFF
--- a/.changeset/init-add-mcp-sdk.md
+++ b/.changeset/init-add-mcp-sdk.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-`neon init` installs the Neon MCP server through add-mcp's library and offers every agent add-mcp supports. Skills still use a fixed map from those agent ids; agents with no skills CLI id are skipped instead of falling back to Cursor.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 3.5.0
+
+### Minor Changes
+
+- 745c267: `neon init` installs the Neon MCP server through add-mcp's library and offers every agent add-mcp supports. Skills still use a fixed map from those agent ids; agents with no skills CLI id are skipped instead of falling back to Cursor.
+
 ## 3.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.4.0",
+	"version": "3.5.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 3.5.0
+
+### Patch Changes
+
+- Updated dependencies [745c267]
+  - neon@3.5.0
+
 ## 3.4.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Bumped

- `neon` 3.4.0 → 3.5.0
- `neonctl` 3.4.0 → 3.5.0 (Changesets fixed group)

Pending publish after merge: `neon` then `neonctl` via `databricks/secure-public-registry-releases-eng` `neon-pkgs.yml`.