### PR TITLE
chore: release neon@4.2.1, neonctl@4.2.1

### DIFF
--- a/.changeset/cli-list-table-invariants.md
+++ b/.changeset/cli-list-table-invariants.md
@@ -1,6 +1,0 @@
----
-"neon": patch
-"neonctl": patch
----
-
-List commands print every populated column at full width on one line per row. A narrow terminal wraps the line instead of dropping or truncating columns. `neon branches list` and `neon snapshots list` show Expires At before Created At, including on get and create. `neon projects list --recoverable-only` shows Recoverable Until before Deleted At.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.2.1
+
+### Patch Changes
+
+- 9c5ecf5: List commands print every populated column at full width on one line per row. A narrow terminal wraps the line instead of dropping or truncating columns. `neon branches list` and `neon snapshots list` show Expires At before Created At, including on get and create. `neon projects list --recoverable-only` shows Recoverable Until before Deleted At.
+
 ## 4.2.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.2.0",
+	"version": "4.2.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.2.1
+
+### Patch Changes
+
+- 9c5ecf5: List commands print every populated column at full width on one line per row. A narrow terminal wraps the line instead of dropping or truncating columns. `neon branches list` and `neon snapshots list` show Expires At before Created At, including on get and create. `neon projects list --recoverable-only` shows Recoverable Until before Deleted At.
+- Updated dependencies [9c5ecf5]
+  - neon@4.2.1
+
 ## 4.2.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
Version bump PR from changesets. It consumes `.changeset/cli-list-table-invariants.md` and writes the changelog entries for both packages. No source changes.

| Package | From | To |
| --- | --- | --- |
| `neon` | 4.2.0 | 4.2.1 |
| `neonctl` | 4.2.0 | 4.2.1 |

`neon` and `neonctl` are `fixed` in `.changeset/config.json`, so they always release together. `neonctl` also picks up the internal dependency bump to `neon@4.2.1`.

## What ships in 4.2.1

The change is already on `main`. It affects how the CLI prints tables:

- List commands print every populated column at full width, one line per row. A narrow terminal wraps the line instead of dropping or truncating columns.
- `neon branches list` and `neon snapshots list` show Expires At before Created At. Same column order on `get` and `create`.
- `neon projects list --recoverable-only` shows Recoverable Until before Deleted At.

Only `-o table` output moves. `-o json` and `-o yaml` are unchanged, and no command, flag or exit code changes.

## Verification

Checked against the diff on this branch:

- both `package.json` versions read `4.2.1`
- both `CHANGELOG.md` files carry a `## 4.2.1` section whose text matches the changeset word for word
- `packages/neonctl/CHANGELOG.md` records the `neon@4.2.1` dependency bump
- the consumed changeset file is deleted, and `.changeset/` now holds only `README.md` and `config.json`, so nothing else is queued for this release

The behavior in the changelog entry was verified on the branch that introduced it. This PR does not touch source, so it re-verifies nothing.

## For your attention

- Merging lands the version bump on `main`. The npm publish is a separate step and does not happen from this repo.
- Anyone parsing `-o table` output with `awk`, `cut` or a fixed column position will see a different column order on branches, snapshots and recoverable projects. `-o json` is the stable path for that.
