### PR TITLE
chore: release neon@4.0.0, neonctl@4.0.0

### DIFF
--- a/.changeset/cli-email-provider-test.md
+++ b/.changeset/cli-email-provider-test.md
@@ -1,6 +1,0 @@
----
-"neon": major
-"neonctl": major
----
-
-`neon neon-auth config email-provider test` now sends through the custom SMTP provider saved on the branch. Only `--recipient-email` is accepted; `--host`, `--port`, `--username`, `--password`, `--sender-email`, and `--sender-name` are rejected. Save the provider first with `neon neon-auth config email-provider update --type standard`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.0.0
+
+### Major Changes
+
+- d606a2e: `neon neon-auth config email-provider test` now sends through the custom SMTP provider saved on the branch. Only `--recipient-email` is accepted; `--host`, `--port`, `--username`, `--password`, `--sender-email`, and `--sender-name` are rejected. Save the provider first with `neon neon-auth config email-provider update --type standard`.
+
 ## 3.6.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "3.6.1",
+	"version": "4.0.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.0.0
+
+### Major Changes
+
+- d606a2e: `neon neon-auth config email-provider test` now sends through the custom SMTP provider saved on the branch. Only `--recipient-email` is accepted; `--host`, `--port`, `--username`, `--password`, `--sender-email`, and `--sender-name` are rejected. Save the provider first with `neon neon-auth config email-provider update --type standard`.
+
+### Patch Changes
+
+- Updated dependencies [d606a2e]
+  - neon@4.0.0
+
 ## 3.6.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "3.6.1",
+  "version": "4.0.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

The email-provider test contract landed in [#461](https://github.com/neondatabase/neon-pkgs/pull/461) (`d606a2e`) and has been sitting on `main` unpublished. npm latest for `neon` is 3.6.0, so nobody running `npx neon` gets it.

This PR is the release: version bump plus CHANGELOG. No source changes.

## What ships

`neon neon-auth config email-provider test` sends through the custom SMTP provider already saved on the branch:

```bash
neon neon-auth config email-provider test --project-id <project-id> --recipient-email user@example.com
```

`--recipient-email` is the only accepted flag. `--host`, `--port`, `--username`, `--password`, `--sender-email` and `--sender-name` are rejected, so a caller that passed connection details on the test command breaks. That is what makes this a major.

The provider has to exist before the test runs:

```bash
neon neon-auth config email-provider update --type standard
```

`neon` and `neonctl` are a Changesets fixed group, so both go to 4.0.0 together.

## The 3.6.1 skip

3.6.1 exists in the CHANGELOGs as a cascade bump from `@neon/sdk@2.2.0`, `@neon/config@1.0.2` and `@neon/config-runtime@1.0.2`. It was never published. Publishing 4.0.0 carries those dependency updates out with it, so users move from 3.6.0 straight to 4.0.0.

## The diff

- `.changeset/cli-email-provider-test.md` deleted, consumed into the CHANGELOG entries
- `packages/cli/package.json` and `packages/neonctl/package.json`: 3.6.1 to 4.0.0
- `packages/cli/CHANGELOG.md` and `packages/neonctl/CHANGELOG.md`: the 4.0.0 major entries, both attributed to `d606a2e`

## Verification

The behavior itself was verified in [#461](https://github.com/neondatabase/neon-pkgs/pull/461). Nothing in this branch touches source, so there is no new behavior to test.

What a reviewer can check on the diff: both packages carry the same version, the CHANGELOG text matches the changeset that was removed, and no changeset is left behind for this change.

Not verified here: the publish itself. `neon@4.0.0` and `neonctl@4.0.0` reaching npm is only confirmable after the release job runs on merge.

## For your attention

- **Major version on a CLI.** Anyone pinned to `neon@^3` stays on 3.6.0 until they move the range.
- **Only the `test` subcommand narrowed.** `email-provider update` keeps its flags.