### PR TITLE
Publish @neon/tools ids verb-first

### DIFF
--- a/.changeset/tools-verb-first-ids.md
+++ b/.changeset/tools-verb-first-ids.md
@@ -2,4 +2,4 @@
 "@neon/tools": minor
 ---
 
-Published tool ids are now verb-first (`projects.list` → `list_projects`). Hosts that need a historical name still pass `names`.
+Published tool ids are now the last SDK-path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.connectionString` → `connection_string_postgres`). Hosts that need a historical name still pass `names`.

--- a/.changeset/tools-verb-first-ids.md
+++ b/.changeset/tools-verb-first-ids.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": minor
+---
+
+Published tool ids are now verb-first (`projects.list` → `list_projects`). Hosts that need a historical name still pass `names`.

--- a/.changeset/tools-verb-first-ids.md
+++ b/.changeset/tools-verb-first-ids.md
@@ -2,4 +2,4 @@
 "@neon/tools": minor
 ---
 
-Published tool ids are now the last SDK-path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.connectionString` → `connection_string_postgres`). Hosts that need a historical name still pass `names`.
+Published tool ids are now the last SDK-path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.connectionString` → `connection_string_postgres`). Hosts that need a historical name still pass `names`. A `descriptions` map keyed by the old published id no longer matches.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -8,12 +8,13 @@ npm install @neon/tools
 
 ## Create tools
 
-Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the last path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.connectionString` → `connection_string_postgres`). `publishedId` derives that string. `toolIds` lists every published selector.
+Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the last path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.roles.resetPassword` → `reset_password_postgres_roles`, `postgres.connectionString` → `connection_string_postgres`). `publishedId` derives that string. `toolIds` lists every published selector.
 
 ```ts
 import { createNeonTools, publishedId } from "@neon/tools";
 
 publishedId("projects.list"); // "list_projects"
+publishedId("postgres.roles.resetPassword"); // "reset_password_postgres_roles"
 
 const apiKey = process.env.NEON_API_KEY;
 if (!apiKey) throw new Error("NEON_API_KEY is required");
@@ -76,7 +77,7 @@ These public client methods are not tools: `projects.create`, `branches.create`,
 
 ### Descriptions
 
-Pass a map keyed by SDK path or published `id`, or a function that can append to the generated text:
+Pass a map keyed by SDK path or the current published `id`, or a function that can append to the generated text. A key that matches neither is ignored.
 
 ```ts
 const tools = createNeonTools({

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -8,10 +8,12 @@ npm install @neon/tools
 
 ## Create tools
 
-Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the last path segment, then the resource, in snake_case (`projects.list` → `list_projects`). `toolIds` lists every published selector.
+Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the last path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.connectionString` → `connection_string_postgres`). `publishedId` derives that string. `toolIds` lists every published selector.
 
 ```ts
-import { createNeonTools } from "@neon/tools";
+import { createNeonTools, publishedId } from "@neon/tools";
+
+publishedId("projects.list"); // "list_projects"
 
 const apiKey = process.env.NEON_API_KEY;
 if (!apiKey) throw new Error("NEON_API_KEY is required");
@@ -228,6 +230,8 @@ MCP annotations are advisory; the protocol does not enforce approval. Tools expo
 
 Eve requires Node.js 24 or later.
 
+`create_and_connect_projects.ts`:
+
 ```ts
 import { defineTool } from "eve/tools";
 import { createNeonTool } from "@neon/tools";
@@ -245,7 +249,7 @@ export default defineTool(
 );
 ```
 
-Eve uses the filename as the model-facing tool name, so name the file after the tool's snake-case `id`. The adapter maps approval requirements to Eve's `approval` hook and forwards its abort signal.
+Eve uses the filename as the model-facing tool name, so name the file after the published `id`. The adapter maps approval requirements to Eve's `approval` hook and forwards its abort signal.
 
 ## Mastra
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -8,7 +8,7 @@ npm install @neon/tools
 
 ## Create tools
 
-Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the path in snake_case (`projects.list` → `projects_list`). `toolIds` lists every published selector.
+Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the last path segment, then the resource, in snake_case (`projects.list` → `list_projects`). `toolIds` lists every published selector.
 
 ```ts
 import { createNeonTools } from "@neon/tools";
