### PR TITLE
chore: release neon@4.6.0, neonctl@4.6.0

### DIFF
--- a/.changeset/bootstrap-no-agent.md
+++ b/.changeset/bootstrap-no-agent.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-`neon bootstrap --agent` is removed. List templates with `--list-templates --output json` (or yaml). Scaffold with `--template` or `--default`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.6.0
+
+### Minor Changes
+
+- e6a4174: `neon bootstrap --agent` is removed. List templates with `--list-templates --output json` (or yaml). Scaffold with `--template` or `--default`.
+
 ## 4.5.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.5.2",
+	"version": "4.6.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.6.0
+
+### Minor Changes
+
+- e6a4174: `neon bootstrap --agent` is removed. List templates with `--list-templates --output json` (or yaml). Scaffold with `--template` or `--default`.
+
+### Patch Changes
+
+- Updated dependencies [e6a4174]
+  - neon@4.6.0
+
 ## 4.5.2
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.5.2",
+  "version": "4.6.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

npm still serves `neon@4.5.2` and `neonctl@4.5.2`. [#488](https://github.com/neondatabase/neon-pkgs/pull/488) already landed on main: `neon bootstrap --agent` is gone, and `--list-templates` honors `--output json` and `--output yaml`. `npx neon` still runs 4.5.2.

## Diagnosis

`.changeset/bootstrap-no-agent.md` was the pending minor for the fixed group (`neon`, `neonctl`). `pnpm changeset version` consumed it and set both packages to 4.6.0. No other maintained package is ahead of npm.

## User-facing interface

```bash
neon bootstrap --list-templates
neon bootstrap --list-templates --output json
neon bootstrap --list-templates --output yaml

neon bootstrap my-app --template hono
neon bootstrap my-app --default
```

```console
$ neon bootstrap --agent
ERROR: `neon bootstrap --agent` was removed. List templates with `neon bootstrap --list-templates --output json`. Scaffold with `neon bootstrap <directory> --template <id>` or `neon bootstrap <directory> --default`.
```

`neonctl` is the compatibility package and depends on `neon@4.6.0`. Same interface through that entry.

## Also in here

The diff is the `changeset version` output: five files.

- deleted `.changeset/bootstrap-no-agent.md`
- `packages/cli/package.json` `4.5.2` → `4.6.0`
- `packages/cli/CHANGELOG.md` adds the 4.6.0 minor line
- `packages/neonctl/package.json` `4.5.2` → `4.6.0`
- `packages/neonctl/CHANGELOG.md` adds the same 4.6.0 minor line plus `neon@4.6.0`

## Verification

- `npm view neon version` / `npm view neonctl version`: `4.5.2`
- `git diff --stat origin/main...HEAD`: 5 files, 19 insertions, 8 deletions
- `pnpm lint:ci` (biome ci) on this branch: passed, 729 files
- `.changeset/` on this branch is `README.md` and `config.json` only

Not verified: npm publish. The bootstrap interface was verified on #488.

## For your attention

Nothing on this branch publishes. After merge, publish `neon` first (confirm `npm view neon version` is `4.6.0` and GitHub release `neon@4.6.0`), then `neonctl`.