### PR TITLE
chore: release neon@4.5.2, neonctl@4.5.2

### DIFF
--- a/.changeset/cli-agent-tooling-help.md
+++ b/.changeset/cli-agent-tooling-help.md
@@ -1,6 +1,0 @@
----
-"neon": patch
-"neonctl": patch
----
-
-`neon skills --help`, `neon mcp --help`, and `neon plugins --help` list supported agents and the install catalogs: skill ids with source repos, the `neon-postgres` plugin contents, and the MCP server URL plus `neon mcp -y` defaults.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.5.2
+
+### Patch Changes
+
+- e869e9e: `neon skills --help`, `neon mcp --help`, and `neon plugins --help` list supported agents and the install catalogs: skill ids with source repos, the `neon-postgres` plugin contents, and the MCP server URL plus `neon mcp -y` defaults.
+
 ## 4.5.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.5.1",
+	"version": "4.5.2",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.5.2
+
+### Patch Changes
+
+- e869e9e: `neon skills --help`, `neon mcp --help`, and `neon plugins --help` list supported agents and the install catalogs: skill ids with source repos, the `neon-postgres` plugin contents, and the MCP server URL plus `neon mcp -y` defaults.
+- Updated dependencies [e869e9e]
+  - neon@4.5.2
+
 ## 4.5.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

