### PR TITLE
chore: release neon@4.1.0, neonctl@4.1.0

### DIFF
--- a/.changeset/quick-taxis-stall.md
+++ b/.changeset/quick-taxis-stall.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-Add `neon inspect db stalled-queries`, a read-only snapshot of active queries running longer than 30 seconds. Table output shows duration, wait event, blocking pids, role, query group, and query. `--output json` includes the full row.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.1.0
+
+### Minor Changes
+
+- 6ff43d7: Add `neon inspect db stalled-queries`, a read-only snapshot of active queries running longer than 30 seconds. Table output shows duration, wait event, blocking pids, role, query group, and query. `--output json` includes the full row.
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.1.0
+
+### Patch Changes
+
+- Updated dependencies [6ff43d7]
+  - neon@4.1.0
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
[#451](https://github.com/neondatabase/neon-pkgs/pull/451) landed `neon inspect db stalled-queries` with a `neon: minor` changeset, and that changeset is still sitting in `.changeset/`. `main` is on `neon@4.0.0` and `neonctl@4.0.0`, so there is no version for the publish workflow to ship the command in. This PR runs `changeset version` to consume it.

## What's in here

The `pnpm changeset version` output and nothing else: the consumed changeset file, two `package.json` version fields and two `CHANGELOG.md` entries. No source changes.

## Versions

| Package | Before | After |
|---|---|---|
| `neon` (`packages/cli`) | 4.0.0 | 4.1.0 |
| `neonctl` (`packages/neonctl`) | 4.0.0 | 4.1.0 |

`neonctl` is the compatibility package that depends on `neon` through `workspace:*` and shares a Changesets fixed group with it, so it moves to the same version. Its CHANGELOG entry records the dependency bump rather than the feature.

## What 4.1.0 ships

```bash
npm i -g neon@4.1.0

neon inspect db stalled-queries
neon inspect db stalled-queries --output json
```

A read-only snapshot of active queries running longer than 30 seconds, taken compute-wide. The table shows duration, wait event, blocking pids, role, query group and query. `--output json` carries the full row, including `observed_at`, `pid`, `leader_pid`, `backend_type`, `database`, `application_name`, `query_id`, `state` and `wait_event_type`.

Nothing changes for anyone on 4.0.0 who does not run the new command.

## Verification

- `git diff origin/main...HEAD --stat` is five files: the deleted changeset, two `package.json`, two `CHANGELOG.md`.
- `pnpm lint:ci` passes (biome, 681 files checked).
- `pnpm-lock.yaml` is unchanged, which is expected for `workspace:*` internal deps.

The command itself is not exercised here. Its behavior was reviewed on #451 and this branch carries no source change.

## For your attention

- Nothing publishes on merge. `neon@4.1.0` and `neonctl@4.1.0` reach npm only after a manual dispatch of the publish workflow, one run per package, `neon` before `neonctl`.
- `@neon/env` is also waiting on that workflow. `main` has 1.1.2, npm has 1.1.1. It is a cascade bump from `@neon/config@1.0.2` and needs its own dispatch.
