### PR TITLE
chore: release neon@4.3.1, neonctl@4.3.1

### DIFF
--- a/.changeset/cli-mcp-project-key.md
+++ b/.changeset/cli-mcp-project-key.md
@@ -1,6 +1,0 @@
----
-"neon": patch
-"neonctl": patch
----
-
-`neon mcp` mints a project-scoped API key when `--project-id` is set or a linked project is pinned, instead of an account-wide key.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.3.1
+
+### Patch Changes
+
+- 894b427: `neon mcp` mints a project-scoped API key when `--project-id` is set or a linked project is pinned, instead of an account-wide key.
+
 ## 4.3.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.3.0",
+	"version": "4.3.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.3.1
+
+### Patch Changes
+
+- 894b427: `neon mcp` mints a project-scoped API key when `--project-id` is set or a linked project is pinned, instead of an account-wide key.
+- Updated dependencies [894b427]
+  - neon@4.3.1
+
 ## 4.3.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## What this releases

`neon` and `neonctl` go 4.3.0 → 4.3.1. `pnpm changeset version` produced the whole diff. There are no source changes.

The behavior being released landed on `main` in [#476](https://github.com/neondatabase/neon-pkgs/pull/476) with its changeset unconsumed. A release in this repo is a version bump plus a `CHANGELOG.md` entry on `main`, so that behavior sits on `main` unreleased until one lands.

## What a user of 4.3.1 gets

`neon mcp` mints a project-scoped API key when the install is pinned to a single project, instead of an account-wide key.

Two ways to pin. Pass the project explicitly:

```bash
neon mcp --project-id <project-id>
```

Or install from a directory whose linked project is already pinned:

```bash
neon link
neon mcp
```

Either way the CLI reports the scope of the key it minted:

```
Limited to <project-id>: it cannot create projects, mint API keys, or read any other project. It can still change and delete everything inside that project.
```

With no project pinned, the key is account-wide and carries the warning it did in 4.3.0:

```
This key reaches everything your account can, in every organization.
```

One case does not mint at all: when the agent config already has a Neon API key, that key is reused and keeps whatever scope it had. Pinning a project in that state prints a warning rather than replacing the key.

```
That key keeps its existing scope. Remove the Neon MCP entry to mint a project-scoped key, or pass --oauth to pin tools without a key.
```

`neon mcp --oauth` installs without minting a key, unchanged.

## Also in here

- `.changeset/cli-mcp-project-key.md` is consumed and deleted. `.changeset/` now holds only `README.md` and `config.json`.
- `neonctl` is in a fixed group with `neon` in `.changeset/config.json`, so it takes the same version and the same changelog entry plus the `neon@4.3.1` dependency line. It depends on `neon` as `workspace:*`, so no dependency range moved.

## Verification

`git diff origin/main...HEAD` at 54ea228 touches five files:

- `packages/cli/package.json`: `4.3.0` → `4.3.1`
- `packages/neonctl/package.json`: `4.3.0` → `4.3.1`
- `packages/cli/CHANGELOG.md`: a `## 4.3.1` patch entry crediting 894b427
- `packages/neonctl/CHANGELOG.md`: the same entry, plus `Updated dependencies [894b427]` and `neon@4.3.1`
- `.changeset/cli-mcp-project-key.md`: deleted

Nothing under `src/`.

No build, test or lint run backs this description. The diff contains no source changes, so the runtime behavior of both packages is whatever 894b427 already put on `main`. The published tarballs are not verified here either, since this repo does not publish to npm.

## For your attention

- **Merging this lands versions only.** The npm publish is a separate release run against the versions on `main`. Until that runs, 4.3.1 exists in the repo and not on the registry.
- **`neonctl` bumps with no change of its own.** The fixed group means it always ships in lockstep with `neon`, so a `neon`-only patch still produces a `neonctl` release.