npm still serves `neon@4.5.0` and `neonctl@4.5.0`. [`#483`](https://github.com/neondatabase/neon-pkgs/pull/483) already landed on main: `neon skills --help`, `neon mcp --help` and `neon plugins --help` print the agent and install catalogs. `npx neon` still runs 4.5.0.

Published 4.5.0 help ends at the examples. `npx neon@4.5.0 skills --help`:

```text
Examples:
neon skills
  Interactive: this directory, agents, skills, then confirm
neon skills -y
  This directory, detected agents, the default skills
neon skills -s neon -s neon-ai-gateway --agent cursor
  Install named skills into specific agents
neon skills --global
  Install user-level skills
```

`--agent` and `--skill` say "Skips the agent picker" / "Skips the skill picker" and stop. `neon mcp --help` and `neon plugins --help` end the same way. The `neon mcp -y` example on 4.5.0 is "Global config, detected agents, minted API key".

## Diagnosis

[`#486`](https://github.com/neondatabase/neon-pkgs/pull/486) already set `neon` and `neonctl` to 4.5.1 on main as a dependent cascade of `@neon/sdk@2.3.0`. That 4.5.1 tarball was never published. The published 4.5.x list is `4.5.0` only.

The 4.5.1 CHANGELOG entry is the dep list from that cascade:

```text
## 4.5.1

### Patch Changes

- Updated dependencies [9b322e7]
  - @neon/sdk@2.3.0
  - @neon/config@1.0.4
  - @neon/config-runtime@1.0.4
```

`#483` merged after that bump and left `.changeset/cli-agent-tooling-help.md`:

```md
---
"neon": patch
"neonctl": patch
---

`neon skills --help`, `neon mcp --help`, and `neon plugins --help` list supported agents and the install catalogs: skill ids with source repos, the `neon-postgres` plugin contents, and the MCP server URL plus `neon mcp -y` defaults.
```

`changeset version` consumed that file. The next patch on top of unpublished 4.5.1 is 4.5.2.

`neonctl` is the Changesets fixed group with `neon` (`.changeset/config.json`: `"fixed": [["neon", "neonctl"]]`), so both packages move to the same version.

## The user-facing interface

Once `neon@4.5.2` and `neonctl@4.5.2` are on npm, those three `--help` epilogues print the catalogs. `--agent`, `--skill` and `--category` describe strings say the values are listed below. The `neon mcp -y` example is "Global config, detected agents, reuse or mint an API key".

Catalogs below are the epilogues rendered from the built CLI on `#483`, `COLUMNS=100`. Flags, install behavior and accepted values are the ones `#483` already landed on main.

### `neon skills --help`

```text
 Supported agents: antigravity, cline, cline-cli, claude-code, claude-desktop, codex, cursor,
     gemini-cli, goose, github-copilot-cli, grok-build, opencode, vscode, windsurf, zed
 Supported skills, by source repo:
   neondatabase/agent-skills: claimable-postgres, neon, neon-ai-gateway, neon-functions,
     neon-object-storage, neon-postgres, neon-postgres-branches, neon-postgres-egress-optimizer
   neondatabase/neon-for-agent-platforms: neon-postgres-agent-platforms
 neon skills -y installs every listed skill except neon-postgres-agent-platforms
```

### `neon mcp --help`

```text
 Installs https://mcp.neon.tech/mcp
 Supported agents at global scope: antigravity, cline, cline-cli, claude-code, codex, cursor,
     gemini-cli, goose, github-copilot-cli, grok-build, mcporter, opencode, vscode, windsurf, zed
 --project does not support: antigravity, cline, cline-cli, goose, windsurf
 Supported categories: projects, branches, schema, querying, neon_auth, data_api, observability,
     docs
 neon mcp -y:
   global config
   every globally detected agent
   reuse an existing Neon MCP API key, else mint an account-wide key
   write tools on, all categories
   no project pin (including from .neon)
```

### `neon plugins --help`

```text
 Supported agents at project scope: claude-code, claude-desktop, codex, cursor
 Also with --global: github-copilot-cli, grok-build, vscode
 Currently one plugin: neon-postgres from neondatabase/agent-skills.
 It includes the Neon MCP server (https://mcp.neon.tech/mcp)
 and these skills: neon, neon-ai-gateway, neon-functions, neon-object-storage, neon-postgres,
     neon-postgres-branches, neon-postgres-egress-optimizer
```

`neonctl` is the compatibility package (`bin.neon` and `bin.neonctl` both `bin/cli.js`) and depends on `neon@4.5.2`. Same help through that entry.

## Also in here

The diff is the `changeset version` output: five files.

- deleted `.changeset/cli-agent-tooling-help.md`
- `packages/cli/package.json` `4.5.1` → `4.5.2`
- `packages/cli/CHANGELOG.md` adds the 4.5.2 patch line above
- `packages/neonctl/package.json` `4.5.1` → `4.5.2`
- `packages/neonctl/CHANGELOG.md` adds the same 4.5.2 patch line plus `neon@4.5.2`

The 4.5.1 CHANGELOG headings stay.

## Verification

- `npm view neon version` / `npm view neonctl version`: `4.5.0`
- `npm view neon versions` has `4.5.0` and does not have `4.5.1`
- `npx neon@4.5.0 --version`: `4.5.0`. `skills --help`, `mcp --help` and `plugins --help` have no catalog epilogue. `neon mcp -y` example is "minted API key"
- `git diff --stat origin/main...HEAD`: 5 files, 16 insertions, 8 deletions
- `pnpm lint:ci` (biome ci) on this branch: passed, 729 files
- `.changeset/` on this branch is `README.md` and `config.json` only

Not verified: npm publish. Catalog contents were checked on `#483` against the built CLI; this diff does not re-run those tests.

## For your attention

- **npm skips 4.5.1.** There will be no `neon@4.5.1` / `neonctl@4.5.1` tarball. The 4.5.2 tarball CHANGELOG still contains the 4.5.1 dep-update heading. Installing 4.5.2 from 4.5.0 also picks up that unpublished cascade (`@neon/sdk@2.3.0`, `@neon/config@1.0.4`, `@neon/config-runtime@1.0.4`).
- **`@neon/config-runtime@1.0.4` is not on npm yet** (latest is `1.0.3`). `neon@4.5.0` depends on `@neon/config-runtime@1.0.3`; the 4.5.2 tarball will declare `1.0.4`. Publish `@neon/config-runtime@1.0.4` before `neon@4.5.2`, or `npm install neon@4.5.2` cannot resolve. `@neon/sdk@2.3.0` and `@neon/config@1.0.4` are already on npm.
- **Publish after merge, in order:** `@neon/config-runtime`, then `neon` (confirm `npm view neon version` is `4.5.2` and GitHub release `neon@4.5.2`), then `neonctl`. Nothing on this branch publishes.
- `@neon/env@1.1.4` is also unpublished from `#486`. `neon` does not depend on it.
