### PR TITLE
Mint a project-scoped MCP key when a project is pinned

### DIFF
--- a/.changeset/cli-mcp-project-key.md
+++ b/.changeset/cli-mcp-project-key.md
@@ -1,0 +1,6 @@
+---
+"neon": patch
+"neonctl": patch
+---
+
+`neon mcp` mints a project-scoped API key when `--project-id` is set or a linked project is pinned, instead of an account-wide key.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -736,7 +736,7 @@ $ neon mcp -y
 # OAuth: no API key minted. The agent prompts for Neon sign-in on first use.
 $ neon mcp --oauth
 
-# Project-level config. A minted key is still account-wide.
+# Project-level config. A minted key is still account-wide unless a project is pinned.
 $ neon mcp --project
 
 $ neon mcp --agent cursor --agent claude-code
@@ -744,7 +744,7 @@ $ neon mcp --agent cursor --agent claude-code
 # Hide write tools. Does not change the minted key.
 $ neon mcp --read-only
 
-# Pin MCP tools to one project. Does not change the minted key.
+# Pin MCP tools to one project. A newly minted API key is limited to that project.
 $ neon mcp --project-id <project-id>
 
 # Limit which tool categories are visible.
@@ -753,11 +753,11 @@ $ neon mcp --category querying --category schema
 
 On a TTY the command asks for config location (global is the default), then agents, then API key vs OAuth, then a summary to confirm before it writes. Detected agents start selected: globally installed agents or project-folder markers such as `.cursor` when the install is project.
 
-`-y` skips those questions. `--project`, `--oauth` and `--agent` skip the question they answer and still apply with `-y`. `--read-only` and `--category` are flags only and are never prompted. A linked project-folder install asks whether to pin MCP tools to that `.neon` project (`?projectId=`). An unlinked project folder does not ask. Global installs never add that param unless you pass `--project-id`. Without a TTY, pass `-y` to mint into every detected agent, `--agent` to name the agents or `--oauth` to write the URL only.
+`-y` skips those questions. `--project`, `--oauth` and `--agent` skip the question they answer and still apply with `-y`. `--read-only` and `--category` are flags only and are never prompted. A linked project-folder install asks whether to pin MCP tools to that `.neon` project (`?projectId=`). If you pin and selected API-key auth, the minted key is limited to that project too. An unlinked project folder does not ask. Global installs never add that param unless you pass `--project-id`. `-y` does not infer a project from `.neon`. Without a TTY, pass `-y` to mint into every detected agent, `--agent` to name the agents or `--oauth` to write the URL only.
 
 `--agent` names: `antigravity`, `cline`, `cline-cli`, `claude-code`, `codex`, `cursor`, `gemini-cli`, `goose`, `github-copilot-cli`, `grok-build`, `mcporter`, `opencode`, `vscode`, `windsurf`, `zed`. Project installs drop `antigravity`, `cline`, `cline-cli`, `goose` and `windsurf`. `claude-desktop` is a known name that is then skipped.
 
-The default mints an account-wide API key (or reuses the Bearer already configured for Neon at `https://mcp.neon.tech/mcp`) and writes it into each selected agent's config. That key reaches everything the account can, in every organization. Revoke it with `neon api-keys revoke <id>`. `--oauth` writes the URL with no `Authorization` header; the agent signs in on first use. `--project` writes into the project config (`.cursor/mcp.json` and similar). `--read-only` adds `?readonly=true`. `--project-id` adds `?projectId=`. `--category` adds `?category=` (repeatable or comma-separated: `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, `docs`). Those query params restrict which MCP tools the server exposes; they do not change what the minted key can do.
+The default mints an account-wide API key (or reuses the Bearer already configured for Neon at `https://mcp.neon.tech/mcp`) and writes it into each selected agent's config. That key reaches everything the account can, in every organization. Revoke it with `neon api-keys revoke <id>`. `--oauth` writes the URL with no `Authorization` header; the agent signs in on first use. `--project` writes into the project config (`.cursor/mcp.json` and similar). `--read-only` adds `?readonly=true`. `--project-id` adds `?projectId=` and, when a key is minted, limits that key to the named project. Accepting the linked-project pin does the same. Revoke a project-scoped key with `neon api-keys revoke <id> --org-id <org>`. A reused Bearer keeps the scope it already has. `--category` adds `?category=` (repeatable or comma-separated: `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, `docs`). `--read-only` and `--category` restrict which MCP tools the server exposes; they do not change what the minted key can do.
 
 ## Snapshots (`snapshots`)
 

