### PR TITLE
chore: release @neon/sdk@2.2.0, @neon/tools@0.5.0

### DIFF
--- a/.changeset/sdk-spec-auth-email-provider-test.md
+++ b/.changeset/sdk-spec-auth-email-provider-test.md
@@ -1,6 +1,0 @@
----
-"@neon/sdk": minor
-"@neon/tools": minor
----
-
-`sendNeonAuthEmailProviderTest` is now on the generated raw client and in `@neon/tools`. It tests a branch's saved email provider without re-supplying the SMTP password. `sendNeonAuthTestEmail` is deprecated but still available for unsaved full SMTP configs.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon-internals/env-core
 
+## 0.0.2
+
+### Patch Changes
+
+- @neon/config@1.0.2
+
 ## 0.0.1
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # neon
 
+## 3.6.1
+
+### Patch Changes
+
+- Updated dependencies [93b93dc]
+  - @neon/sdk@2.2.0
+  - @neon/config@1.0.2
+  - @neon/config-runtime@1.0.2
+
 ## 3.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.6.0",
+	"version": "3.6.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 1.0.2
+
+### Patch Changes
+
+- @neon/config@1.0.2
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 1.0.2
+
+### Patch Changes
+
+- Updated dependencies [93b93dc]
+  - @neon/sdk@2.2.0
+
 ## 1.0.1
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.1.2
+
+### Patch Changes
+
+- @neon/config@1.0.2
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 3.6.1
+
+### Patch Changes
+
+- neon@3.6.1
+
 ## 3.6.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/sdk
 
+## 2.2.0
+
+### Minor Changes
+
+- 93b93dc: `sendNeonAuthEmailProviderTest` is now on the generated raw client and in `@neon/tools`. It tests a branch's saved email provider without re-supplying the SMTP password. `sendNeonAuthTestEmail` is deprecated but still available for unsaved full SMTP configs.
+
 ## 2.1.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @neon/tools
 
+## 0.5.0
+
+### Minor Changes
+
+- 93b93dc: `sendNeonAuthEmailProviderTest` is now on the generated raw client and in `@neon/tools`. It tests a branch's saved email provider without re-supplying the SMTP password. `sendNeonAuthTestEmail` is deprecated but still available for unsaved full SMTP configs.
+
+### Patch Changes
+
+- Updated dependencies [93b93dc]
+  - @neon/sdk@2.2.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Agent tools for the Neon Management API and SDK workflows, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Problem

#459 added `sendNeonAuthEmailProviderTest` to the generated raw client and to `@neon/tools`. It also marked `sendNeonAuthTestEmail` deprecated. It merged with its changeset unconsumed, so npm still serves `@neon/sdk` 2.1.0 and `@neon/tools` 0.4.0.

Nothing in this repo publishes on merge, and the publish workflow takes versions from `main`. A bump has to land before the feature can ship.

This PR is the `changeset version` output for that changeset. It contains no source changes.

## Version bumps

| Package | From | To | Why |
|---|---|---|---|
| `@neon/sdk` | 2.1.0 | 2.2.0 | minor, the new operation |
| `@neon/tools` | 0.4.0 | 0.5.0 | minor, the new operation |
| `neon` | 3.6.0 | 3.6.1 | dependency cascade |
| `neonctl` | 3.6.0 | 3.6.1 | dependency cascade |
| `@neon/env` | 1.1.1 | 1.1.2 | dependency cascade |
| `@neon/config` | 1.0.1 | 1.0.2 | dependency cascade |
| `@neon/config-runtime` | 1.0.1 | 1.0.2 | dependency cascade |
| `@neon-internals/env-core` | 0.0.1 | 0.0.2 | dependency cascade, private, never published |

The six cascade packages have `Updated dependencies` as their only CHANGELOG entry. `updateInternalDependencies: "patch"` over `workspace:*` deps produced them.

## What these versions publish

`@neon/sdk` 2.2.0 exposes the operation on the raw layer:

```ts
import { createNeonClient, raw } from "@neon/sdk";

const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });

// POST /projects/{project_id}/branches/{branch_id}/auth/email_provider/test
const { data, error } = await raw.sendNeonAuthEmailProviderTest({
  client: neon.client,
  path: { project_id, branch_id },
  body: { recipient_email: "someone@example.com" },
});

// data: { success: boolean; error_message?: string }
```

`recipient_email` is the entire body. The branch's saved SMTP host, port, username and password are read server-side, so the caller never supplies the password. `GET .../auth/email_provider` returns that password masked, which is what made round-tripping the provider config through the old endpoint fail SMTP authentication.

A configured custom SMTP provider on a Better Auth integration is required. A shared provider, a missing configuration or a non-Better-Auth integration is rejected.

`@neon/tools` 0.5.0 adds it as a selectable operation:

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
  apiKey: process.env.NEON_API_KEY!,
  operations: ["sendNeonAuthEmailProviderTest"] as const,
});

const { data } = await tools.sendNeonAuthEmailProviderTest.execute({
  project_id,
  branch_id,
  recipient_email: "someone@example.com",
});
```

The tool id is `send_neon_auth_email_provider_test`, with `requiresApproval: true` and `destructiveHint: true`.

`sendNeonAuthTestEmail` is still exported from both packages and still works. It stays the path for an unsaved full SMTP config and for non-Better-Auth providers:

```ts
await raw.sendNeonAuthTestEmail({
  client: neon.client,
  path: { project_id, branch_id },
  body: { host, port, username, password, sender_email, sender_name, recipient_email },
});
```

The OpenAPI document marks it `deprecated: true`. That tag does not reach the published `@neon/sdk` `.d.ts` (the raw re-export through `wrapRaw` drops JSDoc), so editors will not strike the old function. Runtime behavior is unchanged.

Nothing else moves. No signature changed. The cascade packages ship identical code under a new patch version.

## Also in here

- `.changeset/sdk-spec-auth-email-provider-test.md` is deleted. `changeset version` consumes it and writes its summary into the `@neon/sdk` and `@neon/tools` changelogs.
- `@neon-internals/env-core` 0.0.2 is in the diff because Changesets versions every workspace package. It is `private` and is bundled into its consumers rather than published.

## Verification

- `git diff origin/main...HEAD --name-only` lists only the deleted changeset, `package.json` files and `CHANGELOG.md` files. Nothing under `src/`, `spec/` or any test directory.
- every new `package.json` version matches the new heading in that package's CHANGELOG
- `npm view` confirms the public versions are still unpublished: `@neon/sdk` 2.1.0, `@neon/tools` 0.4.0, `neon` and `neonctl` 3.6.0, `@neon/env` 1.1.1, `@neon/config` and `@neon/config-runtime` 1.0.1
- no CHANGELOG version gaps: each new entry follows the previous published version

Not done on this branch: no build, no test run, no live call against the endpoint. The diff changes no code, so behavior at these versions is `main` at 93b93dc, where the operation was added and reviewed.

## For your attention

- **Merging publishes nothing.** Publish is a separate manual `workflow_dispatch` in the releases repo, one run per package. `@neon/sdk` and `@neon/tools` are the two runs the feature needs.
- **Five public packages get a version with no source change.** `neon`, `neonctl`, `@neon/env`, `@neon/config` and `@neon/config-runtime` move only because `@neon/sdk` did. Publishing them can ride out with their next real change.
- `sendNeonAuthTestEmail` is deprecated in this release. Removing it needs a major on `@neon/sdk`.