@@ -34,7 +34,7 @@ const created = await tools["projects.createAndConnect"].execute({
 
 `limit` on a list tool caps how many items come back.
 
-MCP and Mastra publish `tool.id` (`projects_list`), not the record key.
+MCP and Mastra publish `tool.id` (`list_projects`), not the record key.
 
 `apiKey` is a Bearer credential: a Neon API key or a Neon OAuth access token. A function is called on every request, which is how short-lived OAuth tokens get refreshed. A credential is required when a tool executes — at construction, on `execute()`, or from MCP `authInfo` — and an empty value is rejected rather than ignored.
 
@@ -83,7 +83,7 @@ const tools = createNeonTools({
 	descriptions: {
 		"projects.list":
 			"List Neon projects in your account. Do not use for projects shared with you.",
-		projects_delete:
+		delete_projects:
 			"Delete a Neon project and all its data. NEVER run autonomously; always ask the user first.",
 	},
 });
@@ -118,7 +118,7 @@ const tools = createNeonTools({
 });
 ```
 
-Those tools publish as `neon_create_branch` and `neon_projects_list`. The record is still keyed by SDK path (`tools["branches.createWithCompute"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
+Those tools publish as `neon_create_branch` and `neon_list_projects`. The record is still keyed by SDK path (`tools["branches.createWithCompute"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
 
 ### Project and branch injection
 
@@ -265,8 +265,8 @@ const neonTools = createNeonTools({
 });
 const configs = toMastraTools(neonTools);
 
-const listProjects = createTool(configs.projects_list);
-const createProject = createTool(configs.projects_create_and_connect);
+const listProjects = createTool(configs.list_projects);
+const createProject = createTool(configs.create_and_connect_projects);
 ```
 
 The adapter maps approval requirements to Mastra's `requireApproval` field and forwards its abort signal.

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -66,7 +66,7 @@ describe("description overrides", () => {
 			apiKey: "test-key",
 			tools: ["projects.list"] as const,
 			descriptions: {
-				projects_list: "List Neon projects in your account.",
+				list_projects: "List Neon projects in your account.",
 			},
 		});
 
@@ -81,7 +81,7 @@ describe("description overrides", () => {
 			tools: ["projects.list"] as const,
 			descriptions: {
 				"projects.list": "from operationId",
-				projects_list: "from id",
+				list_projects: "from id",
 			},
 		});
 
@@ -128,7 +128,7 @@ describe("onExecute", () => {
 			project_id: "project-id",
 		});
 
-		expect(events).toEqual(["start:projects.get:projects_get", "success"]);
+		expect(events).toEqual(["start:projects.get:get_projects", "success"]);
 		expect(result).toEqual({ data: { id: "project-id" } });
 		expect(requests).toHaveLength(1);
 	});
@@ -470,7 +470,7 @@ describe("description overrides (createNeonTool and contracts)", () => {
 		expect(seen).toEqual([
 			{
 				operationId: "projects.delete",
-				id: "projects_delete",
+				id: "delete_projects",
 				title: generated.title,
 				description: generated.description,
 			},
@@ -607,7 +607,7 @@ describe("onExecute failure and isolation", () => {
 
 		await tool.execute({ project_id: "project-id" });
 
-		expect(events).toEqual(["projects_get"]);
+		expect(events).toEqual(["get_projects"]);
 		expect(requests).toHaveLength(1);
 	});
 });
@@ -970,14 +970,14 @@ describe("tool names", () => {
 		expect(tools["branches.createWithCompute"].id).toBe(
 			"neon_create_branch",
 		);
-		expect(tools["projects.list"].id).toBe("neon_projects_list");
+		expect(tools["projects.list"].id).toBe("neon_list_projects");
 	});
 
 	test("lets a function rename from the generated id", () => {
 		const tool = createNeonTool("branches.createWithCompute", {
 			apiKey: "test-key",
 			names: ({ id }) =>
-				id === "branches_create_with_compute" ? "create_branch" : id,
+				id === "create_with_compute_branches" ? "create_branch" : id,
 		});
 
 		expect(tool.id).toBe("create_branch");

--- a/packages/tools/src/frameworks.test.ts
+++ b/packages/tools/src/frameworks.test.ts
@@ -63,12 +63,12 @@ describe("Mastra compatibility", () => {
 		});
 
 		const configs = toMastraTools(tools);
-		const listProjects = createTool(configs.projects_list);
-		const createProject = createTool(configs.projects_create_and_connect);
+		const listProjects = createTool(configs.list_projects);
+		const createProject = createTool(configs.create_and_connect_projects);
 
-		expect(listProjects.id).toBe("projects_list");
+		expect(listProjects.id).toBe("list_projects");
 		expect(listProjects.requireApproval).toBe(false);
-		expect(createProject.id).toBe("projects_create_and_connect");
+		expect(createProject.id).toBe("create_and_connect_projects");
 		expect(createProject.requireApproval).toBe(true);
 	});
 
@@ -79,7 +79,7 @@ describe("Mastra compatibility", () => {
 			inject: { projectId: "granted-project", omitFromSchema: true },
 		});
 
-		expect(toMastraTools(tools).projects_get.inputSchema).toBe(
+		expect(toMastraTools(tools).get_projects.inputSchema).toBe(
 			tools["projects.get"].inputSchema,
 		);
 		expect(toEveTool(tools["projects.get"]).inputSchema).toBe(
@@ -92,7 +92,7 @@ describe("Mastra compatibility", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["projects.get"],
-			descriptions: { projects_get: "Granted project details." },
+			descriptions: { get_projects: "Granted project details." },
 			inject: { projectId: "granted-project", omitFromSchema: true },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -101,7 +101,7 @@ describe("Mastra compatibility", () => {
 		});
 
 		const eve = toEveTool(tools["projects.get"]);
-		const mastra = toMastraTools(tools).projects_get;
+		const mastra = toMastraTools(tools).get_projects;
 		expect(eve.description).toBe("Granted project details.");
 		expect(mastra.description).toBe("Granted project details.");
 

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -4,8 +4,8 @@ import {
 	type CreateNeonToolsOptions,
 	createNeonTool,
 	createNeonTools,
+	publishedId,
 } from "./index.js";
-import { publishedId } from "./lib/ergonomic/bind.js";
 import { toMastraTools } from "./mastra.js";
 
 expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"list_projects">();

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -5,7 +5,16 @@ import {
 	createNeonTool,
 	createNeonTools,
 } from "./index.js";
+import { publishedId } from "./lib/ergonomic/bind.js";
 import { toMastraTools } from "./mastra.js";
+
+expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"list_projects">();
+expectTypeOf(
+	publishedId("projects.createAndConnect"),
+).toEqualTypeOf<"create_and_connect_projects">();
+expectTypeOf(
+	publishedId("postgres.roles.resetPassword"),
+).toEqualTypeOf<"reset_password_postgres_roles">();
 
 const tools = createNeonTools({
 	apiKey: "test-key",
@@ -40,14 +49,14 @@ oauthTools["projects.list"].execute(
 listProjects.execute({ name: "wrong-operation" });
 
 const mastraTools = toMastraTools(tools);
-expectTypeOf(mastraTools).toHaveProperty("projects_list");
-expectTypeOf(mastraTools).toHaveProperty("projects_create_and_connect");
+expectTypeOf(mastraTools).toHaveProperty("list_projects");
+expectTypeOf(mastraTools).toHaveProperty("create_and_connect_projects");
 
 // @ts-expect-error unselected tools are absent from the Mastra tool record
-mastraTools.projects_delete;
+mastraTools.delete_projects;
 
 // @ts-expect-error Mastra configs preserve tool-specific request types
-mastraTools.projects_list.execute({ limit: "one" }, {});
+mastraTools.list_projects.execute({ limit: "one" }, {});
 
 const eveListProjects = toEveTool(tools["projects.list"]);
 eveListProjects
@@ -104,7 +113,7 @@ eveOmitted
 	});
 
 const mastraOmitted = toMastraTools(omittedProject);
-mastraOmitted.projects_get.execute({}, {}).then((result) => {
+mastraOmitted.get_projects.execute({}, {}).then((result) => {
 	expectTypeOf(result.data.id).toEqualTypeOf<string>();
 });
 
@@ -147,11 +156,11 @@ const renamed = createNeonTools({
 });
 expectTypeOf(renamed["projects.list"].id).toEqualTypeOf<string>();
 expectTypeOf(renamed["branches.createWithCompute"].id).toEqualTypeOf<string>();
-expectTypeOf(tools["projects.list"].id).toEqualTypeOf<"projects_list">();
+expectTypeOf(tools["projects.list"].id).toEqualTypeOf<"list_projects">();
 
 const mastraRenamed = toMastraTools(renamed);
 expectTypeOf(mastraRenamed.neon_create_branch.id).toEqualTypeOf<string>();
-expectTypeOf(mastraRenamed.neon_projects_list.id).toEqualTypeOf<string>();
+expectTypeOf(mastraRenamed.neon_list_projects.id).toEqualTypeOf<string>();
 
 const renamedOne = createNeonTool("branches.createWithCompute", {
 	apiKey: "test-key",

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -22,9 +22,9 @@ describe("createNeonTools", () => {
 			"projects.list",
 			"projects.createAndConnect",
 		]);
-		expect(tools["projects.list"].id).toBe("projects_list");
+		expect(tools["projects.list"].id).toBe("list_projects");
 		expect(tools["projects.createAndConnect"].id).toBe(
-			"projects_create_and_connect",
+			"create_and_connect_projects",
 		);
 	});
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -11,6 +11,8 @@ import {
 import {
 	isNeonToolId,
 	type NeonToolId,
+	type PublishedId,
+	publishedId,
 	type ToolClientOptions,
 	type ToolFactory,
 	toolFactories,
@@ -40,8 +42,8 @@ export type {
 	NeonToolMetadata,
 	NeonToolResult,
 } from "./lib/operation.js";
-export type { NeonToolId };
-export { NeonError, toolIds };
+export type { NeonToolId, PublishedId };
+export { NeonError, publishedId, toolIds };
 
 type ToolFactories = typeof toolFactories;
 

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -47,21 +47,37 @@ type Snake<S extends string> = S extends `${infer Head}${infer Rest}`
 		: `${Head}${Snake<Rest>}`
 	: S;
 
-export type PublishedId<Id extends string> =
-	Id extends `${infer Head}.${infer Rest}`
-		? `${Snake<Head>}_${PublishedId<Rest>}`
-		: Snake<Id>;
+type LastSegment<Id extends string> = Id extends `${string}.${infer Rest}`
+	? LastSegment<Rest>
+	: Id;
 
-export const publishedId = <Id extends string>(id: Id): PublishedId<Id> =>
-	id
-		.split(".")
-		.map((segment) =>
-			segment.replace(
-				/[A-Z]/g,
-				(character) => `_${character.toLowerCase()}`,
-			),
-		)
-		.join("_") as PublishedId<Id>;
+type ResourcePath<
+	Id extends string,
+	Acc extends string = "",
+> = Id extends `${infer Head}.${infer Rest}`
+	? ResourcePath<Rest, Acc extends "" ? Head : `${Acc}.${Head}`>
+	: Acc;
+
+type SnakeDots<Id extends string> = Id extends `${infer Head}.${infer Rest}`
+	? `${Snake<Head>}_${SnakeDots<Rest>}`
+	: Snake<Id>;
+
+export type PublishedId<Id extends string> = Id extends `${string}.${string}`
+	? `${Snake<LastSegment<Id>>}_${SnakeDots<ResourcePath<Id>>}`
+	: Snake<Id>;
+
+const snakeSegment = (segment: string) =>
+	segment.replace(/[A-Z]/g, (character) => `_${character.toLowerCase()}`);
+
+export const publishedId = <Id extends string>(id: Id): PublishedId<Id> => {
+	const dot = id.lastIndexOf(".");
+	if (dot === -1) {
+		return snakeSegment(id) as PublishedId<Id>;
+	}
+	const verb = snakeSegment(id.slice(dot + 1));
+	const resource = id.slice(0, dot).split(".").map(snakeSegment).join("_");
+	return `${verb}_${resource}` as PublishedId<Id>;
+};
 
 const resolveApiKey = (
 	options: ToolClientOptions,

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -5,6 +5,7 @@ import {
 	collectObjectList,
 	collectPages,
 	fromGenerated,
+	publishedId,
 	type ToolClientOptions,
 } from "./bind.js";
 import {
@@ -1234,7 +1235,7 @@ export const toolFactories = {
 			options,
 			{
 				operationId: "regions.list",
-				id: "regions_list",
+				id: publishedId("regions.list"),
 				title: "List regions",
 				description:
 					"Lists Neon regions available to the authenticated account.",

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -1,6 +1,6 @@
 import * as z from "zod";
 import * as zod from "../../generated/zod.gen.js";
-import { bindTool, type ToolClientOptions } from "./bind.js";
+import { bindTool, publishedId, type ToolClientOptions } from "./bind.js";
 
 const writeAnnotations = {
 	readOnlyHint: false,
@@ -86,7 +86,7 @@ export const createBranchWithComputeTool = (options: ToolClientOptions) =>
 		options,
 		{
 			operationId: "branches.createWithCompute",
-			id: "branches_create_with_compute",
+			id: publishedId("branches.createWithCompute"),
 			title: "Create branch with compute",
 			description:
 				"Create a branch with a read-write endpoint and return its connection string. The call waits until operation-backed provisioning finishes, up to five minutes by default.",
@@ -131,7 +131,7 @@ export const createProjectAndConnectTool = (options: ToolClientOptions) =>
 		options,
 		{
 			operationId: "projects.createAndConnect",
-			id: "projects_create_and_connect",
+			id: publishedId("projects.createAndConnect"),
 			title: "Create project and connect",
 			description:
 				"Create a project and return a connection string to its default branch. The call waits until operation-backed provisioning finishes, up to five minutes by default.",
@@ -160,7 +160,7 @@ export const getDefaultTool = (options: ToolClientOptions) =>
 		options,
 		{
 			operationId: "branches.getDefault",
-			id: "branches_get_default",
+			id: publishedId("branches.getDefault"),
 			title: "Get default branch",
 			description:
 				"Resolve the project's default branch by the default flag, not by name.",
@@ -184,7 +184,7 @@ export const connectionStringTool = (options: ToolClientOptions) =>
 		options,
 		{
 			operationId: "postgres.connectionString",
-			id: "postgres_connection_string",
+			id: publishedId("postgres.connectionString"),
 			title: "Get connection string",
 			description:
 				"Resolve a Postgres connection string. Auto-selects the default branch and the sole role and database when those are omitted. Errors when the selection is ambiguous.",
@@ -228,7 +228,7 @@ export const restoreSnapshotTool = (options: ToolClientOptions) =>
 		options,
 		{
 			operationId: "snapshots.restore",
-			id: "snapshots_restore",
+			id: publishedId("snapshots.restore"),
 			title: "Restore snapshot",
 			description:
 				"Restore a snapshot onto a new or existing branch. The call waits until operation-backed provisioning finishes. Preview callbacks are not available on this tool.",
@@ -261,7 +261,7 @@ export const setScheduleTool = (options: ToolClientOptions) =>
 		options,
 		{
 			operationId: "snapshots.setSchedule",
-			id: "snapshots_set_schedule",
+			id: publishedId("snapshots.setSchedule"),
 			title: "Set snapshot schedule",
 			description:
 				"Replace a branch's automatic snapshot schedule. Frequency must be daily, weekly, or monthly.",

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -52,13 +52,13 @@ describe("MCP v2 compatibility", () => {
 
 		const listed = await client.listTools();
 		expect(listed.tools.map((tool) => tool.name)).toEqual([
-			"projects_list",
+			"list_projects",
 		]);
 		expect(listed.tools[0].annotations?.readOnlyHint).toBe(true);
 		expect(listed.tools[0]._meta?.["neon/requiresApproval"]).toBe(false);
 
 		const called = await client.callTool({
-			name: "projects_list",
+			name: "list_projects",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({
@@ -66,7 +66,7 @@ describe("MCP v2 compatibility", () => {
 		});
 
 		const invalid = await client.callTool({
-			name: "projects_list",
+			name: "list_projects",
 			arguments: { limit: "one" },
 		});
 		expect(invalid.isError).toBe(true);
@@ -242,7 +242,7 @@ describe("MCP v1 compatibility", () => {
 		closeables.push(client, server);
 
 		const called = await client.callTool({
-			name: "projects_list",
+			name: "list_projects",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({
@@ -290,7 +290,7 @@ describe("MCP path injection", () => {
 		});
 
 		const called = await client.callTool({
-			name: "projects_get",
+			name: "get_projects",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({
@@ -344,7 +344,7 @@ describe("MCP path injection", () => {
 		});
 
 		const called = await client.callTool({
-			name: "projects_get",
+			name: "get_projects",
 			arguments: {},
 		});
 		expect(called.isError).toBeFalsy();
@@ -385,7 +385,7 @@ describe("MCP path injection", () => {
 		closeables.push(client, server);
 
 		const called = await client.callTool({
-			name: "projects_get",
+			name: "get_projects",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({

--- a/packages/tools/src/published-id.test.ts
+++ b/packages/tools/src/published-id.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { createNeonTool } from "./index.js";
+import { publishedId } from "./lib/ergonomic/bind.js";
+import { toolIds } from "./lib/ergonomic/ids.js";
+
+describe("publishedId", () => {
+	test("moves the last path segment in front", () => {
+		expect(publishedId("projects.list")).toBe("list_projects");
+		expect(publishedId("projects.createAndConnect")).toBe(
+			"create_and_connect_projects",
+		);
+		expect(publishedId("branches.createWithCompute")).toBe(
+			"create_with_compute_branches",
+		);
+		expect(publishedId("postgres.roles.resetPassword")).toBe(
+			"reset_password_postgres_roles",
+		);
+		expect(publishedId("logs.query")).toBe("query_logs");
+		expect(publishedId("user.me")).toBe("me_user");
+		expect(publishedId("regions.list")).toBe("list_regions");
+	});
+
+	test("every catalog tool publishes publishedId(selector)", () => {
+		for (const id of toolIds) {
+			expect(createNeonTool(id, { apiKey: "test-key" }).id).toBe(
+				publishedId(id),
+			);
+		}
+	});
+});

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -62,7 +62,7 @@ describe("branches.createWithCompute", () => {
 
 		expect(Object.keys(tools)).toEqual(["branches.createWithCompute"]);
 		expect(tools["branches.createWithCompute"].id).toBe(
-			"branches_create_with_compute",
+			"create_with_compute_branches",
 		);
 		expect(tools["branches.createWithCompute"].operationId).toBe(
 			"branches.createWithCompute",
@@ -286,7 +286,7 @@ describe("createNeonTool", () => {
 
 		await tool.execute({ project_id: "project-id", name: "feature-x" });
 
-		expect(tool.id).toBe("branches_create_with_compute");
+		expect(tool.id).toBe("create_with_compute_branches");
 		expect(requests[0].url).toBe(
 			"https://console.neon.tech/api/v2/projects/project-id/branches",
 		);


### PR DESCRIPTION
## Problem

`@neon/tools` built a tool's published `id` by snake-casing the SDK path in order. `projects.list` published as `projects_list`, `postgres.connectionString` as `postgres_connection_string`, `postgres.roles.resetPassword` as `postgres_roles_reset_password`.

The published id is the string the model sees and picks from. Deriving it from the path order puts the resource first on every tool in the catalog, so a list of Neon tools reads as a column of `projects_`, `branches_`, `postgres_` prefixes and the action lands at the end of the string. Agent tool catalogs generally name the action first.

## What changed

The last path segment moves in front, the remaining path follows, everything stays snake_case.

| Selector | Before | After |
| --- | --- | --- |
| `projects.list` | `projects_list` | `list_projects` |
| `projects.delete` | `projects_delete` | `delete_projects` |
| `projects.createAndConnect` | `projects_create_and_connect` | `create_and_connect_projects` |
| `branches.createWithCompute` | `branches_create_with_compute` | `create_with_compute_branches` |
| `postgres.connectionString` | `postgres_connection_string` | `connection_string_postgres` |
| `postgres.roles.resetPassword` | `postgres_roles_reset_password` | `reset_password_postgres_roles` |

The current catalog's 98 selectors produce unique ids. `createNeonTools` throws if two selected tools would publish the same id. A later SDK path that snake-flattens onto an existing one (`aiGateway.get` and a hypothetical `ai.gateway.get`) would collide; that is not in this catalog.

## The interface

`publishedId` and the `PublishedId` type are now public. The type resolves to a string literal, so ids stay narrow through the record.

```ts
import { createNeonTools, publishedId, type PublishedId } from "@neon/tools";

publishedId("projects.list"); // "list_projects"
publishedId("postgres.roles.resetPassword"); // "reset_password_postgres_roles"

type ListProjects = PublishedId<"projects.list">; // "list_projects"
```

Selection and the record are unchanged. Selectors are still SDK paths and the record is still keyed by them:

```ts
const tools = createNeonTools({
	apiKey: process.env.NEON_API_KEY,
	tools: ["projects.list", "postgres.roles.resetPassword"] as const,
});

tools["projects.list"].id; // "list_projects"
tools["postgres.roles.resetPassword"].id; // "reset_password_postgres_roles"
```

MCP and Mastra publish `tool.id`, so that is where the change is visible:

```
// before
listTools() -> ["projects_list", "projects_delete", "postgres_connection_string"]

// after
listTools() -> ["list_projects", "delete_projects", "connection_string_postgres"]
```

```ts
const configs = toMastraTools(neonTools);
const listProjects = createTool(configs.list_projects);
const createProject = createTool(configs.create_and_connect_projects);
```

Eve takes the model-facing name from the filename, so an Eve tool file is now named after the new id: `create_and_connect_projects.ts`.

`names` still overrides, keyed by SDK path or by the current published id, and it is how a host keeps a historical string:

```ts
const tools = createNeonTools({
	apiKey,
	tools: ["projects.list", "branches.createWithCompute"] as const,
	names: {
		"projects.list": "projects_list", // keep the pre-0.7 name
		"branches.createWithCompute": "neon_create_branch",
	},
});
```

`descriptions` still takes SDK paths or published ids, so a map written against the old ids needs its keys rewritten:

```ts
const tools = createNeonTools({
	apiKey,
	tools: ["projects.list", "projects.delete"] as const,
	descriptions: {
		"projects.list": "List Neon projects in your account.",
		delete_projects: "Delete a Neon project and all its data.",
	},
});
```

Nothing else moves: selectors, `toolIds`, the record keys, `operationId`, input schemas, annotations, approval metadata and project or branch injection are all the same.

## Also in here

- `catalog.ts` and `composed.ts` held hand-written `id` strings for `regions.list` and the six composed tools. They now call `publishedId(selector)`, so a composed tool cannot drift from the rule the generated ones follow.
- README: the naming rule, the three-segment example, the Mastra config keys, the Eve filename and a note that a `descriptions` key matching neither an SDK path nor the current id is ignored.
- Changeset as a minor. The package is 0.x, so that is the breaking slot.

## Verification

`pnpm --filter @neon/tools exec vitest run` on this branch: 122 tests across 10 files pass. `pnpm --filter @neon/tools exec tsc --noEmit` is clean, which covers the `expectTypeOf` assertions in `src/index.test-d.ts` for `publishedId("projects.list")`, `publishedId("projects.createAndConnect")` and `publishedId("postgres.roles.resetPassword")`.

New behaviours in `src/published-id.test.ts`:

- two-segment, three-segment and camelCase selectors map as documented, including `postgres.roles.resetPassword` and single-segment-verb cases like `logs.query` and `user.me`
- every entry in `toolIds` publishes exactly `publishedId(selector)`, so the catalog cannot carry a hand-written id that disagrees with the rule

The existing MCP, Mastra, Eve, customization and workflow suites were updated to the new ids and pass, which is where the published names get exercised end to end through the in-process MCP client.

Not covered: no run against a live MCP or Mastra host, only the in-process clients in `mcp.test.ts` and `frameworks.test.ts`. The `PublishedId` type is asserted for three selectors; the loop over `toolIds` compares runtime values only, so there is no type-level check that the type and the function agree for every selector.

Nothing outside `packages/tools` in this repo references an old published id, so no other workspace package changes.

## For your attention

- **A `descriptions` map keyed by an old published id is ignored without an error.** Lookup is `descriptions[operationId] ?? descriptions[tool.id]`, and a key matching neither falls through to the generated description. Upgrading with `descriptions: { projects_delete: "..." }` left in place still constructs, still executes, and the model quietly gets the generic text. The same mistake in `names` throws `Unknown Neon tool name override`, because `createNeonTools` validates those keys against the selected tools. This PR does not add the equivalent validation for `descriptions`; adding it would mean rejecting description keys that match no selected tool, which is a second behaviour change on top of the rename.
- **Every host that pins a tool name has to update it.** MCP allowlists and approval policies keyed by name, Eve tool filenames, Mastra config keys. `names` keeps the old string where the host cannot be changed in the same release.
- **No alias period.** Publishing both ids during a deprecation window would double the number of tools the model sees, and the duplicate-id check exists to keep that from happening. Callers upgrade in one step.
- **The rule is mechanical, so a selector whose last segment is a noun reads oddly.** `postgres.connectionString` becomes `connection_string_postgres`, `logs.fieldValues` becomes `field_values_logs`, `user.me` becomes `me_user`. Those names are worse than what a human would pick for those specific tools, and `names` is the only correction.
