### PR TITLE
chore: release @neon/functions@0.8.0

### DIFF
--- a/.changeset/attach-database-pool.md
+++ b/.changeset/attach-database-pool.md
@@ -1,7 +1,0 @@
----
-"@neon/functions": minor
----
-
-Add `attachDatabasePool(pool)` so a module-scope `pg.Pool` does not kill the isolate when Postgres drops an idle client.
-
-Expected idle disconnects are silent. Unexpected idle-client errors go to `console.error`, or to `onUnexpectedError` if you pass one.

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @neondatabase/functions
 
+## 0.8.0
+
+### Minor Changes
+
+- ef8f95c: Add `attachDatabasePool(pool)` so a module-scope `pg.Pool` does not kill the isolate when Postgres drops an idle client.
+
+  Expected idle disconnects are silent. Unexpected idle-client errors go to `console.error`, or to `onUnexpectedError` if you pass one.
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/functions",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, `upgradeWebSocket` for serving WebSockets from a fetch handler, and `attachDatabasePool` for node-postgres idle-client errors.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Bumps `@neon/functions` 0.7.0 → 0.8.0 (changeset for `attachDatabasePool`). No source changes.

After merge, publish with:

```bash
gh workflow run neon-pkgs.yml --repo databricks/secure-public-registry-releases-eng \
  -f package=@neon/functions -f ref=main
```