### PR TITLE
Run catalog-drift and sdk-spec-refresh on the protected runner group

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,10 +4,8 @@ name: Prepare
 
 runs:
   steps:
-    # The protected runner group has no egress to the public npm registry — it
-    # can only reach the Databricks JFrog mirror. Mint a short-lived token via
-    # OIDC and point npm/pnpm at the mirror before anything fetches packages
-    # (including pnpm's own self-installer). Mirrors neondatabase/neonctl.
+    # Protected runners use the Databricks JFrog mirror because
+    # registry.npmjs.org resets TLS. Configure it before pnpm installs itself.
     # The caller must grant `id-token: write`.
     - name: Setup JFrog CLI with OIDC
       id: setup-jfrog

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -2,8 +2,6 @@ name: Catalog Drift
 
 # Maintainer guard: fails when @neon/ai-sdk-provider's pinned model
 # catalog (NEON_MODELS_DEV_IDS) drifts from the live models.dev `neon` provider.
-# Runs on a GitHub-hosted runner because it must reach the public internet
-# (models.dev); the protected runner group has no public egress.
 
 on:
     schedule:
@@ -12,17 +10,20 @@ on:
 
 permissions:
     contents: read
+    id-token: write # mint the JFrog OIDC token in ./.github/actions/prepare
 
 jobs:
     drift:
         name: models.dev catalog drift
-        runs-on: ubuntu-latest
+        runs-on:
+            group: neondatabase-protected-runner-group
+            labels: linux-ubuntu-latest
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+            - name: Harden the runner (Audit all outbound calls)
+              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
               with:
-                  cache: pnpm
-                  node-version-file: .node-version
-            - run: pnpm install --frozen-lockfile
+                  egress-policy: audit
+
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: ./.github/actions/prepare
             - run: pnpm --filter @neon/ai-sdk-provider test:drift

--- a/.github/workflows/sdk-spec-refresh.yml
+++ b/.github/workflows/sdk-spec-refresh.yml
@@ -2,18 +2,13 @@ name: SDK Spec Drift
 
 # Maintainer signal: pull the live Neon OpenAPI spec, regenerate @neon/sdk and
 # @neon/tools, and FAIL when the spec or generated files drift from the commit.
-# This job intentionally does NOT open a PR (the org IP allow list blocks the
-# GitHub-hosted runner from pushing a branch). A red run is the signal to run
-# the refresh locally and open the PR by hand:
+# A red run is the signal to refresh locally and open the PR by hand:
 #
 #   pnpm --filter @neon/sdk spec:pull
 #   pnpm --filter @neon/sdk generate
 #   pnpm --filter @neon/tools generate
 #   pnpm --filter @neon/sdk --filter @neon/tools build
 #   # review + update packages/sdk/src/neon/coverage.ts, add a changeset, open a PR
-#
-# Runs on a GitHub-hosted runner because it must reach neon.com; the protected
-# runner group has no public egress.
 
 on:
     schedule:
@@ -22,22 +17,22 @@ on:
 
 permissions:
     contents: read
+    id-token: write # mint the JFrog OIDC token in ./.github/actions/prepare
 
 jobs:
     drift:
         name: Detect @neon/sdk spec drift
-        runs-on: ubuntu-latest
+        runs-on:
+            group: neondatabase-protected-runner-group
+            labels: linux-ubuntu-latest
         steps:
-            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-            - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+            - name: Harden the runner (Audit all outbound calls)
+              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
               with:
-                  cache: pnpm
-                  node-version-file: .node-version
+                  egress-policy: audit
 
-            - run: pnpm install --frozen-lockfile
+            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+            - uses: ./.github/actions/prepare
 
             - name: Pull live OpenAPI spec
               run: pnpm --filter @neon/sdk spec:pull

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ pnpm test:e2e:live
 | **Workflow** | `.github/workflows/e2e-live.yml` — every PR, every push to `main`, plus `workflow_dispatch` |
 | **Org** | `org-autumn-tree-56376911` ("neon-pkgs Integration Test Org"), Launch plan |
 | **Skipped for** | Fork and Dependabot PRs — GitHub does not expose repository secrets to untrusted PR code |
-| **Runner** | Protected runner group. Unlike `neon.com` and `models.dev`, the Neon **API** is reachable from it |
+| **Runner** | Protected runner group. The Neon API is reachable from it. |
 
 The org needs the **Launch plan or above**: `lifecycle.e2e.test.ts` protects a branch
 through `pushConfig`, and the free plan allows zero protected branches.
@@ -480,7 +480,7 @@ vendored copy on `main`. A scheduled workflow keeps maintainers aware:
 | **When** | Daily at 09:00 UTC; also `workflow_dispatch` |
 | **What** | `spec:pull` → `generate` → `build` on `@neon/sdk` |
 | **Output** | Opens or updates a PR on branch `bot/sdk-spec-refresh` titled `chore(@neon/sdk): refresh OpenAPI spec` — **only when something changed** |
