### PR TITLE
Remove neon bootstrap --agent; honor --output on --list-templates

### DIFF
--- a/.changeset/bootstrap-no-agent.md
+++ b/.changeset/bootstrap-no-agent.md
@@ -1,0 +1,6 @@
+---
+"neon": minor
+"neonctl": minor
+---
+
+`neon bootstrap --agent` is removed. List templates with `--list-templates --output json` (or yaml). Scaffold with `--template` or `--default`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -710,6 +710,12 @@ $ neon bootstrap my-app
 
 # Scaffold a specific template into the current directory (no prompts)
 $ neon bootstrap . --template hono
+
+# List templates
+$ neon bootstrap --list-templates
+
+# Machine-readable catalog
+$ neon bootstrap --list-templates --output json
 ```
 
 The target directory must be empty unless you pass `--force` (a lone `.git` is ignored, so a freshly `git init`ed folder is fine). Symlinks and executable bits in the template are preserved.

--- a/packages/cli/src/commands/bootstrap.test.ts
+++ b/packages/cli/src/commands/bootstrap.test.ts
@@ -2,7 +2,6 @@ import { fork } from "node:child_process";
 import {
 	existsSync,
 	lstatSync,
-	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	readlinkSync,
@@ -16,7 +15,7 @@ import { join } from "node:path";
 import express from "express";
 import { gzipSync } from "fflate";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
-import { makeProjectDir } from "../test_utils/project_dir.js";
+import YAML from "yaml";
 
 // A fixture file in the template repo: its POSIX `mode`/`type` decide whether it
 // lands as a regular file, an executable, or a symlink.
@@ -60,6 +59,14 @@ const MANIFEST_YAML = `templates:
     services:
       - Postgres
       - Functions
+    source:
+      owner: neondatabase
+      repo: examples
+      ref: main
+      subdir: with-hono
+  - id: plain
+    title: "Plain"
+    description: "A template with no services listed."
     source:
       owner: neondatabase
       repo: examples
@@ -140,33 +147,48 @@ const startGithubFixtureServer = (): Promise<Server> => {
 	});
 };
 
