### PR TITLE
fix(cli): rank stalled-queries by oldest group first

### DIFF
--- a/.changeset/stalled-queries-oldest-first.md
+++ b/.changeset/stalled-queries-oldest-first.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+Rank `inspect db stalled-queries` by the oldest query group first.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -871,7 +871,7 @@ All sub-commands honor the [global options](#global-options), including `--outpu
 
 ## Database diagnostics (`inspect`)
 
-`neon inspect db stalled-queries` takes a read-only snapshot of active queries that have run for more than 30 seconds and groups parallel workers with their leader. Oldest groups appear first. Table output shows duration, wait event, blocking pids, role, query group, and query. `--output json` adds timestamps, query IDs, pids, database, and the rest of the row. A blocking pid can belong to an idle-in-transaction backend this command does not list; `neon inspect db locks` shows lock holders.
+`neon inspect db stalled-queries` takes a read-only snapshot of active queries that have run for more than 30 seconds and groups parallel workers with their leader. Oldest group first. Table output shows duration, wait event, blocking pids, role, query group, and query. `--output json` adds timestamps, query IDs, pids, database, and the rest of the row. A blocking pid can belong to an idle-in-transaction backend this command does not list; `neon inspect db locks` shows lock holders.
 
 ```bash
 neon inspect db stalled-queries

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -871,7 +871,7 @@ All sub-commands honor the [global options](#global-options), including `--outpu
 
 ## Database diagnostics (`inspect`)
 
-`neon inspect db stalled-queries` takes a read-only snapshot of active queries that have run for more than 30 seconds and groups parallel workers with their leader. Table output shows duration, wait event, blocking pids, role, query group, and query. `--output json` adds timestamps, query IDs, pids, database, and the rest of the row. A blocking pid can belong to an idle-in-transaction backend this command does not list; `neon inspect db locks` shows lock holders.
+`neon inspect db stalled-queries` takes a read-only snapshot of active queries that have run for more than 30 seconds and groups parallel workers with their leader. Oldest groups appear first. Table output shows duration, wait event, blocking pids, role, query group, and query. `--output json` adds timestamps, query IDs, pids, database, and the rest of the row. A blocking pid can belong to an idle-in-transaction backend this command does not list; `neon inspect db locks` shows lock holders.
 
 ```bash
 neon inspect db stalled-queries

--- a/packages/cli/e2e/inspect.e2e.test.ts
+++ b/packages/cli/e2e/inspect.e2e.test.ts
@@ -66,6 +66,19 @@ async function withSession<T>(
 	}
 }
 
+async function backendPid(session: PgConnection): Promise<number> {
+	const result = await session.query("SELECT pg_backend_pid()");
+	const value = result.rows[0]?.[0];
+	if (typeof value !== "string" && typeof value !== "number") {
+		throw new Error(`pg_backend_pid returned ${String(value)}`);
+	}
+	const pid = Number(value);
+	if (!Number.isFinite(pid) || pid <= 0) {
+		throw new Error(`pg_backend_pid returned ${String(value)}`);
+	}
+	return pid;
+}
+
 /**
  * `pg_locks` and `pg_stat_activity` span the compute, while relation OIDs are
  * database-local. A second database makes foreign rows and misresolved OIDs
@@ -284,9 +297,21 @@ describe.sequential("e2e — neon inspect db against the real API", () => {
 			expect(empty).toEqual([]);
 
 			const uri = await connectionUriFor(projectId, "neondb");
-			const older = await PgConnection.connect(parseConnectionUri(uri));
-			const newer = await PgConnection.connect(parseConnectionUri(uri));
+			const first = await PgConnection.connect(parseConnectionUri(uri));
+			const second = await PgConnection.connect(parseConnectionUri(uri));
 			try {
+				const firstPid = await backendPid(first);
+				const secondPid = await backendPid(second);
+				if (firstPid === secondPid) {
+					throw new Error(
+						`both inspect sessions reported pid ${firstPid}`,
+					);
+				}
+				// Older query on the higher pid, so pid-primary order would
+				// rank it after the newer one.
+				const older = firstPid > secondPid ? first : second;
+				const newer = older === first ? second : first;
+
 				const pendingOlder = older.query(
 					"SELECT pg_sleep(90) /* stall-older */",
 				);
@@ -319,6 +344,9 @@ describe.sequential("e2e — neon inspect db against the real API", () => {
 				expect(olderIdx).toBeGreaterThanOrEqual(0);
 				expect(newerIdx).toBeGreaterThanOrEqual(0);
 				expect(olderIdx).toBeLessThan(newerIdx);
+				expect(Number(stallRows[olderIdx]?.pid)).toBeGreaterThan(
+					Number(stallRows[newerIdx]?.pid),
+				);
 
 				const hit = stallRows[olderIdx];
 				expect(hit?.role).toBe("leader");
@@ -329,8 +357,8 @@ describe.sequential("e2e — neon inspect db against the real API", () => {
 				await older.cancel();
 				await newer.cancel();
 			} finally {
-				await older.close();
-				await newer.close();
+				await first.close();
+				await second.close();
 			}
 		},
 		240_000,

--- a/packages/cli/e2e/inspect.e2e.test.ts
+++ b/packages/cli/e2e/inspect.e2e.test.ts
@@ -267,7 +267,7 @@ describe.sequential("e2e — neon inspect db against the real API", () => {
 	);
 
 	e2eTest(
-		"stalled-queries executes and reports a backend past 30 seconds",
+		"stalled-queries reports backends past 30 seconds, oldest group first",
 		async ({ track }) => {
 			const projectId = await createProject({
 				name: uniqueProjectName("cli-inspect-stall"),
@@ -284,10 +284,18 @@ describe.sequential("e2e — neon inspect db against the real API", () => {
 			expect(empty).toEqual([]);
 
 			const uri = await connectionUriFor(projectId, "neondb");
-			const session = await PgConnection.connect(parseConnectionUri(uri));
+			const older = await PgConnection.connect(parseConnectionUri(uri));
+			const newer = await PgConnection.connect(parseConnectionUri(uri));
 			try {
-				const pending = session.query("SELECT pg_sleep(90)");
-				pending.catch(() => undefined);
+				const pendingOlder = older.query(
+					"SELECT pg_sleep(90) /* stall-older */",
+				);
+				pendingOlder.catch(() => undefined);
+				await sleep(5_000);
+				const pendingNewer = newer.query(
+					"SELECT pg_sleep(90) /* stall-newer */",
+				);
+				pendingNewer.catch(() => undefined);
 				await sleep(32_000);
 
 				const rows = await runCliJson<Record<string, unknown>[]>([
@@ -297,21 +305,32 @@ describe.sequential("e2e — neon inspect db against the real API", () => {
 					"--project-id",
 					projectId,
 				]);
-				const hit = rows.find((row) =>
+				const stallRows = rows.filter((row) =>
 					String(row.query).includes("pg_sleep"),
 				);
-				expect(hit).toBeDefined();
-				if (hit === undefined) {
-					return;
-				}
-				expect(hit.role).toBe("leader");
-				expect(String(hit.query_group)).toBe(String(hit.pid));
-				expect(hit.state).toBe("active");
-				expect(typeof hit.duration).toBe("string");
+				expect(stallRows.length).toBeGreaterThanOrEqual(2);
 
-				await session.cancel();
+				const olderIdx = stallRows.findIndex((row) =>
+					String(row.query).includes("stall-older"),
+				);
+				const newerIdx = stallRows.findIndex((row) =>
+					String(row.query).includes("stall-newer"),
+				);
+				expect(olderIdx).toBeGreaterThanOrEqual(0);
+				expect(newerIdx).toBeGreaterThanOrEqual(0);
+				expect(olderIdx).toBeLessThan(newerIdx);
+
+				const hit = stallRows[olderIdx];
+				expect(hit?.role).toBe("leader");
+				expect(String(hit?.query_group)).toBe(String(hit?.pid));
+				expect(hit?.state).toBe("active");
+				expect(typeof hit?.duration).toBe("string");
+
+				await older.cancel();
+				await newer.cancel();
 			} finally {
-				await session.close();
+				await older.close();
+				await newer.close();
 			}
 		},
 		240_000,

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -137,7 +137,7 @@ describe("inspect db", () => {
 		);
 		expect(INSPECT_QUERIES["stalled-queries"]).toMatchObject({
 			scope: "compute",
-			describe: expect.stringContaining("Oldest groups first"),
+			describe: expect.stringContaining("oldest group first"),
 			sql: expect.stringContaining(
 				"backend_type IN ('client backend', 'parallel worker')",
 			),

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -137,6 +137,7 @@ describe("inspect db", () => {
 		);
 		expect(INSPECT_QUERIES["stalled-queries"]).toMatchObject({
 			scope: "compute",
+			describe: expect.stringContaining("Oldest groups first"),
 			sql: expect.stringContaining(
 				"backend_type IN ('client backend', 'parallel worker')",
 			),

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -126,6 +126,15 @@ describe("inspect db", () => {
 		expect(INSPECT_QUERIES["stalled-queries"].sql).toContain(
 			"array_to_string(pg_blocking_pids(a.pid), ',')",
 		);
+		expect(INSPECT_QUERIES["stalled-queries"].sql).toContain(
+			"min(query_start) AS group_start",
+		);
+		expect(INSPECT_QUERIES["stalled-queries"].sql).toContain(
+			"ORDER BY g.group_start, g.query_group, a.leader_pid NULLS FIRST, a.pid",
+		);
+		expect(INSPECT_QUERIES["stalled-queries"].sql).not.toContain(
+			"SELECT DISTINCT COALESCE(leader_pid, pid) AS query_group",
+		);
 		expect(INSPECT_QUERIES["stalled-queries"]).toMatchObject({
 			scope: "compute",
 			sql: expect.stringContaining(

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -129,7 +129,7 @@ export const INSPECT_QUERIES = {
 	},
 	"stalled-queries": {
 		describe:
-			"Active queries running longer than 30 seconds with parallel workers, waits, and blockers (compute-wide)",
+			"Active queries running longer than 30 seconds with parallel workers, waits, and blockers. Oldest groups first (compute-wide)",
 		scope: "compute",
 		fields: [
 			"duration",

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -149,9 +149,12 @@ export const INSPECT_QUERIES = {
 					AND pid <> pg_backend_pid()
 			),
 			stalled_groups AS (
-				SELECT DISTINCT COALESCE(leader_pid, pid) AS query_group
+				SELECT
+					COALESCE(leader_pid, pid) AS query_group,
+					min(query_start) AS group_start
 				FROM activity
 				WHERE query_start <= statement_timestamp() - interval '30 seconds'
+				GROUP BY COALESCE(leader_pid, pid)
 			)
 			SELECT
 				statement_timestamp() AS observed_at,
@@ -176,7 +179,7 @@ export const INSPECT_QUERIES = {
 			FROM activity a
 			JOIN stalled_groups g
 				ON g.query_group = COALESCE(a.leader_pid, a.pid)
-			ORDER BY g.query_group, a.leader_pid NULLS FIRST, a.pid;
+			ORDER BY g.group_start, g.query_group, a.leader_pid NULLS FIRST, a.pid;
 		`,
 	},
 	locks: {

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -129,7 +129,7 @@ export const INSPECT_QUERIES = {
 	},
 	"stalled-queries": {
 		describe:
-			"Active queries running longer than 30 seconds with parallel workers, waits, and blockers. Oldest groups first (compute-wide)",
+			"Active queries running longer than 30 seconds with parallel workers, waits, and blockers, oldest group first (compute-wide)",
 		scope: "compute",
 		fields: [
 			"duration",


### PR DESCRIPTION
## Problem

`neon inspect db stalled-queries` is the snapshot of active queries that have been running longer than 30 seconds, with parallel workers grouped under their leader. The top of the table and index 0 of `--output json` are where a caller looks for the longest hang.

The result is ordered by `query_group`. That value is `COALESCE(leader_pid, pid)`, so groups rank by pid. A newer query on a lower pid is printed first.

Two `pg_sleep(90)` backends, five seconds apart, with the older query on the higher pid. Ordering by `query_group` prints the newer row first.

## Diagnosis

On `main` the query ends with:

```sql
ORDER BY g.query_group, a.leader_pid NULLS FIRST, a.pid
```

`leader_pid NULLS FIRST, a.pid` keeps each leader above its workers. The first key is what ranks groups against each other, and it is a pid.

`neon inspect db long-running-queries` orders with `ORDER BY now() - query_start DESC`. That command is one row per backend. `stalled-queries` joins workers onto a group, so a per-row `query_start` sort would interleave groups. The sort key that keeps the join intact is `min(query_start)` over the group.

`stalled_groups` already listed those groups as `SELECT DISTINCT COALESCE(leader_pid, pid)`. It now aggregates:

```sql
SELECT
  COALESCE(leader_pid, pid) AS query_group,
  min(query_start) AS group_start
FROM activity
WHERE query_start <= statement_timestamp() - interval '30 seconds'
GROUP BY COALESCE(leader_pid, pid)
```

and ranks with:

```sql
ORDER BY g.group_start, g.query_group, a.leader_pid NULLS FIRST, a.pid
```

`group_start` is used only in `ORDER BY`.

## The user-facing interface

```bash
neon inspect db stalled-queries
neon inspect db stalled-queries --output json
```

`neon inspect db stalled-queries --help`:

```
Active queries running longer than 30 seconds with parallel workers, waits, and blockers, oldest group first (compute-wide)
```

README: `Oldest group first.`

Default table, from the CLI writer with the inspect unit fixture:

```
Duration         Wait Event    Role    Query Group  Query
00:00:41.923425  DataFileRead  worker  952          SELECT customer_id FROM checkout_events WHERE account_id = $1 ORDER BY created_at DESC
```

Same fixture with `blocking_pids` set to `771`:

```
Duration         Wait Event    Blocking Pids  Role    Query Group  Query
00:00:41.923425  DataFileRead  771            worker  952          SELECT customer_id FROM checkout_events WHERE account_id = $1 ORDER BY created_at DESC
```

`--output json` prints the SQL rows in that `ORDER BY`. Index 0 is the oldest group.

A worker that started later still sits in its leader's group, because `group_start` is `min(query_start)` for the group. Within a group the order is still leader first, then pid.

The command, flags, 30-second cutoff, displayed columns, compute-wide scope and worker-with-leader grouping stay as they are.

## Also in here

- Patch changeset on `neon`: Rank `inspect db stalled-queries` by the oldest query group first.
- README sentence quoted above.
- Unit test pins `min(query_start) AS group_start`, `ORDER BY g.group_start, g.query_group, a.leader_pid NULLS FIRST, a.pid` and `describe` containing `oldest group first`. It rejects `SELECT DISTINCT COALESCE(leader_pid, pid) AS query_group`.
- e2e starts two sessions, tags the older sleep `stall-older` on the higher pid, waits 5 seconds, starts `stall-newer`, waits 32 seconds and reads JSON. It asserts `stall-older` precedes `stall-newer` and that the older pid is greater.

## Verification

```bash
cd packages/cli && ./node_modules/.bin/vitest run src/commands/inspect.test.ts
```

20 passed (vitest 3.0.9), including the new SQL and `describe` assertions.

Table samples above used that file's `STALLED_QUERY_ROW` through the same `writer` the command uses.

Help sample: `node dist/cli.js inspect db stalled-queries --help`.

Did not run the live e2e (`stalled-queries reports backends past 30 seconds, oldest group first`). That case creates a Neon project, sleeps about 37 seconds and has a 240-second timeout.

## For your attention

- Groups that share a `group_start` still rank by `query_group` (pid), then leader, then pid.
- JSON consumers that treated index 0 as the lowest stalled pid will now get the oldest group.
