### PR TITLE
chore: release neon@4.3.0, neonctl@4.3.0

### DIFF
--- a/.changeset/cli-neon-skills.md
+++ b/.changeset/cli-neon-skills.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-Add `neon skills` to install Neon agent skills into coding agents. A TTY asks agents and skills, then confirms. `-y` installs the default skills into detected agents in this directory. `--skill` names specific skills. `--global` is user-level. `neon skills update` refreshes installed skills.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.3.0
+
+### Minor Changes
+
+- eb52252: Add `neon skills` to install Neon agent skills into coding agents. A TTY asks agents and skills, then confirms. `-y` installs the default skills into detected agents in this directory. `--skill` names specific skills. `--global` is user-level. `neon skills update` refreshes installed skills.
+
 ## 4.2.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.2.1",
+	"version": "4.3.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.3.0
+
+### Minor Changes
+
+- eb52252: Add `neon skills` to install Neon agent skills into coding agents. A TTY asks agents and skills, then confirms. `-y` installs the default skills into detected agents in this directory. `--skill` names specific skills. `--global` is user-level. `neon skills update` refreshes installed skills.
+
+### Patch Changes
+
+- Updated dependencies [eb52252]
+  - neon@4.3.0
+
 ## 4.2.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.2.1",
+  "version": "4.3.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
`neon` 4.2.1 → 4.3.0. `neonctl` 4.2.1 → 4.3.0, bumped with it as a Changesets fixed group.

`pnpm changeset version` produced the whole diff. There are no source changes.

## What ships

`neon skills` landed on `main` in [#473](https://github.com/neondatabase/neon-pkgs/pull/473) and stays unreleased until a version bump lands. 4.3.0 is that bump.

```bash
neon skills                                      # TTY: pick agents and skills, then confirm
neon skills -y                                   # default skills into the agents detected in this directory
neon skills -s neon -s neon-ai-gateway -a cursor # named skills into named agents
neon skills --global                             # user-level instead of this directory
neon skills update                               # refresh installed skills
```

## Verification

`git diff origin/main...HEAD` at 7906409 touches five files and nothing under `src/`:

- `.changeset/cli-neon-skills.md` is deleted, so `.changeset/` now holds only `README.md` and `config.json`
- `packages/cli/package.json` and `packages/neonctl/package.json` both read `4.3.0`
- both `CHANGELOG.md` files carry the 4.3.0 minor entry, and `neonctl` also carries the `neon@4.3.0` dependency line the fixed group produces

The published packages are not verified here. Merging writes the versions to `main` and does nothing else.

## For your attention

- **Publish is a separate step.** npm gets 4.3.0 from a release workflow dispatch against `main` after this merges, `neon` first and then `neonctl`.