### PR TITLE
chore: release @neon/tools@0.3.0

### DIFF
--- a/.changeset/tools-flat-args.md
+++ b/.changeset/tools-flat-args.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": minor
----
-
-Generated tools take flat arguments instead of an OpenAPI path/query/body envelope. `create_project` takes `{ name, region_id, org_id, ... }`. `name` and `names` rename the published tool id.

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 0.3.0
+
+### Minor Changes
+
+- 7cf9afd: Generated tools take flat arguments instead of an OpenAPI path/query/body envelope. `create_project` takes `{ name, region_id, org_id, ... }`. `name` and `names` rename the published tool id.
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Generated agent tools for every Neon Management API operation, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Bumps `@neon/tools` 0.2.0 → 0.3.0 from the pending changeset.

Publish after merge: `gh workflow run neon-pkgs.yml --repo databricks/secure-public-registry-releases-eng -f package=@neon/tools -f ref=main`