### PR TITLE
fix: separate resource creation from credential retrieval

### DIFF
--- a/.changeset/safe-agent-creation.md
+++ b/.changeset/safe-agent-creation.md
@@ -1,0 +1,7 @@
+---
+"@neon/tools": minor
+"neon": minor
+"neonctl": minor
+---
+
+Publish `projects.create` and `branches.create` as credential-free creation tools, with connection strings retrieved explicitly through `postgres.connectionString`. The combined `projects.createAndConnect` and `branches.createWithCompute` selectors are no longer published. Add `--no-secrets` to project and branch creation in the Neon CLI.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -133,6 +133,18 @@ automation:
 neon branches create --project-id <project-id> --name production --protected
 ```
 
+Project and branch creation include connection credentials in their output by
+default for backward compatibility. When the output may be logged or passed to
+an agent, use `--no-secrets` to return only the created resource metadata:
+
+```bash
+neon projects create --name my-project --output json --no-secrets
+neon branches create --project-id <project-id> --name preview --output json --no-secrets
+```
+
+The flag omits the complete `connection_uris` block rather than redacting one
+field. Retrieve a connection string separately when it is actually needed.
+
 ### Enable logical replication
 
 Enable logical replication for every endpoint in an existing project:

--- a/packages/cli/mocks/main/projects/POST.js
+++ b/packages/cli/mocks/main/projects/POST.js
@@ -1,7 +1,32 @@
 import { expect } from 'vitest';
 
 export default function (req, res) {
-  if (req.body.project?.name === 'test_project_with_fixed_cu') {
+  if (req.body.project?.name === 'test_project_no_secrets') {
+    expect(req.body).toMatchObject({
+      project: { name: 'test_project_no_secrets' },
+    });
+    return res.send({
+      project: {
+        id: 'new-project-safe-output',
+        name: 'test_project_no_secrets',
+        created_at: '2026-08-25T00:00:00.000Z',
+      },
+      connection_uris: [
+        {
+          connection_uri:
+            'postgresql://neondb_owner:never-expose-this-password@example.com/neondb',
+          connection_parameters: {
+            password: 'never-expose-this-password',
+          },
+        },
+      ],
+      branch: {
+        id: 'br-safe-output',
+        name: 'main',
+        created_at: '2026-08-25T00:00:00.000Z',
+      },
+    });
+  } else if (req.body.project?.name === 'test_project_with_fixed_cu') {
     expect(req.body).toMatchObject({
       project: {
         name: 'test_project_with_fixed_cu',

--- a/packages/cli/mocks/main/projects/test/branches/POST.js
+++ b/packages/cli/mocks/main/projects/test/branches/POST.js
@@ -1,7 +1,35 @@
 import { expect } from 'vitest';
 
 export default function (req, res) {
-  if (req.body.branch?.name === 'test_branch_with_parent_name') {
+  if (req.body.branch?.name === 'test_branch_no_secrets') {
+    expect(req.body).toMatchObject({
+      branch: { name: 'test_branch_no_secrets' },
+    });
+    return res.send({
+      branch: {
+        id: 'br-safe-output',
+        name: 'test_branch_no_secrets',
+        created_at: '2026-08-25T00:00:00.000Z',
+      },
+      endpoints: [
+        {
+          id: 'ep-safe-output',
+          type: 'read_write',
+          created_at: '2026-08-25T00:00:00.000Z',
+          host: 'example.com',
+        },
+      ],
+      connection_uris: [
+        {
+          connection_uri:
+            'postgresql://neondb_owner:never-expose-this-password@example.com/neondb',
+          connection_parameters: {
+            password: 'never-expose-this-password',
+          },
+        },
+      ],
+    });
+  } else if (req.body.branch?.name === 'test_branch_with_parent_name') {
     expect(req.body).toMatchObject({
       branch: {
         name: 'test_branch_with_parent_name',

--- a/packages/cli/src/commands/branches.test.ts
+++ b/packages/cli/src/commands/branches.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe } from "vitest";
+import { describe, expect } from "vitest";
 
 import { test } from "../test_utils/fixtures";
 
@@ -60,6 +60,28 @@ describe("branches", () => {
 			"test_branch",
 		]);
 	});
+
+	for (const output of ["table", "json", "yaml"] as const) {
+		test(`create --no-secrets/${output}`, async ({ testCliCommand }) => {
+			const { stdout } = await testCliCommand(
+				[
+					"branches",
+					"create",
+					"--project-id",
+					"test",
+					"--name",
+					"test_branch_no_secrets",
+					"--no-secrets",
+				],
+				{ output, snapshot: false },
+			);
+
+			expect(stdout).toContain("br-safe-output");
+			expect(stdout).not.toContain("never-expose-this-password");
+			expect(stdout).not.toContain("connection_uri");
+			expect(stdout).not.toContain("connection_parameters");
+		});
+	}
 
 	test("create branch and connect with psql", async ({ testCliCommand }) => {
 		await testCliCommand([

--- a/packages/cli/src/commands/branches.ts
+++ b/packages/cli/src/commands/branches.ts
@@ -68,6 +68,12 @@ export const builder = (argv: yargs.Argv) =>
 			"Create a branch",
 			(yargs) =>
 				yargs.options({
+					secrets: {
+						describe:
+							"Include connection credentials in command output. Use --no-secrets to omit them",
+						type: "boolean",
+						default: true,
+					},
 					name: branchCreateRequest["branch.name"],
 					parent: {
 						describe:
@@ -361,6 +367,7 @@ const create = async (
 		type: EndpointType;
 		psql: boolean;
 		fallback: boolean;
+		secrets: boolean;
 		suspendTimeout: number;
 		annotation?: string;
 		schemaOnly: boolean;
@@ -472,7 +479,7 @@ const create = async (
 			emptyMessage: "No endpoints have been found.",
 		});
 	}
-	if (data.connection_uris?.length) {
+	if (props.secrets && data.connection_uris?.length) {
 		out.write(data.connection_uris, {
 			fields: ["connection_uri"],
 			title: "connection_uris",

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -22,6 +22,26 @@ describe("projects", () => {
 		await testCliCommand(["projects", "create", "--name", "test_project"]);
 	});
 
+	for (const output of ["table", "json", "yaml"] as const) {
+		test(`create --no-secrets/${output}`, async ({ testCliCommand }) => {
+			const { stdout } = await testCliCommand(
+				[
+					"projects",
+					"create",
+					"--name",
+					"test_project_no_secrets",
+					"--no-secrets",
+				],
+				{ output, snapshot: false },
+			);
+
+			expect(stdout).toContain("new-project-safe-output");
+			expect(stdout).not.toContain("never-expose-this-password");
+			expect(stdout).not.toContain("connection_uri");
+			expect(stdout).not.toContain("connection_parameters");
+		});
+	}
+
 	test("create with hipaa flag", async ({ testCliCommand }) => {
 		await testCliCommand([
 			"projects",

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -82,6 +82,12 @@ export const builder = (argv: yargs.Argv) => {
 			"Create a project",
 			(yargs) =>
 				yargs.options({
+					secrets: {
+						describe:
+							"Include connection credentials in command output. Use --no-secrets to omit them",
+						type: "boolean",
+						default: true,
+					},
 					"block-public-connections": {
 						describe:
 							projectCreateRequest[
@@ -319,6 +325,7 @@ const create = async (
 		psql: boolean;
 		fallback: boolean;
 		setContext: boolean;
+		secrets: boolean;
 		hipaa?: boolean;
 		"--"?: string[];
 	},
@@ -379,10 +386,12 @@ const create = async (
 
 	const out = writer(props);
 	out.write(data.project, { fields: PROJECT_FIELDS, title: "Project" });
-	out.write(data.connection_uris, {
-		fields: ["connection_uri"],
-		title: "Connection URIs",
-	});
+	if (props.secrets) {
+		out.write(data.connection_uris, {
+			fields: ["connection_uri"],
+			title: "Connection URIs",
+		});
+	}
 	out.end();
 
 	if (props.psql) {

--- a/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
+++ b/packages/cli/src/init/__snapshots__/agent_snapshot.test.ts.snap
@@ -360,7 +360,7 @@ exports[`neon init --agent: every step, against every project shape > connected 
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -1358,7 +1358,7 @@ exports[`neon init --agent: every step, against every project shape > drizzle > 
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -2356,7 +2356,7 @@ exports[`neon init --agent: every step, against every project shape > fully-conf
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -3323,7 +3323,7 @@ exports[`neon init --agent: every step, against every project shape > greenfield
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -4326,7 +4326,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -5329,7 +5329,7 @@ exports[`neon init --agent: every step, against every project shape > next-prism
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -6327,7 +6327,7 @@ exports[`neon init --agent: every step, against every project shape > node-app >
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -7330,7 +7330,7 @@ exports[`neon init --agent: every step, against every project shape > other-data
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -8107,7 +8107,7 @@ exports[`neon init --agent: nested and string-encoded --data payloads > JSON-enc
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -8175,7 +8175,7 @@ exports[`neon init --agent: nested and string-encoded --data payloads > nested o
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -11839,7 +11839,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cla
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -12334,7 +12334,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cod
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -12829,7 +12829,7 @@ exports[`neon init --agent: the response depends on which agent is driving > cur
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",
@@ -13340,7 +13340,7 @@ exports[`neon init --agent: the response depends on which agent is driving > non
       {
         "id": "create_project_if_needed",
         "description": "If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>). If the user chose an existing project, skip this step.",
-        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json"
+        "command": "CI= npx -y neon projects create --name <project-name> --org-id <org-id> --output json --no-secrets"
       },
       {
         "id": "create_neon_context",

--- a/packages/cli/src/init/phases/db.ts
+++ b/packages/cli/src/init/phases/db.ts
@@ -122,7 +122,7 @@ export async function handleDbPhase(
 						},
 					],
 					context:
-						`The agent should ask the user for a project name, then run: ${neonctlCmd()} projects create --name <name> --output json` +
+						`The agent should ask the user for a project name, then run: ${neonctlCmd()} projects create --name <name> --output json --no-secrets` +
 						(options.orgId ? ` --org-id ${options.orgId}` : "") +
 						" and pass the result back.",
 					responseMapping: {
@@ -172,7 +172,7 @@ export async function handleDbPhase(
 				type: "ask_user",
 				question: "Which Neon project would you like to use?",
 				options: projectOptions,
-				context: `If the user wants to create a new project, ask for a name then run: ${neonctlCmd()} projects create --name <name> --output json and use the returned project id.`,
+				context: `If the user wants to create a new project, ask for a name then run: ${neonctlCmd()} projects create --name <name> --output json --no-secrets and use the returned project id.`,
 				responseMapping,
 			},
 		};

--- a/packages/cli/src/init/phases/getting_started.ts
+++ b/packages/cli/src/init/phases/getting_started.ts
@@ -75,7 +75,7 @@ export async function handleGettingStartedPhase(
 						"Ask the user for a project name (suggest the current directory name).",
 						"If the user chose an existing eligible project, skip this step.",
 					].join(" "),
-					command: `${neonctlCmd()} projects create --name <project-name> --org-id <org-id> --region-id aws-us-east-2 --output json`,
+					command: `${neonctlCmd()} projects create --name <project-name> --org-id <org-id> --region-id aws-us-east-2 --output json --no-secrets`,
 				},
 			);
 		} else {
@@ -107,7 +107,7 @@ export async function handleGettingStartedPhase(
 						"If the user chose to create a new project, create it using the CLI command below (replace <org-id> and <project-name>).",
 						"If the user chose an existing project, skip this step.",
 					].join(" "),
-					command: `${neonctlCmd()} projects create --name <project-name> --org-id <org-id> --output json`,
+					command: `${neonctlCmd()} projects create --name <project-name> --org-id <org-id> --output json --no-secrets`,
 				},
 			);
 		}

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -23,15 +23,16 @@ const tools = createNeonTools({
 	apiKey,
 	tools: [
 		"projects.list",
-		"projects.createAndConnect",
-		"branches.createWithCompute",
+		"projects.create",
+		"branches.create",
+		"postgres.connectionString",
 		"branches.resetFromParent",
 		"branches.compareSchema",
 	],
 });
 
 const listed = await tools["projects.list"].execute({ limit: 10 });
