### PR TITLE
chore: release neon@3.6.0, neonctl@3.6.0

### DIFF
--- a/.changeset/cli-human-list-output.md
+++ b/.changeset/cli-human-list-output.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-`neon` list and get commands no longer draw box-drawing tables. Default output is space-padded columns that drop and truncate to the terminal width, or stacked `Label  value` lines for a single object. `--output json` and `--output yaml` keep the same fields; `neon profile list` reports OAuth scope as `account` in every format.

--- a/.changeset/init-profile.md
+++ b/.changeset/init-profile.md
@@ -1,6 +1,0 @@
----
-"neon": minor
----
-
-`neon init` honors `--profile` and `NEON_PROFILE`. `npx neon` subprocesses and agent-emitted commands include `--profile <name>` when a profile was named, and `--config-dir` when you passed it.
-

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neon
 
+## 3.6.0
+
+### Minor Changes
+
+- 23740cd: `neon` list and get commands no longer draw box-drawing tables. Default output is space-padded columns that drop and truncate to the terminal width, or stacked `Label  value` lines for a single object. `--output json` and `--output yaml` keep the same fields; `neon profile list` reports OAuth scope as `account` in every format.
+- e78f193: `neon init` honors `--profile` and `NEON_PROFILE`. `npx neon` subprocesses and agent-emitted commands include `--profile <name>` when a profile was named, and `--config-dir` when you passed it.
+
 ## 3.5.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.5.1",
+	"version": "3.6.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,17 @@
 # neonctl
 
+## 3.6.0
+
+### Minor Changes
+
+- 23740cd: `neon` list and get commands no longer draw box-drawing tables. Default output is space-padded columns that drop and truncate to the terminal width, or stacked `Label  value` lines for a single object. `--output json` and `--output yaml` keep the same fields; `neon profile list` reports OAuth scope as `account` in every format.
+
+### Patch Changes
+
+- Updated dependencies [23740cd]
+- Updated dependencies [e78f193]
+  - neon@3.6.0
+
 ## 3.5.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.5.1",
+  "version": "3.6.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

npm still serves `neon@3.5.1` and `neonctl@3.5.1`. Two changesets are already on `main` and have not been consumed, so those CLI changes have no version.

```
npm view neon version      # 3.5.1
npm view neonctl version   # 3.5.1
```

The pending files were `.changeset/cli-human-list-output.md` (`neon` and `neonctl` minor) and `.changeset/init-profile.md` (`neon` minor).

## Diagnosis

This repo versions with Changesets. Feature PRs land a `.changeset/*.md`; `changeset version` deletes those files, bumps `package.json`, and prepends `CHANGELOG.md`. The CLI behavior is already on `main`. This commit is the version step.

`neon` and `neonctl` are a Changesets fixed group (`.changeset/config.json`: `["neon", "neonctl"]`). A bump to either package versions both together. `packages/neonctl` is the compatibility shim that depends on `neon`. The init `--profile` changeset listed only `neon`; neonctl still moves to 3.6.0 because of that group.

## The user-facing interface

After this merge and the later publish step, installs resolve to 3.6.0:

```
npm install -g neon@3.6.0
neon --version
```

```
npm install -g neonctl@3.6.0
neonctl --version
```

`neon@3.6.0` changelog:

```
`neon` list and get commands no longer draw box-drawing tables. Default output is space-padded columns that drop and truncate to the terminal width, or stacked `Label  value` lines for a single object. `--output json` and `--output yaml` keep the same fields; `neon profile list` reports OAuth scope as `account` in every format.

`neon init` honors `--profile` and `NEON_PROFILE`. `npx neon` subprocesses and agent-emitted commands include `--profile <name>` when a profile was named, and `--config-dir` when you passed it.
```

`neonctl@3.6.0` records the list/get output change as its own minor, and records `neon@3.6.0` as an updated dependency (covering the init `--profile` work).

No flags, commands, or source change in this PR. Callers that stay on 3.5.1 keep that version until they upgrade. `--output json` and `--output yaml` keep the same fields.

## Also in here

Six files, all from `changeset version`:

- deleted `.changeset/cli-human-list-output.md` and `.changeset/init-profile.md`
- `packages/cli/package.json` and `packages/cli/CHANGELOG.md` (`neon` 3.5.1 to 3.6.0)
- `packages/neonctl/package.json` and `packages/neonctl/CHANGELOG.md` (`neonctl` 3.5.1 to 3.6.0)

No lockfile. No other packages. No remaining changeset markdown besides the Changesets README.

## Verification

`git diff --name-status origin/main...HEAD` is those six files only.

`npm view neon version` and `npm view neonctl version` both return `3.5.1`.

Not verified: npm publish. This PR does not publish. CLI tests were not re-run; there is no source change.

## For your attention

- This PR only bumps versions. Publish is a separate manual workflow after merge.
- `@neon/tools` is 0.2.0 on `main` and 404 on npm (bumped in https://github.com/neondatabase/neon-pkgs/pull/445, not yet published). It is not part of this bump.