### PR TITLE
Add `neon skills` to install Neon agent skills into coding agents

### DIFF
--- a/.changeset/cli-neon-skills.md
+++ b/.changeset/cli-neon-skills.md
@@ -1,0 +1,6 @@
+---
+"neon": minor
+"neonctl": minor
+---
+
+Add `neon skills` to install Neon agent skills into coding agents. A TTY asks agents and skills, then confirms. `-y` installs every skill from neondatabase/agent-skills into detected agents in this directory. `--global` is user-level. `neon skills update` refreshes installed skills.

--- a/.changeset/cli-neon-skills.md
+++ b/.changeset/cli-neon-skills.md
@@ -3,4 +3,4 @@
 "neonctl": minor
 ---
 
-Add `neon skills` to install Neon agent skills into coding agents. A TTY asks agents and skills, then confirms. `-y` installs every skill from neondatabase/agent-skills into detected agents in this directory. `--global` is user-level. `neon skills update` refreshes installed skills.
+Add `neon skills` to install Neon agent skills into coding agents. A TTY asks agents and skills, then confirms. `-y` installs the default skills into detected agents in this directory. `--skill` names specific skills. `--global` is user-level. `neon skills update` refreshes installed skills.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -761,7 +761,7 @@ The default mints an account-wide API key (or reuses the Bearer already configur
 
 ## Install Neon agent skills (`skills`)
 
-`neon skills` installs Neon agent skills by running `npx skills add`. It does not call the Neon API.
+`neon skills` installs Neon agent skills by running `npx skills add`. It does not call the Neon API. This command needs Node.js 22.20 or newer. The rest of the CLI supports Node.js 20.19 or newer.
 
 ```bash
 # Interactive: this directory, then agents, then skills, then confirm.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -767,12 +767,14 @@ The default mints an account-wide API key (or reuses the Bearer already configur
 # Interactive: this directory, then agents, then skills, then confirm.
 $ neon skills
 
-# Skip prompts. This directory, every detected agent, every skill from neondatabase/agent-skills.
+# Skip prompts. This directory, every detected agent, the default skills.
 $ neon skills -y
+
+$ neon skills -s neon -s neon-ai-gateway --agent cursor
 
 $ neon skills --agent cursor --agent claude-code
 
-# User-level skills (skills CLI -g).
+# User-level skills.
 $ neon skills --global
 
 # Update installed skills in this directory.
@@ -781,9 +783,11 @@ $ neon skills update -y
 $ neon skills update --global -y
 ```
 
-On a TTY the command asks which agents and which skills, then shows a summary to confirm. Detected agents start selected from project-folder markers such as `.cursor`. `neondatabase/agent-skills` starts selected. `neondatabase/neon-for-agent-platforms` is offered and starts unselected.
+On a TTY the command asks which agents and which skills, then shows a summary to confirm. Detected agents start selected from project-folder markers such as `.cursor`. Default skills start selected. `neon-postgres-agent-platforms` is offered and starts unselected.
 
-`-y` skips those questions and installs every skill from `neondatabase/agent-skills` only. `--agent` and `--global` still apply. Without a TTY, pass `-y`. `--agent` alone is not enough.
+`-y` skips those questions and installs the default skills. `--skill` / `-s` names specific skills and skips the skill picker. `--agent` and `--global` still apply. Without a TTY, pass `-y` or `--skill`. `--agent` alone is not enough.
+
+`--skill` names: `claimable-postgres`, `neon`, `neon-ai-gateway`, `neon-functions`, `neon-object-storage`, `neon-postgres`, `neon-postgres-branches`, `neon-postgres-egress-optimizer`, `neon-postgres-agent-platforms`.
 
 `--agent` names match `neon mcp`, minus agents that cannot install skills: `antigravity`, `cline`, `cline-cli`, `claude-code`, `claude-desktop`, `codex`, `cursor`, `gemini-cli`, `goose`, `github-copilot-cli`, `grok-build`, `opencode`, `vscode`, `windsurf`, `zed`. `mcporter` is a known MCP name that is then skipped.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -759,6 +759,34 @@ On a TTY the command asks for config location (global is the default), then agen
 
 The default mints an account-wide API key (or reuses the Bearer already configured for Neon at `https://mcp.neon.tech/mcp`) and writes it into each selected agent's config. That key reaches everything the account can, in every organization. Revoke it with `neon api-keys revoke <id>`. `--oauth` writes the URL with no `Authorization` header; the agent signs in on first use. `--project` writes into the project config (`.cursor/mcp.json` and similar). `--read-only` adds `?readonly=true`. `--project-id` adds `?projectId=`. `--category` adds `?category=` (repeatable or comma-separated: `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, `docs`). Those query params restrict which MCP tools the server exposes; they do not change what the minted key can do.
 
+## Install Neon agent skills (`skills`)
+
+`neon skills` installs Neon agent skills by running `npx skills add`. It does not call the Neon API.
+
+```bash
+# Interactive: this directory, then agents, then skills, then confirm.
+$ neon skills
+
+# Skip prompts. This directory, every detected agent, every skill from neondatabase/agent-skills.
+$ neon skills -y
+
+$ neon skills --agent cursor --agent claude-code
+
+# User-level skills (skills CLI -g).
+$ neon skills --global
+
+# Update installed skills in this directory.
+$ neon skills update
+$ neon skills update -y
+$ neon skills update --global -y
+```
+
+On a TTY the command asks which agents and which skills, then shows a summary to confirm. Detected agents start selected from project-folder markers such as `.cursor`. `neondatabase/agent-skills` starts selected. `neondatabase/neon-for-agent-platforms` is offered and starts unselected.
+
+`-y` skips those questions and installs every skill from `neondatabase/agent-skills` only. `--agent` and `--global` still apply. Without a TTY, pass `-y`. `--agent` alone is not enough.
+
+`--agent` names match `neon mcp`, minus agents that cannot install skills: `antigravity`, `cline`, `cline-cli`, `claude-code`, `claude-desktop`, `codex`, `cursor`, `gemini-cli`, `goose`, `github-copilot-cli`, `grok-build`, `opencode`, `vscode`, `windsurf`, `zed`. `mcporter` is a known MCP name that is then skipped.
+
 ## Snapshots (`snapshots`)
 
 `neon snapshots` (alias `neon snapshot`) manages **snapshots** — point-in-time backups of a branch that you can list, rename, expire, restore into a branch, or schedule automatically. Snapshots are a Beta Neon feature and were previously only available in the Console and REST API; this command group brings them to the CLI.
@@ -1139,6 +1167,7 @@ Id   Name      Project         Created At            Last Used At          Last 
 | bootstrap                                                                  |                                                                                                              | Scaffold a project from a template |
 | init                                                                       |                                                                                                              | Set up a project for a coding agent |
 | mcp                                                                        |                                                                                                              | Install the Neon MCP server         |
+| skills                                                                     | `update`                                                                                                     | Install Neon agent skills           |
 | bucket                                                                     | `create`, `list`, `delete`, `object list`, `object get`, `object put`, `object delete` (incl. `--recursive`) | Manage buckets and their objects   |
 | [completion](https://neon.com/docs/reference/cli-completion)               |                                                                                                              | Generate a completion script       |
 

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -41,6 +41,7 @@ import {
 	isMcpCommand,
 	isMcpOauth,
 	isProfileCommand,
+	isSkillsCommand,
 } from "../context.js";
 import { storeFor } from "../credential_io.js";
 import { isCi } from "../env.js";
@@ -427,6 +428,11 @@ export const ensureAuth = async (
 
 	// `open` only reads the linked project from `.neon` and launches its Console URL.
 	if (props._[0] === "open") {
+		return;
+	}
+
+	// Neon authentication is unrelated to the child skills CLI.
+	if (isSkillsCommand(props)) {
 		return;
 	}
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -29,6 +29,7 @@ import * as projects from "./projects.js";
 import * as psql from "./psql.js";
 import * as roles from "./roles.js";
 import * as setContext from "./set_context.js";
+import * as skills from "./skills.js";
 import * as snapshots from "./snapshots.js";
 import * as status from "./status.js";
 import * as users from "./user.js";
@@ -60,6 +61,7 @@ export default [
 	open,
 	init,
 	mcp,
+	skills,
 	dataApi,
 	functions,
 	dev,

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -12,7 +12,13 @@ import { join } from "node:path";
 import { afterEach, describe, expect } from "vitest";
 
 import pkg from "../pkg.js";
+import { defaultSkillEntries } from "../skills/catalog.js";
 import { test } from "../test_utils/fixtures";
+
+const defaultSkillIds = defaultSkillEntries().map((entry) => entry.skill);
+
+const skillArgv = (ids: readonly string[]): string[] =>
+	ids.flatMap((id) => ["--skill", id]);
 
 const dirs: string[] = [];
 
@@ -38,8 +44,17 @@ function scratch(): {
 	writeFileSync(
 		join(bin, "npx"),
 		`#!/usr/bin/env node
-const { writeFileSync } = require("node:fs");
-writeFileSync(process.env.SKILLS_ARGV_FILE, JSON.stringify(process.argv.slice(2)));
+const { readFileSync, writeFileSync } = require("node:fs");
+const argvFile = process.env.SKILLS_ARGV_FILE;
+let all = [];
+try {
+  const parsed = JSON.parse(readFileSync(argvFile, "utf8"));
+  all = Array.isArray(parsed) && parsed.every((item) => Array.isArray(item))
+    ? parsed
+    : [parsed];
+} catch {}
+all.push(process.argv.slice(2));
+writeFileSync(argvFile, JSON.stringify(all));
 writeFileSync(process.env.SKILLS_ENV_FILE, JSON.stringify({
   cwd: process.cwd(),
   hasDisable: Object.prototype.hasOwnProperty.call(process.env, "DISABLE_TELEMETRY"),
@@ -86,7 +101,7 @@ function runOptions(
 }
 
 describe("neon skills", () => {
-	test("installs agent-skills into detected project agents", async ({
+	test("installs default skills into detected project agents", async ({
 		testCliCommand,
 	}) => {
 		const { home, cwd, bin, argvFile, envFile } = scratch();
@@ -98,29 +113,30 @@ describe("neon skills", () => {
 		expect(rows).toEqual([
 			{
 				scope: "this directory",
-				source: "neondatabase/agent-skills",
-				skills: "*",
+				skills: defaultSkillIds.join(", "),
 				agents: "cursor",
 				status: "installed",
 			},
 		]);
 		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
-			"-y",
-			"skills",
-			"add",
-			"neondatabase/agent-skills",
-			"--skill",
-			"*",
-			"--agent",
-			"cursor",
-			"-y",
-			"--metadata",
-			JSON.stringify({
-				origin: "neon-cli",
-				command: "skills",
-				version: pkg.version,
-			}),
+			[
+				"-y",
+				"skills",
+				"add",
+				"neondatabase/agent-skills",
+				...skillArgv(defaultSkillIds),
+				"--agent",
+				"cursor",
+				"-y",
+				"--metadata",
+				JSON.stringify({
+					origin: "neon-cli",
+					command: "skills",
+					version: pkg.version,
+				}),
+			],
 		]);
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toHaveLength(1);
 		expect(JSON.parse(readFileSync(envFile, "utf8"))).toMatchObject({
 			cwd: realpathSync(cwd),
 			hasDisable: false,
@@ -134,8 +150,90 @@ describe("neon skills", () => {
 			["skills", "--agent", "cursor"],
 			{ ...runOptions(home, cwd, bin), code: 1 },
 		);
-		expect(stderr).toMatch(/Pass -y to install every skill/);
+		expect(stderr).toMatch(/Pass -y to install the default skills/);
 		expect(() => readFileSync(argvFile, "utf8")).toThrow();
+	});
+
+	test("installs named skills and routes platforms to its repo", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stdout } = await testCliCommand(
+			[
+				"skills",
+				"-s",
+				"neon",
+				"-s",
+				"neon-postgres-agent-platforms",
+				"--agent",
+				"cursor",
+			],
+			runOptions(home, cwd, bin),
+		);
+		expect(JSON.parse(stdout)).toEqual([
+			{
+				scope: "this directory",
+				skills: "neon",
+				agents: "cursor",
+				status: "installed",
+			},
+			{
+				scope: "this directory",
+				skills: "neon-postgres-agent-platforms",
+				agents: "cursor",
+				status: "installed",
+			},
+		]);
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
+			[
+				"-y",
+				"skills",
+				"add",
+				"neondatabase/agent-skills",
+				"--skill",
+				"neon",
+				"--agent",
+				"cursor",
+				"-y",
+				"--metadata",
+				JSON.stringify({
+					origin: "neon-cli",
+					command: "skills",
+					version: pkg.version,
+				}),
+			],
+			[
+				"-y",
+				"skills",
+				"add",
+				"neondatabase/neon-for-agent-platforms",
+				"--skill",
+				"neon-postgres-agent-platforms",
+				"--agent",
+				"cursor",
+				"-y",
+				"--metadata",
+				JSON.stringify({
+					origin: "neon-cli",
+					command: "skills",
+					version: pkg.version,
+				}),
+			],
+		]);
+	});
+
+	test("rejects unknown skills and --skill *", async ({ testCliCommand }) => {
+		const { home, cwd, bin } = scratch();
+		const { stderr: unknownSkill } = await testCliCommand(
+			["skills", "-y", "-s", "eve", "--agent", "cursor"],
+			{ ...runOptions(home, cwd, bin), code: 1 },
+		);
+		expect(unknownSkill).toMatch(/Unknown skill: "eve"/);
+		const { stderr: star } = await testCliCommand(
+			["skills", "-y", "-s", "*", "--agent", "cursor"],
+			{ ...runOptions(home, cwd, bin), code: 1 },
+		);
+		expect(star).toMatch(/does not accept --skill \*/);
 	});
 
 	test("rejects skills-CLI-only agents", async ({ testCliCommand }) => {
@@ -174,11 +272,7 @@ describe("neon skills", () => {
 			{ scope: "this directory", status: "updated" },
 		]);
 		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
-			"-y",
-			"skills",
-			"update",
-			"-p",
-			"-y",
+			["-y", "skills", "update", "-p", "-y"],
 		]);
 	});
 
@@ -249,11 +343,7 @@ describe("neon skills", () => {
 			runOptions(home, cwd, bin),
 		);
 		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
-			"-y",
-			"skills",
-			"update",
-			"-g",
-			"-y",
+			["-y", "skills", "update", "-g", "-y"],
 		]);
 	});
 
@@ -264,6 +354,16 @@ describe("neon skills", () => {
 			{ ...runOptions(home, cwd, bin), code: 1 },
 		);
 		expect(stderr).toMatch(/does not take --agent/);
+		expect(() => readFileSync(argvFile, "utf8")).toThrow();
+	});
+
+	test("update rejects --skill before spawn", async ({ testCliCommand }) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stderr } = await testCliCommand(
+			["skills", "update", "-y", "--skill", "neon"],
+			{ ...runOptions(home, cwd, bin), code: 1 },
+		);
+		expect(stderr).toMatch(/does not take --skill/);
 		expect(() => readFileSync(argvFile, "utf8")).toThrow();
 	});
 
@@ -278,6 +378,7 @@ describe("neon skills", () => {
 		const text = `${stdout}\n${stderr}`;
 		expect(text).toMatch(/skills update/);
 		expect(text).not.toMatch(/--agent/);
+		expect(text).not.toMatch(/--skill/);
 		expect(text).not.toMatch(/-y, -y/);
 	});
 
@@ -299,8 +400,9 @@ describe("neon skills", () => {
 			["skills", "-y", "--global", "--agent", "cursor"],
 			runOptions(home, cwd, bin),
 		);
-		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toContain("-g");
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))[0]).toContain("-g");
 		expect(JSON.parse(stdout)[0].scope).toBe("user-level");
+		expect(JSON.parse(stdout)[0]).not.toHaveProperty("source");
 	});
 
 	test("failed install keeps the child dump out of the table", async ({
@@ -323,11 +425,30 @@ describe("neon skills", () => {
 		expect(row.status).toBe("failed");
 		expect(row.error).toBe("skills CLI failed");
 		expect(row.error).not.toContain("syscall");
-		expect(stderr).toMatch(/Retry with: npx -y skills add/);
-		expect(stderr).toMatch(/--skill '\*'/);
+		expect(stderr).toMatch(/Retry with: neon skills -s claimable-postgres/);
+		expect(stderr).toMatch(/--agent cursor -y/);
+		expect(stderr).not.toMatch(/neondatabase\/agent-skills/);
 		expect(stderr.match(/Retry with:/g)?.length).toBe(1);
 		expect(stderr).not.toMatch(/Command failed with exit code/);
 		expect(stderr.match(/syscall spawn sh/g)?.length).toBe(1);
+	});
+
+	test("failed --global retry keeps user-level scope", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stderr } = await testCliCommand(
+			["skills", "-y", "--global", "--agent", "cursor"],
+			{
+				...runOptions(home, cwd, bin, {
+					SKILLS_CHILD_EXIT: "1",
+					SKILLS_CHILD_STDERR: "boom",
+				}),
+				code: 1,
+			},
+		);
+		expect(stderr).toMatch(/Retry with: neon skills -s claimable-postgres/);
+		expect(stderr).toMatch(/--agent cursor --global -y/);
 	});
 
 	test("names a missing npx", async ({ testCliCommand }) => {
@@ -341,7 +462,8 @@ describe("neon skills", () => {
 				code: 1,
 			},
 		);
-		expect(stderr).toMatch(/npx skills add neondatabase\/agent-skills/);
+		expect(stderr).toMatch(/needs npx \(Node\.js\) to run the skills CLI/);
+		expect(stderr).not.toMatch(/neondatabase\/agent-skills/);
 	});
 
 	test("help lists install and update", async ({ testCliCommand }) => {
@@ -350,8 +472,9 @@ describe("neon skills", () => {
 			...runOptions(home, cwd, bin),
 		});
 		const text = `${stdout}\n${stderr}`;
-		expect(text).toMatch(/neondatabase\/agent-skills/);
+		expect(text).toMatch(/-s, --skill/);
 		expect(text).toMatch(/skills update/);
+		expect(text).not.toMatch(/neondatabase\/agent-skills/);
 		expect(text).not.toMatch(/-y, -y/);
 	});
 });

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -436,6 +436,33 @@ describe("neon skills", () => {
 		expect(stderr.match(/syscall spawn sh/g)?.length).toBe(1);
 	});
 
+	test("failed multi-source retry names every failed skill", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stderr } = await testCliCommand(
+			[
+				"skills",
+				"-s",
+				"neon",
+				"-s",
+				"neon-postgres-agent-platforms",
+				"--agent",
+				"cursor",
+			],
+			{
+				...runOptions(home, cwd, bin, {
+					SKILLS_CHILD_EXIT: "1",
+					SKILLS_CHILD_STDERR: "boom",
+				}),
+				code: 1,
+			},
+		);
+		expect(stderr).toMatch(
+			/Retry with: neon skills -s neon -s neon-postgres-agent-platforms --agent cursor -y/,
+		);
+	});
+
 	test("failed --global retry keeps user-level scope", async ({
 		testCliCommand,
 	}) => {

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -1,0 +1,234 @@
+import {
+	chmodSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect } from "vitest";
+
+import pkg from "../pkg.js";
+import { test } from "../test_utils/fixtures";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function scratch(): {
+	home: string;
+	cwd: string;
+	bin: string;
+	argvFile: string;
+	envFile: string;
+} {
+	const home = mkdtempSync(join(tmpdir(), "neon-skills-home-"));
+	const cwd = mkdtempSync(join(tmpdir(), "neon-skills-cwd-"));
+	const bin = mkdtempSync(join(tmpdir(), "neon-skills-bin-"));
+	dirs.push(home, cwd, bin);
+	const argvFile = join(bin, "argv.json");
+	const envFile = join(bin, "env.json");
+	writeFileSync(
+		join(bin, "npx"),
+		`#!/usr/bin/env node
+const { writeFileSync } = require("node:fs");
+writeFileSync(process.env.SKILLS_ARGV_FILE, JSON.stringify(process.argv.slice(2)));
+writeFileSync(process.env.SKILLS_ENV_FILE, JSON.stringify({
+  cwd: process.cwd(),
+  hasDisable: Object.prototype.hasOwnProperty.call(process.env, "DISABLE_TELEMETRY"),
+  hasDnt: Object.prototype.hasOwnProperty.call(process.env, "DO_NOT_TRACK"),
+}));
+process.stdout.write("SKILLS_CLI_STDOUT");
+`,
+	);
+	chmodSync(join(bin, "npx"), 0o755);
+	mkdirSync(join(cwd, ".cursor"));
+	return { home, cwd, bin, argvFile, envFile };
+}
+
+function runOptions(
+	home: string,
+	cwd: string,
+	bin: string,
+	extra: Record<string, string> = {},
+) {
+	return {
+		cwd,
+		env: {
+			HOME: home,
+			CI: "true",
+			PATH: `${bin}:${join(process.cwd(), "mocks/bin")}:${process.env.PATH}`,
+			SKILLS_ARGV_FILE: join(bin, "argv.json"),
+			SKILLS_ENV_FILE: join(bin, "env.json"),
+			DISABLE_TELEMETRY: "1",
+			DO_NOT_TRACK: "1",
+			...extra,
+		},
+		snapshot: false as const,
+		apiKey: false as const,
+		output: "json" as const,
+	};
+}
+
+describe("neon skills", () => {
+	test("installs agent-skills into detected project agents", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile, envFile } = scratch();
+		const { stdout } = await testCliCommand(
+			["skills", "-y"],
+			runOptions(home, cwd, bin),
+		);
+		expect(stdout).not.toContain("SKILLS_CLI_STDOUT");
+		const rows = JSON.parse(stdout);
+		expect(rows).toEqual([
+			{
+				source: "neondatabase/agent-skills",
+				skills: "*",
+				agents: "cursor",
+				status: "installed",
+			},
+		]);
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
+			"-y",
+			"skills",
+			"add",
+			"neondatabase/agent-skills",
+			"--skill",
+			"*",
+			"--agent",
+			"cursor",
+			"-y",
+			"--metadata",
+			JSON.stringify({
+				origin: "neon-cli",
+				command: "skills",
+				version: pkg.version,
+			}),
+		]);
+		expect(JSON.parse(readFileSync(envFile, "utf8"))).toMatchObject({
+			cwd: realpathSync(cwd),
+			hasDisable: false,
+			hasDnt: false,
+		});
+	});
+
+	test("does not spawn without -y", async ({ testCliCommand }) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stderr } = await testCliCommand(
+			["skills", "--agent", "cursor"],
+			{ ...runOptions(home, cwd, bin), code: 1 },
+		);
+		expect(stderr).toMatch(/Pass -y to install every skill/);
+		expect(() => readFileSync(argvFile, "utf8")).toThrow();
+	});
+
+	test("rejects skills-CLI-only agents", async ({ testCliCommand }) => {
+		const { home, cwd, bin } = scratch();
+		const { stderr } = await testCliCommand(
+			["skills", "-y", "--agent", "eve"],
+			{ ...runOptions(home, cwd, bin), code: 1 },
+		);
+		expect(stderr).toMatch(/Unknown agent: "eve"/);
+	});
+
+	test("skips auth and context enrichment", async ({ testCliCommand }) => {
+		const { home, cwd, bin } = scratch();
+		writeFileSync(
+			join(cwd, ".neon"),
+			JSON.stringify({ projectId: "proj-from-neon" }),
+		);
+		const { stdout, stderr } = await testCliCommand(
+			["skills", "-y", "--agent", "cursor"],
+			runOptions(home, cwd, bin),
+		);
+		expect(stderr).not.toMatch(/Cannot run interactive auth/);
+		expect(stderr).not.toMatch(/Authentication required/);
+		expect(JSON.parse(stdout)[0].status).toBe("installed");
+	});
+
+	test("update routes to npx skills update -p", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stdout } = await testCliCommand(
+			["skills", "update", "-y"],
+			runOptions(home, cwd, bin),
+		);
+		expect(JSON.parse(stdout)).toEqual([
+			{ scope: "this directory", status: "updated" },
+		]);
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
+			"-y",
+			"skills",
+			"update",
+			"-p",
+			"-y",
+		]);
+	});
+
+	test("update --global uses -g", async ({ testCliCommand }) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		await testCliCommand(
+			["skills", "update", "--global", "-y"],
+			runOptions(home, cwd, bin),
+		);
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
+			"-y",
+			"skills",
+			"update",
+			"-g",
+			"-y",
+		]);
+	});
+
+	test("update without -y fails before spawn", async ({ testCliCommand }) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stderr } = await testCliCommand(["skills", "update"], {
+			...runOptions(home, cwd, bin),
+			code: 1,
+		});
+		expect(stderr).toMatch(/Pass -y to update installed skills/);
+		expect(() => readFileSync(argvFile, "utf8")).toThrow();
+	});
+
+	test("install --global passes -g", async ({ testCliCommand }) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		await testCliCommand(
+			["skills", "-y", "--global", "--agent", "cursor"],
+			runOptions(home, cwd, bin),
+		);
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toContain("-g");
+	});
+
+	test("names a missing npx", async ({ testCliCommand }) => {
+		const { home, cwd } = scratch();
+		const empty = mkdtempSync(join(tmpdir(), "neon-skills-empty-"));
+		dirs.push(empty);
+		const { stderr } = await testCliCommand(
+			["skills", "-y", "--agent", "cursor"],
+			{
+				...runOptions(home, cwd, empty, { PATH: empty }),
+				code: 1,
+			},
+		);
+		expect(stderr).toMatch(/npx skills add neondatabase\/agent-skills/);
+	});
+
+	test("help lists install and update", async ({ testCliCommand }) => {
+		const { home, cwd, bin } = scratch();
+		const { stdout, stderr } = await testCliCommand(["skills", "--help"], {
+			...runOptions(home, cwd, bin),
+		});
+		const text = `${stdout}\n${stderr}`;
+		expect(text).toMatch(/neondatabase\/agent-skills/);
+		expect(text).toMatch(/skills update/);
+	});
+});

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -189,7 +189,8 @@ describe("neon skills", () => {
 		const { stdout } = await testCliCommand(
 			["skills", "update", "-y"],
 			runOptions(home, cwd, bin, {
-				SKILLS_CHILD_STDOUT: "No project skills to update.\n",
+				SKILLS_CHILD_STDOUT:
+					"\u001b[38;5;145mChecking for skill updates…\u001b[0m\nNo project skills to update.\n",
 			}),
 		);
 		expect(JSON.parse(stdout)).toEqual([
@@ -197,6 +198,26 @@ describe("neon skills", () => {
 				scope: "this directory",
 				status: "none",
 				detail: "No project skills to update.",
+			},
+		]);
+	});
+
+	test("update detail skips the progress banner", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stdout } = await testCliCommand(
+			["skills", "update", "-y"],
+			runOptions(home, cwd, bin, {
+				SKILLS_CHILD_STDOUT:
+					"Checking for skill updates…\nUpdated 2 skills\n",
+			}),
+		);
+		expect(JSON.parse(stdout)).toEqual([
+			{
+				scope: "this directory",
+				status: "updated",
+				detail: "Updated 2 skills",
 			},
 		]);
 	});
@@ -284,6 +305,8 @@ describe("neon skills", () => {
 		expect(row.error).not.toContain("syscall");
 		expect(stderr).toMatch(/Retry with: npx -y skills add/);
 		expect(stderr).toMatch(/--skill '\*'/);
+		expect(stderr.match(/Retry with:/g)?.length).toBe(1);
+		expect(stderr).not.toMatch(/Command failed with exit code/);
 		expect(stderr.match(/syscall spawn sh/g)?.length).toBe(1);
 	});
 

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -189,6 +189,29 @@ describe("neon skills", () => {
 		]);
 	});
 
+	test("update rejects --agent before spawn", async ({ testCliCommand }) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stderr } = await testCliCommand(
+			["skills", "update", "-y", "--agent", "cursor"],
+			{ ...runOptions(home, cwd, bin), code: 1 },
+		);
+		expect(stderr).toMatch(/does not take --agent/);
+		expect(() => readFileSync(argvFile, "utf8")).toThrow();
+	});
+
+	test("update help does not advertise --agent", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stdout, stderr } = await testCliCommand(
+			["skills", "update", "--help"],
+			runOptions(home, cwd, bin),
+		);
+		const text = `${stdout}\n${stderr}`;
+		expect(text).toMatch(/skills update/);
+		expect(text).not.toMatch(/--agent/);
+	});
+
 	test("update without -y fails before spawn", async ({ testCliCommand }) => {
 		const { home, cwd, bin, argvFile } = scratch();
 		const { stderr } = await testCliCommand(["skills", "update"], {

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -283,6 +283,7 @@ describe("neon skills", () => {
 		expect(row.error).toBe("skills CLI failed");
 		expect(row.error).not.toContain("syscall");
 		expect(stderr).toMatch(/Retry with: npx -y skills add/);
+		expect(stderr).toMatch(/--skill '\*'/);
 		expect(stderr.match(/syscall spawn sh/g)?.length).toBe(1);
 	});
 

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -436,6 +436,39 @@ describe("neon skills", () => {
 		expect(stderr.match(/syscall spawn sh/g)?.length).toBe(1);
 	});
 
+	test("failed update retries the neon command", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stderr } = await testCliCommand(["skills", "update", "-y"], {
+			...runOptions(home, cwd, bin, {
+				SKILLS_CHILD_EXIT: "1",
+				SKILLS_CHILD_STDERR: "boom",
+			}),
+			code: 1,
+		});
+		expect(stderr).toMatch(/Retry with: neon skills update -y/);
+		expect(stderr).not.toMatch(/npx /);
+	});
+
+	test("failed update --global retries with --global", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stderr } = await testCliCommand(
+			["skills", "update", "--global", "-y"],
+			{
+				...runOptions(home, cwd, bin, {
+					SKILLS_CHILD_EXIT: "1",
+					SKILLS_CHILD_STDERR: "boom",
+				}),
+				code: 1,
+			},
+		);
+		expect(stderr).toMatch(/Retry with: neon skills update --global -y/);
+		expect(stderr).not.toMatch(/npx /);
+	});
+
 	test("failed multi-source retry names every failed skill", async ({
 		testCliCommand,
 	}) => {

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -59,6 +59,7 @@ writeFileSync(process.env.SKILLS_ENV_FILE, JSON.stringify({
   cwd: process.cwd(),
   hasDisable: Object.prototype.hasOwnProperty.call(process.env, "DISABLE_TELEMETRY"),
   hasDnt: Object.prototype.hasOwnProperty.call(process.env, "DO_NOT_TRACK"),
+  hasNeonKey: Object.prototype.hasOwnProperty.call(process.env, "NEON_API_KEY"),
 }));
 if (process.env.SKILLS_CHILD_STDOUT) {
   process.stdout.write(process.env.SKILLS_CHILD_STDOUT);
@@ -92,6 +93,7 @@ function runOptions(
 			SKILLS_ENV_FILE: join(bin, "env.json"),
 			DISABLE_TELEMETRY: "1",
 			DO_NOT_TRACK: "1",
+			NEON_API_KEY: "should-not-leak",
 			...extra,
 		},
 		snapshot: false as const,
@@ -141,6 +143,7 @@ describe("neon skills", () => {
 			cwd: realpathSync(cwd),
 			hasDisable: false,
 			hasDnt: false,
+			hasNeonKey: false,
 		});
 	});
 

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -202,7 +202,7 @@ describe("neon skills", () => {
 		]);
 	});
 
-	test("update detail skips the progress banner", async ({
+	test("update detail is the result line after progress", async ({
 		testCliCommand,
 	}) => {
 		const { home, cwd, bin } = scratch();
@@ -210,14 +210,34 @@ describe("neon skills", () => {
 			["skills", "update", "-y"],
 			runOptions(home, cwd, bin, {
 				SKILLS_CHILD_STDOUT:
-					"Checking for skill updates…\nUpdated 2 skills\n",
+					"Checking for skill updates…\nUpdating for: Universal\nRefreshing 1 skill(s)…\n✓ Updated 1 skill(s)\n",
 			}),
 		);
 		expect(JSON.parse(stdout)).toEqual([
 			{
 				scope: "this directory",
 				status: "updated",
-				detail: "Updated 2 skills",
+				detail: "✓ Updated 1 skill(s)",
+			},
+		]);
+	});
+
+	test("update --global none reads the lock-file no-op", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stdout } = await testCliCommand(
+			["skills", "update", "--global", "-y"],
+			runOptions(home, cwd, bin, {
+				SKILLS_CHILD_STDOUT:
+					"Checking for skill updates…\nNo global skills tracked in lock file.\n",
+			}),
+		);
+		expect(JSON.parse(stdout)).toEqual([
+			{
+				scope: "user-level",
+				status: "none",
+				detail: "No global skills tracked in lock file.",
 			},
 		]);
 	});

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -45,7 +45,15 @@ writeFileSync(process.env.SKILLS_ENV_FILE, JSON.stringify({
   hasDisable: Object.prototype.hasOwnProperty.call(process.env, "DISABLE_TELEMETRY"),
   hasDnt: Object.prototype.hasOwnProperty.call(process.env, "DO_NOT_TRACK"),
 }));
-process.stdout.write("SKILLS_CLI_STDOUT");
+if (process.env.SKILLS_CHILD_STDOUT) {
+  process.stdout.write(process.env.SKILLS_CHILD_STDOUT);
+}
+if (process.env.SKILLS_CHILD_STDERR) {
+  process.stderr.write(process.env.SKILLS_CHILD_STDERR);
+}
+if (process.env.SKILLS_CHILD_EXIT) {
+  process.exit(Number(process.env.SKILLS_CHILD_EXIT));
+}
 `,
 	);
 	chmodSync(join(bin, "npx"), 0o755);
@@ -86,10 +94,10 @@ describe("neon skills", () => {
 			["skills", "-y"],
 			runOptions(home, cwd, bin),
 		);
-		expect(stdout).not.toContain("SKILLS_CLI_STDOUT");
 		const rows = JSON.parse(stdout);
 		expect(rows).toEqual([
 			{
+				scope: "this directory",
 				source: "neondatabase/agent-skills",
 				skills: "*",
 				agents: "cursor",
@@ -174,6 +182,25 @@ describe("neon skills", () => {
 		]);
 	});
 
+	test("update reports none when the child has nothing to update", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const { stdout } = await testCliCommand(
+			["skills", "update", "-y"],
+			runOptions(home, cwd, bin, {
+				SKILLS_CHILD_STDOUT: "No project skills to update.\n",
+			}),
+		);
+		expect(JSON.parse(stdout)).toEqual([
+			{
+				scope: "this directory",
+				status: "none",
+				detail: "No project skills to update.",
+			},
+		]);
+	});
+
 	test("update --global uses -g", async ({ testCliCommand }) => {
 		const { home, cwd, bin, argvFile } = scratch();
 		await testCliCommand(
@@ -210,6 +237,7 @@ describe("neon skills", () => {
 		const text = `${stdout}\n${stderr}`;
 		expect(text).toMatch(/skills update/);
 		expect(text).not.toMatch(/--agent/);
+		expect(text).not.toMatch(/-y, -y/);
 	});
 
 	test("update without -y fails before spawn", async ({ testCliCommand }) => {
@@ -222,13 +250,40 @@ describe("neon skills", () => {
 		expect(() => readFileSync(argvFile, "utf8")).toThrow();
 	});
 
-	test("install --global passes -g", async ({ testCliCommand }) => {
+	test("install --global passes -g and names user-level scope", async ({
+		testCliCommand,
+	}) => {
 		const { home, cwd, bin, argvFile } = scratch();
-		await testCliCommand(
+		const { stdout } = await testCliCommand(
 			["skills", "-y", "--global", "--agent", "cursor"],
 			runOptions(home, cwd, bin),
 		);
 		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toContain("-g");
+		expect(JSON.parse(stdout)[0].scope).toBe("user-level");
+	});
+
+	test("failed install keeps the child dump out of the table", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin } = scratch();
+		const dump =
+			"npm error code ENOENT npm error syscall spawn sh npm error path /tmp/x";
+		const { stdout, stderr } = await testCliCommand(
+			["skills", "-y", "--agent", "cursor"],
+			{
+				...runOptions(home, cwd, bin, {
+					SKILLS_CHILD_EXIT: "1",
+					SKILLS_CHILD_STDERR: dump,
+				}),
+				code: 1,
+			},
+		);
+		const row = JSON.parse(stdout)[0];
+		expect(row.status).toBe("failed");
+		expect(row.error).toBe("skills CLI failed");
+		expect(row.error).not.toContain("syscall");
+		expect(stderr).toMatch(/Retry with: npx -y skills add/);
+		expect(stderr.match(/syscall spawn sh/g)?.length).toBe(1);
 	});
 
 	test("names a missing npx", async ({ testCliCommand }) => {
@@ -253,5 +308,6 @@ describe("neon skills", () => {
 		const text = `${stdout}\n${stderr}`;
 		expect(text).toMatch(/neondatabase\/agent-skills/);
 		expect(text).toMatch(/skills update/);
+		expect(text).not.toMatch(/-y, -y/);
 	});
 });

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -4,12 +4,12 @@ import { getAgentDisplayName } from "../init/agents.js";
 import { log } from "../log.js";
 import { assertSkillsCanRun, resolveSkillsPlan } from "../skills/plan.js";
 import {
-	firstChildLine,
 	npxCommand,
 	runSkillsCli,
 	skillsAddArgs,
 	skillsMetadata,
 	skillsUpdateArgs,
+	skillsUpdateDetail,
 	skillsUpdateHadNothing,
 } from "../skills/run.js";
 import { mappedSkillsAgentNames } from "../skills/targets.js";
@@ -280,7 +280,7 @@ const updateHandler = async (props: SkillsProps) => {
 		rows.push({
 			scope: scopeLabel(scope),
 			status: skillsUpdateHadNothing(output) ? "none" : "updated",
-			detail: firstChildLine(output),
+			detail: skillsUpdateDetail(output),
 		});
 	} catch (error) {
 		failure = error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -1,0 +1,270 @@
+import type yargs from "yargs";
+
+import { getAgentDisplayName } from "../init/agents.js";
+import { log } from "../log.js";
+import { assertSkillsCanRun, resolveSkillsPlan } from "../skills/plan.js";
+import {
+	runSkillsCli,
+	skillsAddArgs,
+	skillsMetadata,
+	skillsUpdateArgs,
+} from "../skills/run.js";
+import { mappedSkillsAgentNames } from "../skills/targets.js";
+import { confirmSkillsInstall, confirmSkillsUpdate } from "../skills/wizard.js";
+import type { CommonProps } from "../types.js";
+import { canPickAgentsInteractively } from "../utils/agent_picker.js";
+import { noPassthrough } from "../utils/flags.js";
+import { writer } from "../writer.js";
+
+type SkillsProps = CommonProps & {
+	yes?: boolean;
+	global?: boolean;
+	agent?: string[];
+};
+
+type SkillsInstallRow = {
+	source: string;
+	skills: string;
+	agents: string;
+	status: "installed" | "failed";
+	error?: string;
+};
+
+type SkillsUpdateRow = {
+	scope: string;
+	status: "updated" | "failed";
+	error?: string;
+};
+
+const coerceAgents = (value: unknown): string[] => {
+	if (value === undefined) return [];
+	const list = Array.isArray(value) ? value : [value];
+	if (list.length === 0) {
+		throw new Error(
+			"--agent needs a value. Pass one, or omit the flag entirely.",
+		);
+	}
+	return list.map((item) => {
+		if (typeof item !== "string" || item.trim() === "") {
+			throw new Error(
+				"--agent needs a value. Pass one, or omit the flag entirely.",
+			);
+		}
+		return item;
+	});
+};
+
+export const command = "skills";
+export const describe = "Install Neon agent skills into coding agents";
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 skills [command] [options]")
+		.command(
+			"update",
+			"Update installed skills to the latest versions",
+			(yargs) =>
+				yargs
+					.usage("$0 skills update [options]")
+					.options({
+						yes: {
+							alias: "y",
+							type: "boolean",
+							default: false,
+							describe:
+								"Skip prompts. Update installed skills in this directory",
+						},
+						global: {
+							type: "boolean",
+							default: false,
+							describe:
+								"Update user-level skills (skills CLI -g). Default is this directory",
+						},
+					})
+					.example(
+						"$0 skills update",
+						"Interactive: confirm, then update skills in this directory",
+					)
+					.example(
+						"$0 skills update -y",
+						"Update skills in this directory without prompting",
+					)
+					.example(
+						"$0 skills update --global -y",
+						"Update user-level skills",
+					)
+					.strict()
+					.check(noPassthrough("skills update")),
+			(args) => updateHandler(args as unknown as SkillsProps),
+		)
+		.options({
+			yes: {
+				alias: "y",
+				type: "boolean",
+				default: false,
+				describe:
+					"Skip prompts. Installs every skill from neondatabase/agent-skills into detected agents in this directory. --agent and --global still apply",
+			},
+			global: {
+				type: "boolean",
+				default: false,
+				describe:
+					"Install user-level skills (skills CLI -g). Default is this directory. Skips nothing else",
+			},
+			agent: {
+				alias: "a",
+				type: "array",
+				string: true,
+				describe:
+					"Coding agent to install into (repeatable). Skips the agent picker",
+				coerce: coerceAgents,
+			},
+		})
+		.example(
+			"$0 skills",
+			"Interactive: this directory, agents, skills, then confirm",
+		)
+		.example(
+			"$0 skills -y",
+			"This directory, detected agents, every skill from neondatabase/agent-skills",
+		)
+		.example(
+			"$0 skills --agent cursor --agent claude-code",
+			"Install into specific agents",
+		)
+		.example("$0 skills --global", "Install user-level skills")
+		.strict()
+		.check(noPassthrough("skills"));
+
+export const handler = async (props: SkillsProps) => {
+	const cwd = process.cwd();
+	const yes = props.yes === true;
+	const interactive = canPickAgentsInteractively() && !yes;
+	const plan = await resolveSkillsPlan({
+		global: props.global === true,
+		agents: props.agent ?? [],
+		yes,
+		cwd,
+		interactive,
+	});
+	const mapped = mappedSkillsAgentNames(plan.agents);
+	for (const agent of plan.skipped) {
+		log.warning(
+			"Skipping %s: no skills mapping.",
+			getAgentDisplayName(agent),
+		);
+	}
+
+	if (interactive) {
+		const ok = await confirmSkillsInstall({
+			scope: plan.scope,
+			agents: plan.agents,
+			invocations: plan.invocations,
+		});
+		if (!ok) {
+			log.info("Aborted. Nothing was written.");
+			return;
+		}
+	}
+
+	const metadata = skillsMetadata("skills");
+	const rows: SkillsInstallRow[] = [];
+	const failed: string[] = [];
+	for (const invocation of plan.invocations) {
+		const skills =
+			invocation.skills === "*" ? "*" : invocation.skills.join(", ");
+		try {
+			await runSkillsCli({
+				args: skillsAddArgs({
+					source: invocation.source,
+					skills: invocation.skills,
+					agents: mapped,
+					global: plan.scope === "global",
+					metadata,
+				}),
+				cwd,
+			});
+			rows.push({
+				source: invocation.source,
+				skills,
+				agents: mapped.join(", "),
+				status: "installed",
+			});
+		} catch (error) {
+			const message =
+				error instanceof Error ? error.message : String(error);
+			rows.push({
+				source: invocation.source,
+				skills,
+				agents: mapped.join(", "),
+				status: "failed",
+				error: message,
+			});
+			failed.push(`${invocation.source} (${skills})`);
+		}
+	}
+
+	const out = writer(props);
+	out.write(rows, {
+		fields: ["source", "skills", "agents", "status", "error"],
+		title: "Skills",
+	});
+	out.end();
+
+	if (failed.length === rows.length) {
+		throw new Error(
+			rows[0]?.error ?? "Failed to install Neon agent skills.",
+		);
+	}
+	if (failed.length > 0) {
+		throw new Error(
+			`Failed to install Neon agent skills for: ${failed.join(", ")}.`,
+		);
+	}
+};
+
+const updateHandler = async (props: SkillsProps) => {
+	const cwd = process.cwd();
+	const yes = props.yes === true;
+	const interactive = canPickAgentsInteractively() && !yes;
+	assertSkillsCanRun({ yes, interactive, action: "update" });
+	const scope = props.global === true ? "global" : "project";
+
+	if (interactive) {
+		const ok = await confirmSkillsUpdate({ scope });
+		if (!ok) {
+			log.info("Aborted. Nothing was written.");
+			return;
+		}
+	}
+
+	const rows: SkillsUpdateRow[] = [];
+	try {
+		await runSkillsCli({
+			args: skillsUpdateArgs({ global: scope === "global" }),
+			cwd,
+		});
+		rows.push({
+			scope: scope === "project" ? "this directory" : "user-level",
+			status: "updated",
+		});
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		rows.push({
+			scope: scope === "project" ? "this directory" : "user-level",
+			status: "failed",
+			error: message,
+		});
+	}
+
+	const out = writer(props);
+	out.write(rows, {
+		fields: ["scope", "status", "error"],
+		title: "Skills",
+	});
+	out.end();
+
+	if (rows[0]?.status === "failed") {
+		throw new Error("Failed to update installed skills.");
+	}
+};

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -94,7 +94,17 @@ export const builder = (argv: yargs.Argv) =>
 						"Update user-level skills",
 					)
 					.strict()
-					.check(noPassthrough("skills update")),
+					.hide("agent")
+					.check((args) => {
+						noPassthrough("skills update")(args);
+						const agents = args.agent;
+						if (Array.isArray(agents) && agents.length > 0) {
+							throw new Error(
+								"neon skills update does not take --agent. It refreshes every installed skill in this directory (or --global).",
+							);
+						}
+						return true;
+					}),
 			(args) => updateHandler(args as unknown as SkillsProps),
 		)
 		.options({

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -4,6 +4,7 @@ import { getAgentDisplayName } from "../init/agents.js";
 import { log } from "../log.js";
 import { assertSkillsCanRun, resolveSkillsPlan } from "../skills/plan.js";
 import {
+	neonSkillsRetryCommand,
 	npxCommand,
 	runSkillsCli,
 	skillsAddArgs,
@@ -23,11 +24,11 @@ type SkillsProps = CommonProps & {
 	yes?: boolean;
 	global?: boolean;
 	agent?: string[];
+	skill?: string[];
 };
 
 type SkillsInstallRow = {
 	scope: string;
-	source: string;
 	skills: string;
 	agents: string;
 	status: "installed" | "failed";
@@ -56,6 +57,24 @@ const coerceAgents = (value: unknown): string[] => {
 		if (typeof item !== "string" || item.trim() === "") {
 			throw new Error(
 				"--agent needs a value. Pass one, or omit the flag entirely.",
+			);
+		}
+		return item;
+	});
+};
+
+const coerceSkills = (value: unknown): string[] => {
+	if (value === undefined) return [];
+	const list = Array.isArray(value) ? value : [value];
+	if (list.length === 0) {
+		throw new Error(
+			"--skill needs a value. Pass one, or omit the flag entirely.",
+		);
+	}
+	return list.map((item) => {
+		if (typeof item !== "string" || item.trim() === "") {
+			throw new Error(
+				"--skill needs a value. Pass one, or omit the flag entirely.",
 			);
 		}
 		return item;
@@ -96,12 +115,19 @@ export const builder = (argv: yargs.Argv) =>
 					)
 					.strict()
 					.hide("agent")
+					.hide("skill")
 					.check((args) => {
 						noPassthrough("skills update")(args);
 						const agents = args.agent;
 						if (Array.isArray(agents) && agents.length > 0) {
 							throw new Error(
 								"neon skills update does not take --agent. It refreshes every installed skill in this directory (or --global).",
+							);
+						}
+						const skills = args.skill;
+						if (Array.isArray(skills) && skills.length > 0) {
+							throw new Error(
+								"neon skills update does not take --skill. It refreshes every installed skill in this directory (or --global).",
 							);
 						}
 						return true;
@@ -129,6 +155,14 @@ export const builder = (argv: yargs.Argv) =>
 					"Coding agent to install into (repeatable). Skips the agent picker",
 				coerce: coerceAgents,
 			},
+			skill: {
+				alias: "s",
+				type: "array",
+				string: true,
+				describe:
+					"Skill to install (repeatable). Skips the skill picker",
+				coerce: coerceSkills,
+			},
 		})
 		.example(
 			"$0 skills",
@@ -136,11 +170,11 @@ export const builder = (argv: yargs.Argv) =>
 		)
 		.example(
 			"$0 skills -y",
-			"This directory, detected agents, every skill from neondatabase/agent-skills",
+			"This directory, detected agents, the default skills",
 		)
 		.example(
-			"$0 skills --agent cursor --agent claude-code",
-			"Install into specific agents",
+			"$0 skills -s neon -s neon-ai-gateway --agent cursor",
+			"Install named skills into specific agents",
 		)
 		.example("$0 skills --global", "Install user-level skills")
 		.strict()
@@ -153,6 +187,7 @@ export const handler = async (props: SkillsProps) => {
 	const plan = await resolveSkillsPlan({
 		global: props.global === true,
 		agents: props.agent ?? [],
+		skills: props.skill ?? [],
 		yes,
 		cwd,
 		interactive,
@@ -179,11 +214,14 @@ export const handler = async (props: SkillsProps) => {
 
 	const metadata = skillsMetadata("skills");
 	const rows: SkillsInstallRow[] = [];
-	const failed: { label: string; message: string; args: string[] }[] = [];
+	const failed: {
+		label: string;
+		message: string;
+		skills: readonly string[];
+	}[] = [];
 	const scope = scopeLabel(plan.scope);
 	for (const invocation of plan.invocations) {
-		const skills =
-			invocation.skills === "*" ? "*" : invocation.skills.join(", ");
+		const skills = invocation.skills.join(", ");
 		const args = skillsAddArgs({
 			source: invocation.source,
 			skills: invocation.skills,
@@ -198,7 +236,6 @@ export const handler = async (props: SkillsProps) => {
 			});
 			rows.push({
 				scope,
-				source: invocation.source,
 				skills,
 				agents: mapped.join(", "),
 				status: "installed",
@@ -208,23 +245,22 @@ export const handler = async (props: SkillsProps) => {
 				error instanceof Error ? error.message : String(error);
 			rows.push({
 				scope,
-				source: invocation.source,
 				skills,
 				agents: mapped.join(", "),
 				status: "failed",
 				error: "skills CLI failed",
 			});
 			failed.push({
-				label: `${invocation.source} (${skills})`,
+				label: skills,
 				message,
-				args,
+				skills: invocation.skills,
 			});
 		}
 	}
 
 	const out = writer(props);
 	out.write(rows, {
-		fields: ["scope", "source", "skills", "agents", "status", "error"],
+		fields: ["scope", "skills", "agents", "status", "error"],
 		title: "Skills",
 	});
 	out.end();
@@ -241,7 +277,11 @@ export const handler = async (props: SkillsProps) => {
 	if (first === undefined) {
 		throw new Error("Failed to install Neon agent skills.");
 	}
-	const retry = npxCommand(first.args);
+	const retry = neonSkillsRetryCommand({
+		skills: first.skills,
+		agents: plan.agents,
+		global: plan.scope === "global",
+	});
 	if (first.message.includes("needs npx (Node.js)")) {
 		throw new Error(first.message);
 	}

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -4,8 +4,9 @@ import { getAgentDisplayName } from "../init/agents.js";
 import { log } from "../log.js";
 import { assertSkillsCanRun, resolveSkillsPlan } from "../skills/plan.js";
 import {
+	assertSkillsNode,
 	neonSkillsRetryCommand,
-	npxCommand,
+	neonSkillsUpdateRetryCommand,
 	runSkillsCli,
 	skillsAddArgs,
 	skillsMetadata,
@@ -181,6 +182,7 @@ export const builder = (argv: yargs.Argv) =>
 		.check(noPassthrough("skills"));
 
 export const handler = async (props: SkillsProps) => {
+	assertSkillsNode();
 	const cwd = process.cwd();
 	const yes = props.yes === true;
 	const interactive = canPickAgentsInteractively() && !yes;
@@ -282,7 +284,10 @@ export const handler = async (props: SkillsProps) => {
 		agents: plan.agents,
 		global: plan.scope === "global",
 	});
-	if (first.message.includes("needs npx (Node.js)")) {
+	if (
+		first.message.includes("needs npx (Node.js)") ||
+		first.message.includes("needs Node.js")
+	) {
 		throw new Error(first.message);
 	}
 	if (failed.length === rows.length) {
@@ -294,6 +299,7 @@ export const handler = async (props: SkillsProps) => {
 };
 
 const updateHandler = async (props: SkillsProps) => {
+	assertSkillsNode();
 	const cwd = process.cwd();
 	const yes = props.yes === true;
 	const interactive = canPickAgentsInteractively() && !yes;
@@ -340,9 +346,10 @@ const updateHandler = async (props: SkillsProps) => {
 
 	if (failure !== undefined) {
 		throw new Error(
-			failure.includes("needs npx (Node.js)")
+			failure.includes("needs npx (Node.js)") ||
+				failure.includes("needs Node.js")
 				? failure
-				: `${failure}\nRetry with: ${npxCommand(args)}`,
+				: `${failure}\nRetry with: ${neonSkillsUpdateRetryCommand(scope === "global")}`,
 		);
 	}
 };

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -278,7 +278,7 @@ export const handler = async (props: SkillsProps) => {
 		throw new Error("Failed to install Neon agent skills.");
 	}
 	const retry = neonSkillsRetryCommand({
-		skills: first.skills,
+		skills: failed.flatMap((row) => row.skills),
 		agents: plan.agents,
 		global: plan.scope === "global",
 	});

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -4,10 +4,13 @@ import { getAgentDisplayName } from "../init/agents.js";
 import { log } from "../log.js";
 import { assertSkillsCanRun, resolveSkillsPlan } from "../skills/plan.js";
 import {
+	firstChildLine,
+	npxCommand,
 	runSkillsCli,
 	skillsAddArgs,
 	skillsMetadata,
 	skillsUpdateArgs,
+	skillsUpdateHadNothing,
 } from "../skills/run.js";
 import { mappedSkillsAgentNames } from "../skills/targets.js";
 import { confirmSkillsInstall, confirmSkillsUpdate } from "../skills/wizard.js";
@@ -23,6 +26,7 @@ type SkillsProps = CommonProps & {
 };
 
 type SkillsInstallRow = {
+	scope: string;
 	source: string;
 	skills: string;
 	agents: string;
@@ -32,9 +36,13 @@ type SkillsInstallRow = {
 
 type SkillsUpdateRow = {
 	scope: string;
-	status: "updated" | "failed";
+	status: "updated" | "none" | "failed";
+	detail?: string;
 	error?: string;
 };
+
+const scopeLabel = (scope: "global" | "project"): string =>
+	scope === "project" ? "this directory" : "user-level";
 
 const coerceAgents = (value: unknown): string[] => {
 	if (value === undefined) return [];
@@ -67,13 +75,6 @@ export const builder = (argv: yargs.Argv) =>
 				yargs
 					.usage("$0 skills update [options]")
 					.options({
-						yes: {
-							alias: "y",
-							type: "boolean",
-							default: false,
-							describe:
-								"Skip prompts. Update installed skills in this directory",
-						},
 						global: {
 							type: "boolean",
 							default: false,
@@ -112,14 +113,13 @@ export const builder = (argv: yargs.Argv) =>
 				alias: "y",
 				type: "boolean",
 				default: false,
-				describe:
-					"Skip prompts. Installs every skill from neondatabase/agent-skills into detected agents in this directory. --agent and --global still apply",
+				describe: "Skip prompts",
 			},
 			global: {
 				type: "boolean",
 				default: false,
 				describe:
-					"Install user-level skills (skills CLI -g). Default is this directory. Skips nothing else",
+					"Install user-level skills (skills CLI -g). Default is this directory",
 			},
 			agent: {
 				alias: "a",
@@ -179,22 +179,25 @@ export const handler = async (props: SkillsProps) => {
 
 	const metadata = skillsMetadata("skills");
 	const rows: SkillsInstallRow[] = [];
-	const failed: string[] = [];
+	const failed: { label: string; message: string; args: string[] }[] = [];
+	const scope = scopeLabel(plan.scope);
 	for (const invocation of plan.invocations) {
 		const skills =
 			invocation.skills === "*" ? "*" : invocation.skills.join(", ");
+		const args = skillsAddArgs({
+			source: invocation.source,
+			skills: invocation.skills,
+			agents: mapped,
+			global: plan.scope === "global",
+			metadata,
+		});
 		try {
 			await runSkillsCli({
-				args: skillsAddArgs({
-					source: invocation.source,
-					skills: invocation.skills,
-					agents: mapped,
-					global: plan.scope === "global",
-					metadata,
-				}),
+				args,
 				cwd,
 			});
 			rows.push({
+				scope,
 				source: invocation.source,
 				skills,
 				agents: mapped.join(", "),
@@ -204,33 +207,50 @@ export const handler = async (props: SkillsProps) => {
 			const message =
 				error instanceof Error ? error.message : String(error);
 			rows.push({
+				scope,
 				source: invocation.source,
 				skills,
 				agents: mapped.join(", "),
 				status: "failed",
-				error: message,
+				error: "skills CLI failed",
 			});
-			failed.push(`${invocation.source} (${skills})`);
+			failed.push({
+				label: `${invocation.source} (${skills})`,
+				message,
+				args,
+			});
 		}
 	}
 
 	const out = writer(props);
 	out.write(rows, {
-		fields: ["source", "skills", "agents", "status", "error"],
+		fields: ["scope", "source", "skills", "agents", "status", "error"],
 		title: "Skills",
 	});
 	out.end();
 
+	if (failed.length === 0) {
+		log.info(
+			plan.scope === "project"
+				? "Wrote skills in this directory."
+				: "Wrote user-level skills.",
+		);
+		return;
+	}
+	const first = failed[0];
+	if (first === undefined) {
+		throw new Error("Failed to install Neon agent skills.");
+	}
+	const retry = npxCommand(first.args);
+	if (first.message.includes("needs npx (Node.js)")) {
+		throw new Error(first.message);
+	}
 	if (failed.length === rows.length) {
-		throw new Error(
-			rows[0]?.error ?? "Failed to install Neon agent skills.",
-		);
+		throw new Error(`${first.message}\nRetry with: ${retry}`);
 	}
-	if (failed.length > 0) {
-		throw new Error(
-			`Failed to install Neon agent skills for: ${failed.join(", ")}.`,
-		);
-	}
+	throw new Error(
+		`Failed to install Neon agent skills for: ${failed.map((row) => row.label).join(", ")}.\n${first.message}\nRetry with: ${retry}`,
+	);
 };
 
 const updateHandler = async (props: SkillsProps) => {
@@ -249,32 +269,40 @@ const updateHandler = async (props: SkillsProps) => {
 	}
 
 	const rows: SkillsUpdateRow[] = [];
+	const args = skillsUpdateArgs({ global: scope === "global" });
+	let failure: string | undefined;
 	try {
-		await runSkillsCli({
-			args: skillsUpdateArgs({ global: scope === "global" }),
+		const result = await runSkillsCli({
+			args,
 			cwd,
 		});
+		const output = `${result.stdout}\n${result.stderr}`;
 		rows.push({
-			scope: scope === "project" ? "this directory" : "user-level",
-			status: "updated",
+			scope: scopeLabel(scope),
+			status: skillsUpdateHadNothing(output) ? "none" : "updated",
+			detail: firstChildLine(output),
 		});
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
+		failure = error instanceof Error ? error.message : String(error);
 		rows.push({
-			scope: scope === "project" ? "this directory" : "user-level",
+			scope: scopeLabel(scope),
 			status: "failed",
-			error: message,
+			error: "skills CLI failed",
 		});
 	}
 
 	const out = writer(props);
 	out.write(rows, {
-		fields: ["scope", "status", "error"],
+		fields: ["scope", "status", "detail", "error"],
 		title: "Skills",
 	});
 	out.end();
 
-	if (rows[0]?.status === "failed") {
-		throw new Error("Failed to update installed skills.");
+	if (failure !== undefined) {
+		throw new Error(
+			failure.includes("needs npx (Node.js)")
+				? failure
+				: `${failure}\nRetry with: ${npxCommand(args)}`,
+		);
 	}
 };

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -15,6 +15,7 @@ import {
 	ensureGitignored,
 	isCurrentBranchProbe,
 	isMcpOauth,
+	isSkillsCommand,
 	walkContextFile,
 } from "./context.js";
 
@@ -71,6 +72,18 @@ describe("isCurrentBranchProbe", () => {
 		expect(
 			isCurrentBranchProbe({ _: ["config"], currentBranch: true }),
 		).toBe(false);
+	});
+});
+
+describe("isSkillsCommand", () => {
+	test("true for skills and skills update", () => {
+		expect(isSkillsCommand({ _: ["skills"] })).toBe(true);
+		expect(isSkillsCommand({ _: ["skills", "update"] })).toBe(true);
+	});
+
+	test("false for other commands", () => {
+		expect(isSkillsCommand({ _: ["mcp"] })).toBe(false);
+		expect(isSkillsCommand({ _: ["init"] })).toBe(false);
 	});
 });
 

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -93,6 +93,9 @@ export const isApiKeysCommand = (args: { _: (string | number)[] }): boolean =>
 export const isMcpCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "mcp";
 
+export const isSkillsCommand = (args: { _: (string | number)[] }): boolean =>
+	args._[0] === "skills";
+
 /** Raw argv is required because auth middleware runs before MCP flags are parsed. */
 export const isMcpOauth = (args: { _: (string | number)[] }): boolean =>
 	isMcpCommand(args) && argvEnablesMcpOauth(process.argv);
@@ -219,6 +222,9 @@ export const enrichFromContext = (
 	}
 	// MCP reads the linked project separately; enriching here would silently pin global installs.
 	if (isMcpCommand(args)) {
+		return;
+	}
+	if (isSkillsCommand(args)) {
 		return;
 	}
 	const context = readContextFile(args.contextFile);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -58,6 +58,8 @@ const NO_SUBCOMMANDS_VERBS = [
 
 	"mcp",
 
+	"skills",
+
 	"dev",
 
 	"deploy",

--- a/packages/cli/src/init/agents.ts
+++ b/packages/cli/src/init/agents.ts
@@ -9,6 +9,7 @@ import {
 	listMcpAgentIds,
 	resolveAddMcpAgentId,
 	tryResolveAddMcpAgentId,
+	uniqueAgentIds,
 } from "../mcp/agents.js";
 
 export type { AgentType };
@@ -20,6 +21,7 @@ export {
 	listMcpAgentIds,
 	resolveAddMcpAgentId,
 	tryResolveAddMcpAgentId,
+	uniqueAgentIds,
 };
 
 const SKILLS_AGENT_BY_TYPE: { [K in AgentType]?: string } = {

--- a/packages/cli/src/skills/catalog.test.ts
+++ b/packages/cli/src/skills/catalog.test.ts
@@ -2,25 +2,54 @@ import { describe, expect, test } from "vitest";
 
 import {
 	AGENT_SKILLS_SOURCE,
+	defaultSkillEntries,
 	invocationsForSelection,
+	listSkillIds,
 	NEON_SKILL_CATALOG,
 	PLATFORMS_SKILLS_SOURCE,
+	resolveSkillId,
 	yesInstallInvocations,
 } from "./catalog.js";
 
-const entry = (skill: string) => {
-	const found = NEON_SKILL_CATALOG.find((item) => item.skill === skill);
-	if (!found) {
-		throw new Error(`missing catalog skill: ${skill}`);
-	}
-	return found;
-};
+const entry = (skill: string) => resolveSkillId(skill);
+
+describe("NEON_SKILL_CATALOG", () => {
+	test("skill ids are unique", () => {
+		const ids = listSkillIds();
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});
+
+describe("resolveSkillId", () => {
+	test("rejects * and unknown names", () => {
+		expect(() => resolveSkillId("*")).toThrow(/does not accept --skill \*/);
+		expect(() => resolveSkillId("eve")).toThrow(/Unknown skill: "eve"/);
+	});
+
+	test("maps platforms to its own repo", () => {
+		expect(resolveSkillId("neon-postgres-agent-platforms").source).toBe(
+			PLATFORMS_SKILLS_SOURCE,
+		);
+		expect(resolveSkillId("neon").source).toBe(AGENT_SKILLS_SOURCE);
+	});
+});
 
 describe("yesInstallInvocations", () => {
-	test("installs every skill from agent-skills only", () => {
+	test("installs every default skill from agent-skills only", () => {
 		expect(yesInstallInvocations()).toEqual([
-			{ source: AGENT_SKILLS_SOURCE, skills: "*" },
+			{
+				source: AGENT_SKILLS_SOURCE,
+				skills: defaultSkillEntries().map((item) => item.skill),
+			},
 		]);
+		expect(
+			defaultSkillEntries().some((item) => !item.defaultSelected),
+		).toBe(false);
+		expect(
+			NEON_SKILL_CATALOG.filter((item) => !item.defaultSelected).map(
+				(item) => item.skill,
+			),
+		).toEqual(["neon-postgres-agent-platforms"]);
 	});
 });
 
@@ -29,25 +58,24 @@ describe("invocationsForSelection", () => {
 		expect(() => invocationsForSelection([])).toThrow(/No skills selected/);
 	});
 
-	test("uses --skill * when every catalog skill for a source is selected", () => {
-		const agentSkills = NEON_SKILL_CATALOG.filter(
-			(item) => item.source === AGENT_SKILLS_SOURCE,
-		);
-		expect(invocationsForSelection(agentSkills)).toEqual([
-			{ source: AGENT_SKILLS_SOURCE, skills: "*" },
-		]);
-	});
-
-	test("emits one skill per invocation for a partial source", () => {
+	test("groups one source into one add with every selected -s", () => {
 		expect(
 			invocationsForSelection([entry("neon"), entry("neon-postgres")]),
 		).toEqual([
-			{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
-			{ source: AGENT_SKILLS_SOURCE, skills: ["neon-postgres"] },
+			{
+				source: AGENT_SKILLS_SOURCE,
+				skills: ["neon", "neon-postgres"],
+			},
 		]);
 	});
 
-	test("keeps platforms as its own source", () => {
+	test("dedupes repeated skill ids", () => {
+		expect(invocationsForSelection([entry("neon"), entry("neon")])).toEqual(
+			[{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] }],
+		);
+	});
+
+	test("routes platforms to its own source", () => {
 		expect(
 			invocationsForSelection([
 				entry("neon"),
@@ -57,7 +85,7 @@ describe("invocationsForSelection", () => {
 			{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
 			{
 				source: PLATFORMS_SKILLS_SOURCE,
-				skills: "*",
+				skills: ["neon-postgres-agent-platforms"],
 			},
 		]);
 	});

--- a/packages/cli/src/skills/catalog.test.ts
+++ b/packages/cli/src/skills/catalog.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	AGENT_SKILLS_SOURCE,
+	invocationsForSelection,
+	NEON_SKILL_CATALOG,
+	PLATFORMS_SKILLS_SOURCE,
+	yesInstallInvocations,
+} from "./catalog.js";
+
+const entry = (skill: string) => {
+	const found = NEON_SKILL_CATALOG.find((item) => item.skill === skill);
+	if (!found) {
+		throw new Error(`missing catalog skill: ${skill}`);
+	}
+	return found;
+};
+
+describe("yesInstallInvocations", () => {
+	test("installs every skill from agent-skills only", () => {
+		expect(yesInstallInvocations()).toEqual([
+			{ source: AGENT_SKILLS_SOURCE, skills: "*" },
+		]);
+	});
+});
+
+describe("invocationsForSelection", () => {
+	test("rejects an empty selection", () => {
+		expect(() => invocationsForSelection([])).toThrow(/No skills selected/);
+	});
+
+	test("uses --skill * when every catalog skill for a source is selected", () => {
+		const agentSkills = NEON_SKILL_CATALOG.filter(
+			(item) => item.source === AGENT_SKILLS_SOURCE,
+		);
+		expect(invocationsForSelection(agentSkills)).toEqual([
+			{ source: AGENT_SKILLS_SOURCE, skills: "*" },
+		]);
+	});
+
+	test("emits one skill per invocation for a partial source", () => {
+		expect(
+			invocationsForSelection([entry("neon"), entry("neon-postgres")]),
+		).toEqual([
+			{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
+			{ source: AGENT_SKILLS_SOURCE, skills: ["neon-postgres"] },
+		]);
+	});
+
+	test("keeps platforms as its own source", () => {
+		expect(
+			invocationsForSelection([
+				entry("neon"),
+				entry("neon-postgres-agent-platforms"),
+			]),
+		).toEqual([
+			{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
+			{
+				source: PLATFORMS_SKILLS_SOURCE,
+				skills: "*",
+			},
+		]);
+	});
+});

--- a/packages/cli/src/skills/catalog.ts
+++ b/packages/cli/src/skills/catalog.ts
@@ -1,0 +1,98 @@
+export const AGENT_SKILLS_SOURCE = "neondatabase/agent-skills";
+export const PLATFORMS_SKILLS_SOURCE = "neondatabase/neon-for-agent-platforms";
+
+export type SkillEntry = {
+	source: string;
+	skill: string;
+	defaultSelected: boolean;
+};
+
+export const NEON_SKILL_CATALOG: readonly SkillEntry[] = [
+	{
+		source: AGENT_SKILLS_SOURCE,
+		skill: "claimable-postgres",
+		defaultSelected: true,
+	},
+	{ source: AGENT_SKILLS_SOURCE, skill: "neon", defaultSelected: true },
+	{
+		source: AGENT_SKILLS_SOURCE,
+		skill: "neon-ai-gateway",
+		defaultSelected: true,
+	},
+	{
+		source: AGENT_SKILLS_SOURCE,
+		skill: "neon-functions",
+		defaultSelected: true,
+	},
+	{
+		source: AGENT_SKILLS_SOURCE,
+		skill: "neon-object-storage",
+		defaultSelected: true,
+	},
+	{
+		source: AGENT_SKILLS_SOURCE,
+		skill: "neon-postgres",
+		defaultSelected: true,
+	},
+	{
+		source: AGENT_SKILLS_SOURCE,
+		skill: "neon-postgres-branches",
+		defaultSelected: true,
+	},
+	{
+		source: AGENT_SKILLS_SOURCE,
+		skill: "neon-postgres-egress-optimizer",
+		defaultSelected: true,
+	},
+	{
+		source: PLATFORMS_SKILLS_SOURCE,
+		skill: "neon-postgres-agent-platforms",
+		defaultSelected: false,
+	},
+];
+
+export type SkillsInvocation = {
+	source: string;
+	skills: "*" | readonly string[];
+};
+
+export const yesInstallInvocations = (): SkillsInvocation[] => [
+	{ source: AGENT_SKILLS_SOURCE, skills: "*" },
+];
+
+export const invocationsForSelection = (
+	selected: readonly SkillEntry[],
+): SkillsInvocation[] => {
+	if (selected.length === 0) {
+		throw new Error(
+			"No skills selected. Pass -y to install every skill from neondatabase/agent-skills, or pick at least one skill.",
+		);
+	}
+	const bySource = new Map<string, string[]>();
+	for (const entry of selected) {
+		const list = bySource.get(entry.source) ?? [];
+		list.push(entry.skill);
+		bySource.set(entry.source, list);
+	}
+	const invocations: SkillsInvocation[] = [];
+	for (const [source, names] of bySource) {
+		const catalog = NEON_SKILL_CATALOG.filter(
+			(entry) => entry.source === source,
+		);
+		if (names.length === 0) {
+			continue;
+		}
+		if (
+			catalog.length > 0 &&
+			catalog.every((entry) => names.includes(entry.skill))
+		) {
+			invocations.push({ source, skills: "*" });
+			continue;
+		}
+		// Multiple --skill flags can create dirs without copying SKILL.md.
+		for (const name of names) {
+			invocations.push({ source, skills: [name] });
+		}
+	}
+	return invocations;
+};

--- a/packages/cli/src/skills/catalog.ts
+++ b/packages/cli/src/skills/catalog.ts
@@ -2,97 +2,137 @@ export const AGENT_SKILLS_SOURCE = "neondatabase/agent-skills";
 export const PLATFORMS_SKILLS_SOURCE = "neondatabase/neon-for-agent-platforms";
 
 export type SkillEntry = {
-	source: string;
 	skill: string;
+	source: string;
 	defaultSelected: boolean;
 };
 
 export const NEON_SKILL_CATALOG: readonly SkillEntry[] = [
 	{
-		source: AGENT_SKILLS_SOURCE,
 		skill: "claimable-postgres",
+		source: AGENT_SKILLS_SOURCE,
 		defaultSelected: true,
 	},
-	{ source: AGENT_SKILLS_SOURCE, skill: "neon", defaultSelected: true },
+	{ skill: "neon", source: AGENT_SKILLS_SOURCE, defaultSelected: true },
 	{
-		source: AGENT_SKILLS_SOURCE,
 		skill: "neon-ai-gateway",
+		source: AGENT_SKILLS_SOURCE,
 		defaultSelected: true,
 	},
 	{
-		source: AGENT_SKILLS_SOURCE,
 		skill: "neon-functions",
+		source: AGENT_SKILLS_SOURCE,
 		defaultSelected: true,
 	},
 	{
-		source: AGENT_SKILLS_SOURCE,
 		skill: "neon-object-storage",
+		source: AGENT_SKILLS_SOURCE,
 		defaultSelected: true,
 	},
 	{
-		source: AGENT_SKILLS_SOURCE,
 		skill: "neon-postgres",
+		source: AGENT_SKILLS_SOURCE,
 		defaultSelected: true,
 	},
 	{
-		source: AGENT_SKILLS_SOURCE,
 		skill: "neon-postgres-branches",
-		defaultSelected: true,
-	},
-	{
 		source: AGENT_SKILLS_SOURCE,
-		skill: "neon-postgres-egress-optimizer",
 		defaultSelected: true,
 	},
 	{
-		source: PLATFORMS_SKILLS_SOURCE,
+		skill: "neon-postgres-egress-optimizer",
+		source: AGENT_SKILLS_SOURCE,
+		defaultSelected: true,
+	},
+	{
 		skill: "neon-postgres-agent-platforms",
+		source: PLATFORMS_SKILLS_SOURCE,
 		defaultSelected: false,
 	},
 ];
 
-export type SkillsInvocation = {
-	source: string;
-	skills: "*" | readonly string[];
+const catalogBySkill = (): Map<string, SkillEntry> => {
+	const map = new Map<string, SkillEntry>();
+	for (const entry of NEON_SKILL_CATALOG) {
+		if (map.has(entry.skill)) {
+			throw new Error(`Duplicate catalog skill: ${entry.skill}`);
+		}
+		map.set(entry.skill, entry);
+	}
+	return map;
 };
 
-export const yesInstallInvocations = (): SkillsInvocation[] => [
-	{ source: AGENT_SKILLS_SOURCE, skills: "*" },
-];
+const CATALOG_BY_SKILL = catalogBySkill();
+
+export const listSkillIds = (): string[] =>
+	NEON_SKILL_CATALOG.map((entry) => entry.skill);
+
+export const defaultSkillEntries = (): SkillEntry[] =>
+	NEON_SKILL_CATALOG.filter((entry) => entry.defaultSelected);
+
+export function resolveSkillId(raw: string): SkillEntry {
+	if (raw === "*") {
+		throw new Error(
+			"neon skills does not accept --skill *. Pass --skill <name> for each skill, or omit --skill to install the default skills with -y.",
+		);
+	}
+	const entry = CATALOG_BY_SKILL.get(raw);
+	if (entry === undefined) {
+		throw new Error(
+			`Unknown skill: "${raw}". Supported skills: ${listSkillIds().join(", ")}`,
+		);
+	}
+	return entry;
+}
+
+export function uniqueSkillEntries(
+	entries: readonly SkillEntry[],
+): SkillEntry[] {
+	const seen = new Set<string>();
+	const out: SkillEntry[] = [];
+	for (const entry of entries) {
+		if (seen.has(entry.skill)) {
+			continue;
+		}
+		seen.add(entry.skill);
+		out.push(entry);
+	}
+	return out;
+}
+
+export type SkillsInvocation = {
+	source: string;
+	skills: readonly string[];
+};
 
 export const invocationsForSelection = (
 	selected: readonly SkillEntry[],
 ): SkillsInvocation[] => {
-	if (selected.length === 0) {
+	const unique = uniqueSkillEntries(selected);
+	if (unique.length === 0) {
 		throw new Error(
-			"No skills selected. Pass -y to install every skill from neondatabase/agent-skills, or pick at least one skill.",
+			"No skills selected. Pass -y to install the default skills, or --skill <name>.",
 		);
 	}
 	const bySource = new Map<string, string[]>();
-	for (const entry of selected) {
-		const list = bySource.get(entry.source) ?? [];
-		list.push(entry.skill);
-		bySource.set(entry.source, list);
-	}
-	const invocations: SkillsInvocation[] = [];
-	for (const [source, names] of bySource) {
-		const catalog = NEON_SKILL_CATALOG.filter(
-			(entry) => entry.source === source,
-		);
-		if (names.length === 0) {
-			continue;
-		}
-		if (
-			catalog.length > 0 &&
-			catalog.every((entry) => names.includes(entry.skill))
-		) {
-			invocations.push({ source, skills: "*" });
-			continue;
-		}
-		// Multiple --skill flags can create dirs without copying SKILL.md.
-		for (const name of names) {
-			invocations.push({ source, skills: [name] });
+	const sourceOrder: string[] = [];
+	for (const entry of unique) {
+		const list = bySource.get(entry.source);
+		if (list === undefined) {
+			bySource.set(entry.source, [entry.skill]);
+			sourceOrder.push(entry.source);
+		} else {
+			list.push(entry.skill);
 		}
 	}
-	return invocations;
+	return sourceOrder.map((source) => {
+		const skills = bySource.get(source);
+		if (skills === undefined || skills.length === 0) {
+			throw new Error("skills add needs at least one --skill.");
+		}
+		return { source, skills };
+	});
 };
+
+export const yesInstallInvocations = (): SkillsInvocation[] =>
+	invocationsForSelection(defaultSkillEntries());

--- a/packages/cli/src/skills/plan.test.ts
+++ b/packages/cli/src/skills/plan.test.ts
@@ -1,0 +1,239 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import { AGENT_SKILLS_SOURCE, NEON_SKILL_CATALOG } from "./catalog.js";
+import {
+	assertSkillsCanRun,
+	type ResolveSkillsPlanOptions,
+	resolveSkillsPlan,
+} from "./plan.js";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+	for (const dir of dirs.splice(0)) {
+		rmSync(dir, { recursive: true, force: true });
+	}
+});
+
+function tmpDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "neon-skills-plan-"));
+	dirs.push(dir);
+	return dir;
+}
+
+function planOptions(
+	cwd: string,
+	overrides: Partial<ResolveSkillsPlanOptions> = {},
+): ResolveSkillsPlanOptions {
+	return {
+		global: false,
+		agents: ["cursor"],
+		yes: false,
+		cwd,
+		interactive: true,
+		pickSkills: async () => {
+			throw new Error("skill prompt");
+		},
+		pickAgents: async () => {
+			throw new Error("agent prompt");
+		},
+		...overrides,
+	};
+}
+
+describe("assertSkillsCanRun", () => {
+	test("fails non-TTY without -y, including when agents are named", () => {
+		expect(() =>
+			assertSkillsCanRun({
+				yes: false,
+				interactive: false,
+				action: "install",
+			}),
+		).toThrow(/Pass -y to install every skill/);
+		expect(() =>
+			assertSkillsCanRun({
+				yes: false,
+				interactive: false,
+				action: "update",
+			}),
+		).toThrow(/Pass -y to update installed skills/);
+	});
+
+	test("allows -y or a TTY", () => {
+		expect(() =>
+			assertSkillsCanRun({
+				yes: true,
+				interactive: false,
+				action: "install",
+			}),
+		).not.toThrow();
+		expect(() =>
+			assertSkillsCanRun({
+				yes: false,
+				interactive: true,
+				action: "install",
+			}),
+		).not.toThrow();
+	});
+});
+
+describe("resolveSkillsPlan", () => {
+	test("-y is this directory, specified agents, all agent-skills, and calls no prompts", async () => {
+		const cwd = tmpDir();
+		const plan = await resolveSkillsPlan(
+			planOptions(cwd, {
+				yes: true,
+				interactive: false,
+			}),
+		);
+		expect(plan).toEqual({
+			scope: "project",
+			agents: ["cursor"],
+			skipped: [],
+			invocations: [{ source: AGENT_SKILLS_SOURCE, skills: "*" }],
+		});
+	});
+
+	test("non-TTY without -y fails even when --agent is set", async () => {
+		const cwd = tmpDir();
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					yes: false,
+					interactive: false,
+					agents: ["cursor"],
+				}),
+			),
+		).rejects.toThrow(/Pass -y to install every skill/);
+	});
+
+	test("--global is user-level", async () => {
+		const cwd = tmpDir();
+		const plan = await resolveSkillsPlan(
+			planOptions(cwd, { yes: true, interactive: false, global: true }),
+		);
+		expect(plan.scope).toBe("global");
+	});
+
+	test("--agent skips the agent picker and still asks for skills", async () => {
+		const cwd = tmpDir();
+		const neon = NEON_SKILL_CATALOG.find((item) => item.skill === "neon");
+		if (!neon) {
+			throw new Error("missing neon skill");
+		}
+		const plan = await resolveSkillsPlan(
+			planOptions(cwd, {
+				agents: ["claude"],
+				pickSkills: async () => [neon],
+			}),
+		);
+		expect(plan.agents).toEqual(["claude-code"]);
+		expect(plan.invocations).toEqual([
+			{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
+		]);
+	});
+
+	test("interactive asks agents then skills", async () => {
+		const cwd = tmpDir();
+		mkdirSync(join(cwd, ".cursor"));
+		const neon = NEON_SKILL_CATALOG.find((item) => item.skill === "neon");
+		if (!neon) {
+			throw new Error("missing neon skill");
+		}
+		const calls: string[] = [];
+		const plan = await resolveSkillsPlan(
+			planOptions(cwd, {
+				agents: [],
+				pickAgents: async (options) => {
+					calls.push("agents");
+					expect(options.selected).toEqual(["cursor"]);
+					return ["cursor"];
+				},
+				pickSkills: async () => {
+					calls.push("skills");
+					return [neon];
+				},
+			}),
+		);
+		expect(calls).toEqual(["agents", "skills"]);
+		expect(plan.scope).toBe("project");
+		expect(plan.agents).toEqual(["cursor"]);
+	});
+
+	test("rejects skills-CLI-only agent names", async () => {
+		const cwd = tmpDir();
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					yes: true,
+					interactive: false,
+					agents: ["eve"],
+				}),
+			),
+		).rejects.toThrow(/Unknown agent: "eve"/);
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					yes: true,
+					interactive: false,
+					agents: ["cursor-cli"],
+				}),
+			),
+		).rejects.toThrow(/Unknown agent: "cursor-cli"/);
+	});
+
+	test("rejects --agent *", async () => {
+		const cwd = tmpDir();
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					yes: true,
+					interactive: false,
+					agents: ["*"],
+				}),
+			),
+		).rejects.toThrow(/does not accept --agent \*/);
+	});
+
+	test("skips MCP agents that cannot install skills", async () => {
+		const cwd = tmpDir();
+		const plan = await resolveSkillsPlan(
+			planOptions(cwd, {
+				yes: true,
+				interactive: false,
+				agents: ["cursor", "mcporter"],
+			}),
+		);
+		expect(plan.agents).toEqual(["cursor"]);
+		expect(plan.skipped).toEqual(["mcporter"]);
+	});
+
+	test("fails when every selected agent lacks a skills mapping", async () => {
+		const cwd = tmpDir();
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					yes: true,
+					interactive: false,
+					agents: ["mcporter"],
+				}),
+			),
+		).rejects.toThrow(/None of the selected agents can install skills/);
+	});
+
+	test("non-interactive project with no folder agents fails", async () => {
+		const cwd = tmpDir();
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					agents: [],
+					yes: true,
+					interactive: false,
+				}),
+			),
+		).rejects.toThrow(/No coding agents detected in this project/);
+	});
+});

--- a/packages/cli/src/skills/plan.test.ts
+++ b/packages/cli/src/skills/plan.test.ts
@@ -157,6 +157,25 @@ describe("resolveSkillsPlan", () => {
 		]);
 	});
 
+	test("rejects unknown --skill before asking agents", async () => {
+		const cwd = tmpDir();
+		let asked = false;
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					skills: ["eve"],
+					yes: false,
+					interactive: true,
+					pickAgents: async () => {
+						asked = true;
+						return ["cursor"];
+					},
+				}),
+			),
+		).rejects.toThrow(/Unknown skill: "eve"/);
+		expect(asked).toBe(false);
+	});
+
 	test("rejects --skill * and unknown skill names", async () => {
 		const cwd = tmpDir();
 		await expect(

--- a/packages/cli/src/skills/plan.test.ts
+++ b/packages/cli/src/skills/plan.test.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 
-import { AGENT_SKILLS_SOURCE, NEON_SKILL_CATALOG } from "./catalog.js";
+import {
+	AGENT_SKILLS_SOURCE,
+	defaultSkillEntries,
+	NEON_SKILL_CATALOG,
+} from "./catalog.js";
 import {
 	assertSkillsCanRun,
 	type ResolveSkillsPlanOptions,
@@ -31,6 +35,7 @@ function planOptions(
 	return {
 		global: false,
 		agents: ["cursor"],
+		skills: [],
 		yes: false,
 		cwd,
 		interactive: true,
@@ -52,7 +57,7 @@ describe("assertSkillsCanRun", () => {
 				interactive: false,
 				action: "install",
 			}),
-		).toThrow(/Pass -y to install every skill/);
+		).toThrow(/Pass -y to install the default skills/);
 		expect(() =>
 			assertSkillsCanRun({
 				yes: false,
@@ -60,6 +65,17 @@ describe("assertSkillsCanRun", () => {
 				action: "update",
 			}),
 		).toThrow(/Pass -y to update installed skills/);
+	});
+
+	test("allows named skills without -y", () => {
+		expect(() =>
+			assertSkillsCanRun({
+				yes: false,
+				interactive: false,
+				action: "install",
+				hasSkills: true,
+			}),
+		).not.toThrow();
 	});
 
 	test("allows -y or a TTY", () => {
@@ -81,7 +97,7 @@ describe("assertSkillsCanRun", () => {
 });
 
 describe("resolveSkillsPlan", () => {
-	test("-y is this directory, specified agents, all agent-skills, and calls no prompts", async () => {
+	test("-y is this directory, specified agents, default skills, and calls no prompts", async () => {
 		const cwd = tmpDir();
 		const plan = await resolveSkillsPlan(
 			planOptions(cwd, {
@@ -93,7 +109,12 @@ describe("resolveSkillsPlan", () => {
 			scope: "project",
 			agents: ["cursor"],
 			skipped: [],
-			invocations: [{ source: AGENT_SKILLS_SOURCE, skills: "*" }],
+			invocations: [
+				{
+					source: AGENT_SKILLS_SOURCE,
+					skills: defaultSkillEntries().map((item) => item.skill),
+				},
+			],
 		});
 	});
 
@@ -107,7 +128,7 @@ describe("resolveSkillsPlan", () => {
 					agents: ["cursor"],
 				}),
 			),
-		).rejects.toThrow(/Pass -y to install every skill/);
+		).rejects.toThrow(/Pass -y to install the default skills/);
 	});
 
 	test("--global is user-level", async () => {
@@ -116,6 +137,46 @@ describe("resolveSkillsPlan", () => {
 			planOptions(cwd, { yes: true, interactive: false, global: true }),
 		);
 		expect(plan.scope).toBe("global");
+	});
+
+	test("--skill skips the skill picker", async () => {
+		const cwd = tmpDir();
+		const plan = await resolveSkillsPlan(
+			planOptions(cwd, {
+				skills: ["neon", "neon-postgres-agent-platforms"],
+				yes: false,
+				interactive: false,
+			}),
+		);
+		expect(plan.invocations).toEqual([
+			{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
+			{
+				source: "neondatabase/neon-for-agent-platforms",
+				skills: ["neon-postgres-agent-platforms"],
+			},
+		]);
+	});
+
+	test("rejects --skill * and unknown skill names", async () => {
+		const cwd = tmpDir();
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					skills: ["*"],
+					yes: true,
+					interactive: false,
+				}),
+			),
+		).rejects.toThrow(/does not accept --skill \*/);
+		await expect(
+			resolveSkillsPlan(
+				planOptions(cwd, {
+					skills: ["eve"],
+					yes: true,
+					interactive: false,
+				}),
+			),
+		).rejects.toThrow(/Unknown skill: "eve"/);
 	});
 
 	test("--agent skips the agent picker and still asks for skills", async () => {

--- a/packages/cli/src/skills/plan.ts
+++ b/packages/cli/src/skills/plan.ts
@@ -8,8 +8,10 @@ import {
 } from "../utils/agent_picker.js";
 import {
 	invocationsForSelection,
+	resolveSkillId,
 	type SkillEntry,
 	type SkillsInvocation,
+	uniqueSkillEntries,
 	yesInstallInvocations,
 } from "./catalog.js";
 import {
@@ -29,6 +31,7 @@ export type SkillsPlan = {
 export type ResolveSkillsPlanOptions = {
 	global: boolean;
 	agents: readonly string[];
+	skills: readonly string[];
 	yes: boolean;
 	cwd: string;
 	interactive: boolean;
@@ -40,14 +43,21 @@ export const assertSkillsCanRun = (options: {
 	yes: boolean;
 	interactive: boolean;
 	action: "install" | "update";
+	hasSkills?: boolean;
 }): void => {
-	if (options.yes || options.interactive) {
+	if (options.action === "update") {
+		if (options.yes || options.interactive) {
+			return;
+		}
+		throw new Error(
+			"No interactive terminal. Pass -y to update installed skills.",
+		);
+	}
+	if (options.yes || options.interactive || options.hasSkills === true) {
 		return;
 	}
 	throw new Error(
-		options.action === "update"
-			? "No interactive terminal. Pass -y to update installed skills."
-			: "No interactive terminal. Pass -y to install every skill from neondatabase/agent-skills.",
+		"No interactive terminal. Pass -y to install the default skills, or --skill <name>.",
 	);
 };
 
@@ -58,6 +68,7 @@ export async function resolveSkillsPlan(
 		yes: options.yes,
 		interactive: options.interactive,
 		action: "install",
+		hasSkills: options.skills.length > 0,
 	});
 	const prompt = options.interactive && !options.yes;
 	const scope: SkillsInstallScope = options.global ? "global" : "project";
@@ -103,11 +114,15 @@ export async function resolveSkillsPlan(
 		);
 	}
 
-	const invocations = options.yes
-		? yesInstallInvocations()
-		: invocationsForSelection(
-				await (options.pickSkills ?? pickSkillsInteractively)(),
-			);
+	const specified = uniqueSkillEntries(options.skills.map(resolveSkillId));
+	const invocations =
+		specified.length > 0
+			? invocationsForSelection(specified)
+			: options.yes
+				? yesInstallInvocations()
+				: invocationsForSelection(
+						await (options.pickSkills ?? pickSkillsInteractively)(),
+					);
 
 	return { scope, agents, skipped, invocations };
 }

--- a/packages/cli/src/skills/plan.ts
+++ b/packages/cli/src/skills/plan.ts
@@ -70,6 +70,7 @@ export async function resolveSkillsPlan(
 		action: "install",
 		hasSkills: options.skills.length > 0,
 	});
+	const specified = uniqueSkillEntries(options.skills.map(resolveSkillId));
 	const prompt = options.interactive && !options.yes;
 	const scope: SkillsInstallScope = options.global ? "global" : "project";
 	const available = skillsInstallableAgents();
@@ -114,7 +115,6 @@ export async function resolveSkillsPlan(
 		);
 	}
 
-	const specified = uniqueSkillEntries(options.skills.map(resolveSkillId));
 	const invocations =
 		specified.length > 0
 			? invocationsForSelection(specified)

--- a/packages/cli/src/skills/plan.ts
+++ b/packages/cli/src/skills/plan.ts
@@ -1,0 +1,113 @@
+import { tryResolveAddMcpAgentId } from "../init/agents.js";
+import type { AgentType } from "../mcp/agents.js";
+import {
+	agentChoicesFrom,
+	type PickAgentsOptions,
+	pickAgentsInteractively,
+	resolveAgentSelection,
+} from "../utils/agent_picker.js";
+import {
+	invocationsForSelection,
+	type SkillEntry,
+	type SkillsInvocation,
+	yesInstallInvocations,
+} from "./catalog.js";
+import {
+	detectSkillsAgents,
+	type SkillsInstallScope,
+	skillsInstallableAgents,
+} from "./targets.js";
+import { pickSkillsInteractively } from "./wizard.js";
+
+export type SkillsPlan = {
+	scope: SkillsInstallScope;
+	agents: AgentType[];
+	skipped: AgentType[];
+	invocations: SkillsInvocation[];
+};
+
+export type ResolveSkillsPlanOptions = {
+	global: boolean;
+	agents: readonly string[];
+	yes: boolean;
+	cwd: string;
+	interactive: boolean;
+	pickAgents?: (options: PickAgentsOptions) => Promise<AgentType[]>;
+	pickSkills?: () => Promise<SkillEntry[]>;
+};
+
+export const assertSkillsCanRun = (options: {
+	yes: boolean;
+	interactive: boolean;
+	action: "install" | "update";
+}): void => {
+	if (options.yes || options.interactive) {
+		return;
+	}
+	throw new Error(
+		options.action === "update"
+			? "No interactive terminal. Pass -y to update installed skills."
+			: "No interactive terminal. Pass -y to install every skill from neondatabase/agent-skills.",
+	);
+};
+
+export async function resolveSkillsPlan(
+	options: ResolveSkillsPlanOptions,
+): Promise<SkillsPlan> {
+	assertSkillsCanRun({
+		yes: options.yes,
+		interactive: options.interactive,
+		action: "install",
+	});
+	const prompt = options.interactive && !options.yes;
+	const scope: SkillsInstallScope = options.global ? "global" : "project";
+	const available = skillsInstallableAgents();
+	const detected = await detectSkillsAgents({
+		scope,
+		cwd: options.cwd,
+	});
+	const selected = await resolveAgentSelection({
+		specified: options.agents,
+		choices: agentChoicesFrom(available, detected),
+		detected,
+		message:
+			"Which coding agents should get Neon agent skills? (space to toggle, enter to confirm)",
+		nonInteractiveMessage:
+			scope === "project"
+				? `No coding agents detected in this project. Pass --agent <name>. Supported agents: ${available.join(", ")}`
+				: `No coding agents detected. Pass --agent <name>. Supported agents: ${available.join(", ")}`,
+		resolveSpecified: (raw) => {
+			if (raw === "*") {
+				throw new Error(
+					"neon skills does not accept --agent *. Pass --agent <name> for each coding agent, or omit --agent to use detected agents.",
+				);
+			}
+			const id = tryResolveAddMcpAgentId(raw);
+			if (!id) {
+				throw new Error(
+					`Unknown agent: "${raw}". Supported agents: ${available.join(", ")}`,
+				);
+			}
+			return id;
+		},
+		pick: prompt
+			? (options.pickAgents ?? pickAgentsInteractively)
+			: undefined,
+		interactive: prompt,
+	});
+	const agents = selected.filter((id) => available.includes(id));
+	const skipped = selected.filter((id) => !available.includes(id));
+	if (agents.length === 0) {
+		throw new Error(
+			`None of the selected agents can install skills. Supported agents: ${available.join(", ")}`,
+		);
+	}
+
+	const invocations = options.yes
+		? yesInstallInvocations()
+		: invocationsForSelection(
+				await (options.pickSkills ?? pickSkillsInteractively)(),
+			);
+
+	return { scope, agents, skipped, invocations };
+}

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -2,11 +2,27 @@ import { describe, expect, test } from "vitest";
 
 import pkg from "../pkg.js";
 import {
+	npxCommand,
 	skillsAddArgs,
 	skillsChildEnv,
 	skillsMetadata,
 	skillsUpdateArgs,
+	skillsUpdateHadNothing,
 } from "./run.js";
+
+describe("npxCommand", () => {
+	test("quotes metadata JSON", () => {
+		expect(
+			npxCommand([
+				"-y",
+				"skills",
+				"add",
+				"--metadata",
+				'{"origin":"neon-cli"}',
+			]),
+		).toBe(`npx -y skills add --metadata '{"origin":"neon-cli"}'`);
+	});
+});
 
 describe("skillsMetadata", () => {
 	test("tags the neon CLI as the origin", () => {
@@ -85,6 +101,20 @@ describe("skillsAddArgs", () => {
 				metadata: "{}",
 			}),
 		).toThrow(/at least one --skill/);
+	});
+});
+
+describe("skillsUpdateHadNothing", () => {
+	test("reads the skills CLI no-op lines", () => {
+		expect(
+			skillsUpdateHadNothing(
+				"Checking for skill updates…\nNo project skills to update.",
+			),
+		).toBe(true);
+		expect(skillsUpdateHadNothing("No global skills to update.")).toBe(
+			true,
+		);
+		expect(skillsUpdateHadNothing("Updated 2 skills")).toBe(false);
 	});
 });
 

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -53,6 +53,7 @@ describe("skillsChildEnv", () => {
 			DISABLE_TELEMETRY: "1",
 			DO_NOT_TRACK: "1",
 			NEON_API_KEY: "secret",
+			NeOn_ApI_KeY: "also-secret",
 			CI: "true",
 		});
 		expect(env.PATH).toBe("/usr/bin");
@@ -61,6 +62,7 @@ describe("skillsChildEnv", () => {
 		expect(env).not.toHaveProperty("DISABLE_TELEMETRY");
 		expect(env).not.toHaveProperty("DO_NOT_TRACK");
 		expect(env).not.toHaveProperty("NEON_API_KEY");
+		expect(env).not.toHaveProperty("NeOn_ApI_KeY");
 	});
 });
 

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -7,6 +7,7 @@ import {
 	skillsChildEnv,
 	skillsMetadata,
 	skillsUpdateArgs,
+	skillsUpdateDetail,
 	skillsUpdateHadNothing,
 } from "./run.js";
 
@@ -121,6 +122,27 @@ describe("skillsUpdateHadNothing", () => {
 			true,
 		);
 		expect(skillsUpdateHadNothing("Updated 2 skills")).toBe(false);
+	});
+});
+
+describe("skillsUpdateDetail", () => {
+	test("skips the progress banner and strips ANSI", () => {
+		expect(
+			skillsUpdateDetail(
+				"\u001b[38;5;145mChecking for skill updates…\u001b[0m\nNo project skills to update.\n",
+			),
+		).toBe("No project skills to update.");
+		expect(
+			skillsUpdateDetail(
+				"Checking for skill updates…\nUpdated 2 skills\n",
+			),
+		).toBe("Updated 2 skills");
+	});
+
+	test("returns undefined when only the banner is present", () => {
+		expect(skillsUpdateDetail("Checking for skill updates…\n")).toBe(
+			undefined,
+		);
 	});
 });
 

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 
 import pkg from "../pkg.js";
 import {
+	neonSkillsRetryCommand,
 	npxCommand,
 	skillsAddArgs,
 	skillsChildEnv,
@@ -59,10 +60,10 @@ describe("skillsChildEnv", () => {
 });
 
 describe("skillsAddArgs", () => {
-	test("installs all agent-skills into mapped agents", () => {
+	test("adds named skills into mapped agents", () => {
 		const args = skillsAddArgs({
 			source: "neondatabase/agent-skills",
-			skills: "*",
+			skills: ["neon", "neon-ai-gateway"],
 			agents: ["cursor", "claude-code"],
 			global: false,
 			metadata: '{"origin":"neon-cli"}',
@@ -73,7 +74,9 @@ describe("skillsAddArgs", () => {
 			"add",
 			"neondatabase/agent-skills",
 			"--skill",
-			"*",
+			"neon",
+			"--skill",
+			"neon-ai-gateway",
 			"--agent",
 			"cursor",
 			"--agent",
@@ -82,7 +85,7 @@ describe("skillsAddArgs", () => {
 			"--metadata",
 			'{"origin":"neon-cli"}',
 		]);
-		expect(args.filter((part) => part === "*")).toEqual(["*"]);
+		expect(args.join(" ")).not.toMatch(/--skill \*/);
 		expect(args.join(" ")).not.toMatch(/--agent \*/);
 	});
 
@@ -108,6 +111,20 @@ describe("skillsAddArgs", () => {
 				metadata: "{}",
 			}),
 		).toThrow(/at least one --skill/);
+	});
+});
+
+describe("neonSkillsRetryCommand", () => {
+	test("names skills, agents, and user-level scope", () => {
+		expect(
+			neonSkillsRetryCommand({
+				skills: ["neon", "neon-ai-gateway"],
+				agents: ["cursor"],
+				global: true,
+			}),
+		).toBe(
+			"neon skills -s neon -s neon-ai-gateway --agent cursor --global -y",
+		);
 	});
 });
 

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -22,6 +22,12 @@ describe("npxCommand", () => {
 			]),
 		).toBe(`npx -y skills add --metadata '{"origin":"neon-cli"}'`);
 	});
+
+	test("quotes * so a pasted retry does not glob", () => {
+		expect(npxCommand(["-y", "skills", "add", "--skill", "*"])).toBe(
+			"npx -y skills add --skill '*'",
+		);
+	});
 });
 
 describe("skillsMetadata", () => {

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -118,15 +118,20 @@ describe("skillsUpdateHadNothing", () => {
 				"Checking for skill updates…\nNo project skills to update.",
 			),
 		).toBe(true);
-		expect(skillsUpdateHadNothing("No global skills to update.")).toBe(
-			true,
-		);
-		expect(skillsUpdateHadNothing("Updated 2 skills")).toBe(false);
+		expect(
+			skillsUpdateHadNothing(
+				"Checking for skill updates…\nNo global skills tracked in lock file.",
+			),
+		).toBe(true);
+		expect(
+			skillsUpdateHadNothing("✓ All global skills are up to date"),
+		).toBe(true);
+		expect(skillsUpdateHadNothing("✓ Updated 1 skill(s)")).toBe(false);
 	});
 });
 
 describe("skillsUpdateDetail", () => {
-	test("skips the progress banner and strips ANSI", () => {
+	test("takes the result line, not the progress banner", () => {
 		expect(
 			skillsUpdateDetail(
 				"\u001b[38;5;145mChecking for skill updates…\u001b[0m\nNo project skills to update.\n",
@@ -134,9 +139,14 @@ describe("skillsUpdateDetail", () => {
 		).toBe("No project skills to update.");
 		expect(
 			skillsUpdateDetail(
-				"Checking for skill updates…\nUpdated 2 skills\n",
+				"Checking for skill updates…\nNo global skills tracked in lock file.\nInstall skills with npx skills add -g\n",
 			),
-		).toBe("Updated 2 skills");
+		).toBe("No global skills tracked in lock file.");
+		expect(
+			skillsUpdateDetail(
+				"Checking for skill updates…\nUpdating for: Universal\nRefreshing 1 skill(s)…\nUpdating neon…\n  ✓ Updated neon\n✓ Updated 1 skill(s)\n",
+			),
+		).toBe("✓ Updated 1 skill(s)");
 	});
 
 	test("returns undefined when only the banner is present", () => {

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -4,6 +4,7 @@ import pkg from "../pkg.js";
 import {
 	assertSkillsNode,
 	neonSkillsRetryCommand,
+	neonSkillsUpdateRetryCommand,
 	nodeMeetsMinimum,
 	npxCommand,
 	SKILLS_MIN_NODE,
@@ -142,6 +143,17 @@ describe("neonSkillsRetryCommand", () => {
 			}),
 		).toBe(
 			"neon skills -s neon -s neon-ai-gateway --agent cursor --global -y",
+		);
+	});
+});
+
+describe("neonSkillsUpdateRetryCommand", () => {
+	test("is the neon command, not npx", () => {
+		expect(neonSkillsUpdateRetryCommand(false)).toBe(
+			"neon skills update -y",
+		);
+		expect(neonSkillsUpdateRetryCommand(true)).toBe(
+			"neon skills update --global -y",
 		);
 	});
 });

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+
+import pkg from "../pkg.js";
+import {
+	skillsAddArgs,
+	skillsChildEnv,
+	skillsMetadata,
+	skillsUpdateArgs,
+} from "./run.js";
+
+describe("skillsMetadata", () => {
+	test("tags the neon CLI as the origin", () => {
+		expect(JSON.parse(skillsMetadata("skills"))).toEqual({
+			origin: "neon-cli",
+			command: "skills",
+			version: pkg.version,
+		});
+	});
+});
+
+describe("skillsChildEnv", () => {
+	test("drops telemetry blockers and keeps the rest", () => {
+		const env = skillsChildEnv({
+			PATH: "/usr/bin",
+			HOME: "/tmp/home",
+			DISABLE_TELEMETRY: "1",
+			DO_NOT_TRACK: "1",
+			CI: "true",
+		});
+		expect(env.PATH).toBe("/usr/bin");
+		expect(env.HOME).toBe("/tmp/home");
+		expect(env.CI).toBe("true");
+		expect(env).not.toHaveProperty("DISABLE_TELEMETRY");
+		expect(env).not.toHaveProperty("DO_NOT_TRACK");
+	});
+});
+
+describe("skillsAddArgs", () => {
+	test("installs all agent-skills into mapped agents", () => {
+		const args = skillsAddArgs({
+			source: "neondatabase/agent-skills",
+			skills: "*",
+			agents: ["cursor", "claude-code"],
+			global: false,
+			metadata: '{"origin":"neon-cli"}',
+		});
+		expect(args).toEqual([
+			"-y",
+			"skills",
+			"add",
+			"neondatabase/agent-skills",
+			"--skill",
+			"*",
+			"--agent",
+			"cursor",
+			"--agent",
+			"claude-code",
+			"-y",
+			"--metadata",
+			'{"origin":"neon-cli"}',
+		]);
+		expect(args.filter((part) => part === "*")).toEqual(["*"]);
+		expect(args.join(" ")).not.toMatch(/--agent \*/);
+	});
+
+	test("passes -g for user-level installs", () => {
+		expect(
+			skillsAddArgs({
+				source: "neondatabase/agent-skills",
+				skills: ["neon"],
+				agents: ["cursor"],
+				global: true,
+				metadata: "{}",
+			}),
+		).toContain("-g");
+	});
+
+	test("rejects an empty skill list", () => {
+		expect(() =>
+			skillsAddArgs({
+				source: "neondatabase/agent-skills",
+				skills: [],
+				agents: ["cursor"],
+				global: false,
+				metadata: "{}",
+			}),
+		).toThrow(/at least one --skill/);
+	});
+});
+
+describe("skillsUpdateArgs", () => {
+	test("defaults to project scope", () => {
+		expect(skillsUpdateArgs({ global: false })).toEqual([
+			"-y",
+			"skills",
+			"update",
+			"-p",
+			"-y",
+		]);
+	});
+
+	test("uses -g for user-level updates", () => {
+		expect(skillsUpdateArgs({ global: true })).toEqual([
+			"-y",
+			"skills",
+			"update",
+			"-g",
+			"-y",
+		]);
+	});
+});

--- a/packages/cli/src/skills/run.test.ts
+++ b/packages/cli/src/skills/run.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from "vitest";
 
 import pkg from "../pkg.js";
 import {
+	assertSkillsNode,
 	neonSkillsRetryCommand,
+	nodeMeetsMinimum,
 	npxCommand,
+	SKILLS_MIN_NODE,
 	skillsAddArgs,
 	skillsChildEnv,
 	skillsMetadata,
@@ -49,6 +52,7 @@ describe("skillsChildEnv", () => {
 			HOME: "/tmp/home",
 			DISABLE_TELEMETRY: "1",
 			DO_NOT_TRACK: "1",
+			NEON_API_KEY: "secret",
 			CI: "true",
 		});
 		expect(env.PATH).toBe("/usr/bin");
@@ -56,6 +60,18 @@ describe("skillsChildEnv", () => {
 		expect(env.CI).toBe("true");
 		expect(env).not.toHaveProperty("DISABLE_TELEMETRY");
 		expect(env).not.toHaveProperty("DO_NOT_TRACK");
+		expect(env).not.toHaveProperty("NEON_API_KEY");
+	});
+});
+
+describe("assertSkillsNode", () => {
+	test("accepts the skills CLI floor and refuses older Node", () => {
+		expect(nodeMeetsMinimum("22.20.0", SKILLS_MIN_NODE)).toBe(true);
+		expect(nodeMeetsMinimum("v24.18.0", SKILLS_MIN_NODE)).toBe(true);
+		expect(nodeMeetsMinimum("20.19.0", SKILLS_MIN_NODE)).toBe(false);
+		expect(() => assertSkillsNode("v20.19.0")).toThrow(
+			/needs Node.js 22.20.0 or newer/,
+		);
 	});
 });
 

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -58,22 +58,32 @@ export const quoteNpxArg = (part: string): string =>
 export const npxCommand = (args: readonly string[]): string =>
 	`npx ${args.map(quoteNpxArg).join(" ")}`;
 
-const ANSI = /\u001b\[[0-9;]*m/g;
+const ANSI = /\u001b\[[0-9;]*[A-Za-z]/g;
 const UPDATE_BANNER = /^Checking for skill updates/i;
-const UPDATE_NOTHING = /No (?:project|global) skills to update\.?/i;
+const UPDATE_NOTHING =
+	/No (?:project|global) skills (?:to update|to check|tracked in lock file|can be updated in place)|All global skills are up to date/i;
+const UPDATE_RESULT =
+	/No (?:project|global) skills (?:to update|to check|tracked in lock file|can be updated in place)\.?|All global skills are up to date|(?:✓\s*)?Updated \d+ skills?(?:\(s\))?|(?:✗\s*)?Failed to update \d+ skills?(?:\(s\))?/i;
 
-const stripAnsi = (text: string): string => text.replace(ANSI, "");
+const stripAnsi = (text: string): string =>
+	text.replace(ANSI, "").replace(/\r/g, "");
 
 export const skillsUpdateHadNothing = (output: string): boolean =>
 	UPDATE_NOTHING.test(stripAnsi(output));
 
 export const skillsUpdateDetail = (output: string): string | undefined => {
 	const text = stripAnsi(output);
-	const nothing = text.match(UPDATE_NOTHING);
-	if (nothing?.[0] !== undefined) {
-		return nothing[0];
-	}
+	let last: string | undefined;
 	for (const line of text.split("\n")) {
+		const trimmed = line.trim();
+		if (UPDATE_RESULT.test(trimmed)) {
+			last = trimmed;
+		}
+	}
+	if (last !== undefined) {
+		return last;
+	}
+	for (const line of text.split("\n").reverse()) {
 		const trimmed = line.trim();
 		if (trimmed.length === 0 || UPDATE_BANNER.test(trimmed)) {
 			continue;

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -22,7 +22,11 @@ export const skillsChildEnv = (
 	for (const key of TELEMETRY_BLOCKERS) {
 		delete env[key];
 	}
-	delete env.NEON_API_KEY;
+	for (const key of Object.keys(env)) {
+		if (key.toUpperCase() === "NEON_API_KEY") {
+			delete env[key];
+		}
+	}
 	return env;
 };
 

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -53,7 +53,7 @@ export const skillsAddArgs = (options: {
 };
 
 export const quoteNpxArg = (part: string): string =>
-	/[\s"'\\]/.test(part) ? `'${part.replace(/'/g, `'\\''`)}'` : part;
+	/[\s"'\\*]/.test(part) ? `'${part.replace(/'/g, `'\\''`)}'` : part;
 
 export const npxCommand = (args: readonly string[]): string =>
 	`npx ${args.map(quoteNpxArg).join(" ")}`;

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -52,6 +52,25 @@ export const skillsAddArgs = (options: {
 	return args;
 };
 
+export const quoteNpxArg = (part: string): string =>
+	/[\s"'\\]/.test(part) ? `'${part.replace(/'/g, `'\\''`)}'` : part;
+
+export const npxCommand = (args: readonly string[]): string =>
+	`npx ${args.map(quoteNpxArg).join(" ")}`;
+
+export const firstChildLine = (output: string): string | undefined => {
+	for (const line of output.split("\n")) {
+		const trimmed = line.trim();
+		if (trimmed.length > 0) {
+			return trimmed;
+		}
+	}
+	return undefined;
+};
+
+export const skillsUpdateHadNothing = (output: string): boolean =>
+	/No (?:project|global) skills to update/i.test(output);
+
 export const skillsUpdateArgs = (options: { global: boolean }): string[] => [
 	"-y",
 	"skills",

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -1,0 +1,118 @@
+import { execa } from "execa";
+
+import pkg from "../pkg.js";
+
+const TELEMETRY_BLOCKERS = ["DISABLE_TELEMETRY", "DO_NOT_TRACK"] as const;
+
+export type SkillsMetadataCommand = "skills";
+
+export const skillsMetadata = (command: SkillsMetadataCommand): string =>
+	JSON.stringify({
+		origin: "neon-cli",
+		command,
+		version: pkg.version,
+	});
+
+export const skillsChildEnv = (
+	base: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv => {
+	const env = { ...base };
+	// Neon already telemeters this command. The skills CLI still needs its
+	// own install ping, so drop the blockers a parent shell may have set.
+	for (const key of TELEMETRY_BLOCKERS) {
+		delete env[key];
+	}
+	return env;
+};
+
+export const skillsAddArgs = (options: {
+	source: string;
+	skills: "*" | readonly string[];
+	agents: readonly string[];
+	global: boolean;
+	metadata: string;
+}): string[] => {
+	const args = ["-y", "skills", "add", options.source];
+	if (options.skills === "*") {
+		args.push("--skill", "*");
+	} else if (options.skills.length === 0) {
+		throw new Error("skills add needs at least one --skill.");
+	} else {
+		for (const skill of options.skills) {
+			args.push("--skill", skill);
+		}
+	}
+	for (const agent of options.agents) {
+		args.push("--agent", agent);
+	}
+	if (options.global) {
+		args.push("-g");
+	}
+	args.push("-y", "--metadata", options.metadata);
+	return args;
+};
+
+export const skillsUpdateArgs = (options: { global: boolean }): string[] => [
+	"-y",
+	"skills",
+	"update",
+	options.global ? "-g" : "-p",
+	"-y",
+];
+
+export type SkillsRunResult = {
+	stdout: string;
+	stderr: string;
+};
+
+export const runSkillsCli = async (options: {
+	args: readonly string[];
+	cwd: string;
+}): Promise<SkillsRunResult> => {
+	try {
+		const result = await execa("npx", options.args, {
+			cwd: options.cwd,
+			env: skillsChildEnv(),
+			// extendEnv would copy DISABLE_TELEMETRY / DO_NOT_TRACK back in.
+			extendEnv: false,
+			stdio: "pipe",
+			timeout: 120_000,
+		});
+		return { stdout: result.stdout, stderr: result.stderr };
+	} catch (error) {
+		if (isCommandMissing(error)) {
+			throw new Error(
+				"neon skills needs npx (Node.js) to run the skills CLI (`npx skills add neondatabase/agent-skills`). Install Node.js, then retry.",
+			);
+		}
+		if (isExecaFailure(error)) {
+			const detail = [error.stderr, error.stdout, error.shortMessage]
+				.filter((part) => typeof part === "string" && part.length > 0)
+				.join("\n");
+			throw new Error(
+				detail.length > 0
+					? `skills CLI failed:\n${detail}`
+					: "skills CLI failed.",
+			);
+		}
+		throw error;
+	}
+};
+
+const isCommandMissing = (error: unknown): boolean =>
+	typeof error === "object" &&
+	error !== null &&
+	"code" in error &&
+	error.code === "ENOENT";
+
+const isExecaFailure = (
+	error: unknown,
+): error is {
+	stderr: string;
+	stdout: string;
+	shortMessage: string;
+} =>
+	typeof error === "object" &&
+	error !== null &&
+	"shortMessage" in error &&
+	typeof error.shortMessage === "string";

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -22,7 +22,47 @@ export const skillsChildEnv = (
 	for (const key of TELEMETRY_BLOCKERS) {
 		delete env[key];
 	}
+	delete env.NEON_API_KEY;
 	return env;
+};
+
+export const SKILLS_MIN_NODE = "22.20.0";
+
+const nodeParts = (version: string): [number, number, number] => {
+	const [major, minor, patch] = version
+		.replace(/^v/, "")
+		.split(".")
+		.map((part) => Number.parseInt(part, 10));
+	return [
+		Number.isInteger(major) ? major : 0,
+		Number.isInteger(minor) ? minor : 0,
+		Number.isInteger(patch) ? patch : 0,
+	];
+};
+
+export const nodeMeetsMinimum = (current: string, minimum: string): boolean => {
+	const left = nodeParts(current);
+	const right = nodeParts(minimum);
+	for (let i = 0; i < 3; i += 1) {
+		const a = left[i];
+		const b = right[i];
+		if (a === undefined || b === undefined) {
+			return false;
+		}
+		if (a !== b) {
+			return a > b;
+		}
+	}
+	return true;
+};
+
+export const assertSkillsNode = (version = process.version): void => {
+	if (nodeMeetsMinimum(version, SKILLS_MIN_NODE)) {
+		return;
+	}
+	throw new Error(
+		`neon skills needs Node.js ${SKILLS_MIN_NODE} or newer to run the skills CLI. This process is Node.js ${version.replace(/^v/, "")}. Upgrade Node.js, then retry.`,
+	);
 };
 
 export const skillsAddArgs = (options: {
@@ -126,6 +166,7 @@ export const runSkillsCli = async (options: {
 	args: readonly string[];
 	cwd: string;
 }): Promise<SkillsRunResult> => {
+	assertSkillsNode();
 	try {
 		const result = await execa("npx", options.args, {
 			cwd: options.cwd,

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -27,20 +27,17 @@ export const skillsChildEnv = (
 
 export const skillsAddArgs = (options: {
 	source: string;
-	skills: "*" | readonly string[];
+	skills: readonly string[];
 	agents: readonly string[];
 	global: boolean;
 	metadata: string;
 }): string[] => {
-	const args = ["-y", "skills", "add", options.source];
-	if (options.skills === "*") {
-		args.push("--skill", "*");
-	} else if (options.skills.length === 0) {
+	if (options.skills.length === 0) {
 		throw new Error("skills add needs at least one --skill.");
-	} else {
-		for (const skill of options.skills) {
-			args.push("--skill", skill);
-		}
+	}
+	const args = ["-y", "skills", "add", options.source];
+	for (const skill of options.skills) {
+		args.push("--skill", skill);
 	}
 	for (const agent of options.agents) {
 		args.push("--agent", agent);
@@ -50,6 +47,25 @@ export const skillsAddArgs = (options: {
 	}
 	args.push("-y", "--metadata", options.metadata);
 	return args;
+};
+
+export const neonSkillsRetryCommand = (options: {
+	skills: readonly string[];
+	agents: readonly string[];
+	global: boolean;
+}): string => {
+	const args = ["skills"];
+	for (const skill of options.skills) {
+		args.push("-s", skill);
+	}
+	for (const agent of options.agents) {
+		args.push("--agent", agent);
+	}
+	if (options.global) {
+		args.push("--global");
+	}
+	args.push("-y");
+	return `neon ${args.map(quoteNpxArg).join(" ")}`;
 };
 
 export const quoteNpxArg = (part: string): string =>
@@ -123,7 +139,7 @@ export const runSkillsCli = async (options: {
 	} catch (error) {
 		if (isCommandMissing(error)) {
 			throw new Error(
-				"neon skills needs npx (Node.js) to run the skills CLI (`npx skills add neondatabase/agent-skills`). Install Node.js, then retry.",
+				"neon skills needs npx (Node.js) to run the skills CLI. Install Node.js, then retry.",
 			);
 		}
 		if (isExecaFailure(error)) {

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -112,6 +112,9 @@ export const neonSkillsRetryCommand = (options: {
 	return `neon ${args.map(quoteNpxArg).join(" ")}`;
 };
 
+export const neonSkillsUpdateRetryCommand = (global: boolean): string =>
+	global ? "neon skills update --global -y" : "neon skills update -y";
+
 export const quoteNpxArg = (part: string): string =>
 	/[\s"'\\*]/.test(part) ? `'${part.replace(/'/g, `'\\''`)}'` : part;
 

--- a/packages/cli/src/skills/run.ts
+++ b/packages/cli/src/skills/run.ts
@@ -58,18 +58,30 @@ export const quoteNpxArg = (part: string): string =>
 export const npxCommand = (args: readonly string[]): string =>
 	`npx ${args.map(quoteNpxArg).join(" ")}`;
 
-export const firstChildLine = (output: string): string | undefined => {
-	for (const line of output.split("\n")) {
+const ANSI = /\u001b\[[0-9;]*m/g;
+const UPDATE_BANNER = /^Checking for skill updates/i;
+const UPDATE_NOTHING = /No (?:project|global) skills to update\.?/i;
+
+const stripAnsi = (text: string): string => text.replace(ANSI, "");
+
+export const skillsUpdateHadNothing = (output: string): boolean =>
+	UPDATE_NOTHING.test(stripAnsi(output));
+
+export const skillsUpdateDetail = (output: string): string | undefined => {
+	const text = stripAnsi(output);
+	const nothing = text.match(UPDATE_NOTHING);
+	if (nothing?.[0] !== undefined) {
+		return nothing[0];
+	}
+	for (const line of text.split("\n")) {
 		const trimmed = line.trim();
-		if (trimmed.length > 0) {
-			return trimmed;
+		if (trimmed.length === 0 || UPDATE_BANNER.test(trimmed)) {
+			continue;
 		}
+		return trimmed;
 	}
 	return undefined;
 };
-
-export const skillsUpdateHadNothing = (output: string): boolean =>
-	/No (?:project|global) skills to update/i.test(output);
 
 export const skillsUpdateArgs = (options: { global: boolean }): string[] => [
 	"-y",
@@ -105,9 +117,10 @@ export const runSkillsCli = async (options: {
 			);
 		}
 		if (isExecaFailure(error)) {
-			const detail = [error.stderr, error.stdout, error.shortMessage]
+			const childOut = [error.stderr, error.stdout]
 				.filter((part) => typeof part === "string" && part.length > 0)
 				.join("\n");
+			const detail = childOut.length > 0 ? childOut : error.shortMessage;
 			throw new Error(
 				detail.length > 0
 					? `skills CLI failed:\n${detail}`

--- a/packages/cli/src/skills/targets.test.ts
+++ b/packages/cli/src/skills/targets.test.ts
@@ -1,0 +1,60 @@
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+	detectSkillsAgents,
+	mappedSkillsAgentNames,
+	skillsInstallableAgents,
+} from "./targets.js";
+
+describe("skillsInstallableAgents", () => {
+	test("is the MCP roster minus agents with no skills mapping", () => {
+		const ids = skillsInstallableAgents();
+		expect(ids).toContain("cursor");
+		expect(ids).toContain("claude-desktop");
+		expect(ids).not.toContain("mcporter");
+		expect(ids).not.toContain("eve");
+		expect(ids).not.toContain("cursor-cli");
+	});
+});
+
+describe("mappedSkillsAgentNames", () => {
+	test("dedupes Claude Desktop and Claude Code onto claude-code", () => {
+		expect(
+			mappedSkillsAgentNames(["claude-desktop", "claude-code", "cursor"]),
+		).toEqual(["claude-code", "cursor"]);
+	});
+
+	test("throws when every selected agent lacks a mapping", () => {
+		expect(() => mappedSkillsAgentNames(["mcporter"])).toThrow(
+			/None of the selected agents can install skills/,
+		);
+	});
+});
+
+describe("detectSkillsAgents", () => {
+	const dirs: string[] = [];
+
+	afterEach(() => {
+		for (const dir of dirs.splice(0)) {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	test("project scope detects from the project folder", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-detect-"));
+		dirs.push(cwd);
+		mkdirSync(join(cwd, ".cursor"));
+		expect(await detectSkillsAgents({ scope: "project", cwd })).toContain(
+			"cursor",
+		);
+	});
+
+	test("project scope ignores a folder with no agent markers", async () => {
+		const cwd = mkdtempSync(join(tmpdir(), "neon-skills-detect-empty-"));
+		dirs.push(cwd);
+		expect(await detectSkillsAgents({ scope: "project", cwd })).toEqual([]);
+	});
+});

--- a/packages/cli/src/skills/targets.ts
+++ b/packages/cli/src/skills/targets.ts
@@ -1,0 +1,47 @@
+import { detectProjectAgents } from "add-mcp";
+
+import {
+	type AgentType,
+	detectInstalledAgents,
+	getSkillsAgentName,
+	listMcpAgentIds,
+	supportsSkills,
+	uniqueAgentIds,
+} from "../init/agents.js";
+
+export type SkillsInstallScope = "global" | "project";
+
+export const skillsInstallableAgents = (): AgentType[] =>
+	listMcpAgentIds().filter((id) => supportsSkills(id));
+
+export const detectSkillsAgents = async (options: {
+	scope: SkillsInstallScope;
+	cwd: string;
+}): Promise<AgentType[]> => {
+	const detected =
+		options.scope === "project"
+			? detectProjectAgents(options.cwd)
+			: await detectInstalledAgents();
+	return uniqueAgentIds(detected).filter((id) => supportsSkills(id));
+};
+
+export const mappedSkillsAgentNames = (
+	agents: readonly AgentType[],
+): string[] => {
+	const names: string[] = [];
+	const seen = new Set<string>();
+	for (const agent of agents) {
+		const name = getSkillsAgentName(agent);
+		if (name === undefined || seen.has(name)) {
+			continue;
+		}
+		seen.add(name);
+		names.push(name);
+	}
+	if (names.length === 0) {
+		throw new Error(
+			`None of the selected agents can install skills. Supported agents: ${skillsInstallableAgents().join(", ")}`,
+		);
+	}
+	return names;
+};

--- a/packages/cli/src/skills/wizard.test.ts
+++ b/packages/cli/src/skills/wizard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+
+import { AGENT_SKILLS_SOURCE } from "./catalog.js";
+import { skillsInstallSummary } from "./wizard.js";
+
+describe("skillsInstallSummary", () => {
+	test("names this directory, agents, and sources", () => {
+		expect(
+			skillsInstallSummary({
+				scope: "project",
+				agents: ["cursor"],
+				invocations: [{ source: AGENT_SKILLS_SOURCE, skills: "*" }],
+			}),
+		).toBe(
+			[
+				"Config  this directory",
+				"Agents  Cursor",
+				"Skills  all from neondatabase/agent-skills",
+			].join("\n"),
+		);
+	});
+
+	test("names user-level and a partial skill list", () => {
+		expect(
+			skillsInstallSummary({
+				scope: "global",
+				agents: ["cursor", "claude-code"],
+				invocations: [
+					{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
+				],
+			}),
+		).toContain("user-level");
+		expect(
+			skillsInstallSummary({
+				scope: "global",
+				agents: ["cursor"],
+				invocations: [
+					{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
+				],
+			}),
+		).toContain("neon (neondatabase/agent-skills)");
+	});
+});

--- a/packages/cli/src/skills/wizard.test.ts
+++ b/packages/cli/src/skills/wizard.test.ts
@@ -1,43 +1,44 @@
 import { describe, expect, test } from "vitest";
 
-import { AGENT_SKILLS_SOURCE } from "./catalog.js";
+import { AGENT_SKILLS_SOURCE, PLATFORMS_SKILLS_SOURCE } from "./catalog.js";
 import { skillsInstallSummary } from "./wizard.js";
 
 describe("skillsInstallSummary", () => {
-	test("names this directory, agents, and sources", () => {
+	test("names this directory, agents, and skill ids", () => {
 		expect(
 			skillsInstallSummary({
 				scope: "project",
 				agents: ["cursor"],
-				invocations: [{ source: AGENT_SKILLS_SOURCE, skills: "*" }],
+				invocations: [
+					{
+						source: AGENT_SKILLS_SOURCE,
+						skills: ["neon", "neon-ai-gateway"],
+					},
+				],
 			}),
 		).toBe(
 			[
 				"Config  this directory",
 				"Agents  Cursor",
-				"Skills  all from neondatabase/agent-skills",
+				"Skills  neon, neon-ai-gateway",
 			].join("\n"),
 		);
 	});
 
-	test("names user-level and a partial skill list", () => {
-		expect(
-			skillsInstallSummary({
-				scope: "global",
-				agents: ["cursor", "claude-code"],
-				invocations: [
-					{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
-				],
-			}),
-		).toContain("user-level");
-		expect(
-			skillsInstallSummary({
-				scope: "global",
-				agents: ["cursor"],
-				invocations: [
-					{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
-				],
-			}),
-		).toContain("neon (neondatabase/agent-skills)");
+	test("names user-level skills without repos", () => {
+		const text = skillsInstallSummary({
+			scope: "global",
+			agents: ["cursor", "claude-code"],
+			invocations: [
+				{ source: AGENT_SKILLS_SOURCE, skills: ["neon"] },
+				{
+					source: PLATFORMS_SKILLS_SOURCE,
+					skills: ["neon-postgres-agent-platforms"],
+				},
+			],
+		});
+		expect(text).toContain("user-level");
+		expect(text).toContain("neon, neon-postgres-agent-platforms");
+		expect(text).not.toContain("neondatabase/");
 	});
 });

--- a/packages/cli/src/skills/wizard.ts
+++ b/packages/cli/src/skills/wizard.ts
@@ -21,7 +21,7 @@ const restoreCursorOnAbort = (state: { aborted: boolean }) => {
 export const pickSkillsInteractively = async (): Promise<SkillEntry[]> => {
 	if (!canPickAgentsInteractively()) {
 		throw new Error(
-			"No interactive terminal. Pass -y to install every skill from neondatabase/agent-skills.",
+			"No interactive terminal. Pass -y to install the default skills, or --skill <name>.",
 		);
 	}
 	const { skills } = await prompts({
@@ -35,13 +35,12 @@ export const pickSkillsInteractively = async (): Promise<SkillEntry[]> => {
 		choices: NEON_SKILL_CATALOG.map((entry) => ({
 			value: entry,
 			title: entry.skill,
-			description: entry.source,
 			selected: entry.defaultSelected,
 		})),
 	});
 	if (!Array.isArray(skills) || skills.length === 0) {
 		throw new Error(
-			"No skills selected. Pass -y to install every skill from neondatabase/agent-skills, or pick at least one skill.",
+			"No skills selected. Pass -y to install the default skills, or --skill <name>.",
 		);
 	}
 	return skills.filter(isSkillEntry);
@@ -68,12 +67,8 @@ export const skillsInstallSummary = (options: {
 	invocations: readonly SkillsInvocation[];
 }): string => {
 	const skills = options.invocations
-		.map((invocation) =>
-			invocation.skills === "*"
-				? `all from ${invocation.source}`
-				: `${invocation.skills.join(", ")} (${invocation.source})`,
-		)
-		.join("; ");
+		.flatMap((invocation) => invocation.skills)
+		.join(", ");
 	const rows: [string, string][] = [
 		[
 			"Config",

--- a/packages/cli/src/skills/wizard.ts
+++ b/packages/cli/src/skills/wizard.ts
@@ -1,0 +1,127 @@
+import prompts from "prompts";
+
+import { getAgentDisplayName } from "../init/agents.js";
+import type { AgentType } from "../mcp/agents.js";
+import { canPickAgentsInteractively } from "../utils/agent_picker.js";
+import {
+	NEON_SKILL_CATALOG,
+	type SkillEntry,
+	type SkillsInvocation,
+} from "./catalog.js";
+import type { SkillsInstallScope } from "./targets.js";
+
+const restoreCursorOnAbort = (state: { aborted: boolean }) => {
+	if (state.aborted) {
+		process.stdout.write("\x1B[?25h");
+		process.stdout.write("\n");
+		process.exit(1);
+	}
+};
+
+export const pickSkillsInteractively = async (): Promise<SkillEntry[]> => {
+	if (!canPickAgentsInteractively()) {
+		throw new Error(
+			"No interactive terminal. Pass -y to install every skill from neondatabase/agent-skills.",
+		);
+	}
+	const { skills } = await prompts({
+		onState: restoreCursorOnAbort,
+		type: "multiselect",
+		name: "skills",
+		message:
+			"Which Neon agent skills should be installed? (space to toggle, enter to confirm)",
+		instructions: false,
+		min: 1,
+		choices: NEON_SKILL_CATALOG.map((entry) => ({
+			value: entry,
+			title: entry.skill,
+			description: entry.source,
+			selected: entry.defaultSelected,
+		})),
+	});
+	if (!Array.isArray(skills) || skills.length === 0) {
+		throw new Error(
+			"No skills selected. Pass -y to install every skill from neondatabase/agent-skills, or pick at least one skill.",
+		);
+	}
+	return skills.filter(isSkillEntry);
+};
+
+const isSkillEntry = (value: unknown): value is SkillEntry => {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	if (!("source" in value) || !("skill" in value)) {
+		return false;
+	}
+	return (
+		typeof value.source === "string" &&
+		typeof value.skill === "string" &&
+		value.source.length > 0 &&
+		value.skill.length > 0
+	);
+};
+
+export const skillsInstallSummary = (options: {
+	scope: SkillsInstallScope;
+	agents: readonly AgentType[];
+	invocations: readonly SkillsInvocation[];
+}): string => {
+	const skills = options.invocations
+		.map((invocation) =>
+			invocation.skills === "*"
+				? `all from ${invocation.source}`
+				: `${invocation.skills.join(", ")} (${invocation.source})`,
+		)
+		.join("; ");
+	const rows: [string, string][] = [
+		[
+			"Config",
+			options.scope === "project" ? "this directory" : "user-level",
+		],
+		["Agents", options.agents.map(getAgentDisplayName).join(", ")],
+		["Skills", skills],
+	];
+	const labelWidth = Math.max(...rows.map(([label]) => label.length));
+	return rows
+		.map(([label, value]) => `${label.padEnd(labelWidth)}  ${value}`)
+		.join("\n");
+};
+
+export const confirmSkillsInstall = async (options: {
+	scope: SkillsInstallScope;
+	agents: readonly AgentType[];
+	invocations: readonly SkillsInvocation[];
+}): Promise<boolean> => {
+	if (!canPickAgentsInteractively()) {
+		return true;
+	}
+	process.stdout.write(`\n${skillsInstallSummary(options)}\n\n`);
+	const { ok } = await prompts({
+		onState: restoreCursorOnAbort,
+		type: "confirm",
+		name: "ok",
+		message: "Write Neon agent skills into these agents?",
+		initial: true,
+	});
+	return ok === true;
+};
+
+export const confirmSkillsUpdate = async (options: {
+	scope: SkillsInstallScope;
+}): Promise<boolean> => {
+	if (!canPickAgentsInteractively()) {
+		return true;
+	}
+	const config =
+		options.scope === "project" ? "this directory" : "user-level";
+	process.stdout.write(`\nConfig  ${config}\n\n`);
+	const { ok } = await prompts({
+		onState: restoreCursorOnAbort,
+		type: "confirm",
+		name: "ok",
+		message: "Update installed skills to the latest versions?",
+		initial: true,
+	});
+	return ok === true;
+};


### PR DESCRIPTION
## Problem

Neon publishes agent skills across two GitHub repos: `neondatabase/agent-skills` and `neondatabase/neon-for-agent-platforms`. Installing them means calling the skills CLI directly, which requires knowing which repo holds the skill you want and what each coding agent is called there.

```bash
npx skills add neondatabase/agent-skills --skill neon --skill neon-ai-gateway --agent cursor -y
npx skills add neondatabase/neon-for-agent-platforms --skill neon-postgres-agent-platforms --agent cursor -y
```

That is two invocations for one selection. The split between the repos is a fact about how Neon publishes.

`neon mcp` already installs the Neon MCP server into a coding agent and already carries the agent roster and the detection logic. Skills had no equivalent command.

## The command

```bash
# Interactive: this directory, then agents, then skills, then confirm.
neon skills

# Skip prompts. This directory, every detected agent, the default skills.
neon skills -y

# Named skills into named agents.
neon skills -s neon -s neon-ai-gateway --agent cursor

# User-level instead of this directory.
neon skills --global

# Refresh what is already installed.
neon skills update
neon skills update -y
neon skills update --global -y
```

Installing, run against the real skills CLI in an empty directory containing `.cursor`:

```
$ neon skills -y -s neon -s neon-ai-gateway --agent cursor
Skills
Scope           Skills                 Agents  Status
this directory  neon, neon-ai-gateway  cursor  installed
INFO: Wrote skills in this directory.
```

Updating the same directory:

```
$ neon skills update -y
Skills
Scope           Status   Detail
this directory  updated  ✓ Updated 2 skill(s)
```

`Detail` is the skills CLI's own result line, picked out of its output after the progress banner. When it reports nothing to do, the status is `none` and the detail is the line it printed, such as `No project skills to update.`

On a TTY, `neon skills` asks which agents should get skills and then which skills, prints a summary and asks to confirm. Agents detected from project-folder markers such as `.cursor` start selected. The default skills start selected; `neon-postgres-agent-platforms` is offered and starts unselected. `-y` skips both questions and installs the defaults. `-s` skips the skill question and leaves the agent question in place.

Without a TTY, `-y` or `-s` is required. `--agent` alone is not enough, because it says nothing about which skills to install:

```
$ neon skills --agent cursor < /dev/null
ERROR: No interactive terminal. Pass -y to install the default skills, or --skill <name>.
```

Nothing changes for any existing command. `neon skills` is new, and the only edits outside the new files are the command registration and two guards described under "Also in here".

## Interface decisions

**`-s` takes a skill id.** A catalog in the CLI maps each id to the repo that publishes it. A selection spanning both repos becomes two child invocations, which the user never sees; the confirmation summary and the result table list skill ids and have no source column. Repo names stay out of the interface entirely, so the two-repo split can change without changing what anyone types.

```
$ neon skills -y -s eve --agent cursor
ERROR: Unknown skill: "eve". Supported skills: claimable-postgres, neon, neon-ai-gateway, neon-functions, neon-object-storage, neon-postgres, neon-postgres-branches, neon-postgres-egress-optimizer, neon-postgres-agent-platforms
```

That check runs before the agent picker, so a typo fails before the user picks anything.

**`*` is refused for both `-s` and `--agent`.** The skills CLI accepts it, and it means every skill in the repo, which is not something the Neon CLI should offer as a shorthand.

```
$ neon skills -y -s '*' --agent cursor
ERROR: neon skills does not accept --skill *. Pass --skill <name> for each skill, or omit --skill to install the default skills with -y.
```

**Agent names are the `neon mcp` names.** `--agent cursor`, `--agent claude-code` and every other name resolve the same way they do for MCP. Agents on that roster with no skills equivalent are named in a warning and skipped, and the run continues with the ones that remain:

```
$ neon skills -y -s neon --agent mcporter --agent cursor
WARNING: Skipping MCPorter: no skills mapping.
Skills
Scope           Skills  Agents  Status
this directory  neon    cursor  installed
INFO: Wrote skills in this directory.
```

If every selected agent is skipped, the command fails and lists the ones that can install skills. Agents that share a skills target collapse to one: Claude Desktop and Claude Code both become `claude-code`, VS Code and the GitHub Copilot CLI both become `github-copilot`.

**The retry line for a failed install is a `neon` command.** It names the skills that failed and carries the scope and the agents forward, so it can be pasted as-is:

```
Retry with: neon skills -s neon -s neon-postgres-agent-platforms --agent cursor -y
```

The child's stderr goes into the error message. The `error` column in the table stays `skills CLI failed`, because a multi-line npm dump in a cell destroys the table layout.

**Node.js 22.20 is checked before anything else happens.** The skills CLI needs it; the rest of the `neon` CLI supports 20.19. Running `neon skills` on older Node fails before the table is printed and before any child process is spawned:

```
neon skills needs Node.js 22.20.0 or newer to run the skills CLI. This process is Node.js 20.19.0. Upgrade Node.js, then retry.
```

`neon skills update` takes neither `--agent` nor `--skill`. It refreshes every installed skill in this directory or, with `--global`, at user level. Both flags are hidden from its help and rejected before the child runs.

## Also in here

- `neon skills` does not call the Neon API, so it is excluded from the auth middleware and from context enrichment. Without that, the command would prompt for a login or fail on a missing key before doing work that never needed either.
- The child process gets an environment with `NEON_API_KEY` removed, in any casing. The skills CLI pulls from GitHub and has no use for a Neon key.
- `uniqueAgentIds` is re-exported from `init/agents.ts`, matching how the other agent helpers are surfaced there.
- README section for the command, including the skill ids, the agent names and the Node.js floor.
- Changeset: minor for `neon` and `neonctl`.

## Verification

Built the CLI at `7d049d9` and ran it against the real skills CLI in a scratch directory containing `.cursor`: installed `neon` and `neon-ai-gateway`, then ran `neon skills update -y` over the result. The install, update, unknown-skill, `--skill *`, MCPorter-skip and non-TTY blocks above are copied from those runs. The retry line and the Node.js message above come from the tests, since neither could be triggered on this machine.

`vitest run src/commands/skills.test.ts src/skills src/context.test.ts`: 97 tests across 7 files, all passing. The behaviours covered:

- `-y` installs the default skills into detected project agents, spawning once, with the child's cwd, args and metadata asserted
- a selection spanning both repos produces two invocations, in catalog order, each with only its own skills
- `NEON_API_KEY` is absent from the child environment, including a mixed-case spelling of the name
- an unknown `-s` value throws before the agent picker is called
- `-s *` and `--agent *` are refused, and an unknown agent name is refused
- non-TTY without `-y` fails without spawning anything, even when `--agent` is given
- an agent with no skills mapping is skipped, and an all-skipped selection fails
- `update` routes to `skills update -p`, or `-g` with `--global`
- `update` reports `none` for each of the skills CLI's no-op lines, and reads the result line rather than the progress banner
- `update` rejects `--agent` and `--skill` before spawning, and its help advertises neither
- a failed install keeps the child's stderr out of the table and emits exactly one retry line, which names every failed skill and preserves `--global`
- a missing `npx` is reported as a missing `npx`, with no retry line
- Node below 22.20 is refused, and 22.20 itself is accepted

Not verified: the Node.js floor was not exercised on a real old runtime. Only Node 24.18 was available on the machine that ran this, so the check is covered by a unit test that passes the version string directly. The interactive pickers were not driven end to end either; the summary rendering has a test and the selection paths are covered through injected pickers, but no real TTY session was driven against this branch.

## For your attention

- **The catalog of skill ids is compiled into the CLI.** A skill added to `neondatabase/agent-skills` is not installable through `neon skills` until a release ships the new id, and there is no escape hatch for reaching one early. This is the cost of refusing repo names and `*` at the interface. A drift check between the catalog and the two repos would catch it, and this PR does not add one.
- **`neon skills` requires a newer Node.js than the rest of the CLI.** Anyone on Node 20 keeps every other command and loses this one, with the message above telling them why.
- **The command is a wrapper around `npx skills add`.** Whatever the skills CLI writes is what lands on disk. This PR owns the selection, the refusals, the reporting and the retry line. The install itself belongs to the skills CLI.
- **`--global` maps to the skills CLI's `-g`.** That scope is user-level, so the tables and prompts say "user-level" while the flag keeps the skills CLI's name.
- **Claude Desktop is offered as a skills target** because it maps onto `claude-code`, which is where its skills live. Selecting both writes once.