-const created = await tools["projects.createAndConnect"].execute({
+const created = await tools["projects.create"].execute({
 	name: "agent-project",
 	region_id: "aws-us-east-1",
 });
@@ -70,7 +71,7 @@ Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, 
 Paginated lists call `.all()` and return the item array. Do not pass a cursor; those fields are omitted from the input schema.
 
 ```ts
-const createBranch = createNeonTool("branches.createWithCompute", { apiKey });
+const createBranch = createNeonTool("branches.create", { apiKey });
 ```
 
 ## Writes and waiting
@@ -83,7 +84,9 @@ An abort `signal` on `execute` or a wait timeout stops the poll, not the create:
 
 `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there.
 
-These public client methods are not tools: `projects.create`, `branches.create`, `operations.waitFor`, `postgres.roles.password`, and `storage.objects.get`. Use `projects.createAndConnect` and `branches.createWithCompute` for creates that attach compute and return a connection string. Waiting is what the write tools already do.
+`projects.create` and `branches.create` return only the created resource metadata. They do not return connection credentials. Add a branch compute with `postgres.endpoints.create`, then request a connection string explicitly with `postgres.connectionString` when it is needed.
+
+These public client methods are not tools: `projects.createAndConnect`, `branches.createWithCompute`, `operations.waitFor`, `postgres.roles.password`, and `storage.objects.get`. Waiting is what the write tools already do.
 
 ## Optional host add-ons
 
@@ -127,17 +130,17 @@ This package does not send analytics. Mutating `event.input` does not change a g
 ```ts
 const tools = createNeonTools({
 	apiKey,
-	tools: ["branches.createWithCompute", "projects.list"] as const,
-	names: { "branches.createWithCompute": "create_branch" },
+	tools: ["branches.create", "projects.list"] as const,
+	names: { "branches.create": "create_branch" },
 	name: (id) => `neon_${id}`,
 });
 ```
 
-Those tools publish as `neon_create_branch` and `neon_list_projects`. The record is still keyed by SDK path (`tools["branches.createWithCompute"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
+Those tools publish as `neon_create_branch` and `neon_list_projects`. The record is still keyed by SDK path (`tools["branches.create"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
 
 ### Project and branch injection
 
-Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.createWithCompute`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
+Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.create`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
 
 ```ts
 const tools = createNeonTools({
@@ -193,7 +196,7 @@ const body = zCreateProjectBody.parse({
 });
 ```
 
-These are the raw OpenAPI request shapes, not the tool input. `zCreateProjectBody` still wraps fields in `project`. `projects.createAndConnect` does not.
+These are the raw OpenAPI request shapes, not the tool input. `zCreateProjectBody` still wraps fields in `project`. `projects.create` does not.
 
 These schemas are strict. If a newly added API field is not recognized, upgrade `@neon/tools`; use `@neon/sdk` directly until a matching tools release is available.
 
@@ -212,7 +215,7 @@ if (!apiKey) throw new Error("NEON_API_KEY is required");
 const server = new McpServer({ name: "neon", version: "1.0.0" });
 const tools = createNeonTools({
 	apiKey,
-	tools: ["projects.list", "projects.createAndConnect"] as const,
+	tools: ["projects.list", "projects.create"] as const,
 });
 
 registerNeonTools(server, tools);
@@ -222,7 +225,7 @@ For a remote MCP server that already authenticated the client, omit `apiKey` at 
 
 ```ts
 const tools = createNeonTools({
-	tools: ["projects.list", "projects.createAndConnect"] as const,
+	tools: ["projects.list", "projects.create"] as const,
 });
 registerNeonTools(server, tools);
 ```
@@ -243,7 +246,7 @@ MCP annotations are advisory; the protocol does not enforce approval. Tools expo
 
 Eve requires Node.js 24 or later.
 
-`create_and_connect_projects.ts`:
+`create_projects.ts`:
 
 ```ts
 import { defineTool } from "eve/tools";
@@ -255,7 +258,7 @@ if (!apiKey) throw new Error("NEON_API_KEY is required");
 
 export default defineTool(
 	toEveTool(
-		createNeonTool("projects.createAndConnect", {
+		createNeonTool("projects.create", {
 			apiKey,
 		}),
 	),
@@ -278,12 +281,12 @@ if (!apiKey) throw new Error("NEON_API_KEY is required");
 
 const neonTools = createNeonTools({
 	apiKey,
-	tools: ["projects.list", "projects.createAndConnect"] as const,
+	tools: ["projects.list", "projects.create"] as const,
 });
 const configs = toMastraTools(neonTools);
 
 const listProjects = createTool(configs.list_projects);
-const createProject = createTool(configs.create_and_connect_projects);
+const createProject = createTool(configs.create_projects);
 ```
 
 The adapter maps approval requirements to Mastra's `requireApproval` field and forwards its abort signal.

--- a/packages/tools/src/catalog.test.ts
+++ b/packages/tools/src/catalog.test.ts
@@ -48,10 +48,10 @@ describe("ergonomic catalog coverage", () => {
 		}
 		expect(() =>
 			Reflect.apply(createNeonTool, undefined, [
-				"projects.create",
+				"projects.createAndConnect",
 				{ apiKey: "test-key" },
 			]),
-		).toThrow("projects.createAndConnect");
+		).toThrow("postgres.connectionString");
 	});
 });
 

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -738,7 +738,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.delete", "branches.createWithCompute"] as const,
+			tools: ["branches.delete", "branches.create"] as const,
 			inject: { projectId: "granted-project", omitFromSchema: true },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -749,7 +749,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		await tools["branches.delete"].execute({
 			branch_id: "br-id",
 		});
-		await tools["branches.createWithCompute"].execute({
+		await tools["branches.create"].execute({
 			name: "feature",
 		});
 
@@ -762,7 +762,6 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		);
 		expect(await requests[1].json()).toEqual({
 			branch: { name: "feature" },
-			endpoints: [{ type: "read_write" }],
 		});
 	});
 
@@ -910,19 +909,16 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 	test("drops path from createProjectBranch when project_id is omitted", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute"] as const,
+			tools: ["branches.create"] as const,
 			inject: { projectId: "granted-project", omitFromSchema: true },
 		});
 
-		const schema = z.toJSONSchema(
-			tools["branches.createWithCompute"].inputSchema,
-		);
+		const schema = z.toJSONSchema(tools["branches.create"].inputSchema);
 		expect(schema.properties).not.toHaveProperty("project_id");
 		expect(schema.properties).toHaveProperty("name");
-		expect(
-			tools["branches.createWithCompute"].inputSchema.safeParse({})
-				.success,
-		).toBe(true);
+		expect(tools["branches.create"].inputSchema.safeParse({}).success).toBe(
+			true,
+		);
 	});
 
 	test("isolates request-scoped getters through host AsyncLocalStorage", async () => {
@@ -962,22 +958,20 @@ describe("tool names", () => {
 	test("renames one tool and then applies a global prefix", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute", "projects.list"] as const,
-			names: { "branches.createWithCompute": "create_branch" },
+			tools: ["branches.create", "projects.list"] as const,
+			names: { "branches.create": "create_branch" },
 			name: (id) => `neon_${id}`,
 		});
 
-		expect(tools["branches.createWithCompute"].id).toBe(
-			"neon_create_branch",
-		);
+		expect(tools["branches.create"].id).toBe("neon_create_branch");
 		expect(tools["projects.list"].id).toBe("neon_list_projects");
 	});
 
 	test("lets a function rename from the generated id", () => {
-		const tool = createNeonTool("branches.createWithCompute", {
+		const tool = createNeonTool("branches.create", {
 			apiKey: "test-key",
 			names: ({ id }) =>
-				id === "create_with_compute_branches" ? "create_branch" : id,
+				id === "create_branches" ? "create_branch" : id,
 		});
 
 		expect(tool.id).toBe("create_branch");
@@ -1012,7 +1006,7 @@ describe("tool names", () => {
 		expect(() =>
 			createNeonTools({
 				apiKey: "test-key",
-				tools: ["branches.createWithCompute"] as const,
+				tools: ["branches.create"] as const,
 				names: { createProjectBrunch: "create_branch" },
 			}),
 		).toThrow("Unknown Neon tool name override: createProjectBrunch");

--- a/packages/tools/src/frameworks.test.ts
+++ b/packages/tools/src/frameworks.test.ts
@@ -16,7 +16,7 @@ describe("Eve compatibility", () => {
 		const controller = new AbortController();
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["projects.createAndConnect"],
+			tools: ["projects.create"],
 			fetch: async (input, init) => {
 				const request =
 					input instanceof Request ? input : new Request(input, init);
@@ -29,12 +29,10 @@ describe("Eve compatibility", () => {
 			},
 		});
 
-		const config = toEveTool(tools["projects.createAndConnect"]);
+		const config = toEveTool(tools["projects.create"]);
 		const tool = defineTool(config);
 
-		expect(tool.description).toBe(
-			tools["projects.createAndConnect"].description,
-		);
+		expect(tool.description).toBe(tools["projects.create"].description);
 		expect(typeof tool.approval).toBe("function");
 		await expect(
 			config.execute(
@@ -59,16 +57,16 @@ describe("Mastra compatibility", () => {
 	test("produces createTool-compatible records with approval metadata", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["projects.list", "projects.createAndConnect"],
+			tools: ["projects.list", "projects.create"],
 		});
 
 		const configs = toMastraTools(tools);
 		const listProjects = createTool(configs.list_projects);
-		const createProject = createTool(configs.create_and_connect_projects);
+		const createProject = createTool(configs.create_projects);
 
 		expect(listProjects.id).toBe("list_projects");
 		expect(listProjects.requireApproval).toBe(false);
-		expect(createProject.id).toBe("create_and_connect_projects");
+		expect(createProject.id).toBe("create_projects");
 		expect(createProject.requireApproval).toBe(true);
 	});
 

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -9,9 +9,7 @@ import {
 import { toMastraTools } from "./mastra.js";
 
 expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"list_projects">();
-expectTypeOf(
-	publishedId("projects.createAndConnect"),
-).toEqualTypeOf<"create_and_connect_projects">();
+expectTypeOf(publishedId("projects.create")).toEqualTypeOf<"create_projects">();
 expectTypeOf(
 	publishedId("postgres.roles.resetPassword"),
 ).toEqualTypeOf<"reset_password_postgres_roles">();
@@ -24,14 +22,14 @@ expectTypeOf(
 
 const tools = createNeonTools({
 	apiKey: "test-key",
-	tools: ["projects.list", "projects.createAndConnect"] as const,
+	tools: ["projects.list", "projects.create"] as const,
 });
 
 expectTypeOf(tools).toHaveProperty("projects.list");
-expectTypeOf(tools).toHaveProperty("projects.createAndConnect");
+expectTypeOf(tools).toHaveProperty("projects.create");
 
 tools["projects.list"].execute({ limit: 1 });
-tools["projects.createAndConnect"].execute({ name: "type-safe" });
+tools["projects.create"].execute({ name: "type-safe" });
 tools["projects.list"].execute({}).then((result) => {
 	expectTypeOf(result.data[0]?.id).toEqualTypeOf<string>();
 });
@@ -56,7 +54,7 @@ listProjects.execute({ name: "wrong-operation" });
 
 const mastraTools = toMastraTools(tools);
 expectTypeOf(mastraTools).toHaveProperty("list_projects");
-expectTypeOf(mastraTools).toHaveProperty("create_and_connect_projects");
+expectTypeOf(mastraTools).toHaveProperty("create_projects");
 
 // @ts-expect-error unselected tools are absent from the Mastra tool record
 mastraTools.delete_projects;
@@ -175,21 +173,21 @@ uninjectedProject.execute({});
 
 const renamed = createNeonTools({
 	apiKey: "test-key",
-	tools: ["projects.list", "branches.createWithCompute"] as const,
-	names: { "branches.createWithCompute": "create_branch" },
+	tools: ["projects.list", "branches.create"] as const,
+	names: { "branches.create": "create_branch" },
 	name: (id) => `neon_${id}`,
 });
 expectTypeOf(renamed["projects.list"].id).toEqualTypeOf<string>();
-expectTypeOf(renamed["branches.createWithCompute"].id).toEqualTypeOf<string>();
+expectTypeOf(renamed["branches.create"].id).toEqualTypeOf<string>();
 expectTypeOf(tools["projects.list"].id).toEqualTypeOf<"list_projects">();
 
 const mastraRenamed = toMastraTools(renamed);
 expectTypeOf(mastraRenamed.neon_create_branch.id).toEqualTypeOf<string>();
 expectTypeOf(mastraRenamed.neon_list_projects.id).toEqualTypeOf<string>();
 
-const renamedOne = createNeonTool("branches.createWithCompute", {
+const renamedOne = createNeonTool("branches.create", {
 	apiKey: "test-key",
-	names: { "branches.createWithCompute": "create_branch" },
+	names: { "branches.create": "create_branch" },
 });
 expectTypeOf(renamedOne.id).toEqualTypeOf<string>();
 
@@ -218,40 +216,39 @@ expectTypeOf(createNeonTools(annotatedTools)).toHaveProperty("projects.list");
 
 const createBranch = createNeonTools({
 	apiKey: "test-key",
-	tools: ["branches.createWithCompute"] as const,
+	tools: ["branches.create"] as const,
 });
-expectTypeOf(createBranch).toHaveProperty("branches.createWithCompute");
+expectTypeOf(createBranch).toHaveProperty("branches.create");
 // @ts-expect-error unselected tools are absent
 createBranch["projects.list"];
-createBranch["branches.createWithCompute"].execute({
+createBranch["branches.create"].execute({
 	project_id: "project-id",
 });
 // @ts-expect-error project_id is required without inject
-createBranch["branches.createWithCompute"].execute({});
-createBranch["branches.createWithCompute"]
+createBranch["branches.create"].execute({});
+createBranch["branches.create"]
 	.execute({ project_id: "project-id" })
 	.then((result) => {
-		expectTypeOf(result.data.connectionString).toEqualTypeOf<string>();
-		expectTypeOf(result.data.branch.id).toEqualTypeOf<string>();
+		expectTypeOf(result.data.id).toEqualTypeOf<string>();
 	});
 
 declare const unionOpts:
 	| { apiKey: "test-key"; tools: ["projects.list"] }
-	| { apiKey: "test-key"; tools: ["branches.createWithCompute"] };
+	| { apiKey: "test-key"; tools: ["branches.create"] };
 const unionTools = createNeonTools(unionOpts);
 // @ts-expect-error union options do not share projects.list
 unionTools["projects.list"];
-// @ts-expect-error union options do not share branches.createWithCompute
-unionTools["branches.createWithCompute"];
+// @ts-expect-error union options do not share branches.create
+unionTools["branches.create"];
 
-const createBranchWithCompute = createNeonTool("branches.createWithCompute", {
+const createBranchTool = createNeonTool("branches.create", {
 	apiKey: "test-key",
 });
-createBranchWithCompute.execute({
+createBranchTool.execute({
 	project_id: "project-id",
 	name: "feature-x",
 });
-createBranchWithCompute.execute({
+createBranchTool.execute({
 	project_id: "project-id",
 	// @ts-expect-error parentId is not the tool field name
 	parentId: "br-id",
@@ -259,10 +256,10 @@ createBranchWithCompute.execute({
 
 const omittedWorkflow = createNeonTools({
 	apiKey: "test-key",
-	tools: ["branches.createWithCompute"] as const,
+	tools: ["branches.create"] as const,
 	inject: { projectId: "granted-project", omitFromSchema: true },
 });
-omittedWorkflow["branches.createWithCompute"].execute({ name: "feature-x" });
+omittedWorkflow["branches.create"].execute({ name: "feature-x" });
 
 // @ts-expect-error tools is required
 createNeonTools({ apiKey: "test-key" });

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -15,17 +15,15 @@ describe("createNeonTools", () => {
 	test("creates only the explicitly selected tools", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["projects.list", "projects.createAndConnect"] as const,
+			tools: ["projects.list", "projects.create"] as const,
 		});
 
 		expect(Object.keys(tools)).toEqual([
 			"projects.list",
-			"projects.createAndConnect",
+			"projects.create",
 		]);
 		expect(tools["projects.list"].id).toBe("list_projects");
-		expect(tools["projects.createAndConnect"].id).toBe(
-			"create_and_connect_projects",
-		);
+		expect(tools["projects.create"].id).toBe("create_projects");
 	});
 
 	test("lists every page and returns the unwrapped items", async () => {

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -11,8 +11,7 @@ import {
 import {
 	compareSchemaTool,
 	connectionStringTool,
-	createBranchWithComputeTool,
-	createProjectAndConnectTool,
+	createBranchTool,
 	getDefaultTool,
 	resetFromParentTool,
 	restoreSnapshotTool,
@@ -58,7 +57,13 @@ export const toolFactories = {
 			run: (neon, input, signal) =>
 				neon.projects.get(input.project_id, { signal }),
 		}),
-	"projects.createAndConnect": createProjectAndConnectTool,
+	"projects.create": (options) =>
+		fromGenerated(options, {
+			id: "projects.create",
+			generated: "createProject",
+			run: (neon, input, signal) =>
+				neon.projects.create(input, { signal }),
+		}),
 	"projects.update": (options) =>
 		fromGenerated(options, {
 			id: "projects.update",
@@ -225,7 +230,7 @@ export const toolFactories = {
 					signal,
 				}),
 		}),
-	"branches.createWithCompute": createBranchWithComputeTool,
+	"branches.create": createBranchTool,
 	"branches.update": (options) =>
 		fromGenerated(options, {
 			id: "branches.update",

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -21,25 +21,10 @@ const pooledField = z
 	.optional();
 
 const branchCreateFields = zod.zBranchCreateRequest.shape.branch.unwrap().shape;
-const projectCreateFields = zod.zCreateProjectBody.shape.project.shape;
 
-export const createBranchWithComputeInputSchema = z.strictObject({
+export const createBranchInputSchema = z.strictObject({
 	project_id: zod.zCreateProjectBranchPath.shape.project_id,
-	name: branchCreateFields.name,
-	parent_id: branchCreateFields.parent_id,
-	compute: z
-		.strictObject({
-			min_cu: zod.zComputeUnit.optional(),
-			max_cu: zod.zComputeUnit.optional(),
-			suspend_timeout_seconds: zod.zSuspendTimeoutSeconds.optional(),
-		})
-		.optional(),
-	pooled: pooledField,
-});
-
-export const createProjectAndConnectInputSchema = z.strictObject({
-	...projectCreateFields,
-	pooled: pooledField,
+	...branchCreateFields,
 });
 
 export const getDefaultInputSchema = z.strictObject({
@@ -103,16 +88,16 @@ export const setScheduleInputSchema = z.strictObject({
 	),
 });
 
-export const createBranchWithComputeTool = (options: ToolClientOptions) =>
+export const createBranchTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "branches.createWithCompute",
-			id: publishedId("branches.createWithCompute"),
-			title: "Create branch with compute",
+			operationId: "branches.create",
+			id: publishedId("branches.create"),
+			title: "Create branch",
 			description:
-				"Create a branch with a read-write endpoint and return its connection string. The call waits until operation-backed provisioning finishes, up to five minutes by default.",
-			inputSchema: createBranchWithComputeInputSchema,
+				"Create a branch without returning connection credentials. Add a compute with postgres.endpoints.create and request credentials separately with postgres.connectionString when needed.",
+			inputSchema: createBranchInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,
 			metadata: {
@@ -123,57 +108,9 @@ export const createBranchWithComputeTool = (options: ToolClientOptions) =>
 				tags: ["Branch"],
 			},
 		},
-		(neon, input, signal) =>
-			neon.branches.createWithCompute(
-				input.project_id,
-				{
-					name: input.name,
-					parentId: input.parent_id,
-					compute:
-						input.compute === undefined
-							? undefined
-							: {
-									minCu: input.compute.min_cu,
-									maxCu: input.compute.max_cu,
-									suspendTimeoutSeconds:
-										input.compute.suspend_timeout_seconds,
-								},
-				},
-				{
-					signal,
-					...(input.pooled === undefined
-						? {}
-						: { pooled: input.pooled }),
-				},
-			),
-	);
-
-export const createProjectAndConnectTool = (options: ToolClientOptions) =>
-	bindTool(
-		options,
-		{
-			operationId: "projects.createAndConnect",
-			id: publishedId("projects.createAndConnect"),
-			title: "Create project and connect",
-			description:
-				"Create a project and return a connection string to its default branch. The call waits until operation-backed provisioning finishes, up to five minutes by default.",
-			inputSchema: createProjectAndConnectInputSchema,
-			annotations: writeAnnotations,
-			requiresApproval: true,
-			metadata: {
-				method: "POST",
-				path: "/projects",
-				stability: "stable",
-				deprecated: false,
-				tags: ["Project"],
-			},
-		},
 		(neon, input, signal) => {
-			const { pooled, ...project } = input;
-			return neon.projects.createAndConnect(project, {
-				signal,
-				...(pooled === undefined ? {} : { pooled }),
-			});
+			const { project_id, ...branch } = input;
+			return neon.branches.create(project_id, branch, { signal });
 		},
 	);
 

--- a/packages/tools/src/lib/ergonomic/ids.ts
+++ b/packages/tools/src/lib/ergonomic/ids.ts
@@ -1,7 +1,7 @@
 export const hiddenToolIds = [
 	"operations.waitFor",
-	"branches.create",
-	"projects.create",
+	"branches.createWithCompute",
+	"projects.createAndConnect",
 	"postgres.roles.password",
 	"storage.objects.get",
 ] as const;
@@ -11,7 +11,7 @@ export type HiddenToolId = (typeof hiddenToolIds)[number];
 export const toolIds = [
 	"projects.list",
 	"projects.get",
-	"projects.createAndConnect",
+	"projects.create",
 	"projects.update",
 	"projects.delete",
 	"projects.recover",
@@ -25,7 +25,7 @@ export const toolIds = [
 	"projects.members.removeRole",
 	"branches.list",
 	"branches.get",
-	"branches.createWithCompute",
+	"branches.create",
 	"branches.update",
 	"branches.delete",
 	"branches.getDefault",
@@ -117,10 +117,10 @@ export const isNeonToolId = (id: string): id is NeonToolId =>
 	(toolIds as readonly string[]).includes(id);
 
 const hiddenToolHint: Record<HiddenToolId, string> = {
-	"projects.create":
-		'Use "projects.createAndConnect", which attaches compute and returns a connection string.',
-	"branches.create":
-		'Use "branches.createWithCompute", which attaches compute and returns a connection string.',
+	"projects.createAndConnect":
+		'Use "projects.create", then call "postgres.connectionString" only when credentials are explicitly needed.',
+	"branches.createWithCompute":
+		'Use "branches.create" and "postgres.endpoints.create", then call "postgres.connectionString" only when credentials are explicitly needed.',
 	"operations.waitFor":
 		"Write tools wait for readiness. operations.waitFor is not a tool.",
 	"postgres.roles.password": "Role passwords are not published as a tool.",

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -142,6 +142,48 @@ const captureHandler = () => {
 	};
 };
 
+describe("MCP secret boundaries", () => {
+	for (const [version, register] of [
+		["v2", registerNeonToolsV2],
+		["v1", registerNeonToolsV1],
+	] as const) {
+		test(`${version} project creation omits credentials returned by the API`, async () => {
+			const { server, handler } = captureHandler();
+			const safeTools = createNeonTools({
+				apiKey: "test-key",
+				tools: ["projects.create"],
+				fetch: async () =>
+					new Response(
+						JSON.stringify({
+							project: { id: "project-id", name: "safe" },
+							connection_uris: [
+								{
+									connection_uri:
+										"postgresql://user:never-expose-this-password@example.com/neondb",
+									connection_parameters: {
+										password: "never-expose-this-password",
+									},
+								},
+							],
+						}),
+						{ headers: { "content-type": "application/json" } },
+					),
+			});
+			register(server, safeTools);
+
+			const result = await handler()({ name: "safe" }, {});
+
+			expect(result.structuredContent).toEqual({
+				data: { id: "project-id", name: "safe" },
+			});
+			expect(JSON.stringify(result)).not.toContain(
+				"never-expose-this-password",
+			);
+			expect(JSON.stringify(result)).not.toContain("connection_uri");
+		});
+	}
+});
+
 const toolsWithCapturedAuth = () => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({

--- a/packages/tools/src/published-id.test.ts
+++ b/packages/tools/src/published-id.test.ts
@@ -6,12 +6,8 @@ import { toolIds } from "./lib/ergonomic/ids.js";
 describe("publishedId", () => {
 	test("moves the last path segment in front", () => {
 		expect(publishedId("projects.list")).toBe("list_projects");
-		expect(publishedId("projects.createAndConnect")).toBe(
-			"create_and_connect_projects",
-		);
-		expect(publishedId("branches.createWithCompute")).toBe(
-			"create_with_compute_branches",
-		);
+		expect(publishedId("projects.create")).toBe("create_projects");
+		expect(publishedId("branches.create")).toBe("create_branches");
 		expect(publishedId("postgres.roles.resetPassword")).toBe(
 			"reset_password_postgres_roles",
 		);

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -6,35 +6,31 @@ import {
 	type NeonToolsClientOptions,
 } from "./index.js";
 
+const SECRET = "never-expose-this-password";
+
 const jsonResponse = (body: unknown, status = 201) =>
 	new Response(JSON.stringify(body), {
 		status,
 		headers: { "content-type": "application/json" },
 	});
 
-const branchWithComputeBody = {
+const branchCreateBody = {
 	branch: { id: "br-id", name: "feature-x" },
 	endpoints: [{ id: "ep-id", type: "read_write" }],
 	connection_uris: [
 		{
-			connection_uri: "postgresql://user:pass@ep-host/neondb",
-			connection_parameters: {
-				host: "ep-host",
-				pooler_host: "ep-pooler-host",
-			},
+			connection_uri: `postgresql://user:${SECRET}@ep-host/neondb`,
+			connection_parameters: { password: SECRET },
 		},
 	],
 };
 
-const projectWithUriBody = {
+const projectCreateBody = {
 	project: { id: "project-id", name: "tool-created" },
 	connection_uris: [
 		{
-			connection_uri: "postgresql://user:pass@ep-host/neondb",
-			connection_parameters: {
-				host: "ep-host",
-				pooler_host: "ep-pooler-host",
-			},
+			connection_uri: `postgresql://user:${SECRET}@ep-host/neondb`,
+			connection_parameters: { password: SECRET },
 		},
 	],
 };
@@ -44,49 +40,40 @@ const createBranchTools = (options: NeonToolsClientOptions = {}) => {
 	const tools = createNeonTools({
 		apiKey: "test-key",
 		...options,
-		tools: ["branches.createWithCompute"] as const,
+		tools: ["branches.create"] as const,
 		fetch: async (input, init) => {
 			requests.push(new Request(input, init));
-			return jsonResponse(branchWithComputeBody);
+			return jsonResponse(branchCreateBody);
 		},
 	});
 	return { requests, tools };
 };
 
-describe("branches.createWithCompute", () => {
-	test("creates only the selected tool", () => {
+describe("branches.create", () => {
+	test("creates only the selected safe tool", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute"] as const,
+			tools: ["branches.create"] as const,
 		});
 
-		expect(Object.keys(tools)).toEqual(["branches.createWithCompute"]);
-		expect(tools["branches.createWithCompute"].id).toBe(
-			"create_with_compute_branches",
-		);
-		expect(tools["branches.createWithCompute"].operationId).toBe(
-			"branches.createWithCompute",
-		);
-		expect(tools["branches.createWithCompute"].requiresApproval).toBe(true);
-		expect(tools["branches.createWithCompute"].annotations).toEqual({
+		expect(Object.keys(tools)).toEqual(["branches.create"]);
+		expect(tools["branches.create"].id).toBe("create_branches");
+		expect(tools["branches.create"].operationId).toBe("branches.create");
+		expect(tools["branches.create"].requiresApproval).toBe(true);
+		expect(tools["branches.create"].annotations).toEqual({
 			readOnlyHint: false,
 			destructiveHint: true,
 			openWorldHint: true,
 		});
 	});
 
-	test("posts a read-write endpoint and returns the SDK workflow result", async () => {
+	test("returns branch metadata without credentials from the API response", async () => {
 		const { requests, tools } = createBranchTools();
 
-		const result = await tools["branches.createWithCompute"].execute({
+		const result = await tools["branches.create"].execute({
 			project_id: "project-id",
 			name: "feature-x",
 			parent_id: "br-parent",
-			compute: {
-				min_cu: 0.5,
-				max_cu: 2,
-				suspend_timeout_seconds: 300,
-			},
 		});
 
 		expect(requests).toHaveLength(1);
@@ -96,69 +83,53 @@ describe("branches.createWithCompute", () => {
 		);
 		expect(await requests[0].json()).toEqual({
 			branch: { name: "feature-x", parent_id: "br-parent" },
-			endpoints: [
-				{
-					type: "read_write",
-					autoscaling_limit_min_cu: 0.5,
-					autoscaling_limit_max_cu: 2,
-					suspend_timeout_seconds: 300,
-				},
-			],
 		});
 		expect(result).toEqual({
-			data: {
-				branch: { id: "br-id", name: "feature-x" },
-				endpoint: { id: "ep-id", type: "read_write" },
-				connectionString:
-					"postgresql://user:pass@ep-pooler-host/neondb",
-			},
+			data: { id: "br-id", name: "feature-x" },
 		});
+		expect(JSON.stringify(result)).not.toContain(SECRET);
+		expect(JSON.stringify(result)).not.toContain("connection_uri");
 	});
 
-	test("forwards pooled: false to the SDK connection-string picker", async () => {
-		const { tools } = createBranchTools();
+	test("forwards branch creation options without adding compute", async () => {
+		const { requests, tools } = createBranchTools();
 
-		const result = await tools["branches.createWithCompute"].execute({
+		await tools["branches.create"].execute({
 			project_id: "project-id",
-			pooled: false,
+			protected: true,
 		});
 
-		expect(result.data.connectionString).toBe(
-			"postgresql://user:pass@ep-host/neondb",
-		);
+		expect(await requests[0].json()).toEqual({
+			branch: { protected: true },
+		});
 	});
 
-	test("forwards an abort signal to the SDK call", async () => {
+	test("forwards an abort signal", async () => {
 		const controller = new AbortController();
 		controller.abort();
 		const { tools } = createBranchTools();
 
 		await expect(
-			tools["branches.createWithCompute"].execute(
+			tools["branches.create"].execute(
 				{ project_id: "project-id" },
 				{ signal: controller.signal },
 			),
 		).rejects.toThrow();
 	});
 
-	test("describes pooled on the published schema", () => {
+	test("does not publish connection options on the schema", () => {
 		const { tools } = createBranchTools();
-		const schema = z.toJSONSchema(
-			tools["branches.createWithCompute"].inputSchema,
-		);
-		const pooled = schema.properties?.pooled;
+		const schema = z.toJSONSchema(tools["branches.create"].inputSchema);
 
-		expect(pooled).toMatchObject({
-			type: "boolean",
-			description: expect.stringContaining("Default true"),
-		});
+		expect(schema.properties).not.toHaveProperty("pooled");
+		expect(schema.properties).not.toHaveProperty("compute");
 	});
 
 	test("rejects unknown input fields", () => {
 		const { tools } = createBranchTools();
 
 		expect(
-			tools["branches.createWithCompute"].inputSchema.safeParse({
+			tools["branches.create"].inputSchema.safeParse({
 				project_id: "project-id",
 				parentId: "br-parent",
 			}).success,
@@ -170,9 +141,7 @@ describe("branches.createWithCompute", () => {
 			inject: { projectId: "granted-project", omitFromSchema: true },
 		});
 
-		await tools["branches.createWithCompute"].execute({
-			name: "feature-x",
-		});
+		await tools["branches.create"].execute({ name: "feature-x" });
 
 		expect(requests[0].url).toBe(
 			"https://console.neon.tech/api/v2/projects/granted-project/branches",
@@ -182,11 +151,11 @@ describe("branches.createWithCompute", () => {
 	test("renames the published id", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute"] as const,
-			names: { "branches.createWithCompute": "create_branch" },
+			tools: ["branches.create"] as const,
+			names: { "branches.create": "create_branch" },
 		});
 
-		expect(tools["branches.createWithCompute"].id).toBe("create_branch");
+		expect(tools["branches.create"].id).toBe("create_branch");
 	});
 
 	test("uses an execute-time credential instead of the constructor credential", async () => {
@@ -194,7 +163,7 @@ describe("branches.createWithCompute", () => {
 			apiKey: "constructor-key",
 		});
 
-		await tools["branches.createWithCompute"].execute(
+		await tools["branches.create"].execute(
 			{ project_id: "project-id" },
 			{ apiKey: "oauth-access-token" },
 		);
@@ -210,7 +179,7 @@ describe("branches.createWithCompute", () => {
 		});
 
 		await expect(
-			tools["branches.createWithCompute"].execute(
+			tools["branches.create"].execute(
 				{ project_id: "project-id" },
 				{ apiKey: "" },
 			),
@@ -219,19 +188,19 @@ describe("branches.createWithCompute", () => {
 	});
 });
 
-describe("projects.createAndConnect", () => {
-	test("posts the project body and returns the SDK workflow result", async () => {
+describe("projects.create", () => {
+	test("returns project metadata without credentials from the API response", async () => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["projects.createAndConnect"] as const,
+			tools: ["projects.create"] as const,
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
-				return jsonResponse(projectWithUriBody);
+				return jsonResponse(projectCreateBody);
 			},
 		});
 
-		const result = await tools["projects.createAndConnect"].execute({
+		const result = await tools["projects.create"].execute({
 			name: "tool-created",
 			region_id: "aws-us-east-1",
 		});
@@ -247,48 +216,54 @@ describe("projects.createAndConnect", () => {
 			},
 		});
 		expect(result).toEqual({
-			data: {
-				project: { id: "project-id", name: "tool-created" },
-				connectionString:
-					"postgresql://user:pass@ep-pooler-host/neondb",
-			},
+			data: { id: "project-id", name: "tool-created" },
 		});
+		expect(JSON.stringify(result)).not.toContain(SECRET);
+		expect(JSON.stringify(result)).not.toContain("connection_uri");
 	});
 
-	test("forwards pooled: false", async () => {
+	test("keeps connection-string retrieval as an explicit approved tool", async () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["projects.createAndConnect"] as const,
-			fetch: async () => jsonResponse(projectWithUriBody),
+			tools: ["postgres.connectionString"] as const,
+			fetch: async () =>
+				jsonResponse({
+					uri: `postgresql://user:${SECRET}@ep-host/neondb`,
+				}),
 		});
 
-		const result = await tools["projects.createAndConnect"].execute({
-			name: "tool-created",
-			pooled: false,
+		const result = await tools["postgres.connectionString"].execute({
+			project_id: "project-id",
+			branch_id: "br-id",
+			database_name: "neondb",
+			role_name: "neondb_owner",
 		});
 
-		expect(result.data.connectionString).toBe(
-			"postgresql://user:pass@ep-host/neondb",
-		);
+		expect(tools["postgres.connectionString"].requiresApproval).toBe(true);
+		expect(result.data).toContain(SECRET);
 	});
 });
 
 describe("createNeonTool", () => {
 	test("creates a single ergonomic tool", async () => {
 		const requests: Request[] = [];
-		const tool = createNeonTool("branches.createWithCompute", {
+		const tool = createNeonTool("branches.create", {
 			apiKey: "test-key",
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
-				return jsonResponse(branchWithComputeBody);
+				return jsonResponse(branchCreateBody);
 			},
 		});
 
-		await tool.execute({ project_id: "project-id", name: "feature-x" });
+		const result = await tool.execute({
+			project_id: "project-id",
+			name: "feature-x",
+		});
 
-		expect(tool.id).toBe("create_with_compute_branches");
+		expect(tool.id).toBe("create_branches");
 		expect(requests[0].url).toBe(
 			"https://console.neon.tech/api/v2/projects/project-id/branches",
 		);
+		expect(JSON.stringify(result)).not.toContain(SECRET);
 	});
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #369
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/neondatabase/neon-pkgs/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/neondatabase/neon-pkgs/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I ran into #369 while using the CLI through an agent workflow. The agent only needed the new project ID, but project creation also handed it the full connection string. This PR gives callers a way to create the resource without pulling credentials into the same output.

On the CLI side, `neon projects create` and `neon branches create` now accept `--no-secrets`. Their existing output stays the default for backward compatibility, while commands emitted by `neon init --agent` use the secret-free form automatically.

For `@neon/tools`, creation and credential retrieval are separate operations. The published `projects.create` and `branches.create` tools return only resource metadata; callers can use the approval-gated `postgres.connectionString` tool later if they actually need credentials. This replaces the published `projects.createAndConnect` and `branches.createWithCompute` selectors, and the README examples now reflect that flow.

The regression coverage feeds credential-bearing API responses into the CLI and tool adapters, then checks that the sentinel password never reaches `--no-secrets`, direct tool, MCP v1, or MCP v2 output. It also keeps an explicit check that `postgres.connectionString` still returns the credential when requested.

## Validation

- `pnpm --filter neon... build`
- `pnpm --filter @neon/tools build`
- `pnpm --filter @neon/tools generate:check`
- `pnpm --filter @neon/tools test -- --run` (126 tests passed)
- focused `neon init` phase suites (23 tests passed)
- built CLI verified in table, JSON, and YAML output modes
- Biome checks on the changed source files and `git diff --check`
