### PR TITLE
Add `branches.resetFromParent` and `branches.compareSchema` to the SDK and tools

### DIFF
--- a/.changeset/reset-from-parent-and-schema-compare.md
+++ b/.changeset/reset-from-parent-and-schema-compare.md
@@ -1,0 +1,6 @@
+---
+"@neon/sdk": minor
+"@neon/tools": minor
+---
+
+Add `branches.resetFromParent` and `branches.compareSchema` to the SDK and as tools (`reset_from_parent_branches`, `compare_schema_branches`).

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -238,6 +238,8 @@ await neon.projects.transfer({
 | `createWithCompute(projectId, input, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
 | `getDefault(projectId)` | `Branch` | resolves the default branch by the `default` flag |
 | `setDefault(projectId, branchId)` | `Branch` | |
+| `resetFromParent(projectId, branchId, { preserveUnderName? }?)` | `Branch` | parent HEAD only. `preserveUnderName` is required when the branch has children |
+| `compareSchema(projectId, branchId, input)` | `{ diff? }` | `input`: `{ databaseName, baseBranchId?, lsn?, timestamp?, baseLsn?, baseTimestamp? }`. Omitting `baseBranchId` compares against the parent |
 | `finalizeRestore(projectId, branchId, { name? }?)` | **→void** | commits a restore previewed with `snapshots.restore({ finalize: false })` |
 
 **There is no `recover`.** Neon stopped publishing `POST /projects/{project_id}/branches/{branch_id}/recover` in its OpenAPI spec, so the wrapper is gone until it returns. The endpoint still answers, so a soft-deleted branch can still be recovered through the low-level client — note that this envelope carries the API's own error body rather than a `NeonError`:
@@ -257,6 +259,18 @@ const branch = data?.branch;
 ```ts
 // Resolve the project's default ("production") branch
 const { data: prod } = await neon.branches.getDefault(projectId);
+
+const { data: reset } = await neon.branches.resetFromParent(
+  projectId,
+  feature.id,
+  { preserveUnderName: "feature-before-reset" },
+);
+
+const { data: schema } = await neon.branches.compareSchema(
+  projectId,
+  feature.id,
+  { databaseName: "neondb" },
+);
 
 // Branch off it with its own compute — returns a ready connection string
 const { data } = await neon.branches.createWithCompute(projectId, {

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -238,7 +238,7 @@ await neon.projects.transfer({
 | `createWithCompute(projectId, input, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
 | `getDefault(projectId)` | `Branch` | resolves the default branch by the `default` flag |
 | `setDefault(projectId, branchId)` | `Branch` | |
-| `resetFromParent(projectId, branchId, { preserveUnderName? }?)` | `Branch` | parent HEAD only. `preserveUnderName` is required when the branch has children |
+| `resetFromParent(projectId, branchId, { preserveUnderName? }?)` | `Branch` | parent HEAD only; discards writes since the branch diverged. `preserveUnderName` is required when the branch has children. Pass `{ waitForReadiness: true }` before using the branch |
 | `compareSchema(projectId, branchId, input)` | `{ diff? }` | `input`: `{ databaseName, baseBranchId?, lsn?, timestamp?, baseLsn?, baseTimestamp? }`. Omitting `baseBranchId` compares against the parent |
 | `finalizeRestore(projectId, branchId, { name? }?)` | **→void** | commits a restore previewed with `snapshots.restore({ finalize: false })` |
 
@@ -260,18 +260,6 @@ const branch = data?.branch;
 // Resolve the project's default ("production") branch
 const { data: prod } = await neon.branches.getDefault(projectId);
 
-const { data: reset } = await neon.branches.resetFromParent(
-  projectId,
-  feature.id,
-  { preserveUnderName: "feature-before-reset" },
-);
-
-const { data: schema } = await neon.branches.compareSchema(
-  projectId,
-  feature.id,
-  { databaseName: "neondb" },
-);
-
 // Branch off it with its own compute — returns a ready connection string
 const { data } = await neon.branches.createWithCompute(projectId, {
   name: "preview/pr-123",
@@ -279,6 +267,16 @@ const { data } = await neon.branches.createWithCompute(projectId, {
   compute: { minCu: 0.25, maxCu: 2 },
 });
 // data: { branch, endpoint, connectionString }
+
+const { data: schema } = await neon.branches.compareSchema(
+  projectId,
+  data!.branch.id,
+  { databaseName: "neondb" },
+);
+
+await neon.branches.resetFromParent(projectId, data!.branch.id, undefined, {
+  waitForReadiness: true,
+});
 ```
 
 ### `neon.postgres`

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -62,6 +62,64 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		expect(error).toBeInstanceOf(NeonNotFoundError);
 	});
 
+	it("compares schemas and resets a child back to its parent", async () => {
+		const child = expectOk(
+			await neon.branches.createWithCompute(projectId, {
+				name: "reset-child",
+				parentId: defaultBranchId,
+			}),
+		);
+		const branchId = child.branch.id;
+		const roles = expectOk(
+			await neon.postgres.roles.list(projectId, branchId),
+		);
+		const owner = roles[0];
+		if (!owner) throw new Error("child branch has no role");
+
+		const matching = expectOk(
+			await neon.branches.compareSchema(projectId, branchId, {
+				databaseName: "neondb",
+				baseBranchId: defaultBranchId,
+			}),
+		);
+		expect(matching.diff ?? "").toBe("");
+
+		expectOk(
+			await neon.postgres.databases.create(
+				projectId,
+				branchId,
+				{ name: "child_only", owner_name: owner.name },
+				{ waitForReadiness: true },
+			),
+		);
+
+		expectOk(
+			await neon.branches.resetFromParent(
+				projectId,
+				branchId,
+				undefined,
+				{
+					waitForReadiness: true,
+				},
+			),
+		);
+		const after = expectOk(
+			await neon.postgres.databases.list(projectId, branchId),
+		);
+		expect(after.map((database) => database.name)).not.toContain(
+			"child_only",
+		);
+		const matchingAgain = expectOk(
+			await neon.branches.compareSchema(projectId, branchId, {
+				databaseName: "neondb",
+				baseBranchId: defaultBranchId,
+			}),
+		);
+		expect(matchingAgain.diff ?? "").toBe("");
+
+		expectOk(await neon.branches.delete(projectId, branchId));
+	});
+
 	it("creates a branch with its compute and a connection string in one call", async () => {
 		const created = expectOk(
 			await neon.branches.createWithCompute(projectId, {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -39,7 +39,9 @@ export {
 export type { Page, Paginated } from "./neon/paginate.js";
 export type {
 	BranchWithCompute,
+	CompareSchemaInput,
 	CreateWithComputeInput,
+	ResetFromParentInput,
 } from "./neon/resources/branches.js";
 export type {
 	LogFieldValuesQuery,

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -63,6 +63,20 @@ it("branches + workflows carry the envelope and narrow under throwOnError", () =
 	expectTypeOf(
 		throwing.branches.delete("p", "br"),
 	).resolves.toEqualTypeOf<void>();
+	expectTypeOf(
+		neon.branches.resetFromParent("p", "br"),
+	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	expectTypeOf(
+		neon.branches.resetFromParent(
+			"p",
+			"br",
+			{ preserveUnderName: "old" },
+			{ throwOnError: true },
+		),
+	).resolves.toEqualTypeOf<Branch>();
+	expectTypeOf(
+		neon.branches.compareSchema("p", "br", { databaseName: "neondb" }),
+	).resolves.toEqualTypeOf<NeonResult<{ diff?: string }>>();
 });
 
 it("cancellation and deadline options are accepted on the client and per call", () => {

--- a/packages/sdk/src/neon/coverage.ts
+++ b/packages/sdk/src/neon/coverage.ts
@@ -42,6 +42,8 @@ export const WRAPPED: ReadonlySet<string> = new Set([
 	"deleteProjectBranch",
 	"setDefaultProjectBranch",
 	"finalizeRestoreBranch",
+	"restoreProjectBranch",
+	"getProjectBranchSchemaComparison",
 	// logs (branch-scoped)
 	"queryProjectBranchLogs",
 	"listProjectBranchLogFields",

--- a/packages/sdk/src/neon/resources/branches.test.ts
+++ b/packages/sdk/src/neon/resources/branches.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "../client.js";
+
+function neonRouting(
+	respond: (request: { url: string; method: string; body: unknown }) => {
+		status: number;
+		body: unknown;
+	},
+) {
+	const calls: Array<{ url: string; method: string; body: unknown }> = [];
+	const neon = createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		fetch: async (input, init) => {
+			const request = input instanceof Request ? input : undefined;
+			const url = request ? request.url : String(input);
+			const method = (
+				request?.method ??
+				init?.method ??
+				"GET"
+			).toUpperCase();
+			const raw = request ? await request.clone().text() : init?.body;
+			const call = {
+				url,
+				method,
+				body:
+					typeof raw === "string" && raw.length > 0
+						? JSON.parse(raw)
+						: raw,
+			};
+			calls.push(call);
+			const { status, body } = respond(call);
+			return new Response(JSON.stringify(body), {
+				status,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+	return { neon, calls };
+}
+
+describe("branches.resetFromParent", () => {
+	it("restores from the parent HEAD and unwraps the branch", async () => {
+		const { neon, calls } = neonRouting(({ url }) => {
+			if (url.includes("/restore")) {
+				return {
+					status: 200,
+					body: {
+						branch: { id: "br-child", name: "feature" },
+						operations: [],
+					},
+				};
+			}
+			return {
+				status: 200,
+				body: { branch: { id: "br-child", parent_id: "br-parent" } },
+			};
+		});
+
+		const { data, error } = await neon.branches.resetFromParent(
+			"p-1",
+			"br-child",
+			{ preserveUnderName: "feature-old" },
+		);
+
+		expect(error).toBeUndefined();
+		expect(data).toEqual({ id: "br-child", name: "feature" });
+		expect(calls).toHaveLength(2);
+		expect(calls[1]?.url).toContain(
+			"/projects/p-1/branches/br-child/restore",
+		);
+		expect(calls[1]?.body).toEqual({
+			source_branch_id: "br-parent",
+			preserve_under_name: "feature-old",
+		});
+	});
+
+	it("does not restore when the branch has no parent", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { branch: { id: "br-root" } },
+		}));
+
+		const { data, error } = await neon.branches.resetFromParent(
+			"p-1",
+			"br-root",
+		);
+
+		expect(data).toBeUndefined();
+		expect(error?.kind).toBe("client");
+		expect(error?.message).toBe(
+			"Branch has no parent and cannot be reset.",
+		);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).not.toContain("/restore");
+	});
+});
+
+describe("branches.compareSchema", () => {
+	it("sends databaseName as db_name and returns the diff", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { diff: "--- a\n+++ b\n" },
+		}));
+
+		const { data, error } = await neon.branches.compareSchema(
+			"p-1",
+			"br-child",
+			{
+				databaseName: "neondb",
+				baseBranchId: "br-parent",
+				lsn: "0/1",
+				baseLsn: "0/2",
+			},
+		);
+
+		expect(error).toBeUndefined();
+		expect(data).toEqual({ diff: "--- a\n+++ b\n" });
+		const url = new URL(calls[0]?.url ?? "http://invalid");
+		expect(url.pathname).toBe(
+			"/api/v2/projects/p-1/branches/br-child/compare_schema",
+		);
+		expect(url.searchParams.get("db_name")).toBe("neondb");
+		expect(url.searchParams.get("base_branch_id")).toBe("br-parent");
+		expect(url.searchParams.get("lsn")).toBe("0/1");
+		expect(url.searchParams.get("base_lsn")).toBe("0/2");
+		expect(url.searchParams.has("timestamp")).toBe(false);
+	});
+});

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -3,13 +3,16 @@ import {
 	deleteProjectBranch,
 	finalizeRestoreBranch,
 	getProjectBranch,
+	getProjectBranchSchemaComparison,
 	listProjectBranches,
+	restoreProjectBranch,
 	setDefaultProjectBranch,
 	updateProjectBranch,
 } from "../../client/sdk.gen.js";
 import type {
 	Branch,
 	BranchCreateRequest,
+	BranchSchemaCompareResponse,
 	BranchUpdateRequest,
 	Endpoint,
 	ListProjectBranchesData,
@@ -50,7 +53,20 @@ export interface BranchWithCompute {
 	connectionString: string;
 }
 
-/** Branch resource — one API call per CRUD method, plus the `createWithCompute` workflow. */
+export interface ResetFromParentInput {
+	/** Required when the branch has children so they can move to the preserved branch. */
+	preserveUnderName?: string;
+}
+
+export interface CompareSchemaInput {
+	databaseName: string;
+	baseBranchId?: string;
+	lsn?: string;
+	timestamp?: string;
+	baseLsn?: string;
+	baseTimestamp?: string;
+}
+
 export class Branches<DThrow extends boolean> {
 	readonly #ctx: RequestContext;
 
@@ -315,6 +331,129 @@ export class Branches<DThrow extends boolean> {
 					signal,
 				}),
 			(data) => data.branch,
+		);
+	}
+
+	/**
+	 * Uses the parent's current HEAD; use raw `restoreProjectBranch` for an LSN or timestamp.
+	 *
+	 * @apiCall GET /projects/{project_id}/branches/{branch_id}
+	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/restore
+	 */
+	resetFromParent(
+		projectId: string,
+		branchId: string,
+		input?: ResetFromParentInput,
+	): Promise<Outcome<Branch, DThrow>>;
+	resetFromParent<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		input: ResetFromParentInput | undefined,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<Branch, Throw>>;
+	async resetFromParent(
+		projectId: string,
+		branchId: string,
+		input?: ResetFromParentInput,
+		opts?: CallOptions,
+	): Promise<Branch | NeonResult<Branch>> {
+		const shouldThrow =
+			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
+		const current = await this.#ctx.execute(
+			opts,
+			(client, signal) =>
+				getProjectBranch({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					throwOnError: false,
+					signal,
+				}),
+			(data) => data.branch,
+		);
+		if (current.error) {
+			return finalize(err<Branch>(current.error), shouldThrow);
+		}
+		const parentId = current.data.parent_id;
+		if (!parentId) {
+			return finalize(
+				err<Branch>(
+					new NeonError(
+						"Branch has no parent and cannot be reset.",
+						"client",
+					),
+				),
+				shouldThrow,
+			);
+		}
+		return this.#ctx.run(
+			opts,
+			(client, signal) =>
+				restoreProjectBranch({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					body: {
+						source_branch_id: parentId,
+						...(input?.preserveUnderName === undefined
+							? {}
+							: { preserve_under_name: input.preserveUnderName }),
+					},
+					throwOnError: false,
+					signal,
+				}),
+			(data) => data.branch,
+		);
+	}
+
+	/**
+	 * Returns a unified SQL diff; omitting `baseBranchId` uses the parent branch.
+	 *
+	 * @apiCall GET /projects/{project_id}/branches/{branch_id}/compare_schema
+	 */
+	compareSchema(
+		projectId: string,
+		branchId: string,
+		input: CompareSchemaInput,
+	): Promise<Outcome<BranchSchemaCompareResponse, DThrow>>;
+	compareSchema<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		input: CompareSchemaInput,
+		opts: CallOptions<Throw>,
+	): Promise<Outcome<BranchSchemaCompareResponse, Throw>>;
+	compareSchema(
+		projectId: string,
+		branchId: string,
+		input: CompareSchemaInput,
+		opts?: CallOptions,
+	): Promise<
+		BranchSchemaCompareResponse | NeonResult<BranchSchemaCompareResponse>
+	> {
+		return this.#ctx.run(
+			opts,
+			(client, signal) =>
+				getProjectBranchSchemaComparison({
+					client,
+					path: { project_id: projectId, branch_id: branchId },
+					query: {
+						db_name: input.databaseName,
+						...(input.baseBranchId === undefined
+							? {}
+							: { base_branch_id: input.baseBranchId }),
+						...(input.lsn === undefined ? {} : { lsn: input.lsn }),
+						...(input.timestamp === undefined
+							? {}
+							: { timestamp: input.timestamp }),
+						...(input.baseLsn === undefined
+							? {}
+							: { base_lsn: input.baseLsn }),
+						...(input.baseTimestamp === undefined
+							? {}
+							: { base_timestamp: input.baseTimestamp }),
+					},
+					throwOnError: false,
+					signal,
+				}),
+			(data) => data,
 		);
 	}
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -25,6 +25,8 @@ const tools = createNeonTools({
 		"projects.list",
 		"projects.createAndConnect",
 		"branches.createWithCompute",
+		"branches.resetFromParent",
+		"branches.compareSchema",
 	],
 });
 
@@ -32,6 +34,16 @@ const listed = await tools["projects.list"].execute({ limit: 10 });
 const created = await tools["projects.createAndConnect"].execute({
 	name: "agent-project",
 	region_id: "aws-us-east-1",
+});
+await tools["branches.resetFromParent"].execute({
+	project_id: "project-id",
+	branch_id: "br-feature",
+	preserve_under_name: "feature-before-reset",
+});
+const compared = await tools["branches.compareSchema"].execute({
+	project_id: "project-id",
+	branch_id: "br-feature",
+	database_name: "neondb",
 });
 ```
 

--- a/packages/tools/src/catalog.test.ts
+++ b/packages/tools/src/catalog.test.ts
@@ -260,4 +260,76 @@ describe("special mappings", () => {
 		);
 		expect(tool.inputSchema.safeParse({}).success).toBe(true);
 	});
+
+	test("resetFromParent is destructive; compareSchema is read-only", () => {
+		const reset = createNeonTool("branches.resetFromParent", {
+			apiKey: "test-key",
+		});
+		expect(reset.annotations.destructiveHint).toBe(true);
+		expect(reset.requiresApproval).toBe(true);
+
+		const compare = createNeonTool("branches.compareSchema", {
+			apiKey: "test-key",
+		});
+		expect(compare.annotations.readOnlyHint).toBe(true);
+		expect(compare.requiresApproval).toBe(false);
+	});
+
+	test("maps resetFromParent and compareSchema field names", async () => {
+		const requests: Request[] = [];
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: [
+				"branches.resetFromParent",
+				"branches.compareSchema",
+			] as const,
+			fetch: async (input, init) => {
+				const request = new Request(input, init);
+				requests.push(request);
+				if (request.url.includes("/restore")) {
+					return jsonResponse({
+						branch: { id: "br-child" },
+						operations: [],
+					});
+				}
+				if (request.url.includes("/compare_schema")) {
+					return jsonResponse({ diff: "" });
+				}
+				return jsonResponse({
+					branch: { id: "br-child", parent_id: "br-parent" },
+				});
+			},
+		});
+
+		await tools["branches.resetFromParent"].execute({
+			project_id: "project-id",
+			branch_id: "br-child",
+			preserve_under_name: "old",
+		});
+		const restore = requests.find((request) =>
+			request.url.includes("/restore"),
+		);
+		expect(restore).toBeDefined();
+		expect(await restore?.json()).toEqual({
+			source_branch_id: "br-parent",
+			preserve_under_name: "old",
+		});
+
+		requests.length = 0;
+		await tools["branches.compareSchema"].execute({
+			project_id: "project-id",
+			branch_id: "br-child",
+			database_name: "neondb",
+			base_branch_id: "br-parent",
+		});
+		expect(requests[0].url).toContain("db_name=neondb");
+		expect(requests[0].url).toContain("base_branch_id=br-parent");
+		expect(
+			tools["branches.compareSchema"].inputSchema.safeParse({
+				project_id: "project-id",
+				branch_id: "br-child",
+				db_name: "neondb",
+			}).success,
+		).toBe(false);
+	});
 });

--- a/packages/tools/src/catalog.test.ts
+++ b/packages/tools/src/catalog.test.ts
@@ -1,5 +1,6 @@
 import { createNeonClient } from "@neon/sdk";
 import { describe, expect, test } from "vitest";
+import * as z from "zod";
 import { createNeonTool, createNeonTools, toolIds } from "./index.js";
 import { hiddenToolIds } from "./lib/ergonomic/ids.js";
 
@@ -267,6 +268,15 @@ describe("special mappings", () => {
 		});
 		expect(reset.annotations.destructiveHint).toBe(true);
 		expect(reset.requiresApproval).toBe(true);
+		expect(reset.description).toContain(
+			"Discards every change the branch has written since it diverged",
+		);
+		const preserve = z.toJSONSchema(reset.inputSchema).properties
+			?.preserve_under_name;
+		expect(JSON.stringify(preserve)).toContain(
+			"Required when the branch has children",
+		);
+		expect(JSON.stringify(preserve)).not.toContain("source_branch_id");
 
 		const compare = createNeonTool("branches.compareSchema", {
 			apiKey: "test-key",

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -15,6 +15,12 @@ expectTypeOf(
 expectTypeOf(
 	publishedId("postgres.roles.resetPassword"),
 ).toEqualTypeOf<"reset_password_postgres_roles">();
+expectTypeOf(
+	publishedId("branches.resetFromParent"),
+).toEqualTypeOf<"reset_from_parent_branches">();
+expectTypeOf(
+	publishedId("branches.compareSchema"),
+).toEqualTypeOf<"compare_schema_branches">();
 
 const tools = createNeonTools({
 	apiKey: "test-key",
@@ -64,6 +70,25 @@ eveListProjects
 	.then((result) => {
 		expectTypeOf(result.data[0]?.id).toEqualTypeOf<string>();
 	});
+
+const resetFromParent = createNeonTool("branches.resetFromParent", {
+	apiKey: "test-key",
+});
+resetFromParent.execute({
+	project_id: "project-id",
+	branch_id: "branch-id",
+	preserve_under_name: "old",
+});
+const compareSchema = createNeonTool("branches.compareSchema", {
+	apiKey: "test-key",
+});
+compareSchema.execute({
+	project_id: "project-id",
+	branch_id: "branch-id",
+	database_name: "neondb",
+	// @ts-expect-error compareSchema publishes database_name, not db_name
+	db_name: "neondb",
+});
 
 const revokeCredential = createNeonTool("credentials.revoke", {
 	apiKey: "test-key",

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -9,10 +9,12 @@ import {
 	type ToolClientOptions,
 } from "./bind.js";
 import {
+	compareSchemaTool,
 	connectionStringTool,
 	createBranchWithComputeTool,
 	createProjectAndConnectTool,
 	getDefaultTool,
+	resetFromParentTool,
 	restoreSnapshotTool,
 	setScheduleTool,
 } from "./composed.js";
@@ -260,6 +262,8 @@ export const toolFactories = {
 					signal,
 				}),
 		}),
+	"branches.resetFromParent": resetFromParentTool,
+	"branches.compareSchema": compareSchemaTool,
 	"branches.finalizeRestore": (options) =>
 		fromGenerated(options, {
 			id: "branches.finalizeRestore",

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -49,7 +49,10 @@ export const getDefaultInputSchema = z.strictObject({
 export const resetFromParentInputSchema = z.strictObject({
 	project_id: zod.zRestoreProjectBranchPath.shape.project_id,
 	branch_id: zod.zRestoreProjectBranchPath.shape.branch_id,
-	preserve_under_name: zod.zBranchRestoreRequest.shape.preserve_under_name,
+	preserve_under_name:
+		zod.zBranchRestoreRequest.shape.preserve_under_name.describe(
+			"Name under which to save the current branch before the reset. Required when the branch has children; those children move to the new branch.",
+		),
 });
 
 const compareQuery = zod.zGetProjectBranchSchemaComparisonQuery.shape;
@@ -206,7 +209,7 @@ export const resetFromParentTool = (options: ToolClientOptions) =>
 			id: publishedId("branches.resetFromParent"),
 			title: "Reset branch from parent",
 			description:
-				"Reset a branch to its parent's current HEAD. preserve_under_name is required when the branch has children. Does not restore to an LSN or timestamp.",
+				"Reset a branch to its parent's current HEAD. Discards every change the branch has written since it diverged. preserve_under_name is required when the branch has children. For an LSN or timestamp restore, use the raw restoreProjectBranch operation.",
 			inputSchema: resetFromParentInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -46,6 +46,25 @@ export const getDefaultInputSchema = z.strictObject({
 	project_id: zod.zListProjectBranchesPath.shape.project_id,
 });
 
+export const resetFromParentInputSchema = z.strictObject({
+	project_id: zod.zRestoreProjectBranchPath.shape.project_id,
+	branch_id: zod.zRestoreProjectBranchPath.shape.branch_id,
+	preserve_under_name: zod.zBranchRestoreRequest.shape.preserve_under_name,
+});
+
+const compareQuery = zod.zGetProjectBranchSchemaComparisonQuery.shape;
+
+export const compareSchemaInputSchema = z.strictObject({
+	project_id: zod.zGetProjectBranchSchemaComparisonPath.shape.project_id,
+	branch_id: zod.zGetProjectBranchSchemaComparisonPath.shape.branch_id,
+	database_name: compareQuery.db_name,
+	base_branch_id: compareQuery.base_branch_id,
+	lsn: compareQuery.lsn,
+	timestamp: compareQuery.timestamp,
+	base_lsn: compareQuery.base_lsn,
+	base_timestamp: compareQuery.base_timestamp,
+});
+
 export const connectionStringInputSchema = z.strictObject({
 	project_id: zod.zGetConnectionUriPath.shape.project_id,
 	branch_id: zod.zGetConnectionUriQuery.shape.branch_id,
@@ -177,6 +196,81 @@ export const getDefaultTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) =>
 			neon.branches.getDefault(input.project_id, { signal }),
+	);
+
+export const resetFromParentTool = (options: ToolClientOptions) =>
+	bindTool(
+		options,
+		{
+			operationId: "branches.resetFromParent",
+			id: publishedId("branches.resetFromParent"),
+			title: "Reset branch from parent",
+			description:
+				"Reset a branch to its parent's current HEAD. preserve_under_name is required when the branch has children. Does not restore to an LSN or timestamp.",
+			inputSchema: resetFromParentInputSchema,
+			annotations: writeAnnotations,
+			requiresApproval: true,
+			metadata: {
+				method: "POST",
+				path: "/projects/{project_id}/branches/{branch_id}/restore",
+				stability: "stable",
+				deprecated: false,
+				tags: ["Branch"],
+			},
+		},
+		(neon, input, signal) =>
+			neon.branches.resetFromParent(
+				input.project_id,
+				input.branch_id,
+				input.preserve_under_name === undefined
+					? undefined
+					: { preserveUnderName: input.preserve_under_name },
+				{ signal },
+			),
+	);
+
+export const compareSchemaTool = (options: ToolClientOptions) =>
+	bindTool(
+		options,
+		{
+			operationId: "branches.compareSchema",
+			id: publishedId("branches.compareSchema"),
+			title: "Compare database schema",
+			description:
+				"Compare a branch database schema to another branch. Omitting base_branch_id compares against the parent. Returns a unified SQL diff.",
+			inputSchema: compareSchemaInputSchema,
+			annotations: readAnnotations,
+			requiresApproval: false,
+			metadata: {
+				method: "GET",
+				path: "/projects/{project_id}/branches/{branch_id}/compare_schema",
+				stability: "stable",
+				deprecated: false,
+				tags: ["Branch"],
+			},
+		},
+		(neon, input, signal) =>
+			neon.branches.compareSchema(
+				input.project_id,
+				input.branch_id,
+				{
+					databaseName: input.database_name,
+					...(input.base_branch_id === undefined
+						? {}
+						: { baseBranchId: input.base_branch_id }),
+					...(input.lsn === undefined ? {} : { lsn: input.lsn }),
+					...(input.timestamp === undefined
+						? {}
+						: { timestamp: input.timestamp }),
+					...(input.base_lsn === undefined
+						? {}
+						: { baseLsn: input.base_lsn }),
+					...(input.base_timestamp === undefined
+						? {}
+						: { baseTimestamp: input.base_timestamp }),
+				},
+				{ signal },
+			),
 	);
 
 export const connectionStringTool = (options: ToolClientOptions) =>

--- a/packages/tools/src/lib/ergonomic/ids.ts
+++ b/packages/tools/src/lib/ergonomic/ids.ts
@@ -30,6 +30,8 @@ export const toolIds = [
 	"branches.delete",
 	"branches.getDefault",
 	"branches.setDefault",
+	"branches.resetFromParent",
+	"branches.compareSchema",
 	"branches.finalizeRestore",
 	"postgres.connectionString",
 	"postgres.endpoints.list",


### PR DESCRIPTION
## Problem

Resetting a branch back to its parent, and diffing a database schema between two branches, were both reachable only through the raw generated client.

Reset goes through `POST /projects/{project_id}/branches/{branch_id}/restore`, which requires a `source_branch_id`. "Reset this branch to its parent" therefore starts with a `GET` on the branch to read `parent_id`, and the caller assembles the restore body from it. Schema comparison goes through `GET /projects/{project_id}/branches/{branch_id}/compare_schema`, with the database passed as a `db_name` query param.

`@neon/tools` publishes a closed set of selectors listed in `toolIds`, so neither operation had a tool entry. A tools consumer had to leave the tools layer and hand-roll both flows against the low-level client.

## Why the reset wrapper makes two calls

The restore endpoint has no "restore from my parent" mode. The parent has to be named. `resetFromParent` reads the branch, takes `parent_id` from it and posts the restore with that as `source_branch_id` and no LSN or timestamp, which is what makes it parent HEAD.

A branch with no parent fails before any restore is sent, as a `NeonError` of kind `client`:

```ts
const { error } = await neon.branches.resetFromParent(projectId, rootBranchId);
// error.kind    === "client"
// error.message === "Branch has no parent and cannot be reset."
```

Fixing the source to the parent also narrows `preserve_under_name`. The spec's description of that field covers two situations: a branch that has children, and a self-restore where `source_branch_id` equals the branch being restored. The second one cannot occur here, so the tool republishes the field with the children case only.

## SDK

```ts
import { createNeonClient } from "@neon/sdk";

const neon = createNeonClient({ apiKey });

const { data: schema } = await neon.branches.compareSchema(projectId, branchId, {
  databaseName: "neondb",
  // baseBranchId omitted: compares against the parent branch
});
// data: { diff?: string }  — a unified SQL diff, empty when the schemas match

const { data: branch } = await neon.branches.resetFromParent(
  projectId,
  branchId,
  { preserveUnderName: "feature-before-reset" }, // required when the branch has children
  { waitForReadiness: true },                    // client default is false
);
```

`resetFromParent` discards every write the branch made since it diverged. `preserveUnderName` saves the current state under a new branch first; when the branch has children, they move to that new branch.

`compareSchema` also accepts `lsn`, `timestamp`, `baseLsn` and `baseTimestamp`. Absent fields are left off the query string.

Both methods follow the existing envelope and narrowing rules: `NeonResult<T>` by default, the bare value under `throwOnError`. Two input types are exported from the package root:

```ts
import type { CompareSchemaInput, ResetFromParentInput } from "@neon/sdk";
```

Nothing changes for existing callers. No other method signature moved and no generated code was regenerated.

## Tools

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
  apiKey,
  tools: ["branches.resetFromParent", "branches.compareSchema"],
});

await tools["branches.resetFromParent"].execute({
  project_id: "project-id",
  branch_id: "br-feature",
  preserve_under_name: "feature-before-reset",
});

const compared = await tools["branches.compareSchema"].execute({
  project_id: "project-id",
  branch_id: "br-feature",
  database_name: "neondb",
  base_branch_id: "br-parent", // optional
});
```

| Selector | Published id | Annotations | Approval |
| --- | --- | --- | --- |
| `branches.resetFromParent` | `reset_from_parent_branches` | `destructiveHint` | required |
| `branches.compareSchema` | `compare_schema_branches` | `readOnlyHint` | not required |

The reset tool description tells the model what it is about to lose: "Reset a branch to its parent's current HEAD. Discards every change the branch has written since it diverged. preserve_under_name is required when the branch has children. For an LSN or timestamp restore, use the raw restoreProjectBranch operation."

The compare tool publishes `database_name`. The strict schema rejects `db_name`, and the type test asserts that rejection, so a model copying the HTTP param name gets a validation error rather than a silent miss.

## Also in here

- `restoreProjectBranch` and `getProjectBranchSchemaComparison` are added to the SDK's `WRAPPED` set, so the coverage drift guard now counts them as ergonomically covered instead of raw-only.
- Both package READMEs document the new methods and tools, including the compare-then-reset sequence.
- A changeset marking `@neon/sdk` and `@neon/tools` minor.

## Verification

`pnpm --filter @neon/sdk test:ci` and `pnpm --filter @neon/tools test:ci` pass.

Behaviours covered by the tests in this diff:

- reset reads the branch, then posts `{ source_branch_id: <parent_id>, preserve_under_name }` to the restore path and returns the branch from the restore response
- a branch with no `parent_id` returns the client error above and sends no restore request
- compare sends `db_name`, `base_branch_id`, `lsn` and `base_lsn` as query params and leaves unset ones off the URL entirely
- `resetFromParent` resolves `NeonResult<Branch>` by default and `Branch` under `throwOnError`; `compareSchema` resolves `NeonResult<{ diff?: string }>`
- `publishedId` yields `reset_from_parent_branches` and `compare_schema_branches`
- the reset tool is destructive and requires approval, its description carries the discard sentence, and the published `preserve_under_name` description states the children requirement without mentioning `source_branch_id`
- the compare tool is read-only, requires no approval, accepts `database_name` and rejects `db_name`
- executing both tools through `createNeonTools` produces the restore body and the compare query string shown above

A live `@neon/sdk` e2e case ran against the real API: it created a child branch with compute, compared the child and parent schemas and got an empty diff, created a database that exists only on the child, reset the child from its parent with `waitForReadiness`, then asserted the child-only database was gone and the schemas matched again.

Not verified against the live API:

- `preserveUnderName`. The e2e case passes `undefined`, so the preserved branch and the child-reparenting behaviour are covered by mocked requests only.
- `lsn`, `timestamp`, `baseLsn` and `baseTimestamp` on compare. Covered by the mocked query-string test only.
- the no-parent error path.

## For your attention

- **LSN and timestamp restores are out of scope.** `resetFromParent` always targets parent HEAD. The tool description points at the raw `restoreProjectBranch` operation for the other restore modes, and the raw operation stays available.
- **The parent id is resolved by a separate read.** If the branch is reparented between the `GET` and the restore, the restore uses the parent that the first call saw.
- **Readiness differs between the two layers.** The tools client runs with `waitForReadiness: true`, so the reset tool waits for the restore operations to finish. The SDK default is `false`, so an SDK caller passes `{ waitForReadiness: true }` to get a branch that is usable when the promise resolves. The README example does this.
- **The reset tool is gated twice**, by `destructiveHint` and by `requiresApproval: true`, which is what a host uses to put it behind a confirmation.