### PR TITLE
Add createBranchWithCompute and createProjectAndConnect to @neon/tools

### DIFF
--- a/.changeset/tools-sdk-workflows.md
+++ b/.changeset/tools-sdk-workflows.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": minor
+---
+
+`createNeonTools` accepts a `workflows` array that exposes `@neon/sdk` methods such as `createWithCompute` and `createAndConnect`. Those tools attach compute, wait for readiness, and return a connection string.

--- a/.changeset/tools-sdk-workflows.md
+++ b/.changeset/tools-sdk-workflows.md
@@ -2,4 +2,4 @@
 "@neon/tools": minor
 ---
 
-`createNeonTools` accepts a `workflows` array that exposes `@neon/sdk` methods such as `createWithCompute` and `createAndConnect`. Those tools attach compute, wait for readiness, and return a connection string.
+`createNeonTools` accepts a `workflows` array that exposes `@neon/sdk` methods such as `createWithCompute` and `createAndConnect`. Those tools attach compute, wait for readiness, and return a connection string. `CreateNeonToolsOptions` is a type alias, so an `interface` cannot extend it; `createNeonTools`'s first type argument is the options object.

--- a/.changeset/tools-sdk-workflows.md
+++ b/.changeset/tools-sdk-workflows.md
@@ -2,4 +2,4 @@
 "@neon/tools": minor
 ---
 
-`createNeonTools` accepts a `workflows` array that exposes `@neon/sdk` methods such as `createWithCompute` and `createAndConnect`. Those tools attach compute, wait for readiness, and return a connection string. `CreateNeonToolsOptions` is a type alias, so an `interface` cannot extend it; `createNeonTools`'s first type argument is the options object.
+`createNeonTools` accepts a `workflows` array that exposes `@neon/sdk` methods as `createBranchWithCompute` and `createProjectAndConnect`. Those tools attach compute, wait for readiness, and return a connection string. `CreateNeonToolsOptions` is a type alias, so an `interface` cannot extend it; `createNeonTools`'s first type argument is the options object.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -56,7 +56,7 @@ The returned record is keyed by OpenAPI operation ID or SDK workflow method name
 
 `workflows` selects methods from the `@neon/sdk` ergonomic client. These are not OpenAPI operations: they attach a default compute, wait until the resource is ready, and return a connection string. `operations` is the generated Management API. At least one of the two arrays is required.
 
