### PR TITLE
chore: release neon@4.2.0, neonctl@4.2.0

### DIFF
--- a/.changeset/cli-neon-mcp.md
+++ b/.changeset/cli-neon-mcp.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-Add `neon mcp` to install the Neon MCP server into coding agents. A TTY asks config location (global default), agents, API key vs OAuth, then confirms. Linked project-folder installs also ask whether to pin tools to that project. `-y` is global, detected agents, minted write API key. `--project` is config location only. `--read-only`, `--project-id` and `--category` set MCP URL query params. The minted key is always account-wide.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.2.0
+
+### Minor Changes
+
+- 55f4bf2: Add `neon mcp` to install the Neon MCP server into coding agents. A TTY asks config location (global default), agents, API key vs OAuth, then confirms. Linked project-folder installs also ask whether to pin tools to that project. `-y` is global, detected agents, minted write API key. `--project` is config location only. `--read-only`, `--project-id` and `--category` set MCP URL query params. The minted key is always account-wide.
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.2.0
+
+### Minor Changes
+
+- 55f4bf2: Add `neon mcp` to install the Neon MCP server into coding agents. A TTY asks config location (global default), agents, API key vs OAuth, then confirms. Linked project-folder installs also ask whether to pin tools to that project. `-y` is global, detected agents, minted write API key. `--project` is config location only. `--read-only`, `--project-id` and `--category` set MCP URL query params. The minted key is always account-wide.
+
+### Patch Changes
+
+- Updated dependencies [55f4bf2]
+  - neon@4.2.0
+
 ## 4.1.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

`neon mcp` merged in #465 with a pending minor changeset. Until that changeset is consumed, `neon` and `neonctl` sit at 4.1.0 on `main` and there is nothing to publish.

## What this changes

`changeset version` output only. No source.

| Package | Dir | From | To |
|---|---|---|---|
| `neon` | `packages/cli` | 4.1.0 | 4.2.0 |
| `neonctl` | `packages/neonctl` | 4.1.0 | 4.2.0 |

`neon` and `neonctl` are a fixed group in `.changeset/config.json`, so they move together. `neonctl` depends on `neon` at `workspace:*`, so its changelog also carries the dependency line for `neon@4.2.0`.

No other package is bumped.

## What lands in 4.2.0

`.changeset/cli-neon-mcp.md` is deleted and its text becomes the 4.2.0 entry in both changelogs:

> Add `neon mcp` to install the Neon MCP server into coding agents. A TTY asks config location (global default), agents, API key vs OAuth, then confirms. Linked project-folder installs also ask whether to pin tools to that project. `-y` is global, detected agents, minted write API key. `--project` is config location only. `--read-only`, `--project-id` and `--category` set MCP URL query params. The minted key is always account-wide.

## Verification

- `git diff origin/main...HEAD` against `55f4bf2` is five files: the deleted changeset, two `version` fields and two CHANGELOG entries.
- `.changeset/` now holds only `README.md` and `config.json`, so no pending bump was left behind.
- `pnpm lint:ci` passed on this worktree.

## For your attention

Merging this publishes nothing. Both packages need a separate manual dispatch of the publish workflow once this is on `main`.