### PR TITLE
chore: release @neon/tools@0.4.0

### DIFF
--- a/.changeset/tools-sdk-workflows.md
+++ b/.changeset/tools-sdk-workflows.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": minor
----
-
-`createNeonTools` accepts a `workflows` array that exposes `@neon/sdk` methods as `createBranchWithCompute` and `createProjectAndConnect`. Those tools attach compute, wait for readiness, and return a connection string. `CreateNeonToolsOptions` is a type alias, so an `interface` cannot extend it; `createNeonTools`'s first type argument is the options object.

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 0.4.0
+
+### Minor Changes
+
+- 6a31d50: `createNeonTools` accepts a `workflows` array that exposes `@neon/sdk` methods as `createBranchWithCompute` and `createProjectAndConnect`. Those tools attach compute, wait for readiness, and return a connection string. `CreateNeonToolsOptions` is a type alias, so an `interface` cannot extend it; `createNeonTools`'s first type argument is the options object.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Agent tools for the Neon Management API and SDK workflows, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Bumps `@neon/tools` 0.3.0 → 0.4.0 from the pending changeset. No source changes.

The 0.4.0 entry records the `workflows` selector from #454:

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
	apiKey: process.env.NEON_API_KEY!,
	workflows: ["createBranchWithCompute", "createProjectAndConnect"] as const,
});

const { data } = await tools.createProjectAndConnect.execute({ name: "my-app" });
data.connectionString;
```