-Both workflow tools poll until the resource is ready. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` to bound that, or pass `signal` on `execute` to cancel. `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there. `inject.projectId` still works on `createWithCompute` because its path is `/projects/{project_id}/branches`.
+Both workflow tools poll until the resource is ready. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first. An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist, and the error does not include its id. List before retrying. `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there. `inject.projectId` still works on `createWithCompute` because its path is `/projects/{project_id}/branches`.
 
 ```ts
 const tools = createNeonTools({
@@ -88,7 +88,7 @@ const tools = createNeonTools({
 tools.createWithCompute.id; // "create_branch"
 ```
 
-`create_project_branch` still creates a branch with no compute when `endpoints` is omitted. Use `createWithCompute` when the next step needs a connection string.
+`create_project_branch` still creates a branch with no compute when `endpoints` is omitted. It can attach compute if you pass `endpoints`; it does not wait or return a connection string. Use `createWithCompute` when the next step needs to connect.
 
 ## Optional host add-ons
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -85,7 +85,7 @@ const tools = createNeonTools({
 	names: { createWithCompute: "create_branch" },
 });
 
-tools.createWithCompute.id; // "create_branch"
+tools.createWithCompute.id;
 ```
 
 `create_project_branch` still creates a branch with no compute when `endpoints` is omitted. It can attach compute if you pass `endpoints`; it does not wait or return a connection string. Use `createWithCompute` when the next step needs to connect.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,6 +1,6 @@
 # `@neon/tools`
 
-Generated agent tools for every operation in the Neon Management API. Select only the operations an agent needs, then use the canonical descriptors directly or adapt them for MCP, Eve, or Mastra.
+Agent tools for the Neon Management API and for the `@neon/sdk` workflows that attach compute and return a connection string. Select only the operations and workflows an agent needs, then use the canonical descriptors directly or adapt them for MCP, Eve, and Mastra.
 
 ```bash
 npm install @neon/tools
@@ -48,13 +48,15 @@ await tools.listProjects.execute(
 );
 ```
 
-The returned record is keyed by OpenAPI operation ID. Each tool includes its generated Zod 4 `inputSchema`, snake-case `id`, title, description, safety annotations, stability metadata, and an `execute()` function. Inputs are flat: path, query, header, and body fields sit on one object. A body that is a single object wrapper is lifted, so `create_project` takes `{ name, region_id, org_id, ... }` rather than `{ project: { name } }`. A body with several properties keeps those properties, so `create_project_branch` takes `{ project_id, branch, endpoints, annotation_value }` and `branch` is still an object. Two email-provider updates keep a `body` field because the API request is a discriminated union.
+The returned record is keyed by OpenAPI operation ID or SDK workflow method name. Each tool includes its Zod 4 `inputSchema`, snake-case `id`, title, description, safety annotations, stability metadata, and an `execute()` function. Inputs are flat: path, query, header, and body fields sit on one object. A body that is a single object wrapper is lifted, so `create_project` takes `{ name, region_id, org_id, ... }` rather than `{ project: { name } }`. A body with several properties keeps those properties, so `create_project_branch` takes `{ project_id, branch, endpoints, annotation_value }` and `branch` is still an object. Two email-provider updates keep a `body` field because the API request is a discriminated union.
 
 `operationIds` exports every valid operation selector. `execute()` strictly validates the input, rejects unknown fields instead of dropping them, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller.
 
 ## Workflows
 
-`workflows` selects methods from the `@neon/sdk` ergonomic client. These are not OpenAPI operations: they attach a default compute, wait until the resource is ready, and return a connection string. `operations` stays the generated Management API surface. At least one of the two arrays is required.
+`workflows` selects methods from the `@neon/sdk` ergonomic client. These are not OpenAPI operations: they attach a default compute, wait until the resource is ready, and return a connection string. `operations` is the generated Management API. At least one of the two arrays is required.
+
+Both workflow tools poll until the resource is ready. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` to bound that, or pass `signal` on `execute` to cancel. `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there. `inject.projectId` still works on `createWithCompute` because its path is `/projects/{project_id}/branches`.
 
 ```ts
 const tools = createNeonTools({
@@ -152,7 +154,7 @@ The record is still keyed by operation ID (`tools.createProjectBranch`). MCP and
 
 ### Project and branch injection
 
-Generated tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
+Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `createWithCompute`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
 
 ```ts
 const tools = createNeonTools({
@@ -188,7 +190,7 @@ await grant.run({ projectId: "project-id" }, () => tools.getProject.execute({}))
 
 Injectors only apply to tools that have that path key. `listProjects` is unchanged. Empty inject values fail closed. Invalid ids still fail the original path schema before fetch.
 
-These add-ons do not change workflow results. Grant filtering, read-only filtering, and access-control notices stay in the host.
+`onExecute` and `inject` apply to workflow tools the same way they apply to generated tools. Grant filtering, read-only filtering, and access-control notices stay in the host.
 
 Injection reads the URL template, so it fills path `project_id` and `branch_id` only. Query and body fields with those names stay caller-supplied, including `getConnectionURI.branch_id`, `createOrgApiKey.project_id`, `createNeonAuthIntegration.project_id` / `branch_id`, `createNeonAuthNewUser.project_id`, `createNeonAuthProviderSDKKeys.project_id`, `transferNeonAuthProviderProject.project_id`, `addProjectJWKS.branch_id`, `createProjectEndpoint.branch_id`, `updateProjectEndpoint.branch_id`, and `getProjectAdvisorSecurityIssues.branch_id`. `omitFromSchema: true` does not hide those fields.
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -50,7 +50,43 @@ await tools.listProjects.execute(
 
 The returned record is keyed by OpenAPI operation ID. Each tool includes its generated Zod 4 `inputSchema`, snake-case `id`, title, description, safety annotations, stability metadata, and an `execute()` function. Inputs are flat: path, query, header, and body fields sit on one object. A body that is a single object wrapper is lifted, so `create_project` takes `{ name, region_id, org_id, ... }` rather than `{ project: { name } }`. A body with several properties keeps those properties, so `create_project_branch` takes `{ project_id, branch, endpoints, annotation_value }` and `branch` is still an object. Two email-provider updates keep a `body` field because the API request is a discriminated union.
 
-`operationIds` exports every valid selector. `execute()` strictly validates the input, rejects unknown fields instead of dropping them, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller.
+`operationIds` exports every valid operation selector. `execute()` strictly validates the input, rejects unknown fields instead of dropping them, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller.
+
+## Workflows
+
+`workflows` selects methods from the `@neon/sdk` ergonomic client. These are not OpenAPI operations: they attach a default compute, wait until the resource is ready, and return a connection string. `operations` stays the generated Management API surface. At least one of the two arrays is required.
+
+```ts
+const tools = createNeonTools({
+	apiKey,
+	operations: ["listProjects"],
+	workflows: ["createWithCompute", "createAndConnect"],
+});
+
+const { data } = await tools.createWithCompute.execute({
+	project_id: "project-id",
+	name: "feature-x",
+});
+
+await tools.createAndConnect.execute({
+	name: "agent-project",
+	region_id: "aws-us-east-1",
+});
+```
+
+`workflowIds` lists the selectors. Record keys match the SDK method names (`createWithCompute`, `createAndConnect`). Published ids are `create_with_compute` and `create_and_connect`. Input fields are snake_case, same as generated tools. `names` can rename a workflow the same way it renames an operation:
+
+```ts
+const tools = createNeonTools({
+	apiKey,
+	workflows: ["createWithCompute"],
+	names: { createWithCompute: "create_branch" },
+});
+
+tools.createWithCompute.id; // "create_branch"
+```
+
+`create_project_branch` still creates a branch with no compute when `endpoints` is omitted. Use `createWithCompute` when the next step needs a connection string.
 
 ## Optional host add-ons
 
@@ -152,7 +188,7 @@ await grant.run({ projectId: "project-id" }, () => tools.getProject.execute({}))
 
 Injectors only apply to tools that have that path key. `listProjects` is unchanged. Empty inject values fail closed. Invalid ids still fail the original path schema before fetch.
 
-These add-ons do not add host-only behavior such as returning a connection string from `createProject`. Grant filtering, read-only filtering, and access-control notices stay in the host.
+These add-ons do not change workflow results. Grant filtering, read-only filtering, and access-control notices stay in the host.
 
 Injection reads the URL template, so it fills path `project_id` and `branch_id` only. Query and body fields with those names stay caller-supplied, including `getConnectionURI.branch_id`, `createOrgApiKey.project_id`, `createNeonAuthIntegration.project_id` / `branch_id`, `createNeonAuthNewUser.project_id`, `createNeonAuthProviderSDKKeys.project_id`, `transferNeonAuthProviderProject.project_id`, `addProjectJWKS.branch_id`, `createProjectEndpoint.branch_id`, `updateProjectEndpoint.branch_id`, and `getProjectAdvisorSecurityIssues.branch_id`. `omitFromSchema: true` does not hide those fields.
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -56,21 +56,21 @@ The returned record is keyed by OpenAPI operation ID or SDK workflow method name
 
 `workflows` selects methods from the `@neon/sdk` ergonomic client. These are not OpenAPI operations: they attach a default compute, wait until the resource is ready, and return a connection string. `operations` is the generated Management API. At least one of the two arrays is required.
 
-Both workflow tools poll until the resource is ready. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first. An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist, and the error does not include its id. List before retrying. `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there. `inject.projectId` still works on `createWithCompute` because its path is `/projects/{project_id}/branches`.
+Both workflow tools poll until the resource is ready. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first. An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist, and the error does not include its id. List before retrying. `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there. `inject.projectId` still works on `createBranchWithCompute` because its path is `/projects/{project_id}/branches`.
 
 ```ts
 const tools = createNeonTools({
 	apiKey,
 	operations: ["listProjects"],
-	workflows: ["createWithCompute", "createAndConnect"],
+	workflows: ["createBranchWithCompute", "createProjectAndConnect"],
 });
 
-const { data } = await tools.createWithCompute.execute({
+const { data } = await tools.createBranchWithCompute.execute({
 	project_id: "project-id",
 	name: "feature-x",
 });
 
-await tools.createAndConnect.execute({
+await tools.createProjectAndConnect.execute({
 	name: "agent-project",
 	region_id: "aws-us-east-1",
 });
@@ -79,22 +79,22 @@ await tools.createAndConnect.execute({
 `createNeonTool` accepts the same workflow ids:
 
 ```ts
-const createBranch = createNeonTool("createWithCompute", { apiKey });
+const createBranch = createNeonTool("createBranchWithCompute", { apiKey });
 ```
 
-`workflowIds` lists the selectors. Record keys match the SDK method names (`createWithCompute`, `createAndConnect`). Published ids are `create_with_compute` and `create_and_connect`. Input fields are snake_case, same as generated tools. `names` can rename a workflow the same way it renames an operation:
+`workflowIds` lists the selectors. Record keys name the entity (`createBranchWithCompute`, `createProjectAndConnect`) and call `neon.branches.createWithCompute` and `neon.projects.createAndConnect`. Published ids are `create_branch_with_compute` and `create_project_and_connect`. Input fields are snake_case, same as generated tools. `names` can rename a workflow the same way it renames an operation:
 
 ```ts
 const tools = createNeonTools({
 	apiKey,
-	workflows: ["createWithCompute"],
-	names: { createWithCompute: "create_branch" },
+	workflows: ["createBranchWithCompute"],
+	names: { createBranchWithCompute: "create_branch" },
 });
 
-tools.createWithCompute.id; // "create_branch"
+tools.createBranchWithCompute.id; // "create_branch"
 ```
 
-`create_project_branch` still creates a branch with no compute when `endpoints` is omitted. It can attach compute if you pass `endpoints`; it does not wait or return a connection string. Use `createWithCompute` when the next step needs to connect.
+`create_project_branch` still creates a branch with no compute when `endpoints` is omitted. It can attach compute if you pass `endpoints`; it does not wait or return a connection string. Use `createBranchWithCompute` when the next step needs to connect.
 
 ## Optional host add-ons
 
@@ -160,7 +160,7 @@ The record is still keyed by operation ID (`tools.createProjectBranch`). MCP and
 
 ### Project and branch injection
 
-Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `createWithCompute`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
+Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `createBranchWithCompute`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
 
 ```ts
 const tools = createNeonTools({

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -76,6 +76,12 @@ await tools.createAndConnect.execute({
 });
 ```
 
+`createNeonTool` accepts the same workflow ids:
+
+```ts
+const createBranch = createNeonTool("createWithCompute", { apiKey });
+```
+
 `workflowIds` lists the selectors. Record keys match the SDK method names (`createWithCompute`, `createAndConnect`). Published ids are `create_with_compute` and `create_and_connect`. Input fields are snake_case, same as generated tools. `names` can rename a workflow the same way it renames an operation:
 
 ```ts
@@ -85,7 +91,7 @@ const tools = createNeonTools({
 	names: { createWithCompute: "create_branch" },
 });
 
-tools.createWithCompute.id;
+tools.createWithCompute.id; // "create_branch"
 ```
 
 `create_project_branch` still creates a branch with no compute when `endpoints` is omitted. It can attach compute if you pass `endpoints`; it does not wait or return a connection string. Use `createWithCompute` when the next step needs to connect.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -48,7 +48,7 @@ await tools.listProjects.execute(
 );
 ```
 
-The returned record is keyed by OpenAPI operation ID or SDK workflow method name. Each tool includes its Zod 4 `inputSchema`, snake-case `id`, title, description, safety annotations, stability metadata, and an `execute()` function. Inputs are flat: path, query, header, and body fields sit on one object. A body that is a single object wrapper is lifted, so `create_project` takes `{ name, region_id, org_id, ... }` rather than `{ project: { name } }`. A body with several properties keeps those properties, so `create_project_branch` takes `{ project_id, branch, endpoints, annotation_value }` and `branch` is still an object. Two email-provider updates keep a `body` field because the API request is a discriminated union.
+The returned record is keyed by OpenAPI operation ID or workflow id. Each tool includes its Zod 4 `inputSchema`, snake-case `id`, title, description, safety annotations, stability metadata, and an `execute()` function. Inputs are flat: path, query, header, and body fields sit on one object. A body that is a single object wrapper is lifted, so `create_project` takes `{ name, region_id, org_id, ... }` rather than `{ project: { name } }`. A body with several properties keeps those properties, so `create_project_branch` takes `{ project_id, branch, endpoints, annotation_value }` and `branch` is still an object. Two email-provider updates keep a `body` field because the API request is a discriminated union.
 
 `operationIds` exports every valid operation selector. `execute()` strictly validates the input, rejects unknown fields instead of dropping them, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller.
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@neon/tools",
 	"version": "0.3.0",
-	"description": "Generated agent tools for every Neon Management API operation, compatible with MCP, Eve, and Mastra.",
+	"description": "Agent tools for the Neon Management API and SDK workflows, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",
 		"database",

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -202,37 +202,37 @@ const annotatedWithWorkflow: CreateNeonToolsOptions<["listProjects"]> = {
 	apiKey: "test-key",
 	operations: ["listProjects"],
 	// @ts-expect-error operations-only type excludes workflows
-	workflows: ["createWithCompute"],
+	workflows: ["createBranchWithCompute"],
 };
 void annotatedWithWorkflow;
 
 const bothAnnotated: CreateNeonToolsOptions<
 	["listProjects"],
-	["createWithCompute"]
+	["createBranchWithCompute"]
 > = {
 	apiKey: "test-key",
 	operations: ["listProjects"],
-	workflows: ["createWithCompute"],
+	workflows: ["createBranchWithCompute"],
 };
 expectTypeOf(createNeonTools(bothAnnotated)).toHaveProperty("listProjects");
 expectTypeOf(createNeonTools(bothAnnotated)).toHaveProperty(
-	"createWithCompute",
+	"createBranchWithCompute",
 );
 
 // @ts-expect-error both generic arguments require operations
 const omittedAnnotatedOps: CreateNeonToolsOptions<
 	["listProjects"],
-	["createWithCompute"]
+	["createBranchWithCompute"]
 > = {
 	apiKey: "test-key",
-	workflows: ["createWithCompute"],
+	workflows: ["createBranchWithCompute"],
 };
 void omittedAnnotatedOps;
 
 // @ts-expect-error both generic arguments require workflows
 const omittedAnnotatedWorkflows: CreateNeonToolsOptions<
 	["listProjects"],
-	["createWithCompute"]
+	["createBranchWithCompute"]
 > = {
 	apiKey: "test-key",
 	operations: ["listProjects"],
@@ -241,15 +241,15 @@ void omittedAnnotatedWorkflows;
 
 const workflowOnly = createNeonTools({
 	apiKey: "test-key",
-	workflows: ["createWithCompute"] as const,
+	workflows: ["createBranchWithCompute"] as const,
 });
-expectTypeOf(workflowOnly).toHaveProperty("createWithCompute");
+expectTypeOf(workflowOnly).toHaveProperty("createBranchWithCompute");
 // @ts-expect-error workflow-only selection excludes operations
 workflowOnly.listProjects;
-workflowOnly.createWithCompute.execute({ project_id: "project-id" });
+workflowOnly.createBranchWithCompute.execute({ project_id: "project-id" });
 // @ts-expect-error project_id is required without inject
-workflowOnly.createWithCompute.execute({});
-workflowOnly.createWithCompute
+workflowOnly.createBranchWithCompute.execute({});
+workflowOnly.createBranchWithCompute
 	.execute({ project_id: "project-id" })
 	.then((result) => {
 		expectTypeOf(result.data.connectionString).toEqualTypeOf<string>();
@@ -259,33 +259,39 @@ workflowOnly.createWithCompute
 const combined = createNeonTools({
 	apiKey: "test-key",
 	operations: ["listProjects"] as const,
-	workflows: ["createWithCompute"] as const,
+	workflows: ["createBranchWithCompute"] as const,
 });
 expectTypeOf(combined).toHaveProperty("listProjects");
-expectTypeOf(combined).toHaveProperty("createWithCompute");
+expectTypeOf(combined).toHaveProperty("createBranchWithCompute");
 
 declare const unionOpts:
 	| { apiKey: "test-key"; operations: ["listProjects"] }
-	| { apiKey: "test-key"; workflows: ["createWithCompute"] };
+	| { apiKey: "test-key"; workflows: ["createBranchWithCompute"] };
 const unionTools = createNeonTools(unionOpts);
 // @ts-expect-error union options do not share listProjects
 unionTools.listProjects;
-// @ts-expect-error union options do not share createWithCompute
-unionTools.createWithCompute;
+// @ts-expect-error union options do not share createBranchWithCompute
+unionTools.createBranchWithCompute;
 
-const createWithCompute = createNeonTool("createWithCompute", {
+const createBranchWithCompute = createNeonTool("createBranchWithCompute", {
 	apiKey: "test-key",
 });
-createWithCompute.execute({ project_id: "project-id", name: "feature-x" });
-// @ts-expect-error parentId is not the tool field name
-createWithCompute.execute({ project_id: "project-id", parentId: "br-id" });
+createBranchWithCompute.execute({
+	project_id: "project-id",
+	name: "feature-x",
+});
+createBranchWithCompute.execute({
+	project_id: "project-id",
+	// @ts-expect-error parentId is not the tool field name
+	parentId: "br-id",
+});
 
 const omittedWorkflow = createNeonTools({
 	apiKey: "test-key",
-	workflows: ["createWithCompute"] as const,
+	workflows: ["createBranchWithCompute"] as const,
 	inject: { projectId: "granted-project", omitFromSchema: true },
 });
-omittedWorkflow.createWithCompute.execute({ name: "feature-x" });
+omittedWorkflow.createBranchWithCompute.execute({ name: "feature-x" });
 
 // @ts-expect-error at least one of operations or workflows is required
 createNeonTools({ apiKey: "test-key" });

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -264,6 +264,15 @@ const combined = createNeonTools({
 expectTypeOf(combined).toHaveProperty("listProjects");
 expectTypeOf(combined).toHaveProperty("createWithCompute");
 
+declare const unionOpts:
+	| { apiKey: "test-key"; operations: ["listProjects"] }
+	| { apiKey: "test-key"; workflows: ["createWithCompute"] };
+const unionTools = createNeonTools(unionOpts);
+// @ts-expect-error union options do not share listProjects
+unionTools.listProjects;
+// @ts-expect-error union options do not share createWithCompute
+unionTools.createWithCompute;
+
 const createWithCompute = createNeonTool("createWithCompute", {
 	apiKey: "test-key",
 });

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -201,7 +201,7 @@ expectTypeOf(createNeonTools(annotatedOperations)).toHaveProperty(
 const annotatedWithWorkflow: CreateNeonToolsOptions<["listProjects"]> = {
 	apiKey: "test-key",
 	operations: ["listProjects"],
-	// @ts-expect-error operations-only annotation does not accept a workflow
+	// @ts-expect-error operations-only type excludes workflows
 	workflows: ["createWithCompute"],
 };
 void annotatedWithWorkflow;
@@ -219,7 +219,7 @@ expectTypeOf(createNeonTools(bothAnnotated)).toHaveProperty(
 	"createWithCompute",
 );
 
-// @ts-expect-error both generics specified requires operations
+// @ts-expect-error both generic arguments require operations
 const omittedAnnotatedOps: CreateNeonToolsOptions<
 	["listProjects"],
 	["createWithCompute"]
@@ -229,7 +229,7 @@ const omittedAnnotatedOps: CreateNeonToolsOptions<
 };
 void omittedAnnotatedOps;
 
-// @ts-expect-error both generics specified requires workflows
+// @ts-expect-error both generic arguments require workflows
 const omittedAnnotatedWorkflows: CreateNeonToolsOptions<
 	["listProjects"],
 	["createWithCompute"]
@@ -244,7 +244,7 @@ const workflowOnly = createNeonTools({
 	workflows: ["createWithCompute"] as const,
 });
 expectTypeOf(workflowOnly).toHaveProperty("createWithCompute");
-// @ts-expect-error operations are absent when only workflows are selected
+// @ts-expect-error workflow-only selection excludes operations
 workflowOnly.listProjects;
 workflowOnly.createWithCompute.execute({ project_id: "project-id" });
 // @ts-expect-error project_id is required without inject

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -191,6 +191,21 @@ const unnamedBag: CreateNeonToolsOptions<["listProjects"]> = {
 };
 void unnamedBag;
 
+const annotatedOperations: CreateNeonToolsOptions<["listProjects"]> = {
+	apiKey: "test-key",
+	operations: ["listProjects"],
+};
+expectTypeOf(createNeonTools(annotatedOperations)).toHaveProperty(
+	"listProjects",
+);
+const annotatedWithWorkflow: CreateNeonToolsOptions<["listProjects"]> = {
+	apiKey: "test-key",
+	operations: ["listProjects"],
+	// @ts-expect-error operations-only annotation does not accept a workflow
+	workflows: ["createWithCompute"],
+};
+void annotatedWithWorkflow;
+
 const workflowOnly = createNeonTools({
 	apiKey: "test-key",
 	workflows: ["createWithCompute"] as const,

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -206,6 +206,39 @@ const annotatedWithWorkflow: CreateNeonToolsOptions<["listProjects"]> = {
 };
 void annotatedWithWorkflow;
 
+const bothAnnotated: CreateNeonToolsOptions<
+	["listProjects"],
+	["createWithCompute"]
+> = {
+	apiKey: "test-key",
+	operations: ["listProjects"],
+	workflows: ["createWithCompute"],
+};
+expectTypeOf(createNeonTools(bothAnnotated)).toHaveProperty("listProjects");
+expectTypeOf(createNeonTools(bothAnnotated)).toHaveProperty(
+	"createWithCompute",
+);
+
+// @ts-expect-error both generics specified requires operations
+const omittedAnnotatedOps: CreateNeonToolsOptions<
+	["listProjects"],
+	["createWithCompute"]
+> = {
+	apiKey: "test-key",
+	workflows: ["createWithCompute"],
+};
+void omittedAnnotatedOps;
+
+// @ts-expect-error both generics specified requires workflows
+const omittedAnnotatedWorkflows: CreateNeonToolsOptions<
+	["listProjects"],
+	["createWithCompute"]
+> = {
+	apiKey: "test-key",
+	operations: ["listProjects"],
+};
+void omittedAnnotatedWorkflows;
+
 const workflowOnly = createNeonTools({
 	apiKey: "test-key",
 	workflows: ["createWithCompute"] as const,

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -190,3 +190,45 @@ const unnamedBag: CreateNeonToolsOptions<["listProjects"]> = {
 	name: (id: string) => `neon_${id}`,
 };
 void unnamedBag;
+
+const workflowOnly = createNeonTools({
+	apiKey: "test-key",
+	workflows: ["createWithCompute"] as const,
+});
+expectTypeOf(workflowOnly).toHaveProperty("createWithCompute");
+// @ts-expect-error operations are absent when only workflows are selected
+workflowOnly.listProjects;
+workflowOnly.createWithCompute.execute({ project_id: "project-id" });
+// @ts-expect-error project_id is required without inject
+workflowOnly.createWithCompute.execute({});
+workflowOnly.createWithCompute
+	.execute({ project_id: "project-id" })
+	.then((result) => {
+		expectTypeOf(result.data.connectionString).toEqualTypeOf<string>();
+		expectTypeOf(result.data.branch.id).toEqualTypeOf<string>();
+	});
+
+const combined = createNeonTools({
+	apiKey: "test-key",
+	operations: ["listProjects"] as const,
+	workflows: ["createWithCompute"] as const,
+});
+expectTypeOf(combined).toHaveProperty("listProjects");
+expectTypeOf(combined).toHaveProperty("createWithCompute");
+
+const createWithCompute = createNeonTool("createWithCompute", {
+	apiKey: "test-key",
+});
+createWithCompute.execute({ project_id: "project-id", name: "feature-x" });
+// @ts-expect-error parentId is not the tool field name
+createWithCompute.execute({ project_id: "project-id", parentId: "br-id" });
+
+const omittedWorkflow = createNeonTools({
+	apiKey: "test-key",
+	workflows: ["createWithCompute"] as const,
+	inject: { projectId: "granted-project", omitFromSchema: true },
+});
+omittedWorkflow.createWithCompute.execute({ name: "feature-x" });
+
+// @ts-expect-error at least one of operations or workflows is required
+createNeonTools({ apiKey: "test-key" });

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -157,7 +157,7 @@ describe("createNeonTools", () => {
 				"listProjcts",
 				{ apiKey: "test-key" },
 			]),
-		).toThrow('Unknown Neon operation "listProjcts"');
+		).toThrow('Unknown Neon operation or workflow "listProjcts"');
 	});
 });
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -86,7 +86,7 @@ type WithPublishedId<Tool> = Tool extends { id: string }
 	: Tool;
 
 export interface NeonToolsClientOptions
-	extends Pick<NeonConfig, "baseUrl" | "fetch">,
+	extends Pick<NeonConfig, "baseUrl" | "fetch" | "wait">,
 		Omit<NeonToolCustomizeOptions, "name" | "names"> {
 	apiKey?: NeonBearerCredential;
 }
@@ -116,6 +116,7 @@ const createRawClient = (options: NeonToolsClientOptions) =>
 				: requireBearerCredential(options.apiKey),
 		...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
 		...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+		...(options.wait === undefined ? {} : { wait: options.wait }),
 	}).client;
 
 const operationFactoryFor = (operationId: NeonOperationId) => {
@@ -182,7 +183,9 @@ const bindTools = <
 	const operations = options.operations ?? [];
 	const workflows = options.workflows ?? [];
 	if (operations.length === 0 && workflows.length === 0) {
-		throw new TypeError("createNeonTools requires operations or workflows");
+		throw new TypeError(
+			"createNeonTools requires at least one operation or workflow",
+		);
 	}
 
 	const selectedOperations = new Set<NeonOperationId>();

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -91,14 +91,39 @@ export interface NeonToolsClientOptions
 	apiKey?: NeonBearerCredential;
 }
 
+type CreateNeonToolsInput = NeonToolsClientOptions &
+	(
+		| {
+				operations: readonly NeonOperationId[];
+				workflows?: readonly NeonWorkflowId[];
+		  }
+		| {
+				workflows: readonly NeonWorkflowId[];
+				operations?: readonly NeonOperationId[];
+		  }
+	);
+
 export type CreateNeonToolsOptions<
 	Operations extends readonly NeonOperationId[] = readonly NeonOperationId[],
 	Workflows extends readonly NeonWorkflowId[] = readonly [],
 > = NeonToolsClientOptions &
-	(
-		| { operations: Operations; workflows?: Workflows }
-		| { operations?: Operations; workflows: Workflows }
-	);
+	(Workflows extends readonly []
+		? { operations: Operations; workflows?: Workflows }
+		: Operations extends readonly []
+			? { workflows: Workflows; operations?: Operations }
+			: { operations: Operations; workflows: Workflows });
+
+type SelectedOperations<T> = T extends {
+	operations: infer O extends readonly NeonOperationId[];
+}
+	? O
+	: [];
+
+type SelectedWorkflows<T> = T extends {
+	workflows: infer W extends readonly NeonWorkflowId[];
+}
+	? W
+	: [];
 
 type NeonToolId = NeonOperationId | NeonWorkflowId;
 
@@ -170,15 +195,14 @@ function assertNeonTools<
 	}
 }
 
-const bindTools = <
-	Operations extends readonly NeonOperationId[],
-	Workflows extends readonly NeonWorkflowId[],
->(
-	options: CreateNeonToolsOptions<Operations, Workflows> & {
-		name?: (id: string) => string;
-		names?: NeonToolNameOverrides;
-	},
-): NeonTools<Operations, Workflows> => {
+type BindableToolsInput<T extends CreateNeonToolsInput> = T & {
+	name?: (id: string) => string;
+	names?: NeonToolNameOverrides;
+};
+
+const bindTools = <T extends CreateNeonToolsInput>(
+	options: BindableToolsInput<T>,
+): NeonTools<SelectedOperations<T>, SelectedWorkflows<T>> => {
 	assertToolCustomizeOptions(options);
 	const operations = options.operations ?? [];
 	const workflows = options.workflows ?? [];
@@ -234,7 +258,7 @@ const bindTools = <
 	}
 	const tools: unknown = Object.fromEntries(entries);
 	assertNeonTools(tools, operations, workflows);
-	return tools as NeonTools<Operations, Workflows>;
+	return tools as NeonTools<SelectedOperations<T>, SelectedWorkflows<T>>;
 };
 
 type NamedNeonTools<
@@ -265,44 +289,35 @@ type NamedNeonTool<Id extends NeonToolId, Inject> = WithPublishedId<
 >;
 
 export function createNeonTools<
-	const Operations extends readonly NeonOperationId[] = [],
-	const Workflows extends readonly NeonWorkflowId[] = [],
+	const T extends CreateNeonToolsInput,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	options: CreateNeonToolsOptions<Operations, Workflows> & {
-		inject?: Inject;
-	} & (
+	options: T & { inject?: Inject } & (
 			| { name: (id: string) => string; names?: NeonToolNameOverrides }
 			| { names: NeonToolNameOverrides; name?: (id: string) => string }
 		),
-): NamedNeonTools<Operations, Workflows, Inject>;
+): NamedNeonTools<SelectedOperations<T>, SelectedWorkflows<T>, Inject>;
 export function createNeonTools<
-	const Operations extends readonly NeonOperationId[] = [],
-	const Workflows extends readonly NeonWorkflowId[] = [],
+	const T extends CreateNeonToolsInput,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	options: CreateNeonToolsOptions<Operations, Workflows> & {
-		inject?: Inject;
-	},
+	options: T & { inject?: Inject },
 ): Inject extends NeonToolInjectOptions
-	? InjectedNeonTools<Operations, Inject, Workflows>
-	: NeonTools<Operations, Workflows>;
+	? InjectedNeonTools<SelectedOperations<T>, Inject, SelectedWorkflows<T>>
+	: NeonTools<SelectedOperations<T>, SelectedWorkflows<T>>;
 export function createNeonTools<
-	const Operations extends readonly NeonOperationId[] = [],
-	const Workflows extends readonly NeonWorkflowId[] = [],
+	const T extends CreateNeonToolsInput,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	options: CreateNeonToolsOptions<Operations, Workflows> & {
-		inject?: Inject;
-	},
+	options: T & { inject?: Inject },
 ):
-	| NamedNeonTools<Operations, Workflows, Inject>
-	| InjectedNeonTools<Operations, Inject, Workflows>
-	| NeonTools<Operations, Workflows> {
-	return bindTools(options) as
-		| NamedNeonTools<Operations, Workflows, Inject>
-		| InjectedNeonTools<Operations, Inject, Workflows>
-		| NeonTools<Operations, Workflows>;
+	| NamedNeonTools<SelectedOperations<T>, SelectedWorkflows<T>, Inject>
+	| InjectedNeonTools<SelectedOperations<T>, Inject, SelectedWorkflows<T>>
+	| NeonTools<SelectedOperations<T>, SelectedWorkflows<T>> {
+	return bindTools(options as BindableToolsInput<T>) as
+		| NamedNeonTools<SelectedOperations<T>, SelectedWorkflows<T>, Inject>
+		| InjectedNeonTools<SelectedOperations<T>, Inject, SelectedWorkflows<T>>
+		| NeonTools<SelectedOperations<T>, SelectedWorkflows<T>>;
 }
 
 export function createNeonTool<

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -93,7 +93,7 @@ export interface NeonToolsClientOptions
 
 export type CreateNeonToolsOptions<
 	Operations extends readonly NeonOperationId[] = readonly NeonOperationId[],
-	Workflows extends readonly NeonWorkflowId[] = readonly NeonWorkflowId[],
+	Workflows extends readonly NeonWorkflowId[] = readonly [],
 > = NeonToolsClientOptions &
 	(
 		| { operations: Operations; workflows?: Workflows }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -125,6 +125,12 @@ type SelectedWorkflows<T> = T extends {
 	? W
 	: [];
 
+type NeonToolsFor<T, Inject> = T extends CreateNeonToolsInput
+	? Inject extends NeonToolInjectOptions
+		? InjectedNeonTools<SelectedOperations<T>, Inject, SelectedWorkflows<T>>
+		: NeonTools<SelectedOperations<T>, SelectedWorkflows<T>>
+	: never;
+
 type NeonToolId = NeonOperationId | NeonWorkflowId;
 
 type ToolForId<Id extends NeonToolId> = Id extends NeonWorkflowId
@@ -288,6 +294,10 @@ type NamedNeonTool<Id extends NeonToolId, Inject> = WithPublishedId<
 		: ToolForId<Id>
 >;
 
+type NamedNeonToolsFor<T, Inject> = T extends CreateNeonToolsInput
+	? NamedNeonTools<SelectedOperations<T>, SelectedWorkflows<T>, Inject>
+	: never;
+
 export function createNeonTools<
 	const T extends CreateNeonToolsInput,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
@@ -296,28 +306,20 @@ export function createNeonTools<
 			| { name: (id: string) => string; names?: NeonToolNameOverrides }
 			| { names: NeonToolNameOverrides; name?: (id: string) => string }
 		),
-): NamedNeonTools<SelectedOperations<T>, SelectedWorkflows<T>, Inject>;
+): NamedNeonToolsFor<T, Inject>;
+export function createNeonTools<
+	const T extends CreateNeonToolsInput,
+	const Inject extends NeonToolInjectOptions | undefined = undefined,
+>(options: T & { inject?: Inject }): NeonToolsFor<T, Inject>;
 export function createNeonTools<
 	const T extends CreateNeonToolsInput,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
 	options: T & { inject?: Inject },
-): Inject extends NeonToolInjectOptions
-	? InjectedNeonTools<SelectedOperations<T>, Inject, SelectedWorkflows<T>>
-	: NeonTools<SelectedOperations<T>, SelectedWorkflows<T>>;
-export function createNeonTools<
-	const T extends CreateNeonToolsInput,
-	const Inject extends NeonToolInjectOptions | undefined = undefined,
->(
-	options: T & { inject?: Inject },
-):
-	| NamedNeonTools<SelectedOperations<T>, SelectedWorkflows<T>, Inject>
-	| InjectedNeonTools<SelectedOperations<T>, Inject, SelectedWorkflows<T>>
-	| NeonTools<SelectedOperations<T>, SelectedWorkflows<T>> {
+): NamedNeonToolsFor<T, Inject> | NeonToolsFor<T, Inject> {
 	return bindTools(options as BindableToolsInput<T>) as
-		| NamedNeonTools<SelectedOperations<T>, SelectedWorkflows<T>, Inject>
-		| InjectedNeonTools<SelectedOperations<T>, Inject, SelectedWorkflows<T>>
-		| NeonTools<SelectedOperations<T>, SelectedWorkflows<T>>;
+		| NamedNeonToolsFor<T, Inject>
+		| NeonToolsFor<T, Inject>;
 }
 
 export function createNeonTool<

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -14,6 +14,13 @@ import {
 	type NeonToolNameOverrides,
 } from "./lib/customize.js";
 import {
+	isNeonWorkflowId,
+	type NeonWorkflowId,
+	type WorkflowFactories,
+	workflowFactoryFor,
+	workflowIds,
+} from "./lib/workflows.js";
+import {
 	type NeonOperationId,
 	operationFactories,
 	operationIds,
@@ -41,23 +48,34 @@ export type {
 	NeonToolMetadata,
 	NeonToolResult,
 } from "./lib/operation.js";
-export type { NeonOperationId };
-export { NeonError, operationIds };
+export type { NeonOperationId, NeonWorkflowId };
+export { NeonError, operationIds, workflowIds };
 
 type OperationFactories = typeof operationFactories;
 
-export type NeonTools<Operations extends readonly NeonOperationId[]> = {
+export type NeonTools<
+	Operations extends readonly NeonOperationId[] = [],
+	Workflows extends readonly NeonWorkflowId[] = [],
+> = {
 	[Operation in Operations[number]]: ReturnType<
 		OperationFactories[Operation]
 	>;
+} & {
+	[Workflow in Workflows[number]]: ReturnType<WorkflowFactories[Workflow]>;
 };
 
 export type InjectedNeonTools<
 	Operations extends readonly NeonOperationId[],
 	Inject,
+	Workflows extends readonly NeonWorkflowId[] = [],
 > = {
 	[Operation in Operations[number]]: InjectedNeonTool<
 		ReturnType<OperationFactories[Operation]>,
+		Inject
+	>;
+} & {
+	[Workflow in Workflows[number]]: InjectedNeonTool<
+		ReturnType<WorkflowFactories[Workflow]>,
 		Inject
 	>;
 };
@@ -72,11 +90,22 @@ export interface NeonToolsClientOptions
 	apiKey?: NeonBearerCredential;
 }
 
-export interface CreateNeonToolsOptions<
-	Operations extends readonly NeonOperationId[],
-> extends NeonToolsClientOptions {
-	operations: Operations;
-}
+export type CreateNeonToolsOptions<
+	Operations extends readonly NeonOperationId[] = readonly NeonOperationId[],
+	Workflows extends readonly NeonWorkflowId[] = readonly NeonWorkflowId[],
+> = NeonToolsClientOptions &
+	(
+		| { operations: Operations; workflows?: Workflows }
+		| { operations?: Operations; workflows: Workflows }
+	);
+
+type NeonToolId = NeonOperationId | NeonWorkflowId;
+
+type ToolForId<Id extends NeonToolId> = Id extends NeonWorkflowId
+	? ReturnType<WorkflowFactories[Id]>
+	: Id extends NeonOperationId
+		? ReturnType<OperationFactories[Id]>
+		: never;
 
 const createRawClient = (options: NeonToolsClientOptions) =>
 	createNeonClient({
@@ -114,10 +143,14 @@ const assertKnownNameKeys = (
 	}
 };
 
-function assertNeonTools<Operations extends readonly NeonOperationId[]>(
+function assertNeonTools<
+	Operations extends readonly NeonOperationId[],
+	Workflows extends readonly NeonWorkflowId[],
+>(
 	value: unknown,
 	operations: Operations,
-): asserts value is NeonTools<Operations> {
+	workflows: Workflows,
+): asserts value is NeonTools<Operations, Workflows> {
 	if (typeof value !== "object" || value === null) {
 		throw new TypeError("Expected generated Neon tools to be an object.");
 	}
@@ -128,56 +161,83 @@ function assertNeonTools<Operations extends readonly NeonOperationId[]>(
 			);
 		}
 	}
+	for (const workflowId of workflows) {
+		if (!(workflowId in value)) {
+			throw new TypeError(`Missing Neon workflow tool "${workflowId}".`);
+		}
+	}
 }
 
-const bindTools = <Operations extends readonly NeonOperationId[]>(
-	options: CreateNeonToolsOptions<Operations> & {
+const bindTools = <
+	Operations extends readonly NeonOperationId[],
+	Workflows extends readonly NeonWorkflowId[],
+>(
+	options: CreateNeonToolsOptions<Operations, Workflows> & {
 		name?: (id: string) => string;
 		names?: NeonToolNameOverrides;
 	},
-): NeonTools<Operations> => {
+): NeonTools<Operations, Workflows> => {
 	assertToolCustomizeOptions(options);
-	const selected = new Set<NeonOperationId>();
-	const selectedFactories = options.operations.map((operationId) => {
-		if (selected.has(operationId)) {
+	const operations = options.operations ?? [];
+	const workflows = options.workflows ?? [];
+	if (operations.length === 0 && workflows.length === 0) {
+		throw new TypeError("createNeonTools requires operations or workflows");
+	}
+
+	const selectedOperations = new Set<NeonOperationId>();
+	const operationEntries = operations.map((operationId) => {
+		if (selectedOperations.has(operationId)) {
 			throw new Error(`Duplicate Neon operation "${operationId}"`);
 		}
-		selected.add(operationId);
-		return [operationId, operationFactoryFor(operationId)] as const;
+		selectedOperations.add(operationId);
+		return [
+			operationId,
+			operationFactoryFor(operationId)(createRawClient(options)),
+		] as const;
 	});
-	const client = createRawClient(options);
-	const rawEntries = selectedFactories.map(([operationId, factory]) => {
-		const tool = factory(client);
-		return [operationId, tool] as const;
+
+	const selectedWorkflows = new Set<NeonWorkflowId>();
+	const workflowEntries = workflows.map((workflowId) => {
+		if (selectedWorkflows.has(workflowId)) {
+			throw new Error(`Duplicate Neon workflow "${workflowId}"`);
+		}
+		selectedWorkflows.add(workflowId);
+		return [workflowId, workflowFactoryFor(workflowId)(options)] as const;
 	});
+
+	const rawEntries = [...operationEntries, ...workflowEntries];
 	assertKnownNameKeys(
 		options.names,
 		rawEntries.map(([, tool]) => tool),
 	);
-	const entries = rawEntries.map(([operationId, tool]) => {
+	const entries = rawEntries.map(([id, tool]) => {
 		return [
-			operationId,
+			id,
 			hasToolCustomization(options)
 				? applyToolCustomization(tool, options)
 				: tool,
 		] as const;
 	});
 	const publishedIds = new Map<string, string>();
-	for (const [operationId, tool] of entries) {
+	for (const [id, tool] of entries) {
 		const previous = publishedIds.get(tool.id);
 		if (previous !== undefined) {
 			throw new Error(
-				`Duplicate Neon tool id "${tool.id}" for ${previous}, ${operationId}`,
+				`Duplicate Neon tool id "${tool.id}" for ${previous}, ${id}`,
 			);
 		}
-		publishedIds.set(tool.id, operationId);
+		publishedIds.set(tool.id, id);
 	}
 	const tools: unknown = Object.fromEntries(entries);
-	assertNeonTools(tools, options.operations);
-	return tools;
+	assertNeonTools(tools, operations, workflows);
+	return tools as NeonTools<Operations, Workflows>;
 };
 
-type NamedNeonTools<Operations extends readonly NeonOperationId[], Inject> = {
+type NamedNeonTools<
+	Operations extends readonly NeonOperationId[],
+	Workflows extends readonly NeonWorkflowId[],
+	Inject,
+> = {
 	[Operation in Operations[number]]: WithPublishedId<
 		Inject extends NeonToolInjectOptions
 			? InjectedNeonTool<
@@ -186,91 +246,106 @@ type NamedNeonTools<Operations extends readonly NeonOperationId[], Inject> = {
 				>
 			: ReturnType<OperationFactories[Operation]>
 	>;
+} & {
+	[Workflow in Workflows[number]]: WithPublishedId<
+		Inject extends NeonToolInjectOptions
+			? InjectedNeonTool<ReturnType<WorkflowFactories[Workflow]>, Inject>
+			: ReturnType<WorkflowFactories[Workflow]>
+	>;
 };
 
-type NamedNeonTool<Operation extends NeonOperationId, Inject> = WithPublishedId<
+type NamedNeonTool<Id extends NeonToolId, Inject> = WithPublishedId<
 	Inject extends NeonToolInjectOptions
-		? InjectedNeonTool<ReturnType<OperationFactories[Operation]>, Inject>
-		: ReturnType<OperationFactories[Operation]>
+		? InjectedNeonTool<ToolForId<Id>, Inject>
+		: ToolForId<Id>
 >;
 
 export function createNeonTools<
-	const Operations extends readonly NeonOperationId[],
+	const Operations extends readonly NeonOperationId[] = [],
+	const Workflows extends readonly NeonWorkflowId[] = [],
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	options: CreateNeonToolsOptions<Operations> & {
+	options: CreateNeonToolsOptions<Operations, Workflows> & {
 		inject?: Inject;
 	} & (
 			| { name: (id: string) => string; names?: NeonToolNameOverrides }
 			| { names: NeonToolNameOverrides; name?: (id: string) => string }
 		),
-): NamedNeonTools<Operations, Inject>;
+): NamedNeonTools<Operations, Workflows, Inject>;
 export function createNeonTools<
-	const Operations extends readonly NeonOperationId[],
+	const Operations extends readonly NeonOperationId[] = [],
+	const Workflows extends readonly NeonWorkflowId[] = [],
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	options: CreateNeonToolsOptions<Operations> & { inject?: Inject },
+	options: CreateNeonToolsOptions<Operations, Workflows> & {
+		inject?: Inject;
+	},
 ): Inject extends NeonToolInjectOptions
-	? InjectedNeonTools<Operations, Inject>
-	: NeonTools<Operations>;
+	? InjectedNeonTools<Operations, Inject, Workflows>
+	: NeonTools<Operations, Workflows>;
 export function createNeonTools<
-	const Operations extends readonly NeonOperationId[],
+	const Operations extends readonly NeonOperationId[] = [],
+	const Workflows extends readonly NeonWorkflowId[] = [],
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	options: CreateNeonToolsOptions<Operations> & { inject?: Inject },
+	options: CreateNeonToolsOptions<Operations, Workflows> & {
+		inject?: Inject;
+	},
 ):
-	| NamedNeonTools<Operations, Inject>
-	| InjectedNeonTools<Operations, Inject>
-	| NeonTools<Operations> {
+	| NamedNeonTools<Operations, Workflows, Inject>
+	| InjectedNeonTools<Operations, Inject, Workflows>
+	| NeonTools<Operations, Workflows> {
 	return bindTools(options) as
-		| NamedNeonTools<Operations, Inject>
-		| InjectedNeonTools<Operations, Inject>
-		| NeonTools<Operations>;
+		| NamedNeonTools<Operations, Workflows, Inject>
+		| InjectedNeonTools<Operations, Inject, Workflows>
+		| NeonTools<Operations, Workflows>;
 }
 
 export function createNeonTool<
-	const Operation extends NeonOperationId,
+	const Id extends NeonToolId,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	operationId: Operation,
+	id: Id,
 	options: NeonToolsClientOptions & {
 		inject?: Inject;
 	} & (
 			| { name: (id: string) => string; names?: NeonToolNameOverrides }
 			| { names: NeonToolNameOverrides; name?: (id: string) => string }
 		),
-): NamedNeonTool<Operation, Inject>;
+): NamedNeonTool<Id, Inject>;
 export function createNeonTool<
-	const Operation extends NeonOperationId,
+	const Id extends NeonToolId,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	operationId: Operation,
+	id: Id,
 	options: NeonToolsClientOptions & { inject?: Inject },
 ): Inject extends NeonToolInjectOptions
-	? InjectedNeonTool<ReturnType<OperationFactories[Operation]>, Inject>
-	: ReturnType<OperationFactories[Operation]>;
+	? InjectedNeonTool<ToolForId<Id>, Inject>
+	: ToolForId<Id>;
 export function createNeonTool<
-	const Operation extends NeonOperationId,
+	const Id extends NeonToolId,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
 >(
-	operationId: Operation,
+	id: Id,
 	options: NeonToolsClientOptions & {
 		inject?: Inject;
 		name?: (id: string) => string;
 		names?: NeonToolNameOverrides;
 	},
 ):
-	| NamedNeonTool<Operation, Inject>
-	| InjectedNeonTool<ReturnType<OperationFactories[Operation]>, Inject>
-	| ReturnType<OperationFactories[Operation]> {
+	| NamedNeonTool<Id, Inject>
+	| InjectedNeonTool<ToolForId<Id>, Inject>
+	| ToolForId<Id> {
 	assertToolCustomizeOptions(options);
-	const tool = operationFactoryFor(operationId)(createRawClient(options));
+	const tool = isNeonWorkflowId(id)
+		? workflowFactoryFor(id)(options)
+		: operationFactoryFor(id)(createRawClient(options));
 	assertKnownNameKeys(options.names, [tool]);
 	const customized = hasToolCustomization(options)
 		? applyToolCustomization(tool, options)
 		: tool;
 	return customized as
-		| NamedNeonTool<Operation, Inject>
-		| InjectedNeonTool<ReturnType<OperationFactories[Operation]>, Inject>
-		| ReturnType<OperationFactories[Operation]>;
+		| NamedNeonTool<Id, Inject>
+		| InjectedNeonTool<ToolForId<Id>, Inject>
+		| ToolForId<Id>;
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -13,6 +13,7 @@ import {
 	type NeonToolInjectOptions,
 	type NeonToolNameOverrides,
 } from "./lib/customize.js";
+import type { NeonTool } from "./lib/operation.js";
 import {
 	isNeonWorkflowId,
 	type NeonWorkflowId,
@@ -337,9 +338,18 @@ export function createNeonTool<
 	| InjectedNeonTool<ToolForId<Id>, Inject>
 	| ToolForId<Id> {
 	assertToolCustomizeOptions(options);
-	const tool = isNeonWorkflowId(id)
-		? workflowFactoryFor(id)(options)
-		: operationFactoryFor(id)(createRawClient(options));
+	let tool: NeonTool;
+	if (isNeonWorkflowId(id)) {
+		tool = workflowFactoryFor(id)(options);
+	} else {
+		const knownOperationId = operationIds.find(
+			(candidate) => candidate === id,
+		);
+		if (knownOperationId === undefined) {
+			throw new TypeError(`Unknown Neon operation or workflow "${id}".`);
+		}
+		tool = operationFactories[knownOperationId](createRawClient(options));
+	}
 	assertKnownNameKeys(options.names, [tool]);
 	const customized = hasToolCustomization(options)
 		? applyToolCustomization(tool, options)

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -91,17 +91,18 @@ export interface NeonToolsClientOptions
 	apiKey?: NeonBearerCredential;
 }
 
+interface OperationSelection {
+	operations: readonly NeonOperationId[];
+	workflows?: readonly NeonWorkflowId[];
+}
+
+interface WorkflowSelection {
+	workflows: readonly NeonWorkflowId[];
+	operations?: readonly NeonOperationId[];
+}
+
 type CreateNeonToolsInput = NeonToolsClientOptions &
-	(
-		| {
-				operations: readonly NeonOperationId[];
-				workflows?: readonly NeonWorkflowId[];
-		  }
-		| {
-				workflows: readonly NeonWorkflowId[];
-				operations?: readonly NeonOperationId[];
-		  }
-	);
+	(OperationSelection | WorkflowSelection);
 
 export type CreateNeonToolsOptions<
 	Operations extends readonly NeonOperationId[] = readonly NeonOperationId[],

--- a/packages/tools/src/lib/workflows.ts
+++ b/packages/tools/src/lib/workflows.ts
@@ -36,7 +36,7 @@ const pooledField = z
 	)
 	.optional();
 
-export const createWithComputeInputSchema = z.strictObject({
+export const createBranchWithComputeInputSchema = z.strictObject({
 	project_id: zod.zCreateProjectBranchPath.shape.project_id,
 	name: branchCreateFields.name,
 	parent_id: branchCreateFields.parent_id,
@@ -50,12 +50,15 @@ export const createWithComputeInputSchema = z.strictObject({
 	pooled: pooledField,
 });
 
-export const createAndConnectInputSchema = z.strictObject({
+export const createProjectAndConnectInputSchema = z.strictObject({
 	...projectCreateFields,
 	pooled: pooledField,
 });
 
-export const workflowIds = ["createWithCompute", "createAndConnect"] as const;
+export const workflowIds = [
+	"createBranchWithCompute",
+	"createProjectAndConnect",
+] as const;
 
 export type NeonWorkflowId = (typeof workflowIds)[number];
 
@@ -113,16 +116,16 @@ const bindWorkflow = <
 	},
 });
 
-const createWithComputeTool = (options: WorkflowClientOptions) =>
+const createBranchWithComputeTool = (options: WorkflowClientOptions) =>
 	bindWorkflow(
 		options,
 		{
-			operationId: "createWithCompute",
-			id: "create_with_compute",
+			operationId: "createBranchWithCompute",
+			id: "create_branch_with_compute",
 			title: "Create branch with compute",
 			description:
 				"Create a branch with a read-write endpoint and return its connection string. Use this instead of create_project_branch when the next step needs to connect: create_project_branch omits compute unless you pass endpoints, and it does not wait or return a connection string. The call waits until the compute is ready, up to five minutes by default.",
-			inputSchema: createWithComputeInputSchema,
+			inputSchema: createBranchWithComputeInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,
 			metadata: {
@@ -158,16 +161,16 @@ const createWithComputeTool = (options: WorkflowClientOptions) =>
 			),
 	);
 
-const createAndConnectTool = (options: WorkflowClientOptions) =>
+const createProjectAndConnectTool = (options: WorkflowClientOptions) =>
 	bindWorkflow(
 		options,
 		{
-			operationId: "createAndConnect",
-			id: "create_and_connect",
+			operationId: "createProjectAndConnect",
+			id: "create_project_and_connect",
 			title: "Create project and connect",
 			description:
 				"Create a project and return a connection string to its default branch. Use this instead of create_project when the next step needs to connect. The call waits until the default compute is ready, up to five minutes by default.",
-			inputSchema: createAndConnectInputSchema,
+			inputSchema: createProjectAndConnectInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,
 			metadata: {
@@ -188,8 +191,8 @@ const createAndConnectTool = (options: WorkflowClientOptions) =>
 	);
 
 export const workflowFactories = {
-	createWithCompute: createWithComputeTool,
-	createAndConnect: createAndConnectTool,
+	createBranchWithCompute: createBranchWithComputeTool,
+	createProjectAndConnect: createProjectAndConnectTool,
 };
 
 export type WorkflowFactories = typeof workflowFactories;

--- a/packages/tools/src/lib/workflows.ts
+++ b/packages/tools/src/lib/workflows.ts
@@ -1,4 +1,4 @@
-import { createNeonClient, type NeonClient } from "@neon/sdk";
+import { createNeonClient, type NeonClient, type NeonConfig } from "@neon/sdk";
 import * as z from "zod";
 import * as zod from "../generated/zod.gen.js";
 import {
@@ -17,6 +17,7 @@ export interface WorkflowClientOptions {
 	apiKey?: NeonBearerCredential;
 	baseUrl?: string;
 	fetch?: typeof fetch;
+	wait?: NeonConfig["wait"];
 }
 
 const branchCreateFields = zod.zBranchCreateRequest.shape.branch.unwrap().shape;
@@ -28,7 +29,12 @@ const writeAnnotations = {
 	openWorldHint: true,
 } as const;
 
-const pooledField = z.boolean().optional();
+const pooledField = z
+	.boolean()
+	.describe(
+		"Return a pooled connection string. Default true. Set false for a direct connection.",
+	)
+	.optional();
 
 export const createWithComputeInputSchema = z.strictObject({
 	project_id: zod.zCreateProjectBranchPath.shape.project_id,
@@ -79,6 +85,7 @@ const workflowClient = (
 		throwOnError: true,
 		...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
 		...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+		...(options.wait === undefined ? {} : { wait: options.wait }),
 	});
 
 const bindWorkflow = <
@@ -114,7 +121,7 @@ const createWithComputeTool = (options: WorkflowClientOptions) =>
 			id: "create_with_compute",
 			title: "Create branch with compute",
 			description:
-				"Create a branch with a read-write endpoint and return a ready-to-use connection string. One API call (Neon creates the endpoint inline) plus readiness polling.",
+				"Create a branch with a read-write endpoint and return its connection string. Use this instead of create_project_branch whenever the branch will be connected to. create_project_branch creates no compute and returns no connection string. The call waits until the compute is ready, up to five minutes by default.",
 			inputSchema: createWithComputeInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,
@@ -159,7 +166,7 @@ const createAndConnectTool = (options: WorkflowClientOptions) =>
 			id: "create_and_connect",
 			title: "Create project and connect",
 			description:
-				"Create a project and return a ready-to-use connection string to its default branch. One API call plus readiness polling.",
+				"Create a project and return a connection string to its default branch. Use this instead of create_project when the next step needs to connect. The call waits until the default compute is ready, up to five minutes by default.",
 			inputSchema: createAndConnectInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,

--- a/packages/tools/src/lib/workflows.ts
+++ b/packages/tools/src/lib/workflows.ts
@@ -1,0 +1,203 @@
+import { createNeonClient, type NeonClient } from "@neon/sdk";
+import * as z from "zod";
+import * as zod from "../generated/zod.gen.js";
+import {
+	missingBearerCredential,
+	type NeonBearerCredential,
+	requireBearerCredential,
+} from "./auth.js";
+import type {
+	JsonSafe,
+	NeonTool,
+	NeonToolExecutionContext,
+} from "./operation.js";
+import { toToolResult } from "./result.js";
+
+export interface WorkflowClientOptions {
+	apiKey?: NeonBearerCredential;
+	baseUrl?: string;
+	fetch?: typeof fetch;
+}
+
+const branchCreateFields = zod.zBranchCreateRequest.shape.branch.unwrap().shape;
+const projectCreateFields = zod.zCreateProjectBody.shape.project.shape;
+
+const writeAnnotations = {
+	readOnlyHint: false,
+	destructiveHint: true,
+	openWorldHint: true,
+} as const;
+
+const pooledField = z.boolean().optional();
+
+export const createWithComputeInputSchema = z.strictObject({
+	project_id: zod.zCreateProjectBranchPath.shape.project_id,
+	name: branchCreateFields.name,
+	parent_id: branchCreateFields.parent_id,
+	compute: z
+		.strictObject({
+			min_cu: zod.zComputeUnit.optional(),
+			max_cu: zod.zComputeUnit.optional(),
+			suspend_timeout_seconds: zod.zSuspendTimeoutSeconds.optional(),
+		})
+		.optional(),
+	pooled: pooledField,
+});
+
+export const createAndConnectInputSchema = z.strictObject({
+	...projectCreateFields,
+	pooled: pooledField,
+});
+
+export const workflowIds = ["createWithCompute", "createAndConnect"] as const;
+
+export type NeonWorkflowId = (typeof workflowIds)[number];
+
+const resolveApiKey = (
+	options: WorkflowClientOptions,
+	context?: NeonToolExecutionContext,
+): NeonBearerCredential => {
+	if (context !== undefined && "apiKey" in context) {
+		if (context.apiKey === undefined) {
+			throw new TypeError(
+				"A Neon API key or OAuth access token is required",
+			);
+		}
+		return requireBearerCredential(context.apiKey);
+	}
+	return options.apiKey === undefined
+		? missingBearerCredential
+		: requireBearerCredential(options.apiKey);
+};
+
+const workflowClient = (
+	options: WorkflowClientOptions,
+	context?: NeonToolExecutionContext,
+): NeonClient<true> =>
+	createNeonClient({
+		apiKey: resolveApiKey(options, context),
+		throwOnError: true,
+		...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
+		...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+	});
+
+const bindWorkflow = <
+	const InputSchema extends z.ZodType,
+	const Id extends string,
+	Output,
+>(
+	options: WorkflowClientOptions,
+	tool: Omit<NeonTool<InputSchema, Id, JsonSafe<Awaited<Output>>>, "execute">,
+	run: (
+		neon: NeonClient<true>,
+		input: z.output<InputSchema>,
+		signal?: AbortSignal,
+	) => Promise<Output>,
+): NeonTool<InputSchema, Id, JsonSafe<Awaited<Output>>> => ({
+	...tool,
+	async execute(input, context) {
+		const parsed = await tool.inputSchema.parseAsync(input);
+		const result = await run(
+			workflowClient(options, context),
+			parsed,
+			context?.signal,
+		);
+		return toToolResult(result);
+	},
+});
+
+const createWithComputeTool = (options: WorkflowClientOptions) =>
+	bindWorkflow(
+		options,
+		{
+			operationId: "createWithCompute",
+			id: "create_with_compute",
+			title: "Create branch with compute",
+			description:
+				"Create a branch with a read-write endpoint and return a ready-to-use connection string. One API call (Neon creates the endpoint inline) plus readiness polling.",
+			inputSchema: createWithComputeInputSchema,
+			annotations: writeAnnotations,
+			requiresApproval: true,
+			metadata: {
+				method: "POST",
+				path: "/projects/{project_id}/branches",
+				stability: "stable",
+				deprecated: false,
+				tags: ["Branch"],
+			},
+		},
+		(neon, input, signal) =>
+			neon.branches.createWithCompute(
+				input.project_id,
+				{
+					name: input.name,
+					parentId: input.parent_id,
+					compute:
+						input.compute === undefined
+							? undefined
+							: {
+									minCu: input.compute.min_cu,
+									maxCu: input.compute.max_cu,
+									suspendTimeoutSeconds:
+										input.compute.suspend_timeout_seconds,
+								},
+				},
+				{
+					signal,
+					...(input.pooled === undefined
+						? {}
+						: { pooled: input.pooled }),
+				},
+			),
+	);
+
+const createAndConnectTool = (options: WorkflowClientOptions) =>
+	bindWorkflow(
+		options,
+		{
+			operationId: "createAndConnect",
+			id: "create_and_connect",
+			title: "Create project and connect",
+			description:
+				"Create a project and return a ready-to-use connection string to its default branch. One API call plus readiness polling.",
+			inputSchema: createAndConnectInputSchema,
+			annotations: writeAnnotations,
+			requiresApproval: true,
+			metadata: {
+				method: "POST",
+				path: "/projects",
+				stability: "stable",
+				deprecated: false,
+				tags: ["Project"],
+			},
+		},
+		(neon, input, signal) => {
+			const { pooled, ...project } = input;
+			return neon.projects.createAndConnect(project, {
+				signal,
+				...(pooled === undefined ? {} : { pooled }),
+			});
+		},
+	);
+
+export const workflowFactories = {
+	createWithCompute: createWithComputeTool,
+	createAndConnect: createAndConnectTool,
+};
+
+export type WorkflowFactories = typeof workflowFactories;
+
+export const isNeonWorkflowId = (id: string): id is NeonWorkflowId =>
+	(workflowIds as readonly string[]).includes(id);
+
+export const workflowFactoryFor = (
+	workflowId: NeonWorkflowId,
+): WorkflowFactories[NeonWorkflowId] => {
+	const knownWorkflowId = workflowIds.find(
+		(candidate) => candidate === workflowId,
+	);
+	if (knownWorkflowId === undefined) {
+		throw new TypeError(`Unknown Neon workflow "${workflowId}".`);
+	}
+	return workflowFactories[knownWorkflowId];
+};

--- a/packages/tools/src/lib/workflows.ts
+++ b/packages/tools/src/lib/workflows.ts
@@ -121,7 +121,7 @@ const createWithComputeTool = (options: WorkflowClientOptions) =>
 			id: "create_with_compute",
 			title: "Create branch with compute",
 			description:
-				"Create a branch with a read-write endpoint and return its connection string. Use this instead of create_project_branch whenever the branch will be connected to. create_project_branch creates no compute and returns no connection string. The call waits until the compute is ready, up to five minutes by default.",
+				"Create a branch with a read-write endpoint and return its connection string. Use this instead of create_project_branch when the next step needs to connect: create_project_branch omits compute unless you pass endpoints, and it does not wait or return a connection string. The call waits until the compute is ready, up to five minutes by default.",
 			inputSchema: createWithComputeInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -109,7 +109,7 @@ describe("createNeonTools workflows", () => {
 				"createWithComput",
 				{ apiKey: "test-key" },
 			]),
-		).toThrow('Unknown Neon operation "createWithComput"');
+		).toThrow('Unknown Neon operation or workflow "createWithComput"');
 	});
 
 	test("rejects a published-id collision between an operation and a workflow", () => {

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -44,7 +44,7 @@ const createBranchTools = (options: NeonToolsClientOptions = {}) => {
 	const tools = createNeonTools({
 		apiKey: "test-key",
 		...options,
-		workflows: ["createWithCompute"] as const,
+		workflows: ["createBranchWithCompute"] as const,
 		fetch: async (input, init) => {
 			requests.push(new Request(input, init));
 			return jsonResponse(branchWithComputeBody);
@@ -57,14 +57,18 @@ describe("createNeonTools workflows", () => {
 	test("creates only the selected workflow", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			workflows: ["createWithCompute"] as const,
+			workflows: ["createBranchWithCompute"] as const,
 		});
 
-		expect(Object.keys(tools)).toEqual(["createWithCompute"]);
-		expect(tools.createWithCompute.id).toBe("create_with_compute");
-		expect(tools.createWithCompute.operationId).toBe("createWithCompute");
-		expect(tools.createWithCompute.requiresApproval).toBe(true);
-		expect(tools.createWithCompute.annotations).toEqual({
+		expect(Object.keys(tools)).toEqual(["createBranchWithCompute"]);
+		expect(tools.createBranchWithCompute.id).toBe(
+			"create_branch_with_compute",
+		);
+		expect(tools.createBranchWithCompute.operationId).toBe(
+			"createBranchWithCompute",
+		);
+		expect(tools.createBranchWithCompute.requiresApproval).toBe(true);
+		expect(tools.createBranchWithCompute.annotations).toEqual({
 			readOnlyHint: false,
 			destructiveHint: true,
 			openWorldHint: true,
@@ -75,12 +79,12 @@ describe("createNeonTools workflows", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			operations: ["listProjects"] as const,
-			workflows: ["createWithCompute"] as const,
+			workflows: ["createBranchWithCompute"] as const,
 		});
 
 		expect(Object.keys(tools)).toEqual([
 			"listProjects",
-			"createWithCompute",
+			"createBranchWithCompute",
 		]);
 	});
 
@@ -96,9 +100,12 @@ describe("createNeonTools workflows", () => {
 		expect(() =>
 			createNeonTools({
 				apiKey: "test-key",
-				workflows: ["createWithCompute", "createWithCompute"],
+				workflows: [
+					"createBranchWithCompute",
+					"createBranchWithCompute",
+				],
 			}),
-		).toThrow('Duplicate Neon workflow "createWithCompute"');
+		).toThrow('Duplicate Neon workflow "createBranchWithCompute"');
 	});
 
 	test("reports unknown runtime workflow ids", () => {
@@ -120,20 +127,20 @@ describe("createNeonTools workflows", () => {
 			createNeonTools({
 				apiKey: "test-key",
 				operations: ["createProject"] as const,
-				workflows: ["createAndConnect"] as const,
-				names: { createAndConnect: "create_project" },
+				workflows: ["createProjectAndConnect"] as const,
+				names: { createProjectAndConnect: "create_project" },
 			}),
 		).toThrow(
-			'Duplicate Neon tool id "create_project" for createProject, createAndConnect',
+			'Duplicate Neon tool id "create_project" for createProject, createProjectAndConnect',
 		);
 	});
 });
 
-describe("createWithCompute", () => {
+describe("createBranchWithCompute", () => {
 	test("posts a read-write endpoint and returns the SDK workflow result", async () => {
 		const { requests, tools } = createBranchTools();
 
-		const result = await tools.createWithCompute.execute({
+		const result = await tools.createBranchWithCompute.execute({
 			project_id: "project-id",
 			name: "feature-x",
 			parent_id: "br-parent",
@@ -173,7 +180,7 @@ describe("createWithCompute", () => {
 	test("forwards pooled: false to the SDK connection-string picker", async () => {
 		const { tools } = createBranchTools();
 
-		const result = await tools.createWithCompute.execute({
+		const result = await tools.createBranchWithCompute.execute({
 			project_id: "project-id",
 			pooled: false,
 		});
@@ -189,7 +196,7 @@ describe("createWithCompute", () => {
 		const { tools } = createBranchTools();
 
 		await expect(
-			tools.createWithCompute.execute(
+			tools.createBranchWithCompute.execute(
 				{ project_id: "project-id" },
 				{ signal: controller.signal },
 			),
@@ -198,7 +205,9 @@ describe("createWithCompute", () => {
 
 	test("describes pooled on the published schema", () => {
 		const { tools } = createBranchTools();
-		const schema = z.toJSONSchema(tools.createWithCompute.inputSchema);
+		const schema = z.toJSONSchema(
+			tools.createBranchWithCompute.inputSchema,
+		);
 		const pooled = schema.properties?.pooled;
 
 		expect(pooled).toMatchObject({
@@ -211,7 +220,7 @@ describe("createWithCompute", () => {
 		const { tools } = createBranchTools();
 
 		expect(
-			tools.createWithCompute.inputSchema.safeParse({
+			tools.createBranchWithCompute.inputSchema.safeParse({
 				project_id: "project-id",
 				parentId: "br-parent",
 			}).success,
@@ -223,7 +232,7 @@ describe("createWithCompute", () => {
 			inject: { projectId: "granted-project", omitFromSchema: true },
 		});
 
-		await tools.createWithCompute.execute({ name: "feature-x" });
+		await tools.createBranchWithCompute.execute({ name: "feature-x" });
 
 		expect(requests[0].url).toBe(
 			"https://console.neon.tech/api/v2/projects/granted-project/branches",
@@ -233,11 +242,11 @@ describe("createWithCompute", () => {
 	test("renames the published id", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			workflows: ["createWithCompute"] as const,
-			names: { createWithCompute: "create_branch" },
+			workflows: ["createBranchWithCompute"] as const,
+			names: { createBranchWithCompute: "create_branch" },
 		});
 
-		expect(tools.createWithCompute.id).toBe("create_branch");
+		expect(tools.createBranchWithCompute.id).toBe("create_branch");
 	});
 
 	test("uses an execute-time credential instead of the constructor credential", async () => {
@@ -245,7 +254,7 @@ describe("createWithCompute", () => {
 			apiKey: "constructor-key",
 		});
 
-		await tools.createWithCompute.execute(
+		await tools.createBranchWithCompute.execute(
 			{ project_id: "project-id" },
 			{ apiKey: "oauth-access-token" },
 		);
@@ -261,7 +270,7 @@ describe("createWithCompute", () => {
 		});
 
 		await expect(
-			tools.createWithCompute.execute(
+			tools.createBranchWithCompute.execute(
 				{ project_id: "project-id" },
 				{ apiKey: "" },
 			),
@@ -275,7 +284,7 @@ describe("createWithCompute", () => {
 		});
 
 		await expect(
-			tools.createWithCompute.execute(
+			tools.createBranchWithCompute.execute(
 				{ project_id: "project-id" },
 				{ apiKey: () => "" },
 			),
@@ -284,19 +293,19 @@ describe("createWithCompute", () => {
 	});
 });
 
-describe("createAndConnect", () => {
+describe("createProjectAndConnect", () => {
 	test("posts the project body and returns the SDK workflow result", async () => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			workflows: ["createAndConnect"] as const,
+			workflows: ["createProjectAndConnect"] as const,
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
 				return jsonResponse(projectWithUriBody);
 			},
 		});
 
-		const result = await tools.createAndConnect.execute({
+		const result = await tools.createProjectAndConnect.execute({
 			name: "tool-created",
 			region_id: "aws-us-east-1",
 		});
@@ -323,11 +332,11 @@ describe("createAndConnect", () => {
 	test("forwards pooled: false", async () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			workflows: ["createAndConnect"] as const,
+			workflows: ["createProjectAndConnect"] as const,
 			fetch: async () => jsonResponse(projectWithUriBody),
 		});
 
-		const result = await tools.createAndConnect.execute({
+		const result = await tools.createProjectAndConnect.execute({
 			name: "tool-created",
 			pooled: false,
 		});
@@ -341,7 +350,7 @@ describe("createAndConnect", () => {
 describe("createNeonTool workflow", () => {
 	test("creates a single workflow tool", async () => {
 		const requests: Request[] = [];
-		const tool = createNeonTool("createWithCompute", {
+		const tool = createNeonTool("createBranchWithCompute", {
 			apiKey: "test-key",
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -351,7 +360,7 @@ describe("createNeonTool workflow", () => {
 
 		await tool.execute({ project_id: "project-id", name: "feature-x" });
 
-		expect(tool.id).toBe("create_with_compute");
+		expect(tool.id).toBe("create_branch_with_compute");
 		expect(requests[0].url).toBe(
 			"https://console.neon.tech/api/v2/projects/project-id/branches",
 		);

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import * as z from "zod";
 import {
 	createNeonTool,
 	createNeonTools,
@@ -86,7 +87,9 @@ describe("createNeonTools workflows", () => {
 	test("rejects a call with neither operations nor workflows", () => {
 		expect(() =>
 			Reflect.apply(createNeonTools, undefined, [{ apiKey: "test-key" }]),
-		).toThrow("createNeonTools requires operations or workflows");
+		).toThrow(
+			"createNeonTools requires at least one operation or workflow",
+		);
 	});
 
 	test("rejects duplicate workflow selections", () => {
@@ -191,6 +194,17 @@ describe("createWithCompute", () => {
 				{ signal: controller.signal },
 			),
 		).rejects.toThrow();
+	});
+
+	test("describes pooled on the published schema", () => {
+		const { tools } = createBranchTools();
+		const schema = z.toJSONSchema(tools.createWithCompute.inputSchema);
+		const pooled = schema.properties?.pooled;
+
+		expect(pooled).toMatchObject({
+			type: "boolean",
+			description: expect.stringContaining("Default true"),
+		});
 	});
 
 	test("rejects unknown input fields", () => {

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, test } from "vitest";
+import {
+	createNeonTool,
+	createNeonTools,
+	type NeonToolsClientOptions,
+} from "./index.js";
+
+const jsonResponse = (body: unknown, status = 201) =>
+	new Response(JSON.stringify(body), {
+		status,
+		headers: { "content-type": "application/json" },
+	});
+
+const branchWithComputeBody = {
+	branch: { id: "br-id", name: "feature-x" },
+	endpoints: [{ id: "ep-id", type: "read_write" }],
+	connection_uris: [
+		{
+			connection_uri: "postgresql://user:pass@ep-host/neondb",
+			connection_parameters: {
+				host: "ep-host",
+				pooler_host: "ep-pooler-host",
+			},
+		},
+	],
+};
+
+const projectWithUriBody = {
+	project: { id: "project-id", name: "tool-created" },
+	connection_uris: [
+		{
+			connection_uri: "postgresql://user:pass@ep-host/neondb",
+			connection_parameters: {
+				host: "ep-host",
+				pooler_host: "ep-pooler-host",
+			},
+		},
+	],
+};
+
+const createBranchTools = (options: NeonToolsClientOptions = {}) => {
+	const requests: Request[] = [];
+	const tools = createNeonTools({
+		apiKey: "test-key",
+		...options,
+		workflows: ["createWithCompute"] as const,
+		fetch: async (input, init) => {
+			requests.push(new Request(input, init));
+			return jsonResponse(branchWithComputeBody);
+		},
+	});
+	return { requests, tools };
+};
+
+describe("createNeonTools workflows", () => {
+	test("creates only the selected workflow", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			workflows: ["createWithCompute"] as const,
+		});
+
+		expect(Object.keys(tools)).toEqual(["createWithCompute"]);
+		expect(tools.createWithCompute.id).toBe("create_with_compute");
+		expect(tools.createWithCompute.operationId).toBe("createWithCompute");
+		expect(tools.createWithCompute.requiresApproval).toBe(true);
+		expect(tools.createWithCompute.annotations).toEqual({
+			readOnlyHint: false,
+			destructiveHint: true,
+			openWorldHint: true,
+		});
+	});
+
+	test("merges operations and workflows on one record", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			operations: ["listProjects"] as const,
+			workflows: ["createWithCompute"] as const,
+		});
+
+		expect(Object.keys(tools)).toEqual([
+			"listProjects",
+			"createWithCompute",
+		]);
+	});
+
+	test("rejects a call with neither operations nor workflows", () => {
+		expect(() =>
+			Reflect.apply(createNeonTools, undefined, [{ apiKey: "test-key" }]),
+		).toThrow("createNeonTools requires operations or workflows");
+	});
+
+	test("rejects duplicate workflow selections", () => {
+		expect(() =>
+			createNeonTools({
+				apiKey: "test-key",
+				workflows: ["createWithCompute", "createWithCompute"],
+			}),
+		).toThrow('Duplicate Neon workflow "createWithCompute"');
+	});
+
+	test("reports unknown runtime workflow ids", () => {
+		expect(() =>
+			Reflect.apply(createNeonTools, undefined, [
+				{ apiKey: "test-key", workflows: ["createWithComput"] },
+			]),
+		).toThrow('Unknown Neon workflow "createWithComput"');
+		expect(() =>
+			Reflect.apply(createNeonTool, undefined, [
+				"createWithComput",
+				{ apiKey: "test-key" },
+			]),
+		).toThrow('Unknown Neon operation "createWithComput"');
+	});
+
+	test("rejects a published-id collision between an operation and a workflow", () => {
+		expect(() =>
+			createNeonTools({
+				apiKey: "test-key",
+				operations: ["createProject"] as const,
+				workflows: ["createAndConnect"] as const,
+				names: { createAndConnect: "create_project" },
+			}),
+		).toThrow(
+			'Duplicate Neon tool id "create_project" for createProject, createAndConnect',
+		);
+	});
+});
+
+describe("createWithCompute", () => {
+	test("posts a read-write endpoint and returns the SDK workflow result", async () => {
+		const { requests, tools } = createBranchTools();
+
+		const result = await tools.createWithCompute.execute({
+			project_id: "project-id",
+			name: "feature-x",
+			parent_id: "br-parent",
+			compute: {
+				min_cu: 0.5,
+				max_cu: 2,
+				suspend_timeout_seconds: 300,
+			},
+		});
+
+		expect(requests).toHaveLength(1);
+		expect(requests[0].method).toBe("POST");
+		expect(requests[0].url).toBe(
+			"https://console.neon.tech/api/v2/projects/project-id/branches",
+		);
+		expect(await requests[0].json()).toEqual({
+			branch: { name: "feature-x", parent_id: "br-parent" },
+			endpoints: [
+				{
+					type: "read_write",
+					autoscaling_limit_min_cu: 0.5,
+					autoscaling_limit_max_cu: 2,
+					suspend_timeout_seconds: 300,
+				},
+			],
+		});
+		expect(result).toEqual({
+			data: {
+				branch: { id: "br-id", name: "feature-x" },
+				endpoint: { id: "ep-id", type: "read_write" },
+				connectionString:
+					"postgresql://user:pass@ep-pooler-host/neondb",
+			},
+		});
+	});
+
+	test("forwards pooled: false to the SDK connection-string picker", async () => {
+		const { tools } = createBranchTools();
+
+		const result = await tools.createWithCompute.execute({
+			project_id: "project-id",
+			pooled: false,
+		});
+
+		expect(result.data.connectionString).toBe(
+			"postgresql://user:pass@ep-host/neondb",
+		);
+	});
+
+	test("forwards an abort signal to the SDK call", async () => {
+		const controller = new AbortController();
+		controller.abort();
+		const { tools } = createBranchTools();
+
+		await expect(
+			tools.createWithCompute.execute(
+				{ project_id: "project-id" },
+				{ signal: controller.signal },
+			),
+		).rejects.toThrow();
+	});
+
+	test("rejects unknown input fields", () => {
+		const { tools } = createBranchTools();
+
+		expect(
+			tools.createWithCompute.inputSchema.safeParse({
+				project_id: "project-id",
+				parentId: "br-parent",
+			}).success,
+		).toBe(false);
+	});
+
+	test("injects project_id from a grant", async () => {
+		const { requests, tools } = createBranchTools({
+			inject: { projectId: "granted-project", omitFromSchema: true },
+		});
+
+		await tools.createWithCompute.execute({ name: "feature-x" });
+
+		expect(requests[0].url).toBe(
+			"https://console.neon.tech/api/v2/projects/granted-project/branches",
+		);
+	});
+
+	test("renames the published id", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			workflows: ["createWithCompute"] as const,
+			names: { createWithCompute: "create_branch" },
+		});
+
+		expect(tools.createWithCompute.id).toBe("create_branch");
+	});
+
+	test("uses an execute-time credential instead of the constructor credential", async () => {
+		const { requests, tools } = createBranchTools({
+			apiKey: "constructor-key",
+		});
+
+		await tools.createWithCompute.execute(
+			{ project_id: "project-id" },
+			{ apiKey: "oauth-access-token" },
+		);
+
+		expect(requests[0].headers.get("authorization")).toBe(
+			"Bearer oauth-access-token",
+		);
+	});
+
+	test("does not fall back to the constructor credential when execute overrides it with an empty value", async () => {
+		const { requests, tools } = createBranchTools({
+			apiKey: "constructor-key",
+		});
+
+		await expect(
+			tools.createWithCompute.execute(
+				{ project_id: "project-id" },
+				{ apiKey: "" },
+			),
+		).rejects.toThrow("A Neon API key or OAuth access token is required");
+		expect(requests).toHaveLength(0);
+	});
+
+	test("does not fall back to the constructor credential when an execute-time getter resolves empty", async () => {
+		const { requests, tools } = createBranchTools({
+			apiKey: "constructor-key",
+		});
+
+		await expect(
+			tools.createWithCompute.execute(
+				{ project_id: "project-id" },
+				{ apiKey: () => "" },
+			),
+		).rejects.toThrow("A Neon API key or OAuth access token is required");
+		expect(requests).toHaveLength(0);
+	});
+});
+
+describe("createAndConnect", () => {
+	test("posts the project body and returns the SDK workflow result", async () => {
+		const requests: Request[] = [];
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			workflows: ["createAndConnect"] as const,
+			fetch: async (input, init) => {
+				requests.push(new Request(input, init));
+				return jsonResponse(projectWithUriBody);
+			},
+		});
+
+		const result = await tools.createAndConnect.execute({
+			name: "tool-created",
+			region_id: "aws-us-east-1",
+		});
+
+		expect(requests[0].method).toBe("POST");
+		expect(requests[0].url).toBe(
+			"https://console.neon.tech/api/v2/projects",
+		);
+		expect(await requests[0].json()).toEqual({
+			project: {
+				name: "tool-created",
+				region_id: "aws-us-east-1",
+			},
+		});
+		expect(result).toEqual({
+			data: {
+				project: { id: "project-id", name: "tool-created" },
+				connectionString:
+					"postgresql://user:pass@ep-pooler-host/neondb",
+			},
+		});
+	});
+
+	test("forwards pooled: false", async () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			workflows: ["createAndConnect"] as const,
+			fetch: async () => jsonResponse(projectWithUriBody),
+		});
+
+		const result = await tools.createAndConnect.execute({
+			name: "tool-created",
+			pooled: false,
+		});
+
+		expect(result.data.connectionString).toBe(
+			"postgresql://user:pass@ep-host/neondb",
+		);
+	});
+});
+
+describe("createNeonTool workflow", () => {
+	test("creates a single workflow tool", async () => {
+		const requests: Request[] = [];
+		const tool = createNeonTool("createWithCompute", {
+			apiKey: "test-key",
+			fetch: async (input, init) => {
+				requests.push(new Request(input, init));
+				return jsonResponse(branchWithComputeBody);
+			},
+		});
+
+		await tool.execute({ project_id: "project-id", name: "feature-x" });
+
+		expect(tool.id).toBe("create_with_compute");
+		expect(requests[0].url).toBe(
+			"https://console.neon.tech/api/v2/projects/project-id/branches",
+		);
+	});
+});


### PR DESCRIPTION
## Problem

A host that gives an agent `@neon/tools` gets the generated Management API operations, so "create a branch" means `create_project_branch`. That operation creates a branch with no compute unless the caller passes `endpoints`, and it returns as soon as the control plane accepts the request. No readiness wait, no connection string.

The agent ends up with a branch id and nothing to connect to. To make the next step work the host has to know to pass `endpoints`, poll the operations itself and assemble the connection string out of `connection_uris`.

`@neon/sdk` already does both jobs: `neon.branches.createWithCompute` and `neon.projects.createAndConnect` attach compute, wait for readiness and hand back a connection string. Neither was reachable from the tool record.

## What this adds

`createNeonTools` takes a `workflows` array beside `operations`. Each is optional on its own and at least one has to be present.

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
	apiKey,
	operations: ["listProjects"],
	workflows: ["createBranchWithCompute", "createProjectAndConnect"],
});
```

| Selector | Published `id` | SDK method | `data` |
| --- | --- | --- | --- |
| `createBranchWithCompute` | `create_branch_with_compute` | `neon.branches.createWithCompute` | `{ branch, endpoint, connectionString }` |
| `createProjectAndConnect` | `create_project_and_connect` | `neon.projects.createAndConnect` | `{ project, connectionString }` |

The selectors name the entity that gets created, so the record key reads the same way an operation key does. `workflowIds` exports them, next to the existing `operationIds`. Nothing changes for a call that passes only `operations`.

### Calls

```ts
const { data } = await tools.createBranchWithCompute.execute({
	project_id: "project-id",
	name: "feature-x",
	parent_id: "br-parent", // defaults to the project's default branch
	compute: { min_cu: 0.5, max_cu: 2, suspend_timeout_seconds: 300 },
	pooled: true, // default
});

data.connectionString; // postgresql://user:pass@ep-pooler-host/neondb

await tools.createProjectAndConnect.execute({
	name: "agent-project",
	region_id: "aws-us-east-1",
});
```

Input fields are snake_case like the generated tools, so `parent_id` rather than the SDK's `parentId`, and unknown fields are rejected instead of dropped. `createProjectAndConnect` takes the same project fields as `create_project`.

One tool at a time works too:

```ts
const createBranch = createNeonTool("createBranchWithCompute", { apiKey });
createBranch.id; // "create_branch_with_compute"
```

### Waiting, pooling and aborts

Both tools poll until the compute is ready. The budget is `wait.timeoutMs`, five minutes by default:

```ts
const tools = createNeonTools({
	apiKey,
	workflows: ["createProjectAndConnect"],
	wait: { timeoutMs: 30_000 },
});
```

Set it under the host's own tool-call timeout, otherwise the host gives up before the tool does.

`pooled` defaults to `true` and returns the pooler host. `pooled: false` returns the direct host.

An abort `signal` on `execute` or a wait timeout stops the poll, and the create is already in flight by then. The branch or project can exist afterwards, and the thrown error does not carry its id, so a host that retries blind creates a second one. List before retrying.

`metadata.method` and `metadata.path` describe the first request only, `POST /projects/{project_id}/branches` and `POST /projects`. The readiness GETs are not in there.

### Host add-ons

`names`, `inject` and `onExecute` apply to workflow tools the way they apply to generated ones.

```ts
const tools = createNeonTools({
	apiKey,
	workflows: ["createBranchWithCompute"],
	names: { createBranchWithCompute: "create_branch" },
	inject: { projectId: "granted-project", omitFromSchema: true },
});

tools.createBranchWithCompute.id; // "create_branch"
await tools.createBranchWithCompute.execute({ name: "feature-x" });
```

`inject.projectId` reaches `createBranchWithCompute` because injection reads the URL template and that tool's path is `/projects/{project_id}/branches`.

Annotations match the generated write tools: `readOnlyHint: false`, `destructiveHint: true`, `openWorldHint: true` and `requiresApproval: true`.

Published ids are still checked across the whole record, so a rename that collides with a selected operation throws:

```
Duplicate Neon tool id "create_project" for createProject, createProjectAndConnect
```

### Types

Three things a caller can notice.

`CreateNeonToolsOptions` is a type alias now, because the two selectors form a union of "operations required" and "workflows required". An `interface` can no longer extend it.

```ts
type HostOptions = CreateNeonToolsOptions<["listProjects"]> & { hostName: string };
```

Naming both generic arguments makes both fields required on the value:

```ts
const options: CreateNeonToolsOptions<
	["listProjects"],
	["createBranchWithCompute"]
> = {
	apiKey,
	operations: ["listProjects"],
	workflows: ["createBranchWithCompute"], // omitting this is an error
};
```

`createNeonTools`'s first type argument is the options object rather than the operations tuple, and the returned record is typed from the selector fields present on the options value. Inference from a value argument is unchanged. An explicit `createNeonTools<["listProjects"]>({ ... })` has to drop the argument or pass the options type.

The record type distributes over a union of option shapes, so a union only yields the keys both branches have:

```ts
declare const options:
	| { apiKey: string; operations: ["listProjects"] }
	| { apiKey: string; workflows: ["createBranchWithCompute"] };

const tools = createNeonTools(options);
tools.listProjects; // error, the workflows branch has no such key
tools.createBranchWithCompute; // error, the operations branch has no such key
```

## Also in here

- `wait` joins `baseUrl` and `fetch` on `NeonToolsClientOptions`, so it also reaches the client behind the generated operations, where nothing polls.
- `createNeonTool` resolves both kinds of id, so its unknown-id error is now `Unknown Neon operation or workflow "listProjcts"`. `createNeonTools` still reports per array, `Unknown Neon operation` and `Unknown Neon workflow`.
- Operation and workflow entries are assembled in one pass, so each selected operation builds its own client instance instead of sharing one.
- README: a `Workflows` section, and the add-ons section no longer says a connection string from a create is host-only work, because it is a tool now.
- `package.json` description covers workflows alongside the Management API.
- Changeset: `minor` for `@neon/tools`.

## Verification

`pnpm --filter @neon/tools exec vitest run` at `ff42f68`: 116 tests across 8 files pass, 19 of them new in `src/workflows.test.ts`. `pnpm --filter @neon/tools exec tsc --noEmit` is clean, which is what enforces the `@ts-expect-error` cases added to `src/index.test-d.ts`.

Behaviors covered by the new tests:

- a workflow-only selection yields exactly that key, with its published id, annotations and `requiresApproval`
- operations and workflows land on one record
- selecting neither throws, a duplicate workflow throws, an unknown workflow id throws from both entry points
- a rename that collides with a selected operation's published id throws
- `createBranchWithCompute` posts a `read_write` endpoint with the mapped autoscaling fields and returns `{ branch, endpoint, connectionString }`
- `createProjectAndConnect` posts the project body and returns `{ project, connectionString }`
- `pooled: false` returns the direct host on both tools, and `pooled` carries its description into the published JSON schema
- an abort signal reaches the SDK call
- `inject.projectId` with `omitFromSchema` fills the path and drops the field
- an execute-time credential replaces the constructor credential, and an empty execute-time credential fails before any request instead of falling back
- unknown input fields are rejected

Type tests cover the workflow-only record, the merged record, injection, the union distribution and the `CreateNeonToolsOptions` requirements.

Not verified against a live Neon project. The tests drive a `fetch` stub whose create response carries no operations, so the readiness poll, the five-minute default and the state left behind by a timeout are untested. `wait.timeoutMs` pass-through has no test.

## For your attention

- **A timeout or abort leaves the created resource behind and the error cannot name it.** The workflow tools do not clean up, and the id is not in the response the host sees. A host that retries on timeout doubles the branch or project. The mitigation available today is `wait.timeoutMs` set under the host's tool-call timeout plus a list before retry.
- **`CreateNeonToolsOptions` going from interface to type alias, and `createNeonTools`'s first type argument changing to the options object, break source that spells either one out.** Value-inferred calls compile unchanged. The changeset is `minor`, which matches a pre-1.0 package but is worth a look if any host pins those types.
- **`src/lib/workflows.ts` is hand-written, so `pnpm generate:check` does not cover it.** A signature change in `@neon/sdk` shows up as a type error in the build rather than as generator drift.