+const HONO_LIST_ROW = {
+	id: "hono",
+	title: "Hono API (Drizzle, Lakebase Postgres) on Neon Functions",
+	description:
+		"A Hono API using Drizzle ORM and Lakebase Postgres, ready to deploy as a Neon Function.",
+	services: ["Postgres", "Functions"],
+};
+
+const PLAIN_LIST_ROW: typeof HONO_LIST_ROW = {
+	id: "plain",
+	title: "Plain",
+	description: "A template with no services listed.",
+	services: [],
+};
+
+const TABLE_LIST_OUTPUT = `${HONO_LIST_ROW.id} — ${HONO_LIST_ROW.description} [Postgres · Functions]\n${PLAIN_LIST_ROW.id} — ${PLAIN_LIST_ROW.description}\n`;
+
 const runBootstrap = (
 	server: Server,
 	args: string[],
 ): Promise<{ code: number; stdout: string; stderr: string }> => {
 	const base = `http://localhost:${(server.address() as AddressInfo).port}`;
+	const argv = [
+		"bootstrap",
+		...args,
+		"--api-key",
+		"test-key",
+		"--no-analytics",
+	];
+	if (!args.includes("--output") && !args.includes("-o")) {
+		argv.push("--output", "yaml");
+	}
 	return new Promise((resolve, reject) => {
-		const cp = fork(
-			join(process.cwd(), "./dist/index.js"),
-			[
-				"bootstrap",
-				...args,
-				"--api-key",
-				"test-key",
-				"--no-analytics",
-				"--output",
-				"yaml",
-			],
-			{
-				stdio: "pipe",
-				env: {
-					...process.env,
-					CI: "true",
-					NEON_BOOTSTRAP_GITHUB_CODELOAD: base,
-					NEON_BOOTSTRAP_MANIFEST_URL: `${base}/manifest/bootstrap.yaml`,
-				},
+		const cp = fork(join(process.cwd(), "./dist/index.js"), argv, {
+			stdio: "pipe",
+			env: {
+				...process.env,
+				CI: "true",
+				NEON_BOOTSTRAP_GITHUB_CODELOAD: base,
+				NEON_BOOTSTRAP_MANIFEST_URL: `${base}/manifest/bootstrap.yaml`,
 			},
-		);
+		});
 		let stdout = "";
 		let stderr = "";
 		cp.stdout?.on("data", (data: Buffer) => {
@@ -182,14 +204,12 @@ const runBootstrap = (
 	});
 };
 
-// `--agent` writes a single JSON state-machine object to stdout (logs go to
-// stderr), so the structured output stays machine-parseable.
-const parseAgentOutput = (stdout: string): Record<string, unknown> => {
+const parseListedTemplates = (stdout: string): unknown[] => {
 	const parsed: unknown = JSON.parse(stdout.trim());
-	if (typeof parsed !== "object" || parsed === null) {
-		throw new Error(`Expected a JSON object, got: ${stdout}`);
+	if (!Array.isArray(parsed)) {
+		throw new Error(`Expected a JSON array, got: ${stdout}`);
 	}
-	return parsed as Record<string, unknown>;
+	return parsed;
 };
 
 describe("bootstrap", () => {
@@ -273,14 +293,64 @@ describe("bootstrap", () => {
 	});
 
 	test("--list prints available templates to stdout from the remote manifest", async () => {
-		const { code, stdout, stderr } = await runBootstrap(server, ["--list"]);
+		const { code, stdout, stderr } = await runBootstrap(server, [
+			"--list",
+			"--output",
+			"table",
+		]);
 		expect(code, stderr).toBe(0);
-		expect(stdout).toContain("hono");
-		expect(stdout).toContain(
-			"A Hono API using Drizzle ORM and Lakebase Postgres",
-		);
-		// The services from the manifest are surfaced alongside each template.
-		expect(stdout).toContain("[Postgres · Functions]");
+		expect(stdout).toBe(TABLE_LIST_OUTPUT);
+	});
+
+	test("--list-templates --output json prints id, title, description, and services", async () => {
+		const { code, stdout, stderr } = await runBootstrap(server, [
+			"--list-templates",
+			"--output",
+			"json",
+		]);
+		expect(code, stderr).toBe(0);
+		const rows = parseListedTemplates(stdout);
+		expect(rows).toEqual([HONO_LIST_ROW, PLAIN_LIST_ROW]);
+		for (const row of rows) {
+			if (typeof row !== "object" || row === null) {
+				throw new Error(`Expected an object row, got: ${stdout}`);
+			}
+			expect(Object.keys(row).sort()).toEqual([
+				"description",
+				"id",
+				"services",
+				"title",
+			]);
+		}
+	});
+
+	test("--list-templates --output yaml prints the same rows", async () => {
+		const { code, stdout, stderr } = await runBootstrap(server, [
+			"--list-templates",
+			"--output",
+			"yaml",
+		]);
+		expect(code, stderr).toBe(0);
+		expect(YAML.parse(stdout)).toEqual([HONO_LIST_ROW, PLAIN_LIST_ROW]);
+	});
+
+	test("--agent is refused and points at --list-templates --output json", async () => {
+		const { code, stdout, stderr } = await runBootstrap(server, [
+			"--agent",
+		]);
+		expect(code).toBe(1);
+		expect(stdout.trim()).toBe("");
+		expect(stderr).toContain("bootstrap --agent");
+		expect(stderr).toContain("--list-templates --output json");
+		expect(stderr).toContain("--template <id>");
+		expect(stderr).toContain("bootstrap <directory> --default");
+	});
+
+	test("help omits --agent", async () => {
+		const { code, stderr } = await runBootstrap(server, ["--help"]);
+		expect(code, stderr).toBe(0);
+		expect(stderr).toContain("--list-templates");
+		expect(stderr).not.toContain("--agent");
 	});
 
 	test("--default scaffolds and inits git without prompting", async () => {
@@ -299,132 +369,5 @@ describe("bootstrap", () => {
 		);
 		// git init ran as part of the quick start.
 		expect(existsSync(join(dest, ".git"))).toBe(true);
-	});
-
-	describe("--agent (JSON state machine)", () => {
-		test("asks for a template when none is given", async () => {
-			const { code, stdout, stderr } = await runBootstrap(server, [
-				"--agent",
-			]);
-			expect(code, stderr).toBe(0);
-			const res = parseAgentOutput(stdout);
-			expect(res.status).toBe("needs_template");
-			// Options come from the remote manifest, including the services list.
-			expect(res.options).toEqual(
-				expect.arrayContaining([
-					expect.objectContaining({
-						id: "hono",
-						services: ["Postgres", "Functions"],
-					}),
-				]),
-			);
-			expect(res.next_command_template).toContain(
-				"--template <template_id>",
-			);
-		});
-
-		test("asks for a directory when only the template is given", async () => {
-			const { code, stdout, stderr } = await runBootstrap(server, [
-				"--agent",
-				"--template",
-				"hono",
-			]);
-			expect(code, stderr).toBe(0);
-			const res = parseAgentOutput(stdout);
-			expect(res.status).toBe("needs_directory");
-			expect(res.next_command_template).toContain("<directory>");
-			expect(res.next_command_template).toContain("--template hono");
-		});
-
-		test("scaffolds and returns the install + git + link next steps", async () => {
-			// Pin the target to npm so the assertion below doesn't depend on
-			// which package manager launched the test run.
-			mkdirSync(join(dest, ".git"));
-			writeFileSync(join(dest, "package-lock.json"), "");
-
-			const { code, stdout, stderr } = await runBootstrap(server, [
-				"--agent",
-				dest,
-				"--template",
-				"hono",
-				"--force",
-			]);
-			expect(code, stderr).toBe(0);
-			const res = parseAgentOutput(stdout);
-			expect(res.status).toBe("scaffolded");
-			expect(res.template).toEqual({
-				id: "hono",
-				title: expect.any(String),
-			});
-			expect(res.files_written).toBeGreaterThan(0);
-
-			// The files really landed on disk (end to end, no mocks).
-			expect(readFileSync(join(dest, "package.json"), "utf8")).toBe(
-				'{\n  "name": "with-hono"\n}\n',
-			);
-
-			// All follow-ups come back as structured, runnable next steps.
-			const steps = res.next_steps as Record<string, unknown>[];
-			const actions = steps.map((step) => step.action);
-			expect(actions).toEqual([
-				"install_dependencies",
-				"initialize_git",
-				"link_neon_project",
-			]);
-			// Anchored, because "pnpm install" contains "npm install" as a
-			// substring — a toContain here passes whichever manager we emit.
-			expect(steps[0].command).toMatch(/ && npm install$/);
-			expect(steps[1].command).toContain("git init");
-			expect(steps[2].command).toContain("neon link --agent");
-		});
-
-		test("the install step uses the target project's package manager", async () => {
-			const { dir, cleanup } = makeProjectDir("pnpm");
-			try {
-				const { code, stdout, stderr } = await runBootstrap(server, [
-					"--agent",
-					dir,
-					"--template",
-					"hono",
-					"--force",
-				]);
-				expect(code, stderr).toBe(0);
-				const res = parseAgentOutput(stdout);
-				const steps = res.next_steps as Record<string, unknown>[];
-				expect(steps[0].command).toMatch(/ && pnpm install$/);
-			} finally {
-				cleanup();
-			}
-		});
-
-		test("errors with UNKNOWN_TEMPLATE for a bad template id", async () => {
-			const { code, stdout } = await runBootstrap(server, [
-				"--agent",
-				dest,
-				"--template",
-				"does-not-exist",
-				"--force",
-			]);
-			expect(code).toBe(1);
-			const res = parseAgentOutput(stdout);
-			expect(res.status).toBe("error");
-			expect(res.code).toBe("UNKNOWN_TEMPLATE");
-		});
-
-		test("errors with TARGET_NOT_EMPTY when the directory is not empty", async () => {
-			writeFileSync(join(dest, "keep.txt"), "mine\n");
-			const { code, stdout } = await runBootstrap(server, [
-				"--agent",
-				dest,
-				"--template",
-				"hono",
-			]);
-			expect(code).toBe(1);
-			const res = parseAgentOutput(stdout);
-			expect(res.status).toBe("error");
-			expect(res.code).toBe("TARGET_NOT_EMPTY");
-			// Nothing was scaffolded over the existing contents.
-			expect(readFileSync(join(dest, "keep.txt"), "utf8")).toBe("mine\n");
-		});
 	});
 });

--- a/packages/cli/src/commands/bootstrap.ts
+++ b/packages/cli/src/commands/bootstrap.ts
@@ -6,7 +6,6 @@ import prompts, { type InitialReturnValue } from "prompts";
 import type yargs from "yargs";
 import { isCi } from "../env.js";
 import {
-	BootstrapInputError,
 	type BootstrapTemplate,
 	ensureTargetUsable,
 	FALLBACK_TEMPLATES,
@@ -19,7 +18,6 @@ import { log } from "../log.js";
 import type { CommonProps } from "../types.js";
 import { getCliName } from "../utils/cli_name.js";
 import {
-	DO_NOT_SUBSTITUTE_HINT,
 	formatInstallCommand,
 	inferPackageManager,
 	installArgs,
@@ -28,13 +26,14 @@ import {
 	resolvePackageManager,
 	runCommand,
 } from "../utils/package_manager.js";
+import { writer } from "../writer.js";
 
 type BootstrapProps = CommonProps & {
 	directory?: string;
 	template?: string;
 	force: boolean;
 	listTemplates: boolean;
-	agent: boolean;
+	agent?: boolean;
 	default: boolean;
 	install: boolean;
 	git: boolean;
@@ -44,50 +43,8 @@ type BootstrapProps = CommonProps & {
 	profile?: string;
 };
 
-// ----------------------------------------------------------------------------
-// Agent mode (JSON state machine)
-// ----------------------------------------------------------------------------
-
-type AgentTemplateOption = {
-	id: string;
-	title: string;
-	description: string;
-	services?: string[];
-};
-
-/**
- * One follow-up the caller should offer the user after scaffolding. The agent
- * is expected to ask the user, then run `command` from the project directory
- * (the `link` step intentionally chains into `neon link --agent`'s own state
- * machine). Mirrors `link --agent`'s instruction/next_command_template style.
- */
-type AgentNextStep = {
-	action: "install_dependencies" | "initialize_git" | "link_neon_project";
-	instruction: string;
-	command: string;
-};
-
-type AgentResponse =
-	| {
-			status: "needs_template";
-			instruction: string;
-			options: AgentTemplateOption[];
-			next_command_template: string;
-	  }
-	| {
-			status: "needs_directory";
-			instruction: string;
-			next_command_template: string;
-	  }
-	| {
-			status: "scaffolded";
-			directory: string;
-			template: { id: string; title: string };
-			files_written: number;
-			next_steps: AgentNextStep[];
-			message: string;
-	  }
-	| { status: "error"; code: string; message: string };
+const removedAgent = () =>
+	`\`${getCliName()} bootstrap --agent\` was removed. List templates with \`${getCliName()} bootstrap --list-templates --output json\`. Scaffold with \`${getCliName()} bootstrap <directory> --template <id>\` or \`${getCliName()} bootstrap <directory> --default\`.`;
 
 // The directory positional is optional: omitting it in an interactive terminal
 // prompts for one. In a non-interactive context a missing directory is an error.
@@ -110,7 +67,8 @@ export const builder = (argv: yargs.Argv) =>
 			},
 			"list-templates": {
 				alias: ["list", "ls"],
-				describe: "List available templates and exit.",
+				describe:
+					"List available templates and exit. --output json and --output yaml print a machine-readable catalog.",
 				type: "boolean",
 				default: false,
 			},
@@ -121,10 +79,8 @@ export const builder = (argv: yargs.Argv) =>
 				default: false,
 			},
 			agent: {
-				describe:
-					"Emit a JSON state-machine response designed for AI agents instead of prompting. The output is a single JSON object with a discriminated `status` field describing the next step.",
+				hidden: true,
 				type: "boolean",
-				default: false,
 			},
 			default: {
 				alias: "y",
@@ -164,14 +120,32 @@ export const builder = (argv: yargs.Argv) =>
 			"Quick start: scaffold the default template and run setup without prompting",
 		)
 		.example(
-			"$0 bootstrap my-app --template hono --agent",
-			"Scaffold without prompting and emit the JSON state machine for AI agents",
+			"$0 bootstrap --list-templates --output json",
+			"Print the template catalog as JSON",
 		)
+		.check((argv) => {
+			if (argv.agent === true) {
+				throw new Error(removedAgent());
+			}
+			return true;
+		})
 		.strict();
 
 export const handler = async (props: BootstrapProps): Promise<void> => {
 	if (props.listTemplates) {
 		const templates = await fetchTemplates();
+		if (props.output === "json" || props.output === "yaml") {
+			writer(props).end(
+				templates.map((t) => ({
+					id: t.id,
+					title: t.title,
+					description: t.description,
+					services: t.services ?? [],
+				})),
+				{ fields: ["id", "title", "description", "services"] },
+			);
+			return;
+		}
 		for (const t of templates) {
 			const services =
 				t.services && t.services.length > 0
@@ -179,11 +153,6 @@ export const handler = async (props: BootstrapProps): Promise<void> => {
 					: "";
 			process.stdout.write(`${t.id} — ${t.description}${services}\n`);
 		}
-		return;
-	}
-
-	if (props.agent) {
-		await runAgentSafely(props);
 		return;
 	}
 
@@ -341,15 +310,6 @@ const scaffold = async (
 // Post-scaffold steps (install dependencies, git init, link to a Neon project)
 // ----------------------------------------------------------------------------
 
-/**
- * After a human scaffold, offer the things you almost always do next: install
- * dependencies, initialize a git repo, and link the directory to a Neon
- * project. In an interactive terminal each is a y/n prompt (skippable up front
- * with --no-install / --no-git / --no-link); `--default` runs install + git
- * without asking; otherwise we just print the manual steps so nothing runs
- * behind the user's back. Agent mode never reaches here — it returns these as
- * structured `next_steps` instead (see {@link runAgent}).
- */
 const runPostScaffoldSteps = async (
 	props: BootstrapProps,
 	targetDir: string,
@@ -574,123 +534,6 @@ const printNextSteps = (
 	log.info("");
 };
 
-const runAgentSafely = async (props: BootstrapProps): Promise<void> => {
-	try {
-		await runAgent(props);
-	} catch (err) {
-		emitAgent(toAgentError(err));
-		process.exit(1);
-	}
-};
-
-/**
- * The `--agent` flow: resolve what the flags determine and emit one JSON object
- * describing either the next input needed (`needs_template` / `needs_directory`)
- * or the terminal result (`scaffolded`). Unlike interactive mode it never
- * prompts and never runs install/git/link itself — those come back as structured
- * `next_steps` so the agent can confirm with the user and run them (the link
- * step chains into `neon link --agent`).
- */
-const runAgent = async (props: BootstrapProps): Promise<void> => {
-	if (!props.template) {
-		const templates = await fetchTemplates();
-		emitAgent({
-			status: "needs_template",
-			instruction: `Ask the user which template to scaffold, then re-run the next_command_template with the chosen --template value${
-				props.directory ? "" : " and a target directory"
-			}.`,
-			options: templates.map((template) => ({
-				id: template.id,
-				title: template.title,
-				description: template.description,
-				...(template.services ? { services: template.services } : {}),
-			})),
-			next_command_template: `${getCliName()} bootstrap --agent ${
-				props.directory ? shellArg(props.directory) : "<directory>"
-			} --template <template_id>`,
-		});
-		return;
-	}
-
-	const templates = await resolveTemplateList(props);
-	const template = findTemplate(templates, props.template);
-	if (!template) {
-		throw new BootstrapInputError(
-			`Unknown template "${props.template}". Available templates: ${templateIds(templates)}.`,
-			"UNKNOWN_TEMPLATE",
-		);
-	}
-
-	if (props.directory === undefined) {
-		emitAgent({
-			status: "needs_directory",
-			instruction:
-				'Ask the user which directory to scaffold into (use "." for the current directory), then re-run the next_command_template with it.',
-			next_command_template: `${getCliName()} bootstrap --agent <directory> --template ${shellArg(
-				template.id,
-			)}`,
-		});
-		return;
-	}
-
-	const targetDir = resolve(
-		process.cwd(),
-		props.directory === "." ? "" : props.directory,
-	);
-	ensureTargetUsable(targetDir, props.force);
-	const filesWritten = await scaffold(template, targetDir);
-
-	const dir = displayDir(targetDir);
-	const runIn = isCurrentDir(targetDir) ? "" : `cd ${shellArg(dir)} && `;
-	const installPm = resolvePackageManager(targetDir);
-	emitAgent({
-		status: "scaffolded",
-		directory: targetDir,
-		template: { id: template.id, title: template.title },
-		files_written: filesWritten,
-		next_steps: [
-			{
-				action: "install_dependencies",
-				instruction: `Ask the user whether to install dependencies, then run this in the project directory. ${DO_NOT_SUBSTITUTE_HINT}`,
-				command: `${runIn}${formatInstallCommand(installPm)}`,
-			},
-			{
-				action: "initialize_git",
-				instruction:
-					"Ask the user whether to initialize a git repository in the project directory.",
-				command: `${runIn}git init`,
-			},
-			{
-				action: "link_neon_project",
-				instruction:
-					"Ask the user whether to link the project to a Neon project now. This runs the link state machine — follow its JSON output for the next step.",
-				command: `${runIn}${getCliName()} link --agent`,
-			},
-		],
-		message: `Scaffolded "${template.title}" (${filesWritten} files) into ${dir}. Offer the next_steps to the user: install dependencies, initialize git, then link a Neon project.`,
-	});
-};
-
-const emitAgent = (response: AgentResponse): void => {
-	process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
-};
-
-const toAgentError = (
-	err: unknown,
-): Extract<AgentResponse, { status: "error" }> => {
-	if (err instanceof BootstrapInputError) {
-		return { status: "error", code: err.agentCode, message: err.message };
-	}
-	if (err instanceof Error) {
-		return {
-			status: "error",
-			code: "INTERNAL_ERROR",
-			message: err.message,
-		};
-	}
-	return { status: "error", code: "INTERNAL_ERROR", message: String(err) };
-};
-
 // ----------------------------------------------------------------------------
 // Path display helpers
 // ----------------------------------------------------------------------------
@@ -709,13 +552,6 @@ const displayDir = (targetDir: string): string => {
 		return ".";
 	}
 	return rel.startsWith("..") ? targetDir : rel;
-};
-
-const shellArg = (value: string): string => {
-	if (/^[A-Za-z0-9._:/-]+$/.test(value)) {
-		return value;
-	}
-	return `'${value.replace(/'/g, `'\\''`)}'`;
 };
 
 const onPromptState = (state: {

--- a/packages/cli/src/init/bootstrap.ts
+++ b/packages/cli/src/init/bootstrap.ts
@@ -501,12 +501,7 @@ export const downloadTemplate = async (
 // Target validation + scaffolding to disk
 // ---------------------------------------------------------------------------
 
-/**
- * A bad caller-supplied input that an agent (or human) can correct: an unknown
- * template id or a non-empty target directory. Carries an `agentCode` so an
- * agent surface can report a precise error code instead of a generic
- * INTERNAL_ERROR, while a human path just surfaces the clear `message`.
- */
+/** `agentCode` lets programmatic callers branch without parsing human-readable messages. */
 export class BootstrapInputError extends Error {
 	readonly agentCode: string;
 	constructor(message: string, agentCode: string) {


### PR DESCRIPTION
## Problem

Agents need to inspect the template catalog before scaffolding. `--list-templates` ignored the global structured output setting and returned terminal-oriented lines:

```console
$ neon bootstrap --list-templates --output json
hono — A Hono REST API on Neon Functions, backed by Lakebase Postgres via Drizzle. [Postgres · Functions]
graphql — A GraphQL Yoga API on Hono running on Neon Functions, backed by Lakebase Postgres via Drizzle. [Postgres · Functions]
```

Structured discovery instead lived inside the separate `--agent` state machine. Automation had to parse human output or implement a command-specific protocol for a job already covered by `--output`.

## Diagnosis

The list handler fetched the remote manifest and wrote each line directly to stdout. That bypassed the CLI writer responsible for JSON and YAML output.

The structured template mapping existed only inside `--agent`. This PR moves that mapping to `--list-templates` and removes the bootstrap state machine. Table output keeps its existing format.

## User-facing interface

Human-readable output remains unchanged:

```console
$ neon bootstrap --list-templates
hono — A Hono REST API on Neon Functions, backed by Lakebase Postgres via Drizzle. [Postgres · Functions]
graphql — A GraphQL Yoga API on Hono running on Neon Functions, backed by Lakebase Postgres via Drizzle. [Postgres · Functions]
```

JSON and YAML return arrays with `id`, `title`, `description` and `services`. Templates without services return `services: []`.

```console
$ neon bootstrap --list-templates --output json | jq '.[0]'
{
  "id": "hono",
  "title": "REST API",
  "description": "A Hono REST API on Neon Functions, backed by Lakebase Postgres via Drizzle.",
  "services": [
    "Postgres",
    "Functions"
  ]
}
```

```bash
neon bootstrap --list-templates --output json
neon bootstrap --list-templates --output yaml

neon bootstrap my-app --template hono
neon bootstrap my-app --default
```

`--agent` remains hidden but parses long enough to return a migration error. It exits with code 1 and writes nothing to stdout:

```console
$ neon bootstrap --agent
ERROR: `neon bootstrap --agent` was removed. List templates with `neon bootstrap --list-templates --output json`. Scaffold with `neon bootstrap <directory> --template <id>` or `neon bootstrap <directory> --default`.
```

## Also in here

- The CLI README documents human-readable and JSON template listing.
- The bootstrap fixture includes a template without services to pin the empty-array contract.
- A minor changeset covers both `neon` and the `neonctl` compatibility package.

## Verification

```console
$ pnpm --filter neon test
Test Files  179 passed | 3 skipped (182)
Tests       4574 passed | 6 skipped (4580)
```

That suite includes `src/commands/bootstrap.test.ts`, which covers:

- exact table output
- equivalent JSON and YAML rows
- the four structured fields on every row
- `services: []` when the manifest omits services
- the `--agent` exit code, empty stdout and migration message
- hidden `--agent` help
- existing scaffold, target validation and `--default` behavior

The built CLI was run against the live catalog:

```console
$ node packages/cli/dist/index.js bootstrap --list-templates --output json --no-analytics --api-key test-key
[
  {
    "id": "hono",
    "title": "REST API",
    "description": "A Hono REST API on Neon Functions, backed by Lakebase Postgres via Drizzle.",
    "services": [
      "Postgres",
      "Functions"
    ]
  }
]
```

The command exited 0 and returned the live catalog as a JSON array.

## For your attention

- Existing `bootstrap --agent` callers now exit with code 1. The changeset records this as a minor release.
- Table mode keeps the current line-oriented format instead of switching to the CLI writer's column layout.
- `neon link --agent` is unchanged.