### PR TITLE
chore: release @neon/tools@0.7.0

### DIFF
--- a/.changeset/tools-verb-first-ids.md
+++ b/.changeset/tools-verb-first-ids.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": minor
----
-
-Published tool ids are now the last SDK-path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.connectionString` → `connection_string_postgres`). Hosts that need a historical name still pass `names`. A `descriptions` map keyed by the old published id no longer matches.

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 0.7.0
+
+### Minor Changes
+
+- 8a86bb3: Published tool ids are now the last SDK-path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.connectionString` → `connection_string_postgres`). Hosts that need a historical name still pass `names`. A `descriptions` map keyed by the old published id no longer matches.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.6.0",
+	"version": "0.7.0",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
@neon/tools: 0.6.0 → 0.7.0

Nothing else bumped. Publish is a separate dispatch of neon-pkgs.yml with package=@neon/tools.