### PR TITLE
feat(functions): add attachDatabasePool for idle pg.Pool errors

### DIFF
--- a/.changeset/attach-database-pool.md
+++ b/.changeset/attach-database-pool.md
@@ -1,0 +1,7 @@
+---
+"@neon/functions": minor
+---
+
+Add `attachDatabasePool(pool)` so a module-scope `pg.Pool` does not kill the isolate when Postgres drops an idle client.
+
+Expected idle disconnects are silent. Unexpected idle-client errors go to `console.error`, or to `onUnexpectedError` if you pass one.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -144,7 +144,7 @@ The first call wins. A second `attachDatabasePool(pool)` is a no-op. A second ca
 passes `onUnexpectedError` is also a no-op and logs a warning.
 
 If `onUnexpectedError` throws, or returns a promise that rejects, both the pool error and
-the reporter error are logged. Neither reaches the pool's `error` path, so the isolate stays up.
+the reporter error are logged. Neither is rethrown from the listener, so the isolate stays up.
 
 This does not close the pool. Isolate teardown tears the connections down with the process.
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -4,6 +4,7 @@ Runtime helpers for [Neon Functions](https://neon.com):
 
 - **`waitUntil`** — defer background work past a response.
 - **`upgradeWebSocket`** — serve WebSockets from a `fetch` handler.
+- **`attachDatabasePool`** — keep a module-scope `pg.Pool` from killing the isolate when Postgres drops an idle client.
 
 ## Install
 
@@ -99,6 +100,40 @@ no protocol is negotiated: the response header is absent and `socket.protocol` i
 `upgradeWebSocket` needs a Neon Functions runtime that provides the upgrade — deployed, or
 locally under `neon dev`. On an older runtime it throws the "only available inside a Neon
 Functions invocation" `TypeError` rather than misbehaving.
+
+## `attachDatabasePool`
+
+A Neon Function reuses a `pg.Pool` across requests on the same isolate. When Postgres
+closes an idle client — compute scale-to-zero, pooler reclaim, a TCP reset — node-postgres
+emits `error` on the pool. With no listener, that is an uncaught exception and the isolate
+exits.
+
+Call this once after constructing the pool. The pool has already discarded the dead client;
+the next checkout opens a new connection.
+
+```ts
+import { attachDatabasePool } from "@neon/functions";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+attachDatabasePool(pool);
+```
+
+Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, and
+node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is
+logged with `console.error`.
+
+To send unexpected errors to your own reporter instead of `console.error`:
+
+```ts
+attachDatabasePool(pool, {
+	onUnexpectedError: (err) => Sentry.captureException(err),
+});
+```
+
+The first call wins. A second `attachDatabasePool` on the same pool is a no-op.
+
+This does not close the pool. Isolate teardown tears the connections down with the process.
 
 ## Runtime integration
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -115,23 +115,33 @@ the next checkout opens a new connection.
 import { attachDatabasePool } from "@neon/functions";
 import { Pool } from "pg";
 
-const pool = new Pool({ connectionString: process.env.DATABASE_URL, max: 5 });
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 attachDatabasePool(pool);
 ```
+
+This helper does not need a Neon Functions runtime. The same call works in plain Node
+and under `neon dev`.
 
 Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, and
 node-postgres's `Connection terminated unexpectedly`) are silent. Anything else is
 logged with `console.error`.
 
-To send unexpected errors to your own reporter instead of `console.error`:
+To send unexpected errors to your own reporter instead of `console.error`, pass it on
+the first call, next to `new Pool`:
 
 ```ts
+import * as Sentry from "@sentry/node";
+import { attachDatabasePool } from "@neon/functions";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 attachDatabasePool(pool, {
 	onUnexpectedError: (err) => Sentry.captureException(err),
 });
 ```
 
-The first call wins. A second `attachDatabasePool` on the same pool is a no-op.
+The first call wins. A second `attachDatabasePool(pool)` is a no-op. A second call that
+passes `onUnexpectedError` is also a no-op and logs a warning.
 
 This does not close the pool. Isolate teardown tears the connections down with the process.
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -143,6 +143,9 @@ attachDatabasePool(pool, {
 The first call wins. A second `attachDatabasePool(pool)` is a no-op. A second call that
 passes `onUnexpectedError` is also a no-op and logs a warning.
 
+If `onUnexpectedError` throws, or returns a promise that rejects, both the pool error and
+the reporter error are logged. Neither reaches the pool's `error` path, so the isolate stays up.
+
 This does not close the pool. Isolate teardown tears the connections down with the process.
 
 ## Runtime integration

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@neon/functions",
 	"version": "0.7.0",
-	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, and `upgradeWebSocket` for serving WebSockets from a fetch handler.",
+	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, `upgradeWebSocket` for serving WebSockets from a fetch handler, and `attachDatabasePool` for node-postgres idle-client errors.",
 	"keywords": [
 		"neon",
 		"database",

--- a/packages/functions/src/index.ts
+++ b/packages/functions/src/index.ts
@@ -1,14 +1,8 @@
-/**
- * `@neon/functions` — runtime helpers for Neon Functions.
- *
- * - `waitUntil(promise)` — defers async work past the response by handing the promise to
- *   the current invocation context. No-op off-platform (local dev, tests, non-Neon hosts).
- *   Mirrors `@vercel/functions`.
- * - `upgradeWebSocket(request)` — turns a WebSocket handshake into a live connection from
- *   inside a `fetch` handler, returning `{ socket, response }`. Mirrors
- *   `Deno.upgradeWebSocket`. Throws off-platform, where no socket can be upgraded.
- */
-
+export {
+	type AttachDatabasePoolOptions,
+	attachDatabasePool,
+	type DatabasePool,
+} from "./lib/attach-database-pool.js";
 export {
 	type UpgradeWebSocketOptions,
 	upgradeWebSocket,

--- a/packages/functions/src/lib/attach-database-pool.test.ts
+++ b/packages/functions/src/lib/attach-database-pool.test.ts
@@ -121,6 +121,30 @@ describe("attachDatabasePool", () => {
 		expect(pool.listenerCount("error")).toBe(1);
 	});
 
+	it("logs and does not throw when onUnexpectedError returns a rejected promise", async () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const reporterError = new Error("sentry down");
+		const pool = new EventEmitter();
+		attachDatabasePool(pool, {
+			onUnexpectedError: async () => {
+				throw reporterError;
+			},
+		});
+		const err = new Error("unexpected");
+
+		expect(() => pool.emit("error", err)).not.toThrow();
+		await vi.waitFor(() => {
+			expect(error).toHaveBeenCalledWith(
+				"attachDatabasePool: unexpected database pool error",
+				err,
+			);
+			expect(error).toHaveBeenCalledWith(
+				"attachDatabasePool: onUnexpectedError threw",
+				reporterError,
+			);
+		});
+	});
+
 	it("logs and does not throw when onUnexpectedError throws", () => {
 		const error = vi.spyOn(console, "error").mockImplementation(() => {});
 		const reporterError = new Error("sentry down");

--- a/packages/functions/src/lib/attach-database-pool.test.ts
+++ b/packages/functions/src/lib/attach-database-pool.test.ts
@@ -59,7 +59,10 @@ describe("attachDatabasePool", () => {
 		pool.emit("error", err);
 
 		expect(error).toHaveBeenCalledTimes(1);
-		expect(error).toHaveBeenCalledWith(err);
+		expect(error).toHaveBeenCalledWith(
+			"attachDatabasePool: unexpected database pool error",
+			err,
+		);
 	});
 
 	it("reports unexpected errors through onUnexpectedError instead of console.error", () => {
@@ -93,6 +96,7 @@ describe("attachDatabasePool", () => {
 	});
 
 	it("keeps the first attachment when called twice", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 		const first = vi.fn();
 		const second = vi.fn();
 		const pool = new EventEmitter();
@@ -104,26 +108,39 @@ describe("attachDatabasePool", () => {
 		expect(pool.listenerCount("error")).toBe(1);
 		expect(first).toHaveBeenCalledTimes(1);
 		expect(second).not.toHaveBeenCalled();
+		expect(warn).toHaveBeenCalledTimes(1);
 	});
 
-	it("does not record the pool if on() throws", () => {
-		let calls = 0;
-		const pool = {
-			on: () => {
-				calls += 1;
-				if (calls === 1) {
-					throw new Error("subscribe failed");
-				}
+	it("does not warn when a second call passes no reporter", () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		const pool = new EventEmitter();
+		attachDatabasePool(pool);
+		attachDatabasePool(pool);
+
+		expect(warn).not.toHaveBeenCalled();
+		expect(pool.listenerCount("error")).toBe(1);
+	});
+
+	it("logs and does not throw when onUnexpectedError throws", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const reporterError = new Error("sentry down");
+		const pool = new EventEmitter();
+		attachDatabasePool(pool, {
+			onUnexpectedError: () => {
+				throw reporterError;
 			},
-		};
+		});
+		const err = new Error("unexpected");
 
-		expect(() => attachDatabasePool(pool)).toThrow("subscribe failed");
-		expect(() => attachDatabasePool(pool)).not.toThrow();
-		expect(calls).toBe(2);
-	});
-
-	it("returns undefined", () => {
-		expect(attachDatabasePool(new EventEmitter())).toBeUndefined();
+		expect(() => pool.emit("error", err)).not.toThrow();
+		expect(error).toHaveBeenCalledWith(
+			"attachDatabasePool: unexpected database pool error",
+			err,
+		);
+		expect(error).toHaveBeenCalledWith(
+			"attachDatabasePool: onUnexpectedError threw",
+			reporterError,
+		);
 	});
 
 	it("throws a TypeError when the argument is not a pool", () => {
@@ -132,7 +149,9 @@ describe("attachDatabasePool", () => {
 		// @ts-expect-error Invalid inputs are possible from JavaScript.
 		expect(() => attachDatabasePool(42)).toThrow(TypeError);
 		// @ts-expect-error Invalid inputs are possible from JavaScript.
-		expect(() => attachDatabasePool({})).toThrow(TypeError);
+		expect(() => attachDatabasePool({})).toThrow(
+			/requires a node-postgres Pool with an on\(\) method/,
+		);
 	});
 
 	it("throws a TypeError when onUnexpectedError is not a function", () => {

--- a/packages/functions/src/lib/attach-database-pool.test.ts
+++ b/packages/functions/src/lib/attach-database-pool.test.ts
@@ -65,6 +65,13 @@ describe("attachDatabasePool", () => {
 		);
 	});
 
+	it("accepts a reporter that returns a value", () => {
+		const pool = new EventEmitter();
+		const onUnexpectedError = (err: Error) => err.message;
+		attachDatabasePool(pool, { onUnexpectedError });
+		expect(pool.listenerCount("error")).toBe(1);
+	});
+
 	it("reports unexpected errors through onUnexpectedError instead of console.error", () => {
 		const error = vi.spyOn(console, "error").mockImplementation(() => {});
 		const onUnexpectedError = vi.fn();

--- a/packages/functions/src/lib/attach-database-pool.test.ts
+++ b/packages/functions/src/lib/attach-database-pool.test.ts
@@ -1,0 +1,153 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { attachDatabasePool } from "./attach-database-pool.js";
+
+class CodedError extends Error {
+	constructor(
+		message: string,
+		readonly code?: string,
+	) {
+		super(message);
+	}
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("attachDatabasePool", () => {
+	it("does not throw when an idle client is dropped", () => {
+		const pool = new EventEmitter();
+		attachDatabasePool(pool);
+
+		expect(() =>
+			pool.emit("error", new CodedError("read ECONNRESET", "ECONNRESET")),
+		).not.toThrow();
+	});
+
+	it("stays silent for expected idle disconnects", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const pool = new EventEmitter();
+		attachDatabasePool(pool);
+
+		for (const err of [
+			new CodedError("read ECONNRESET", "ECONNRESET"),
+			new CodedError("write EPIPE", "EPIPE"),
+			new CodedError("connect ETIMEDOUT", "ETIMEDOUT"),
+			new CodedError(
+				"terminating connection due to administrator command",
+				"57P01",
+			),
+			new Error("Connection terminated unexpectedly"),
+		]) {
+			pool.emit("error", err);
+		}
+
+		expect(error).not.toHaveBeenCalled();
+	});
+
+	it("logs unexpected idle-client errors", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const pool = new EventEmitter();
+		attachDatabasePool(pool);
+		const err = new CodedError(
+			"password authentication failed for user",
+			"28P01",
+		);
+
+		pool.emit("error", err);
+
+		expect(error).toHaveBeenCalledTimes(1);
+		expect(error).toHaveBeenCalledWith(err);
+	});
+
+	it("reports unexpected errors through onUnexpectedError instead of console.error", () => {
+		const error = vi.spyOn(console, "error").mockImplementation(() => {});
+		const onUnexpectedError = vi.fn();
+		const pool = new EventEmitter();
+		attachDatabasePool(pool, { onUnexpectedError });
+		const err = new CodedError("crash", "57P02");
+
+		pool.emit("error", err);
+
+		expect(onUnexpectedError).toHaveBeenCalledTimes(1);
+		expect(onUnexpectedError).toHaveBeenCalledWith(err);
+		expect(error).not.toHaveBeenCalled();
+	});
+
+	it("does not call onUnexpectedError for expected idle disconnects", () => {
+		const onUnexpectedError = vi.fn();
+		const pool = new EventEmitter();
+		attachDatabasePool(pool, { onUnexpectedError });
+
+		pool.emit(
+			"error",
+			new CodedError(
+				"terminating connection due to administrator command",
+				"57P01",
+			),
+		);
+
+		expect(onUnexpectedError).not.toHaveBeenCalled();
+	});
+
+	it("keeps the first attachment when called twice", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		const pool = new EventEmitter();
+		attachDatabasePool(pool, { onUnexpectedError: first });
+		attachDatabasePool(pool, { onUnexpectedError: second });
+
+		pool.emit("error", new Error("unexpected"));
+
+		expect(pool.listenerCount("error")).toBe(1);
+		expect(first).toHaveBeenCalledTimes(1);
+		expect(second).not.toHaveBeenCalled();
+	});
+
+	it("does not record the pool if on() throws", () => {
+		let calls = 0;
+		const pool = {
+			on: () => {
+				calls += 1;
+				if (calls === 1) {
+					throw new Error("subscribe failed");
+				}
+			},
+		};
+
+		expect(() => attachDatabasePool(pool)).toThrow("subscribe failed");
+		expect(() => attachDatabasePool(pool)).not.toThrow();
+		expect(calls).toBe(2);
+	});
+
+	it("returns undefined", () => {
+		expect(attachDatabasePool(new EventEmitter())).toBeUndefined();
+	});
+
+	it("throws a TypeError when the argument is not a pool", () => {
+		// @ts-expect-error Invalid inputs are possible from JavaScript.
+		expect(() => attachDatabasePool(null)).toThrow(TypeError);
+		// @ts-expect-error Invalid inputs are possible from JavaScript.
+		expect(() => attachDatabasePool(42)).toThrow(TypeError);
+		// @ts-expect-error Invalid inputs are possible from JavaScript.
+		expect(() => attachDatabasePool({})).toThrow(TypeError);
+	});
+
+	it("throws a TypeError when onUnexpectedError is not a function", () => {
+		expect(() =>
+			attachDatabasePool(new EventEmitter(), {
+				// @ts-expect-error Invalid inputs are possible from JavaScript.
+				onUnexpectedError: 42,
+			}),
+		).toThrow(TypeError);
+	});
+
+	it("throws a TypeError when options is not an object", () => {
+		expect(() =>
+			// @ts-expect-error Invalid inputs are possible from JavaScript.
+			attachDatabasePool(new EventEmitter(), 42),
+		).toThrow(TypeError);
+	});
+});

--- a/packages/functions/src/lib/attach-database-pool.ts
+++ b/packages/functions/src/lib/attach-database-pool.ts
@@ -11,6 +11,12 @@ const IDLE_DISCONNECT_CODES = new Set([
 
 const attached = new WeakSet<object>();
 
+const UNEXPECTED_POOL_ERROR =
+	"attachDatabasePool: unexpected database pool error";
+const REPORTER_THREW = "attachDatabasePool: onUnexpectedError threw";
+const ALREADY_ATTACHED =
+	"attachDatabasePool() was already called for this pool; the first onUnexpectedError stays attached and this one is ignored.";
+
 export type DatabasePool = {
 	on(event: "error", listener: (err: Error) => void): unknown;
 };
@@ -44,6 +50,20 @@ function describeValue(value: unknown): string {
 	return typeof value;
 }
 
+function requireDatabasePool(pool: unknown): DatabasePool {
+	if (isDatabasePool(pool)) {
+		return pool;
+	}
+	if (typeof pool === "object" && pool !== null) {
+		throw new TypeError(
+			"attachDatabasePool() requires a node-postgres Pool with an on() method, got an object without one",
+		);
+	}
+	throw new TypeError(
+		`attachDatabasePool() requires a node-postgres Pool, got ${describeValue(pool)}`,
+	);
+}
+
 function resolveOnUnexpectedError(
 	options: unknown,
 ): ((err: Error) => void) | undefined {
@@ -72,28 +92,39 @@ function resolveOnUnexpectedError(
 	};
 }
 
+function reportUnexpectedError(
+	err: Error,
+	onUnexpectedError: ((err: Error) => void) | undefined,
+): void {
+	if (!onUnexpectedError) {
+		console.error(UNEXPECTED_POOL_ERROR, err);
+		return;
+	}
+	try {
+		onUnexpectedError(err);
+	} catch (reporterError) {
+		console.error(UNEXPECTED_POOL_ERROR, err);
+		console.error(REPORTER_THREW, reporterError);
+	}
+}
+
 export function attachDatabasePool(
 	pool: DatabasePool,
 	options?: AttachDatabasePoolOptions,
 ): void {
-	if (!isDatabasePool(pool)) {
-		throw new TypeError(
-			`attachDatabasePool() requires a node-postgres Pool, got ${describeValue(pool)}`,
-		);
-	}
-	if (attached.has(pool)) {
+	const databasePool = requireDatabasePool(pool);
+	const onUnexpectedError = resolveOnUnexpectedError(options);
+	if (attached.has(databasePool)) {
+		if (onUnexpectedError) {
+			console.warn(ALREADY_ATTACHED);
+		}
 		return;
 	}
-	const onUnexpectedError = resolveOnUnexpectedError(options);
-	pool.on("error", (err) => {
+	databasePool.on("error", (err) => {
 		if (isIdleDisconnect(err)) {
 			return;
 		}
-		if (onUnexpectedError) {
-			onUnexpectedError(err);
-			return;
-		}
-		console.error(err);
+		reportUnexpectedError(err, onUnexpectedError);
 	});
-	attached.add(pool);
+	attached.add(databasePool);
 }

--- a/packages/functions/src/lib/attach-database-pool.ts
+++ b/packages/functions/src/lib/attach-database-pool.ts
@@ -22,7 +22,7 @@ export type DatabasePool = {
 };
 
 export type AttachDatabasePoolOptions = {
-	onUnexpectedError?: (err: Error) => void;
+	onUnexpectedError?: (err: Error) => void | Promise<void>;
 };
 
 function isDatabasePool(value: unknown): value is DatabasePool {
@@ -50,6 +50,15 @@ function describeValue(value: unknown): string {
 	return typeof value;
 }
 
+function isPromise(value: unknown): value is Promise<unknown> {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"then" in value &&
+		typeof value.then === "function"
+	);
+}
+
 function requireDatabasePool(pool: unknown): DatabasePool {
 	if (isDatabasePool(pool)) {
 		return pool;
@@ -66,7 +75,7 @@ function requireDatabasePool(pool: unknown): DatabasePool {
 
 function resolveOnUnexpectedError(
 	options: unknown,
-): ((err: Error) => void) | undefined {
+): ((err: Error) => unknown) | undefined {
 	if (options === undefined) {
 		return undefined;
 	}
@@ -87,21 +96,25 @@ function resolveOnUnexpectedError(
 			`attachDatabasePool() onUnexpectedError must be a function, got ${typeof handler}`,
 		);
 	}
-	return (err: Error) => {
-		handler(err);
-	};
+	return (err: Error) => handler(err);
 }
 
 function reportUnexpectedError(
 	err: Error,
-	onUnexpectedError: ((err: Error) => void) | undefined,
+	onUnexpectedError: ((err: Error) => unknown) | undefined,
 ): void {
 	if (!onUnexpectedError) {
 		console.error(UNEXPECTED_POOL_ERROR, err);
 		return;
 	}
 	try {
-		onUnexpectedError(err);
+		const result = onUnexpectedError(err);
+		if (isPromise(result)) {
+			result.catch((reporterError: unknown) => {
+				console.error(UNEXPECTED_POOL_ERROR, err);
+				console.error(REPORTER_THREW, reporterError);
+			});
+		}
 	} catch (reporterError) {
 		console.error(UNEXPECTED_POOL_ERROR, err);
 		console.error(REPORTER_THREW, reporterError);

--- a/packages/functions/src/lib/attach-database-pool.ts
+++ b/packages/functions/src/lib/attach-database-pool.ts
@@ -15,14 +15,14 @@ const UNEXPECTED_POOL_ERROR =
 	"attachDatabasePool: unexpected database pool error";
 const REPORTER_THREW = "attachDatabasePool: onUnexpectedError threw";
 const ALREADY_ATTACHED =
-	"attachDatabasePool() was already called for this pool; the first onUnexpectedError stays attached and this one is ignored.";
+	"attachDatabasePool() was already called for this pool; this onUnexpectedError is ignored. Pass it on the first call.";
 
 export type DatabasePool = {
 	on(event: "error", listener: (err: Error) => void): unknown;
 };
 
 export type AttachDatabasePoolOptions = {
-	onUnexpectedError?: (err: Error) => void | Promise<void>;
+	onUnexpectedError?: (err: Error) => unknown;
 };
 
 function isDatabasePool(value: unknown): value is DatabasePool {

--- a/packages/functions/src/lib/attach-database-pool.ts
+++ b/packages/functions/src/lib/attach-database-pool.ts
@@ -1,0 +1,99 @@
+// node-postgres treats an idle-client pool error with no listener as fatal.
+// The pool has already discarded the client; the next checkout replaces it.
+
+const PG_ADMIN_SHUTDOWN = "57P01";
+const IDLE_DISCONNECT_CODES = new Set([
+	"ECONNRESET",
+	"EPIPE",
+	"ETIMEDOUT",
+	PG_ADMIN_SHUTDOWN,
+]);
+
+const attached = new WeakSet<object>();
+
+export type DatabasePool = {
+	on(event: "error", listener: (err: Error) => void): unknown;
+};
+
+export type AttachDatabasePoolOptions = {
+	onUnexpectedError?: (err: Error) => void;
+};
+
+function isDatabasePool(value: unknown): value is DatabasePool {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"on" in value &&
+		typeof value.on === "function"
+	);
+}
+
+function isIdleDisconnect(err: Error): boolean {
+	const code =
+		"code" in err && typeof err.code === "string" ? err.code : undefined;
+	return (
+		(code !== undefined && IDLE_DISCONNECT_CODES.has(code)) ||
+		err.message === "Connection terminated unexpectedly"
+	);
+}
+
+function describeValue(value: unknown): string {
+	if (value === null) {
+		return "null";
+	}
+	return typeof value;
+}
+
+function resolveOnUnexpectedError(
+	options: unknown,
+): ((err: Error) => void) | undefined {
+	if (options === undefined) {
+		return undefined;
+	}
+	if (typeof options !== "object" || options === null) {
+		throw new TypeError(
+			`attachDatabasePool() options must be an object, got ${describeValue(options)}`,
+		);
+	}
+	if (
+		!("onUnexpectedError" in options) ||
+		options.onUnexpectedError === undefined
+	) {
+		return undefined;
+	}
+	const handler = options.onUnexpectedError;
+	if (typeof handler !== "function") {
+		throw new TypeError(
+			`attachDatabasePool() onUnexpectedError must be a function, got ${typeof handler}`,
+		);
+	}
+	return (err: Error) => {
+		handler(err);
+	};
+}
+
+export function attachDatabasePool(
+	pool: DatabasePool,
+	options?: AttachDatabasePoolOptions,
+): void {
+	if (!isDatabasePool(pool)) {
+		throw new TypeError(
+			`attachDatabasePool() requires a node-postgres Pool, got ${describeValue(pool)}`,
+		);
+	}
+	if (attached.has(pool)) {
+		return;
+	}
+	const onUnexpectedError = resolveOnUnexpectedError(options);
+	pool.on("error", (err) => {
+		if (isIdleDisconnect(err)) {
+			return;
+		}
+		if (onUnexpectedError) {
+			onUnexpectedError(err);
+			return;
+		}
+		console.error(err);
+	});
+	attached.add(pool);
+}


### PR DESCRIPTION
## Problem

A Neon Function that keeps a module-scope `pg.Pool` dies when Postgres drops an idle client.

Neon compute scale-to-zero, pooler reclaim, and a TCP reset all close idle connections. node-postgres emits `error` on the pool. With no listener, that is an uncaught exception and the isolate exits. The next request never runs. The pool already discarded the dead client, and the next checkout would open a new connection.

## Diagnosis

node-postgres treats an idle-client pool error with no listener as fatal. The pool has already removed that client. The isolate dies because `EventEmitter` has no `error` listener, not because the pool cannot serve the next query.

The fix is a listener. Expected idle disconnects (`ECONNRESET`, `EPIPE`, `ETIMEDOUT`, Postgres `57P01`, and node-postgres's `Connection terminated unexpectedly`) are ignored. Anything else is reported. The pool is not recreated and is not closed.

A `pool.on("error", ...)` in application code already prevents the crash. The Neon Functions pattern is a module-scope `Pool` next to `fetch` with no listener. That path dies on the first idle disconnect. `@neon/functions` did not export a helper for it. The same `error` event kills a long-lived Node process, so the helper does not need a Neon Functions runtime.

## The user-facing interface

Call once after `new Pool`:

```ts
import { attachDatabasePool } from "@neon/functions";
import { Pool } from "pg";

const pool = new Pool({ connectionString: process.env.DATABASE_URL });
attachDatabasePool(pool);
```

Optional reporter, on the first call:

```ts
import * as Sentry from "@sentry/node";
import { attachDatabasePool } from "@neon/functions";
import { Pool } from "pg";

const pool = new Pool({ connectionString: process.env.DATABASE_URL });
attachDatabasePool(pool, {
	onUnexpectedError: (err) => Sentry.captureException(err),
});
```

```ts
export type DatabasePool = {
	on(event: "error", listener: (err: Error) => void): unknown;
};

export type AttachDatabasePoolOptions = {
	onUnexpectedError?: (err: Error) => unknown;
};

export function attachDatabasePool(
	pool: DatabasePool,
	options?: AttachDatabasePoolOptions,
): void;
```

`onUnexpectedError` is `(err: Error) => unknown`, not `void` or `Promise<void>`. Value-returning reporters such as `Sentry.captureException` compile.

The same call works in plain Node and under `neon dev`.

| Call | Behavior |
| --- | --- |
| First `attachDatabasePool(pool)` | Attaches one `error` listener |
| Second call, no reporter | Silent no-op |
| Second call with `onUnexpectedError` | No-op. `console.warn` exactly: `attachDatabasePool() was already called for this pool; this onUnexpectedError is ignored. Pass it on the first call.` |
| Expected idle disconnect | Silent |
| Unexpected error, no reporter | `console.error("attachDatabasePool: unexpected database pool error", err)` |
| Unexpected error, with reporter | Reporter runs. No `console.error` |
| Reporter throws, or returns a rejected promise | Logs the pool error and `attachDatabasePool: onUnexpectedError threw`. Isolate stays up |

`TypeError` on a non-pool, a non-object `options`, or a non-function `onUnexpectedError`:

```
attachDatabasePool() requires a node-postgres Pool, got number
attachDatabasePool() requires a node-postgres Pool with an on() method, got an object without one
attachDatabasePool() options must be an object, got number
attachDatabasePool() onUnexpectedError must be a function, got number
```

This does not close the pool. Isolate teardown tears the connections down with the process.

`waitUntil` and `upgradeWebSocket` are unchanged.

## Also in here

- README section for `attachDatabasePool`
- `package.json` description names the helper
- File-level JSDoc on `packages/functions/src/index.ts` is gone. The barrel is the three export groups
- Changeset: minor for `@neon/functions`

## Verification

`pnpm --filter @neon/functions test:ci`: 27 passed (13 `attachDatabasePool`, 5 `waitUntil`, 9 `upgradeWebSocket`).

- idle `ECONNRESET` does not throw
- `ECONNRESET`, `EPIPE`, `ETIMEDOUT`, `57P01`, and `Connection terminated unexpectedly` stay silent
- unexpected codes log through `console.error`
- a reporter that returns a value is accepted
- unexpected errors go to `onUnexpectedError`, not `console.error`
- expected idle disconnects do not call the reporter
- first attachment wins; a second reporter is ignored and warned
- a second call with no reporter does not warn
- a throwing reporter and a rejected-promise reporter both log both errors and do not throw from `emit`
- non-pool, non-function reporter, and non-object options throw `TypeError`

Packed tarball typechecks against `pg.Pool`.

Live Neon: `pg_terminate_backend` on an idle pooled client. With the helper the process survives and the next query reconnects. Without it: Unhandled `'error'` event, `57P01`, exit 1. The smoke project was deleted after the run.

## For your attention

- Examples and agent-skills still inline the classifier. They are not updated here.
- `pg.Client` used for `LISTEN` has no sibling helper. This attaches a pool only.
- `DatabasePool` is duck-typed. Any object with `on` is accepted, not only `pg.Pool`.
- The first call wins for the lifetime of that pool object. There is no detach or replace. A later `onUnexpectedError` is ignored.
- Only those five idle-disconnect cases are silent. A different SQLSTATE on an idle client is unexpected.
- The helper never calls `pool.end()`.
