### PR TITLE
chore: release @neon/sdk@2.1.0, @neon/tools@0.2.0

### DIFF
--- a/.changeset/sdk-spec-email-server.md
+++ b/.changeset/sdk-spec-email-server.md
@@ -1,6 +1,0 @@
----
-"@neon/sdk": minor
-"@neon/tools": minor
----
-
-Email-server GET responses now use `StandardEmailServerResponse` / `NeonAuthEmailServerConfigResponse`. `StandardEmailServer` is the write shape and its fields are optional, so a Better Auth project can send a partial update. A Stack Auth project still needs all six fields or the API returns 400. Code that read `host` (or the other five fields) off `StandardEmailServer` should switch the annotation to `StandardEmailServerResponse`.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @neon-internals/env-core
+
+## 0.0.1
+
+### Patch Changes
+
+- @neon/config@1.0.1

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # neon
 
+## 3.5.1
+
+### Patch Changes
+
+- Updated dependencies [5c57d00]
+  - @neon/sdk@2.1.0
+  - @neon/config@1.0.1
+  - @neon/config-runtime@1.0.1
+
 ## 3.5.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.5.0",
+	"version": "3.5.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 1.0.1
+
+### Patch Changes
+
+- @neon/config@1.0.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 1.0.1
+
+### Patch Changes
+
+- Updated dependencies [5c57d00]
+  - @neon/sdk@2.1.0
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.1.1
+
+### Patch Changes
+
+- @neon/config@1.0.1
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 3.5.1
+
+### Patch Changes
+
+- neon@3.5.1
+
 ## 3.5.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/sdk
 
+## 2.1.0
+
+### Minor Changes
+
+- 5c57d00: Email-server GET responses now use `StandardEmailServerResponse` / `NeonAuthEmailServerConfigResponse`. `StandardEmailServer` is the write shape and its fields are optional, so a Better Auth project can send a partial update. A Stack Auth project still needs all six fields or the API returns 400. Code that read `host` (or the other five fields) off `StandardEmailServer` should switch the annotation to `StandardEmailServerResponse`.
+
 ## 2.0.0
 
 ### Major Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "2.0.0",
+	"version": "2.1.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @neon/tools
 
+## 0.2.0
+
+### Minor Changes
+
+- 5c57d00: Email-server GET responses now use `StandardEmailServerResponse` / `NeonAuthEmailServerConfigResponse`. `StandardEmailServer` is the write shape and its fields are optional, so a Better Auth project can send a partial update. A Stack Auth project still needs all six fields or the API returns 400. Code that read `host` (or the other five fields) off `StandardEmailServer` should switch the annotation to `StandardEmailServerResponse`.
+
+### Patch Changes
+
+- Updated dependencies [5c57d00]
+  - @neon/sdk@2.1.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"description": "Generated agent tools for every Neon Management API operation, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Problem

npm still serves `@neon/sdk` 2.0.0 and `@neon/tools` 0.1.0. The email-server GET and write types from #444 (`5c57d00`) are on `main` and not in a published version.

## Diagnosis

The source already landed. A pending changeset marked `@neon/sdk` and `@neon/tools` minor. This PR consumes that changeset.

This PR is version and CHANGELOG only. It does not change source, types, or generated clients.

Dependents bump patch because `updateInternalDependencies` is `"patch"`. `neon` and `neonctl` share a Changesets `fixed` group, so they move together.

## The user-facing interface

| Package | From | To |
|---|---|---|
| `@neon/sdk` | 2.0.0 | 2.1.0 |
| `@neon/tools` | 0.1.0 | 0.2.0 |
| `neon` | 3.5.0 | 3.5.1 |
| `neonctl` | 3.5.0 | 3.5.1 |
| `@neon/config` | 1.0.0 | 1.0.1 |
| `@neon/config-runtime` | 1.0.0 | 1.0.1 |
| `@neon/env` | 1.1.0 | 1.1.1 |

```
npm install @neon/sdk@2.1.0
npm install @neon/tools@0.2.0
```

`@neon/sdk` 2.1.0:

```
## 2.1.0

### Minor Changes

- 5c57d00: Email-server GET responses now use `StandardEmailServerResponse` / `NeonAuthEmailServerConfigResponse`. `StandardEmailServer` is the write shape and its fields are optional, so a Better Auth project can send a partial update. A Stack Auth project still needs all six fields or the API returns 400. Code that read `host` (or the other five fields) off `StandardEmailServer` should switch the annotation to `StandardEmailServerResponse`.
```

`@neon/tools` 0.2.0 uses the same minor note, plus:

```
### Patch Changes

- Updated dependencies [5c57d00]
  - @neon/sdk@2.1.0
```

Existing `neon`, `neonctl`, `@neon/config`, `@neon/config-runtime`, and `@neon/env` call sites do not change. Their new versions exist only because they depend on a bumped package:

```
# neon 3.5.1
Updated dependencies [5c57d00]
  - @neon/sdk@2.1.0
  - @neon/config@1.0.1
  - @neon/config-runtime@1.0.1

# neonctl 3.5.1
- neon@3.5.1

# @neon/config 1.0.1
Updated dependencies [5c57d00]
  - @neon/sdk@2.1.0

# @neon/config-runtime 1.0.1
- @neon/config@1.0.1

# @neon/env 1.1.1
- @neon/config@1.0.1
```

## Also in here

Deletes `.changeset/sdk-spec-email-server.md`. That was the last pending changeset.

`@neon-internals/env-core` 0.0.0 → 0.0.1, with a new CHANGELOG that records `@neon/config@1.0.1`. The package is private and is not published.

## Verification

On `6280c4c`:

```
pnpm lint:ci
```

```
Checked 666 files in 126ms. No fixes applied.
```

Not run: `pnpm test:ci` (no source in the diff) and a live npm publish (post-merge).

## For your attention

The type split a caller has to act on is already on `main` (#444). This PR only versions it. Taking `@neon/sdk@2.1.0` is a TypeScript change for GET email-server annotations.

`@neon-internals/env-core` will not appear on npm.