### PR TITLE
chore: release neon@4.4.0, neonctl@4.4.0

### DIFF
--- a/.changeset/cli-neon-plugins.md
+++ b/.changeset/cli-neon-plugins.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-Add `neon plugins` to install the Neon agent plugin into coding agents. A TTY asks agents, then confirms. `-y` installs into detected agents at project scope. `--agent` names specific agents. `--global` is user scope.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.3.2
+
+### Patch Changes
+
+- Attribute CLI telemetry to Claude Code and Codex command trees.
+
 ## 4.3.1
 
 ### Patch Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neon
 
+## 4.4.0
+
+### Minor Changes
+
+- bdb0db6: Add `neon plugins` to install the Neon agent plugin into coding agents. A TTY asks agents, then confirms. `-y` installs into detected agents at project scope. `--agent` names specific agents. `--global` is user scope.
+
+### Patch Changes
+
+- Attribute CLI telemetry to Claude Code and Codex command trees.
+
 ## 4.3.1
 
 ### Patch Changes

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,11 +1,5 @@
 # neon
 
-## 4.3.2
-
-### Patch Changes
-
-- Attribute CLI telemetry to Claude Code and Codex command trees.
-
 ## 4.3.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.3.1",
+	"version": "4.4.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.3.2",
+	"version": "4.3.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.3.1",
+	"version": "4.3.2",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,17 @@
 # neonctl
 
+## 4.4.0
+
+### Minor Changes
+
+- bdb0db6: Add `neon plugins` to install the Neon agent plugin into coding agents. A TTY asks agents, then confirms. `-y` installs into detected agents at project scope. `--agent` names specific agents. `--global` is user scope.
+
+### Patch Changes
+
+- Updated dependencies [bdb0db6]
+- Updated dependencies
+  - neon@4.4.0
+
 ## 4.3.1
 
 ### Patch Changes

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.3.2
+
+### Patch Changes
+
+- Updated dependencies
+  - neon@4.3.2
+
 ## 4.3.1
 
 ### Patch Changes

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,12 +1,5 @@
 # neonctl
 
-## 4.3.2
-
-### Patch Changes
-
-- Updated dependencies
-  - neon@4.3.2
-
 ## 4.3.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.3.2",
+  "version": "4.3.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
`neon` 4.3.1 → 4.4.0. `neonctl` 4.3.1 → 4.4.0, bumped with it as a Changesets fixed group.

`pnpm changeset version` produced the whole diff. There are no source changes.

## What ships

Two changes are sitting on `main` unreleased. A release in this repo is a version bump plus a `CHANGELOG.md` entry, so 4.4.0 is what puts them on the registry.

`neon plugins` installs the Neon agent plugin into coding agents:

```bash
neon plugins                                    # TTY: pick agents, then confirm
neon plugins -y                                 # detected agents in this directory, no prompts
neon plugins --agent cursor --agent claude-code # named agents
neon plugins --global                           # user scope instead of this directory
```

The patch is telemetry attribution. CLI analytics events now carry an `agent` property set to `claude-code` or `codex` when the environment the CLI runs in says the invocation came from one of those tools.

## Verification

`git diff origin/main...HEAD` at 6a436f0 touches five files and nothing under `src/`:

- `.changeset/cli-neon-plugins.md` is deleted, so `.changeset/` now holds only `README.md` and `config.json`
- `packages/cli/package.json` and `packages/neonctl/package.json` both read `4.4.0`
- both `CHANGELOG.md` files carry the 4.4.0 minor and patch entries, and `neonctl` also carries the `neon@4.4.0` dependency line the fixed group produces

`pnpm lint:ci` passed.

The published packages are not verified here. Merging writes the versions to `main` and does nothing else.

## For your attention

- **Publish is a separate step.** npm gets 4.4.0 from a release workflow dispatch against `main` after this merges, `neon` first and then `neonctl`.
- **`neonctl` bumps with no change of its own.** It depends on `neon` as `workspace:*`, so no dependency range moved.