### PR TITLE
chore: release @neon/tools@0.6.0

### DIFF
--- a/.changeset/tools-ergonomic-client.md
+++ b/.changeset/tools-ergonomic-client.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": minor
----
-
-`createNeonTools` now selects `@neon/sdk` methods by path (`tools: ["projects.list"]`). Operation-backed writes wait for readiness. `operations` and `workflows` selectors are removed.

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 0.6.0
+
+### Minor Changes
+
+- c41fae7: `createNeonTools` now selects `@neon/sdk` methods by path (`tools: ["projects.list"]`). Operation-backed writes wait for readiness. `operations` and `workflows` selectors are removed.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.5.0",
+	"version": "0.6.0",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## What this releases

`@neon/tools` was rebuilt on the `@neon/sdk` ergonomic client in [#457](https://github.com/neondatabase/neon-pkgs/pull/457), which landed on `main` with its changeset unconsumed. A release in this repo is a version bump plus a `CHANGELOG.md` entry on `main`, so the rewrite is sitting on `main` unreleased until one lands. This cuts `@neon/tools` 0.5.0 to 0.6.0.

There are no source changes. `pnpm changeset version` produced the whole diff: the changeset file is consumed, `packages/tools/package.json` moves to `0.6.0` and the changelog entry is appended.

## What a user of 0.6.0 gets

Selectors are `@neon/sdk` method paths, and the returned record is keyed by those paths:

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
	apiKey: process.env.NEON_API_KEY,
	tools: ["projects.list", "projects.createAndConnect"],
});

const created = await tools["projects.createAndConnect"].execute({
	name: "agent-project",
	region_id: "aws-us-east-1",
});
```

Operation-backed writes wait. When a mutation response carries an `operations` array, `execute()` polls until those operations finish, with a five minute default deadline that `wait: { timeoutMs }` bounds.

The `operations` and `workflows` selectors that 0.4.0 added are removed. A `workflows: ["createProjectAndConnect"]` selection becomes `tools: ["projects.createAndConnect"]`, and `createBranchWithCompute` becomes `branches.createWithCompute`.

`packages/tools/README.md` documents the rest of the 0.6.0 interface.

## Also in here

No other package version changed. Nothing in the workspace depends on `@neon/tools`, so `changeset version` had no internal dependents to patch-bump. `.changeset/` now holds only its `README.md` and `config.json`.

## Verification

- `pnpm lint:ci` on 4ffb700: 681 files checked, no fixes applied.
- `git diff origin/main...HEAD` touches three files: the deleted changeset, the `package.json` version and the changelog entry. Nothing under `src/`.

The published artifact is not verified here. This repo does not publish to npm.

## For your attention

- **0.6.0 removes selectors.** `@neon/tools` is pre-1.0, so a removal ships as a minor bump. Anyone passing `workflows` or `operations` has to change the call when they upgrade.
- **Merging does not publish.** The npm release is a separate workflow dispatch against the version on `main`.