-| **Runner** | `ubuntu-latest` (public egress to `neon.com`). CI uses the protected runner group + JFrog mirror and **cannot** reach the public spec URL — same constraint as `catalog-drift.yml` |
+| **Runner** | Protected runner group + JFrog. The spec is pulled from neon.com. |
 
 **The bot PR is a starting point, not merge-ready.** The workflow deliberately does
 not run `test:ci`. CI will fail on `packages/sdk/src/neon/coverage.test.ts` until


### PR DESCRIPTION
## Problem

`catalog-drift.yml` and `sdk-spec-refresh.yml` were the last two workflows in the repo still on `ubuntu-latest`. Everything else runs on `neondatabase-protected-runner-group`.

Both files carried the reason in a comment:

```
# Runs on a GitHub-hosted runner because it must reach neon.com; the protected
# runner group has no public egress.
```

## Diagnosis

The protected group does reach `models.dev` and `neon.com`. The host it cannot reach is `registry.npmjs.org`, which resets the TLS connection, so a bare `pnpm install --frozen-lockfile` fails there.

That is already solved for the seven other workflows. `./.github/actions/prepare` mints a JFrog OIDC token, writes `~/.npmrc` pointing npm and pnpm at the Databricks mirror, then runs `pnpm/action-setup`, `setup-node` and `pnpm install --frozen-lockfile`. These two workflows were doing the setup and install steps inline instead of calling it, so they inherited the npm registry problem and stayed on a GitHub-hosted runner to avoid it.

The two runs linked under Verification fetch the live models.dev catalog and the live spec from `https://neon.com/api_spec/release/v2.json` on the protected group.

## The workflows

The checks themselves are unchanged. `catalog-drift` runs `test:drift` against models.dev, and `sdk-spec-refresh` pulls the live spec, regenerates and fails on drift.

`.github/workflows/catalog-drift.yml`:

```yaml
permissions:
    contents: read
    id-token: write # mint the JFrog OIDC token in ./.github/actions/prepare

jobs:
    drift:
        name: models.dev catalog drift
        runs-on:
            group: neondatabase-protected-runner-group
            labels: linux-ubuntu-latest
        steps:
            - name: Harden the runner (Audit all outbound calls)
              uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
              with:
                  egress-policy: audit

            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
            - uses: ./.github/actions/prepare
            - run: pnpm --filter @neon/ai-sdk-provider test:drift
```

`.github/workflows/sdk-spec-refresh.yml` gets the same three changes (`id-token: write`, the runner group, harden-runner plus `prepare` in place of the inline setup). Its spec steps are untouched:

```yaml
            - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
            - uses: ./.github/actions/prepare

            - name: Pull live OpenAPI spec
              run: pnpm --filter @neon/sdk spec:pull

            - name: Regenerate client
              run: pnpm --filter @neon/sdk generate

            - name: Regenerate tools
              run: pnpm --filter @neon/tools generate

            - name: Build generated packages (typecheck + bundle)
              run: pnpm --filter @neon/sdk --filter @neon/tools build

            - name: Fail when spec or generated packages drifted
              run: |
                  ...
```

Triggers, schedules and failure output stay as they were. `sdk-spec-refresh` still does not open a PR; a red run is the signal to refresh locally and open one by hand.

## Also in here

- The comment in `.github/actions/prepare/action.yml` now names the failure it works around (`registry.npmjs.org` resets TLS) instead of the no-egress claim.
- Two runner rows in `AGENTS.md`: the live e2e row lost its comparison to `neon.com` and `models.dev`, and the spec-refresh row now says protected group plus JFrog.
- Both workflows gained the `harden-runner` audit step that the other six already run.
- No changeset. Nothing in a published package changes.

## Verification

Both workflows dispatched from this branch, both green:

- [catalog-drift](https://github.com/neondatabase/neon-pkgs/actions/runs/32779570539) - JFrog prepare, then `pnpm --filter @neon/ai-sdk-provider test:drift` against the live models.dev catalog.
- [sdk-spec-refresh](https://github.com/neondatabase/neon-pkgs/actions/runs/32779573346) - JFrog prepare, `curl -fsSL https://neon.com/api_spec/release/v2.json`, generate, build, no drift.

Not verified: the scheduled path. `schedule` only fires from the default branch, so the Monday and daily crons can first be confirmed after this merges.

## For your attention

- Both jobs now depend on the JFrog OIDC mint. When the mirror is unavailable they fail at install, before the drift check runs. That is the same failure mode as every other workflow in this repo.
- The `Coverage` job in `ci.yml` stays on `ubuntu-latest` for the Codecov upload. It is the only GitHub-hosted job left and is not touched here.
- `AGENTS.md` still describes the spec refresh Output as opening or updating a PR on `bot/sdk-spec-refresh`. The workflow fails the run instead. That row predates this branch and I left it alone.