--- a/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
+++ b/packages/cli/mocks/main/organizations/org-7/api_keys/POST.js
@@ -30,6 +30,22 @@ export default function (req, res) {
 		case "nokey":
 			return res.json({ ...base, id: 401 });
 		default:
+			if (req.body.project_id === "proj-mismatch") {
+				return res.json({
+					...base,
+					id: 401,
+					key: "napi_wrong_scope",
+					project_id: "some-other-project",
+				});
+			}
+			if (req.body.project_id === "proj-revoke-fail") {
+				return res.json({
+					...base,
+					id: 500,
+					key: "napi_org_secret",
+					project_id: "proj-revoke-fail",
+				});
+			}
 			return res.json({
 				...base,
 				id: 303,

--- a/packages/cli/mocks/main/projects/proj-mismatch/GET.json
+++ b/packages/cli/mocks/main/projects/proj-mismatch/GET.json
@@ -1,0 +1,9 @@
+{
+  "project": {
+    "id": "proj-mismatch",
+    "name": "Mismatch Project",
+    "org_id": "org-7",
+    "region_id": "aws-us-east-2",
+    "created_at": "2019-01-01T00:00:00Z"
+  }
+}

--- a/packages/cli/mocks/main/projects/proj-revoke-fail/GET.json
+++ b/packages/cli/mocks/main/projects/proj-revoke-fail/GET.json
@@ -1,0 +1,9 @@
+{
+  "project": {
+    "id": "proj-revoke-fail",
+    "name": "Revoke Fail Project",
+    "org_id": "org-7",
+    "region_id": "aws-us-east-2",
+    "created_at": "2019-01-01T00:00:00Z"
+  }
+}

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -427,6 +427,7 @@ const revoke = async (props: RevokeProps) => {
 export const orgIdForProject = async (
 	client: NeonApiClient,
 	projectId: string,
+	usage: "api-keys" | "mcp" = "api-keys",
 ): Promise<string> => {
 	let orgId: string | undefined;
 	try {
@@ -438,7 +439,9 @@ export const orgIdForProject = async (
 		if (isNeonApiError(err) && err.status === 404) {
 			throw new Error(
 				projectId.startsWith("org-")
-					? `Project ${projectId} not found. That looks like an organization id. Pass it as --org-id instead.`
+					? usage === "mcp"
+						? `Project ${projectId} not found. That looks like an organization id. neon mcp takes a project id on --project-id.`
+						: `Project ${projectId} not found. That looks like an organization id. Pass it as --org-id instead.`
 					: `Project ${projectId} not found. Check the id with \`neon projects list\`.`,
 			);
 		}
@@ -446,7 +449,9 @@ export const orgIdForProject = async (
 	}
 	if (!orgId) {
 		throw new Error(
-			`Project ${projectId} does not belong to an organization, so it cannot have a project-scoped API key. Omit --project-id to create an account key.`,
+			usage === "mcp"
+				? `Project ${projectId} does not belong to an organization, so it cannot have a project-scoped API key. Pass --oauth to pin tools without minting, or omit --project-id to mint an account-wide key.`
+				: `Project ${projectId} does not belong to an organization, so it cannot have a project-scoped API key. Omit --project-id to create an account key.`,
 		);
 	}
 	return orgId;

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -24,6 +24,7 @@ afterEach(() => {
 });
 
 const SECRET = "napi_account_secret";
+const PROJECT_SECRET = "napi_org_secret";
 
 function scratch(): { home: string; cwd: string } {
 	const home = mkdtempSync(join(tmpdir(), "neon-mcp-home-"));
@@ -258,10 +259,20 @@ describe("neon mcp", () => {
 				projectId: "proj-in-org",
 			}),
 		);
-		await testCliCommand(["mcp", "-y", "--project"], runOptions(home, cwd));
-		expect(
+		const { stderr } = await testCliCommand(
+			["mcp", "-y", "--project"],
+			runOptions(home, cwd),
+		);
+		const written = JSON.parse(
 			readFileSync(join(cwd, ".cursor", "mcp.json"), "utf8"),
-		).toContain("mcp.neon.tech");
+		);
+		expect(written.mcpServers.Neon.url).toBe(NEON_MCP_URL);
+		expect(written.mcpServers.Neon.headers.Authorization).toBe(
+			`Bearer ${SECRET}`,
+		);
+		expect(stderr).toMatch(/, account/);
+		expect(stderr).toMatch(/everything your account can/);
+		expect(stderr).not.toMatch(/--org-id/);
 	});
 
 	test("-y --project does not use a global install as project detection", async ({
@@ -516,23 +527,60 @@ describe("neon mcp", () => {
 		expect(stderr).toMatch(/\?readonly=true/);
 	});
 
-	test("--project-id writes ?projectId= with an account key", async ({
+	test("--project-id writes ?projectId= with a project-scoped key", async ({
 		testCliCommand,
 	}) => {
 		const { home, cwd } = scratch();
 		const { stderr } = await testCliCommand(
-			["mcp", "--project-id", "proj-flag", "--agent", "cursor"],
+			["mcp", "--project-id", "proj-in-org", "--agent", "cursor"],
 			runOptions(home, cwd),
 		);
 		const written = JSON.parse(
 			readFileSync(join(home, ".cursor", "mcp.json"), "utf8"),
 		);
 		expect(written.mcpServers.Neon.url).toBe(
-			neonMcpUrl({ projectId: "proj-flag" }),
+			neonMcpUrl({ projectId: "proj-in-org" }),
 		);
-		expect(stderr).toMatch(/account/);
+		expect(written.mcpServers.Neon.headers.Authorization).toBe(
+			`Bearer ${PROJECT_SECRET}`,
+		);
 		expect(stderr).toMatch(/Minted API key/);
-		expect(stderr).toMatch(/\?projectId=proj-flag/);
+		expect(stderr).toMatch(/, project/);
+		expect(stderr).toMatch(/Limited to proj-in-org/);
+		expect(stderr).toMatch(/api-keys revoke 303 --org-id org-7/);
+		expect(stderr).not.toMatch(/everything your account can/);
+		expect(stderr).toMatch(/\?projectId=proj-in-org/);
+		assertNoSecret("", stderr);
+	});
+
+	test("unknown --project-id fails without minting", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd } = scratch();
+		const { stderr } = await testCliCommand(
+			["mcp", "--project-id", "proj-flag", "--agent", "cursor"],
+			{ ...runOptions(home, cwd), code: 1 },
+		);
+		expect(stderr).toMatch(/Project proj-flag not found/);
+		expect(stderr).not.toMatch(/Minted API key/);
+		expect(existsSync(join(home, ".cursor", "mcp.json"))).toBe(false);
+	});
+
+	test("a project-scoped mint with the wrong project_id is withdrawn", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd } = scratch();
+		const { stderr } = await testCliCommand(
+			["mcp", "--project-id", "proj-mismatch", "--agent", "cursor"],
+			{ ...runOptions(home, cwd), code: 1 },
+		);
+		expect(stderr).toMatch(
+			/scoped to some-other-project rather than proj-mismatch/,
+		);
+		expect(stderr).toMatch(/has been revoked/);
+		expect(stderr).not.toMatch(/Minted API key/);
+		expect(existsSync(join(home, ".cursor", "mcp.json"))).toBe(false);
+		assertNoSecret("", stderr);
 	});
 
 	test("--category accepts repeated flags and CSV", async ({
@@ -606,7 +654,7 @@ describe("neon mcp", () => {
 		expect(written.mcpServers.Neon.url).toBe(NEON_MCP_URL);
 	});
 
-	test("--project --project-id writes ?projectId= with an account key", async ({
+	test("--project --project-id scopes the key to the flag, not .neon", async ({
 		testCliCommand,
 	}) => {
 		const { home, cwd } = scratch();
@@ -614,7 +662,7 @@ describe("neon mcp", () => {
 			join(cwd, ".neon"),
 			JSON.stringify({
 				orgId: "org-7",
-				projectId: "proj-in-org",
+				projectId: "proj-from-neon",
 			}),
 		);
 		const { stderr } = await testCliCommand(
@@ -622,7 +670,7 @@ describe("neon mcp", () => {
 				"mcp",
 				"--project",
 				"--project-id",
-				"proj-other",
+				"proj-in-org",
 				"--agent",
 				"cursor",
 			],
@@ -632,14 +680,17 @@ describe("neon mcp", () => {
 			readFileSync(join(cwd, ".cursor", "mcp.json"), "utf8"),
 		);
 		expect(written.mcpServers.Neon.url).toBe(
-			neonMcpUrl({ projectId: "proj-other" }),
+			neonMcpUrl({ projectId: "proj-in-org" }),
 		);
 		expect(written.mcpServers.Neon.headers.Authorization).toBe(
-			`Bearer ${SECRET}`,
+			`Bearer ${PROJECT_SECRET}`,
 		);
 		expect(stderr).toMatch(/Minted API key/);
-		expect(stderr).toMatch(/, account/);
-		expect(stderr).toMatch(/\?projectId=proj-other/);
+		expect(stderr).toMatch(/, project/);
+		expect(stderr).toMatch(/Limited to proj-in-org/);
+		expect(stderr).toMatch(/api-keys revoke 303 --org-id org-7/);
+		expect(stderr).not.toMatch(/proj-from-neon/);
+		expect(stderr).toMatch(/\?projectId=proj-in-org/);
 		assertNoSecret("", stderr);
 	});
 
@@ -678,20 +729,47 @@ describe("neon mcp", () => {
 			runOptions(home, cwd),
 		);
 		const { stderr } = await testCliCommand(
-			["mcp", "--project-id", "proj-flag", "--agent", "cursor"],
+			["mcp", "--project-id", "proj-in-org", "--agent", "cursor"],
 			runOptions(home, cwd),
 		);
 		const written = JSON.parse(
 			readFileSync(join(home, ".cursor", "mcp.json"), "utf8"),
 		);
 		expect(written.mcpServers.Neon.url).toBe(
-			neonMcpUrl({ projectId: "proj-flag" }),
+			neonMcpUrl({ projectId: "proj-in-org" }),
 		);
 		expect(written.mcpServers.Neon.headers.Authorization).toBe(
 			`Bearer ${SECRET}`,
 		);
 		expect(stderr).toMatch(/Reusing the API key/);
 		expect(stderr).not.toMatch(/Minted API key/);
-		expect(stderr).toMatch(/\?projectId=proj-flag/);
+		expect(stderr).toMatch(/\?projectId=proj-in-org/);
+	});
+
+	test("revokes a project-scoped key when every write fails", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd } = scratch();
+		mkdirSync(join(home, ".cursor", "mcp.json"));
+		const { stderr } = await testCliCommand(
+			["mcp", "--project-id", "proj-in-org", "--agent", "cursor"],
+			{ ...runOptions(home, cwd), code: 1 },
+		);
+		expect(stderr).toMatch(/has been revoked/);
+		expect(stderr).not.toMatch(/could NOT be revoked/);
+	});
+
+	test("failed project-key revoke names --org-id", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd } = scratch();
+		mkdirSync(join(home, ".cursor", "mcp.json"));
+		const { stderr } = await testCliCommand(
+			["mcp", "--project-id", "proj-revoke-fail", "--agent", "cursor"],
+			{ ...runOptions(home, cwd), code: 1 },
+		);
+		expect(stderr).toMatch(/could NOT be revoked/);
+		expect(stderr).toMatch(/api-keys revoke 500 --org-id org-7/);
+		assertNoSecret("", stderr);
 	});
 });

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -553,6 +553,38 @@ describe("neon mcp", () => {
 		assertNoSecret("", stderr);
 	});
 
+	test("--project-id that looks like an org id does not suggest --org-id", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd } = scratch();
+		const { stderr } = await testCliCommand(
+			["mcp", "--project-id", "org-7", "--agent", "cursor"],
+			{ ...runOptions(home, cwd), code: 1 },
+		);
+		expect(stderr).toMatch(/looks like an organization id/);
+		expect(stderr).toMatch(/neon mcp takes a project id on --project-id/);
+		expect(stderr).not.toMatch(/Pass it as --org-id/);
+		expect(stderr).not.toMatch(/Minted API key/);
+		expect(existsSync(join(home, ".cursor", "mcp.json"))).toBe(false);
+	});
+
+	test("a project with no organization names --oauth", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd } = scratch();
+		const { stderr } = await testCliCommand(
+			["mcp", "--project-id", "test", "--agent", "cursor"],
+			{ ...runOptions(home, cwd), code: 1 },
+		);
+		expect(stderr).toMatch(/does not belong to an organization/);
+		expect(stderr).toMatch(/Pass --oauth to pin tools without minting/);
+		expect(stderr).not.toMatch(
+			/Omit --project-id to create an account key/,
+		);
+		expect(stderr).not.toMatch(/Minted API key/);
+		expect(existsSync(join(home, ".cursor", "mcp.json"))).toBe(false);
+	});
+
 	test("unknown --project-id fails without minting", async ({
 		testCliCommand,
 	}) => {
@@ -742,6 +774,8 @@ describe("neon mcp", () => {
 			`Bearer ${SECRET}`,
 		);
 		expect(stderr).toMatch(/Reusing the API key/);
+		expect(stderr).toMatch(/keeps its existing scope/);
+		expect(stderr).toMatch(/--oauth/);
 		expect(stderr).not.toMatch(/Minted API key/);
 		expect(stderr).toMatch(/\?projectId=proj-in-org/);
 	});

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -58,7 +58,7 @@ export const builder = (argv: yargs.Argv) =>
 				type: "boolean",
 				default: false,
 				describe:
-					"Write project-level MCP config. Skips the config-location question. Does not change the minted key",
+					"Write project-level MCP config. Skips the config-location question. A linked project-folder install may still pin a project and scope a newly minted key",
 			},
 			yes: {
 				alias: "y",
@@ -249,6 +249,11 @@ export const handler = async (props: McpProps) => {
 		log.info(
 			"Reusing the API key already configured for the Neon MCP server.",
 		);
+		if (plan.urlProjectId) {
+			log.warning(
+				"That key keeps its existing scope. Remove the Neon MCP entry to mint a project-scoped key, or pass --oauth to pin tools without a key.",
+			);
+		}
 	} else {
 		minted = await mintMcpApiKey({
 			apiClient: props.apiClient,

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -11,7 +11,11 @@ import {
 	parseMcpCategories,
 	trackedProjectMcpConfig,
 } from "../mcp/install.js";
-import { mintMcpApiKey, withdrawMintedKey } from "../mcp/mint.js";
+import {
+	mintedKeyRevokeCommand,
+	mintMcpApiKey,
+	withdrawMintedKey,
+} from "../mcp/mint.js";
 import { resolveMcpPlan } from "../mcp/plan.js";
 import { resolveInstallTargets } from "../mcp/targets.js";
 import { confirmMcpInstall } from "../mcp/wizard.js";
@@ -97,7 +101,7 @@ export const builder = (argv: yargs.Argv) =>
 			"project-id": {
 				type: "string",
 				describe:
-					"Pin MCP tools to one Neon project (?projectId=). Does not change the minted key. Interactive asks only for a linked project-folder install",
+					"Pin MCP tools to one Neon project (?projectId=). A newly minted API key is limited to that project. A linked project-folder install asks the same when you pick API-key auth",
 				coerce: single("project-id"),
 			},
 			category: {
@@ -228,6 +232,7 @@ export const handler = async (props: McpProps) => {
 			auth: plan.auth,
 			reuse: existing !== undefined,
 			url,
+			mintProjectId: plan.urlProjectId,
 		});
 		if (!ok) {
 			log.info("Aborted. Nothing was written.");
@@ -247,11 +252,19 @@ export const handler = async (props: McpProps) => {
 	} else {
 		minted = await mintMcpApiKey({
 			apiClient: props.apiClient,
+			projectId: plan.urlProjectId,
 		});
 		auth = { kind: "api-key", apiKey: minted.key };
-		log.warning(
-			"This key reaches everything your account can, in every organization.",
-		);
+		if (minted.projectId) {
+			log.info(
+				"Limited to %s: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.",
+				minted.projectId,
+			);
+		} else {
+			log.warning(
+				"This key reaches everything your account can, in every organization.",
+			);
+		}
 	}
 
 	const rows: McpInstallRow[] = [];
@@ -294,7 +307,7 @@ export const handler = async (props: McpProps) => {
 			throw new Error(
 				withdrawn
 					? "Failed to write Neon MCP config to any agent. The minted API key has been revoked."
-					: `Failed to write Neon MCP config to any agent. The minted API key could NOT be revoked. Remove it with \`${getCliName()} api-keys revoke ${minted.id}\`.`,
+					: `Failed to write Neon MCP config to any agent. The minted API key could NOT be revoked. Remove it with \`${mintedKeyRevokeCommand(minted)}\`.`,
 			);
 		}
 		throw new Error("Failed to write Neon MCP config to any agent.");
@@ -311,10 +324,11 @@ export const handler = async (props: McpProps) => {
 
 	if (minted) {
 		log.info(
-			"Minted API key %s (id %d, account). Revoke with: %s",
+			"Minted API key %s (id %d, %s). Revoke with: %s",
 			minted.name,
 			minted.id,
-			`${getCliName()} api-keys revoke ${minted.id}`,
+			minted.projectId ? "project" : "account",
+			mintedKeyRevokeCommand(minted),
 		);
 	}
 

--- a/packages/cli/src/mcp/mint.ts
+++ b/packages/cli/src/mcp/mint.ts
@@ -127,7 +127,11 @@ export async function mintMcpApiKey(options: {
 	const name = mintedKeyName("mcp");
 	const projectId = options.projectId;
 	if (projectId !== undefined) {
-		const orgId = await orgIdForProject(options.apiClient, projectId);
+		const orgId = await orgIdForProject(
+			options.apiClient,
+			projectId,
+			"mcp",
+		);
 		return createAndAssert(
 			options.apiClient,
 			() =>

--- a/packages/cli/src/mcp/mint.ts
+++ b/packages/cli/src/mcp/mint.ts
@@ -1,4 +1,5 @@
 import { isNeonApiError, type NeonApiClient } from "../api.js";
+import { orgIdForProject } from "../commands/api_keys.js";
 import { log } from "../log.js";
 import { mintedKeyName } from "../profile_keys.js";
 import { getCliName } from "../utils/cli_name.js";
@@ -7,20 +8,33 @@ export type MintedMcpKey = {
 	id: number;
 	name: string;
 	key: string;
+	orgId?: string;
+	projectId?: string;
 };
 
 const cannotMintMessage =
 	"This CLI credential cannot mint API keys. Organization and project-scoped keys cannot create other keys. Sign in with `neon auth` or pass a personal API key.";
 
+export function mintedKeyRevokeCommand(
+	key: Pick<MintedMcpKey, "id" | "orgId">,
+): string {
+	return key.orgId
+		? `${getCliName()} api-keys revoke ${key.id} --org-id ${key.orgId}`
+		: `${getCliName()} api-keys revoke ${key.id}`;
+}
+
 const withdraw = async (
 	client: NeonApiClient,
 	keyId: number | undefined,
+	orgId?: string,
 ): Promise<boolean> => {
 	if (!Number.isSafeInteger(keyId) || keyId === undefined || keyId <= 0) {
 		return false;
 	}
 	try {
-		const { data } = await client.revokeApiKey(keyId);
+		const { data } = orgId
+			? await client.revokeOrgApiKey(orgId, keyId)
+			: await client.revokeApiKey(keyId);
 		return data.revoked === true && data.id === keyId;
 	} catch (err) {
 		log.error(
@@ -36,17 +50,21 @@ const assertUsable = async (
 	client: NeonApiClient,
 	data: { id?: number; key?: string; name?: string; project_id?: string },
 	fallbackName: string,
+	scope: { orgId?: string; projectId?: string },
 ): Promise<MintedMcpKey> => {
+	const wanted = scope.projectId;
 	const problem =
 		typeof data.key !== "string" || data.key.trim() === ""
 			? "Neon returned no key."
-			: data.project_id !== undefined
-				? `Neon returned a key scoped to ${data.project_id} rather than the whole account.`
+			: data.project_id !== wanted
+				? wanted === undefined
+					? `Neon returned a key scoped to ${data.project_id} rather than the whole account.`
+					: `Neon returned a key scoped to ${data.project_id ?? "nothing"} rather than ${wanted}.`
 				: !Number.isSafeInteger(data.id)
 					? "Neon returned no key id."
 					: null;
 	if (problem) {
-		const withdrawn = await withdraw(client, data.id);
+		const withdrawn = await withdraw(client, data.id, scope.orgId);
 		throw new Error(
 			`${problem} ${
 				withdrawn
@@ -54,7 +72,10 @@ const assertUsable = async (
 					: `The key could NOT be revoked and may still be live${
 							data.id === undefined
 								? ""
-								: `. Remove it with \`${getCliName()} api-keys revoke ${data.id}\``
+								: `. Remove it with \`${mintedKeyRevokeCommand({
+										id: data.id,
+										orgId: scope.orgId,
+									})}\``
 						}.`
 			}`,
 		);
@@ -70,29 +91,65 @@ const assertUsable = async (
 		id,
 		name: data.name ?? fallbackName,
 		key,
+		orgId: scope.orgId,
+		projectId: scope.projectId,
 	};
 };
 
-export async function mintMcpApiKey(options: {
-	apiClient: NeonApiClient;
-}): Promise<MintedMcpKey> {
-	const name = mintedKeyName("mcp");
+const createAndAssert = async (
+	client: NeonApiClient,
+	create: () => Promise<{
+		data: {
+			id?: number;
+			key?: string;
+			name?: string;
+			project_id?: string;
+		};
+	}>,
+	name: string,
+	scope: { orgId?: string; projectId?: string },
+): Promise<MintedMcpKey> => {
 	try {
-		const { data } = await options.apiClient.createApiKey({
-			key_name: name,
-		});
-		return assertUsable(options.apiClient, data, name);
+		const { data } = await create();
+		return assertUsable(client, data, name, scope);
 	} catch (err) {
 		if (isNeonApiError(err) && (err.status === 403 || err.status === 404)) {
 			throw new Error(cannotMintMessage);
 		}
 		throw err;
 	}
+};
+
+export async function mintMcpApiKey(options: {
+	apiClient: NeonApiClient;
+	projectId?: string;
+}): Promise<MintedMcpKey> {
+	const name = mintedKeyName("mcp");
+	const projectId = options.projectId;
+	if (projectId !== undefined) {
+		const orgId = await orgIdForProject(options.apiClient, projectId);
+		return createAndAssert(
+			options.apiClient,
+			() =>
+				options.apiClient.createOrgApiKey(orgId, {
+					key_name: name,
+					project_id: projectId,
+				}),
+			name,
+			{ orgId, projectId },
+		);
+	}
+	return createAndAssert(
+		options.apiClient,
+		() => options.apiClient.createApiKey({ key_name: name }),
+		name,
+		{},
+	);
 }
 
 export async function withdrawMintedKey(
 	apiClient: NeonApiClient,
 	key: MintedMcpKey,
 ): Promise<boolean> {
-	return withdraw(apiClient, key.id);
+	return withdraw(apiClient, key.id, key.orgId);
 }

--- a/packages/cli/src/mcp/plan.test.ts
+++ b/packages/cli/src/mcp/plan.test.ts
@@ -89,9 +89,10 @@ describe("resolveMcpPlan", () => {
 					calls.push("auth");
 					return "oauth";
 				},
-				pickProjectPin: async (linked) => {
+				pickProjectPin: async (linked, willMintKey) => {
 					calls.push("pin");
 					expect(linked).toBe("proj-linked");
+					expect(willMintKey).toBe(false);
 					return true;
 				},
 			}),
@@ -167,6 +168,26 @@ describe("resolveMcpPlan", () => {
 		expect(plan.agents).toEqual(["claude-code"]);
 	});
 
+	test("pin yes with API-key auth sets urlProjectId", async () => {
+		const cwd = tmpDir();
+		mkdirSync(join(cwd, ".cursor"));
+		const plan = await resolveMcpPlan(
+			planOptions(cwd, {
+				project: true,
+				agents: ["cursor"],
+				linkedProjectId: "proj-linked",
+				pickAuth: async () => "api-key",
+				pickProjectPin: async (linked, willMintKey) => {
+					expect(linked).toBe("proj-linked");
+					expect(willMintKey).toBe(true);
+					return true;
+				},
+			}),
+		);
+		expect(plan.auth).toBe("api-key");
+		expect(plan.urlProjectId).toBe("proj-linked");
+	});
+
 	test("--project-id skips the pin prompt", async () => {
 		const cwd = tmpDir();
 		const plan = await resolveMcpPlan(
@@ -211,6 +232,23 @@ describe("resolveMcpPlan", () => {
 				},
 			}),
 		);
+		expect(plan.urlProjectId).toBeUndefined();
+	});
+
+	test("pin no with API-key auth leaves urlProjectId unset", async () => {
+		const cwd = tmpDir();
+		const plan = await resolveMcpPlan(
+			planOptions(cwd, {
+				project: true,
+				linkedProjectId: "proj-linked",
+				pickAuth: async () => "api-key",
+				pickProjectPin: async (_linked, willMintKey) => {
+					expect(willMintKey).toBe(true);
+					return false;
+				},
+			}),
+		);
+		expect(plan.auth).toBe("api-key");
 		expect(plan.urlProjectId).toBeUndefined();
 	});
 
@@ -325,5 +363,19 @@ describe("mcpInstallSummary", () => {
 			"mint an account-wide API key that reaches every organization",
 		);
 		expect(summary).toContain("this directory");
+	});
+
+	test("--project-id names a key limited to that project", () => {
+		expect(
+			mcpInstallSummary({
+				scope: "global",
+				install: ["cursor"],
+				skipped: [],
+				auth: "api-key",
+				reuse: false,
+				url: neonMcpUrl({ projectId: "proj-in-org" }),
+				mintProjectId: "proj-in-org",
+			}),
+		).toContain("mint an API key limited to proj-in-org");
 	});
 });

--- a/packages/cli/src/mcp/plan.ts
+++ b/packages/cli/src/mcp/plan.ts
@@ -39,7 +39,10 @@ export type ResolveMcpPlanOptions = {
 	pickScope?: () => Promise<McpInstallScope>;
 	pickAgents?: (options: PickAgentsOptions) => Promise<AgentType[]>;
 	pickAuth?: () => Promise<McpAuthKind>;
-	pickProjectPin?: (linkedProjectId: string) => Promise<boolean>;
+	pickProjectPin?: (
+		linkedProjectId: string,
+		willMintKey: boolean,
+	) => Promise<boolean>;
 };
 
 export async function resolveMcpPlan(
@@ -94,6 +97,7 @@ export async function resolveMcpPlan(
 	) {
 		const pin = await (options.pickProjectPin ?? pickMcpProjectPin)(
 			options.linkedProjectId,
+			auth === "api-key",
 		);
 		if (pin) {
 			urlProjectId = options.linkedProjectId;

--- a/packages/cli/src/mcp/wizard.ts
+++ b/packages/cli/src/mcp/wizard.ts
@@ -90,7 +90,7 @@ export const pickMcpProjectPin = async (
 		type: "confirm",
 		name: "pin",
 		message: willMintKey
-			? `Pin MCP tools and the minted API key to the linked project ${linkedProjectId}?`
+			? `Pin MCP tools to the linked project ${linkedProjectId}? A newly minted API key would be limited to that project.`
 			: `Pin MCP tools to the linked project ${linkedProjectId}?`,
 		initial: true,
 	});

--- a/packages/cli/src/mcp/wizard.ts
+++ b/packages/cli/src/mcp/wizard.ts
@@ -80,6 +80,7 @@ export const pickMcpAuth = async (): Promise<McpAuthKind> => {
 
 export const pickMcpProjectPin = async (
 	linkedProjectId: string,
+	willMintKey = false,
 ): Promise<boolean> => {
 	if (!canPickAgentsInteractively()) {
 		return false;
@@ -88,7 +89,9 @@ export const pickMcpProjectPin = async (
 		onState: restoreCursorOnAbort,
 		type: "confirm",
 		name: "pin",
-		message: `Pin MCP tools to the linked project ${linkedProjectId}?`,
+		message: willMintKey
+			? `Pin MCP tools and the minted API key to the linked project ${linkedProjectId}?`
+			: `Pin MCP tools to the linked project ${linkedProjectId}?`,
 		initial: true,
 	});
 	return pin === true;
@@ -101,6 +104,7 @@ export const mcpInstallSummary = (options: {
 	auth: McpAuthKind;
 	reuse: boolean;
 	url: string;
+	mintProjectId?: string;
 }): string => {
 	const agents = options.install.map(getAgentDisplayName).join(", ");
 	const auth =
@@ -108,7 +112,9 @@ export const mcpInstallSummary = (options: {
 			? "OAuth, agent signs in on first use"
 			: options.reuse
 				? "reuse the API key already in agent config"
-				: "mint an account-wide API key that reaches every organization";
+				: options.mintProjectId
+					? `mint an API key limited to ${options.mintProjectId}`
+					: "mint an account-wide API key that reaches every organization";
 	const rows: [string, string][] = [
 		[
 			"Config",
@@ -141,6 +147,7 @@ export const confirmMcpInstall = async (options: {
 	auth: McpAuthKind;
 	reuse: boolean;
 	url: string;
+	mintProjectId?: string;
 }): Promise<boolean> => {
 	if (!canPickAgentsInteractively()) {
 		return true;


### PR DESCRIPTION
## Problem

`neon mcp --project-id <id>` pins the MCP tools to one project by adding `?projectId=` to the server URL. The API key it minted was account-wide. The agent ended up holding a credential that reaches every project in every organization the account belongs to, while its tool list was restricted to one project.

The linked-project pin had the same result. A project-folder install in a `.neon`-linked directory asks whether to pin MCP tools to that project; answering yes changed the URL and left the key account-wide.

The mint call was `POST /api_keys`, which takes a key name and nothing else. There was no place to put the project the user had just named.

## Diagnosis

Project-scoped keys only exist on the organization endpoint: `POST /organizations/{org_id}/api_keys` with a `project_id` in the body. Minting one needs an org id and the pin only ever carried a project id, so scoping the key looked like it needed a second question in an already long wizard.

It needs no question. `neon api-keys create --project-id` already resolves the org from the project through `orgIdForProject` and it also verifies the result: the response's `project_id` is optional, so a key that comes back scoped to something other than what was asked for is revoked instead of handed over. `neon mcp` now calls the same three steps in the same order.

## What a pinned mint does now

```console
$ neon mcp --project-id proj-in-org --agent cursor
INFO: Limited to proj-in-org: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.
INFO: Wrote /Users/andre/.cursor/mcp.json
INFO: URL: https://mcp.neon.tech/mcp?projectId=proj-in-org
MCP
Agent   Status
cursor  installed
INFO: Minted API key neon-cli-mcp-20260825T052713Z-e30a (id 303, project). Revoke with: neon api-keys revoke 303 --org-id org-7
```

The written config carries the project-scoped key (the run above went against the repo's mock API, so the Bearer is the mock fixture value):

```json
{
  "mcpServers": {
    "Neon": {
      "url": "https://mcp.neon.tech/mcp?projectId=proj-in-org",
      "headers": {
        "Authorization": "Bearer napi_org_secret"
      }
    }
  }
}
```

Two things in that output are new besides the scope of the key. The mint line says `project` where it used to always say `account`. The revoke command it prints carries `--org-id`, because a project-scoped key cannot be revoked through the account endpoint.

Without a pin, nothing changes:

```console
$ neon mcp --agent cursor
WARNING: This key reaches everything your account can, in every organization.
...
INFO: Minted API key neon-cli-mcp-20260825T052722Z-ae0a (id 201, account). Revoke with: neon api-keys revoke 201
```

## When the minted key is scoped

| Invocation | Key |
| --- | --- |
| `neon mcp --project-id <id>` | scoped to `<id>` |
| `neon mcp --project` in a `.neon`-linked folder, pin accepted, API-key auth | scoped to the linked project |
| `neon mcp --project` in a `.neon`-linked folder, pin declined | account-wide |
| `neon mcp`, `neon mcp -y`, `neon mcp --project -y` | account-wide |
| `--oauth`, with or without a pin | no key is minted |
| a Bearer already in the agent config | reused as it is, whatever scope it has |

`-y` still does not read a project out of `.neon`, with or without `--project`. A pinned key is a narrower credential than the previous default. Inferring it from the working directory would change what a scripted `neon mcp -y` writes. The pin stays something you either ask for on the command line or accept at the prompt.

## The interactive path

When API-key auth is the selected mode, the pin prompt says what accepting it does to the key:

```text
? Pin MCP tools to the linked project proj-linked? A newly minted API key would be limited to that project. (Y/n)
```

The confirmation summary names the scope on the `Auth` row, so the last thing shown before anything is written is the reach of the credential:

```text
Config  this directory
Agents  Cursor
Auth    mint an API key limited to proj-in-org
URL     https://mcp.neon.tech/mcp?projectId=proj-in-org
```

## Reusing a Bearer

A key already configured for `https://mcp.neon.tech/mcp` is still reused rather than replaced. Pinning a project now says out loud that reuse leaves that key's scope alone:

```console
$ neon mcp --project-id proj-in-org --agent cursor
INFO: Reusing the API key already configured for the Neon MCP server.
WARNING: That key keeps its existing scope. Remove the Neon MCP entry to mint a project-scoped key, or pass --oauth to pin tools without a key.
INFO: URL: https://mcp.neon.tech/mcp?projectId=proj-in-org
```

## Errors

Resolving the project happens before the mint, so a bad `--project-id` costs nothing: no key is created and no agent config is written.

The first of these used to say to pass the id as `--org-id`, which is an `api-keys` flag that `neon mcp` does not have. The second offered only dropping `--project-id`. Both now name remedies that exist on this command:

```console
$ neon mcp --project-id org-7 --agent cursor
ERROR: Project org-7 not found. That looks like an organization id. neon mcp takes a project id on --project-id.

$ neon mcp --project-id test --agent cursor
ERROR: Project test does not belong to an organization, so it cannot have a project-scoped API key. Pass --oauth to pin tools without minting, or omit --project-id to mint an account-wide key.

$ neon mcp --project-id proj-flag --agent cursor
ERROR: Project proj-flag not found. Check the id with `neon projects list`.
```

`neon api-keys create --project-id` and `neon profile` keep the wording they had. `orgIdForProject` takes a `usage` argument that defaults to the `api-keys` phrasing and only `neon mcp` passes the other value.

## Checking the scope Neon returned

A key whose returned `project_id` is not the one that was asked for is revoked before the command fails:

```console
$ neon mcp --project-id proj-mismatch --agent cursor
ERROR: Neon returned a key scoped to some-other-project rather than proj-mismatch. The key has been revoked; nothing was issued.
```

The same holds for the existing "every agent write failed" path, which already withdrew the key it had just minted. It now withdraws through the org endpoint when the key is project-scoped. When the revoke itself fails it prints a command that works:

```console
ERROR: Failed to revoke API key 500: Internal error
ERROR: Failed to write Neon MCP config to any agent. The minted API key could NOT be revoked. Remove it with `neon api-keys revoke 500 --org-id org-7`.
```

## Also in here

- `packages/cli/README.md`: the `mcp` section describing `--project-id` and `--project` as leaving the key account-wide, plus the two flag descriptions in `neon mcp --help` that said the same thing. The README also now states that `-y` does not infer a project from `.neon`, which was true before and undocumented.
- A patch changeset for `neon` and `neonctl`.
- Mock fixtures for the two failure paths: a project whose org mint returns the wrong `project_id` and one whose revoke returns a 500. Both are reachable only through the org endpoint, so neither had a fixture.

## Verification

`vitest run` in `packages/cli` at `003a716`: 4390 passed, 6 pre-existing skips. `tsc --noEmit` and `biome check src` are clean.

The built CLI was run against the repo's mock API for every case shown above, including the two error paths, the mismatch revoke and the reuse warning.

Behaviours covered by the tests:

- `--project-id` mints on the org endpoint, writes the project-scoped Bearer, prints `project` and a revoke command with `--org-id` and never prints the account-wide warning
- `--project --project-id` scopes to the flag and the id in `.neon` appears nowhere in the output
- `-y --project` in a linked folder mints an account key and adds no `?projectId=`
- the pin prompt is passed whether a key will be minted, for both the accept and the decline answer
- the confirmation summary names the project the key will be limited to
- an unknown project, an org id passed as a project id and a project with no organization all fail before any key exists and before any config is written
- a returned `project_id` that disagrees with the request is revoked and the command fails without writing a config
- a failed revoke of a project-scoped key prints `--org-id`
- reuse of an existing Bearer with a pin warns and mints nothing

Not verified against the live Neon API. The org mint, the org revoke and the shape of the org-endpoint response are exercised against the repo's mocks only. The interactive prompt and summary strings are covered by unit tests rather than a real TTY.

## For your attention

- **A pinned mint fails where it used to succeed.** A project with no organization cannot have a project-scoped key, so `neon mcp --project-id <id>` against such a project now exits 1 instead of writing an account key. The message names both ways forward. This is the compatibility break in the change.
- **The mint needs a credential that can create org keys.** Project-scoped keys are created through the organization, so the caller needs the org permission to mint. An org-scoped or project-scoped CLI credential cannot mint at all, which was already true for account keys and produces the existing "This CLI credential cannot mint API keys" error.
- **Revoking a pinned key takes an extra flag.** `neon api-keys revoke <id>` alone will not find it. Every message that prints a revoke command for a project-scoped key includes `--org-id` and the README says so, but a user working from memory of the old output will reach for the short form.
- **The pin and the key can still disagree.** A reused Bearer keeps its own scope while the URL carries `?projectId=`. Removing the Neon entry from the agent config and re-running is the way to get both, which the warning says.
