### PR TITLE
chore: release neon@4.5.0, neonctl@4.5.0

### DIFF
--- a/.changeset/calm-bears-claim.md
+++ b/.changeset/calm-bears-claim.md
@@ -1,8 +1,0 @@
----
-"neon": minor
-"@neon/config": patch
----
-
-Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`. `list` prints `state` from the assertion clock and the project expiry, and `delete` drops a local record after the identity assertion expires. `create` prints CLI service names and `project_expires_at`.
-
-Recognize Claimable Neon capability errors in Config-as-Code so unavailable pre-claim services keep their actionable claim guidance instead of being reported as API-key failures.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neon-internals/env-core
 
+## 0.0.3
+
+### Patch Changes
+
+- Updated dependencies [512baf3]
+  - @neon/config@1.0.3
+
 ## 0.0.2
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # neon
 
+## 4.5.0
+
+### Minor Changes
+
+- 512baf3: Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`. `list` prints `state` from the assertion clock and the project expiry, and `delete` drops a local record after the identity assertion expires. `create` prints CLI service names and `project_expires_at`.
+
+  Recognize Claimable Neon capability errors in Config-as-Code so unavailable pre-claim services keep their actionable claim guidance instead of being reported as API-key failures.
+
+### Patch Changes
+
+- Updated dependencies [512baf3]
+  - @neon/config@1.0.3
+  - @neon/config-runtime@1.0.3
+
 ## 4.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.4.0",
+	"version": "4.5.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config-runtime
 
+## 1.0.3
+
+### Patch Changes
+
+- Updated dependencies [512baf3]
+  - @neon/config@1.0.3
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @neondatabase/config
 
+## 1.0.3
+
+### Patch Changes
+
+- 512baf3: Add `neon claim` and its `claimable` alias for creating, using, claiming, listing, and deleting temporary Claimable Neon projects without an account. `status`, `accept`, and `delete` take an optional project id from `claim list`. `list` prints `state` from the assertion clock and the project expiry, and `delete` drops a local record after the identity assertion expires. `create` prints CLI service names and `project_expires_at`.
+
+  Recognize Claimable Neon capability errors in Config-as-Code so unavailable pre-claim services keep their actionable claim guidance instead of being reported as API-key failures.
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/env
 
+## 1.1.3
+
+### Patch Changes
+
+- Updated dependencies [512baf3]
+  - @neon/config@1.0.3
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.5.0
+
+### Patch Changes
+
+- Updated dependencies [512baf3]
+  - neon@4.5.0
+
 ## 4.4.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

`neon claim` and its `claimable` alias are on `main` from #423, along with the Claimable Neon capability-error handling in Config-as-Code. Neither is on npm. `npm latest` is still `neon@4.4.0` / `neonctl@4.4.0`, and `npx neon@4.4.0 claim --help` does not list `create`, so anyone following the claim flow against the published CLI hits a command that isn't there.

The pending changeset `.changeset/calm-bears-claim.md` is what blocks the release. Until it is consumed, no version exists to publish.

## The change

`changeset version` run on `main`. The changeset file is deleted, `package.json` versions are bumped and each `CHANGELOG.md` gets the entry. No source files change.

| Package | From | To | Why |
| --- | --- | --- | --- |
| `neon` | 4.4.0 | 4.5.0 | minor: `neon claim` / `claimable` |
| `neonctl` | 4.4.0 | 4.5.0 | fixed group with `neon` |
| `@neon/config` | 1.0.2 | 1.0.3 | patch: Claimable Neon capability errors |
| `@neon/config-runtime` | 1.0.2 | 1.0.3 | dependent of `@neon/config` |
| `@neon/env` | 1.1.2 | 1.1.3 | dependent of `@neon/config` |
| `@neon-internals/env-core` | 0.0.2 | 0.0.3 | dependent of `@neon/config`; private, never published |

## What users get on merge

The published `neon` gains the claim command group. From the changeset now in `packages/cli/CHANGELOG.md`:

```
neon claim
neon claimable   # alias
```

`create`, `use`, `accept`, `list`, `status` and `delete`. `status`, `accept` and `delete` take an optional project id from `claim list`. `list` prints `state` from the assertion clock plus the project expiry. `delete` drops a local record once the identity assertion has expired. `create` prints the CLI service names and `project_expires_at`.

`neonctl` behavior is unchanged; it moves to 4.5.0 only because it is versioned in a fixed group with `neon`.

For `@neon/config`, `@neon/config-runtime` and `@neon/env` callers, no exported signature changes. The `@neon/config` patch is the capability-error recognition from #423: an unavailable pre-claim service keeps its claim guidance instead of surfacing as an API-key failure.

## Verification

- `biome ci --error-on-warnings` passed across 726 files.
- The version bumps and changelog entries in this diff are the output of the changesets tool, not hand-edited.

Not verified here: the `neon claim` behavior itself. That was exercised in #423 against the live service. This branch contains no code to exercise.

Nothing has been published from this branch. Release happens through the pipeline after merge, and `npm latest` should be checked for `neon@4.5.0` and `neonctl@4.5.0` once it completes.

## For your attention

- `@neon/config` ships a patch that has nothing to do with claiming, from the same changeset. #423 changed both, so they release together. Splitting them now would mean editing a consumed changeset.
- `@neon-internals/env-core` is bumped but private. The version move is bookkeeping inside the monorepo and no artifact leaves it.