### PR TITLE
Remove neon link --agent

### DIFF
--- a/.changeset/link-no-agent.md
+++ b/.changeset/link-no-agent.md
@@ -1,0 +1,6 @@
+---
+"neon": minor
+"neonctl": minor
+---
+
+`neon link --agent` is removed. List orgs with `orgs list --output json` and projects with `projects list --org-id <org-id> --output json`. Link with `--project-id`, or create with `--org-id --project-name --region-id`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -322,7 +322,7 @@ neon link --no-checks --org-id org-abc123 --project-id polished-snowflake-123456
 
 Every supplied identifier is checked before anything is written, with actionable errors — e.g. `Project '…' not found`, `You don't have access to project '…'`, `Organization '…' not found, or your API key doesn't have access to it`, `Project '…' belongs to organization 'A', not 'B'`, or `Branch '…' not found in project '…'. Available branches: …`.
 
-**Agents and scripts (no TTY)** — list, then link. `neon link --help` prints the same recipe.
+**Agents and scripts (no TTY):** List, then link. `neon link --help` prints the same recipe.
 
 ```bash
 neon orgs list --output json

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -256,14 +256,14 @@ The Neon CLI supports autocompletion, which you can configure in a few easy step
 `link` resolves what it can and **verifies every identifier you pass** before writing, so a `.neon` is never left half-written or pointing at something that doesn't exist:
 
 - **org** is inferred from the project (so `--project-id` alone is enough); it's omitted only when the project has no organization (personal account).
-- **project** is taken from `--project-id` (or chosen interactively / via `--agent`).
+- **project** is taken from `--project-id` (or chosen interactively).
 - **branch** is left to an explicit [`neon checkout <branch>`](#checkout) — `link` never silently pins a project's default branch (that would make later commands quietly target, say, production). It only records a branch when you pass `--branch`, when one is already pinned for the same project (preserved), when you pick one in the interactive picker, or for a freshly **created** project (whose single branch is unambiguous).
 
 When a branch ends up pinned, `link` also runs [`env pull`](#env-pull) so the branch's Neon env vars (`DATABASE_URL`, …) land in a local `.env`. With no branch pinned there is nothing to pull, so `link` instead nudges you to run `neon checkout`. Pass `--no-env-pull` to skip the pull (for example when injecting env at runtime with `neon-env run` or `neon dev`).
 
 > **Migrating from `set-context`?** `set-context` is **deprecated** in favor of `link` (see [below](#set-context-is-deprecated)). It still works exactly as before for now (a raw write), it just prints a deprecation warning. The `.neon` `branchId` field is also superseded by `branch` (which stores the branch **name** when known); old `branchId` files are still read and are upgraded to `branch` the next time `link`/`checkout` writes the context.
 
-There are three modes:
+There are two modes:
 
 **Interactive (default)** — guided prompts for humans:
 
@@ -322,64 +322,21 @@ neon link --no-checks --org-id org-abc123 --project-id polished-snowflake-123456
 
 Every supplied identifier is checked before anything is written, with actionable errors — e.g. `Project '…' not found`, `You don't have access to project '…'`, `Organization '…' not found, or your API key doesn't have access to it`, `Project '…' belongs to organization 'A', not 'B'`, or `Branch '…' not found in project '…'. Available branches: …`.
 
-**Agent mode (`--agent`)** — a JSON state machine designed for AI coding assistants. Each invocation returns a single JSON object with a `status` discriminator describing the next step, the available options, and the exact follow-up command to run.
+**Agents and scripts (no TTY)** — list, then link. `neon link --help` prints the same recipe.
 
 ```bash
-$ neon link --agent
-{
-  "status": "needs_org",
-  "instruction": "Ask the user which of these 2 organizations they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.",
-  "options": [
-    { "id": "org-abc123", "name": "Personal Org" },
-    { "id": "org-team",   "name": "Team Org" }
-  ],
-  "next_command_template": "neon link --agent --org-id <org_id>"
-}
-
-$ neon link --agent --org-id org-abc123
-{
-  "status": "needs_project",
-  "instruction": "Ask the user whether to link to one of these 1 existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).",
-  "options": [
-    { "id": "polished-snowflake-12345678", "name": "my-app" }
-  ],
-  "create_option": {
-    "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
-    "next_command_template": "neon link --agent --org-id org-abc123 --project-name <name> --region-id <region_id>"
-  },
-  "next_command_template": "neon link --agent --org-id org-abc123 --project-id <project_id>"
-}
-
-$ neon link --agent --org-id org-abc123 --project-id polished-snowflake-12345678
-{
-  "status": "linked",
-  "context_file": "/path/to/cwd/.neon",
-  "context": {
-    "orgId": "org-abc123",
-    "projectId": "polished-snowflake-12345678"
-  },
-  "project": { "id": "polished-snowflake-12345678" },
-  "message": "Linked /path/to/cwd/.neon to project polished-snowflake-12345678 (org org-abc123). No branch pinned — run `neon checkout <branch>` (omit the branch to list options) to pin one and pull its env vars."
-}
+neon orgs list --output json
+neon projects list --org-id <org-id> --output json
+neon link --project-id <project-id>
+neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2
 ```
 
-The `linked` response omits `branch` unless one was pinned (via `--branch`, an existing pin, or project creation); pass `--branch <name|id>` to include it. The agent flow also handles project creation: if the agent sends `--project-name` without `--region-id`, the next response is `needs_project_details` with the list of supported regions.
+Organization-scoped API keys cannot list user organizations (`orgs list`) or call the regions endpoint:
 
-**Organization-scoped API keys** (those created at the organization level rather than the user level) cannot list user organizations or call the regions endpoint. `link` handles this transparently:
-
-- If the API key is org-scoped and at least one project already exists in the org, the CLI auto-detects the `org_id` from the first project. In interactive mode it prints an informational message; in `--agent` mode it skips straight to `needs_project`.
-- If the API key is org-scoped and no projects exist yet, `--agent` returns a `needs_org` response with `options: []` and an instruction telling the user to find their org ID in the Neon Console. Interactive mode prints an error pointing to `--org-id`.
-- When the regions endpoint is not allowed, `link` falls back to a built-in static region list.
-
-**Agent error contract**: any unexpected failure in `--agent` mode is reported as JSON to stdout with exit code 1, so agents can always parse the response:
-
-```json
-{
-  "status": "error",
-  "code": "CLIENT_ERROR",
-  "message": "user has no access to projects"
-}
-```
+- Pass `--org-id` (Neon Console → Settings) or `--project-id` (org is inferred from the project).
+- If the key is org-scoped and at least one project already exists, interactive `link` auto-detects the org from the first project and prints an informational message.
+- If no projects exist yet, interactive `link` errors pointing at `--org-id`.
+- When the regions endpoint is not allowed, interactive create falls back to a built-in static region list. Non-interactive create already requires `--region-id`.
 
 **Offline writes (`--no-checks`)** — write the `.neon` with no API calls at all: no org inference, no existence/access verification, no env pull. Because nothing can be resolved offline, it requires both `--org-id` and `--project-id` (`--branch` optional, stored verbatim). Handy for scripted/CI setups or re-creating a `.neon` from values you already trust:
 

--- a/packages/cli/mocks/org-key/projects/detected-project-12345/GET.json
+++ b/packages/cli/mocks/org-key/projects/detected-project-12345/GET.json
@@ -1,0 +1,9 @@
+{
+  "project": {
+    "id": "detected-project-12345",
+    "name": "detected_project",
+    "org_id": "org-detected-99887766",
+    "region_id": "aws-us-east-2",
+    "created_at": "2024-01-01T00:00:00.000Z"
+  }
+}

--- a/packages/cli/src/commands/__snapshots__/link.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/link.test.ts.snap
@@ -1,158 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`link > --agent mode > with full project details creates project and emits linked JSON 1`] = `
-"{
-  "status": "linked",
-  "context_file": "<TMP>/agent_linked_create/.neon",
-  "context": {
-    "orgId": "org-2",
-    "projectId": "new-project-789012",
-    "branch": "test_branch"
-  },
-  "project": {
-    "id": "new-project-789012",
-    "name": "test_project"
-  },
-  "message": "Created project new-project-789012 (\\"test_project\\") in aws-us-east-2 and linked <TMP>/agent_linked_create/.neon on branch test_branch. Skipped env pull (--no-env-pull); run \`neon env pull\` later, or inject env at runtime with \`neon-env run -- <your dev command>\`."
-}
-"
-`;
-
-exports[`link > --agent mode > with full project details creates project and emits linked JSON 2`] = `
-"{
-  "orgId": "org-2",
-  "projectId": "new-project-789012",
-  "branch": "test_branch"
-}"
-`;
-
-exports[`link > --agent mode > with no flags emits needs_org JSON 1`] = `
-"{
-  "status": "needs_org",
-  "instruction": "Ask the user which of these 3 organizations they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.",
-  "options": [
-    {
-      "id": 1,
-      "name": "Organization 1"
-    },
-    {
-      "id": 2,
-      "name": "Organization 2"
-    },
-    {
-      "id": 3,
-      "name": "Organization 3"
-    }
-  ],
-  "next_command_template": "neon link --agent --org-id <org_id>"
-}
-"
-`;
-
-exports[`link > --agent mode > with only --org-id emits needs_project JSON 1`] = `
-"{
-  "status": "needs_project",
-  "instruction": "Ask the user whether to link to one of these 3 existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).",
-  "options": [
-    {
-      "id": 4,
-      "name": "Project_4"
-    },
-    {
-      "id": 5,
-      "name": "Project_5"
-    },
-    {
-      "id": 6,
-      "name": "Project_6"
-    }
-  ],
-  "create_option": {
-    "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
-    "next_command_template": "neon link --agent --org-id org-2 --project-name <name> --region-id <region_id>"
-  },
-  "next_command_template": "neon link --agent --org-id org-2 --project-id <project_id>"
-}
-"
-`;
-
-exports[`link > --agent mode > with only --project-id infers the org and emits linked JSON 1`] = `
-"{
-  "status": "linked",
-  "context_file": "<TMP>/agent_linked_infer/.neon",
-  "context": {
-    "orgId": "org-7",
-    "projectId": "proj-in-org"
-  },
-  "project": {
-    "id": "proj-in-org"
-  },
-  "message": "Linked <TMP>/agent_linked_infer/.neon to project proj-in-org (org org-7). No branch pinned — run \`neon checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars."
-}
-"
-`;
-
-exports[`link > --agent mode > with only --project-id infers the org and emits linked JSON 2`] = `
-"{
-  "orgId": "org-7",
-  "projectId": "proj-in-org"
-}"
-`;
-
-exports[`link > --agent mode > with org+project emits linked JSON (no branch) and writes .neon 1`] = `
-"{
-  "status": "linked",
-  "context_file": "<TMP>/agent_linked_existing/.neon",
-  "context": {
-    "orgId": "org-2",
-    "projectId": "test"
-  },
-  "project": {
-    "id": "test"
-  },
-  "message": "Linked <TMP>/agent_linked_existing/.neon to project test (org org-2). No branch pinned — run \`neon checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars."
-}
-"
-`;
-
-exports[`link > --agent mode > with org+project emits linked JSON (no branch) and writes .neon 2`] = `
-"{
-  "orgId": "org-2",
-  "projectId": "test"
-}"
-`;
-
-exports[`link > --agent mode > with org+projectName but no region emits needs_project_details JSON 1`] = `
-"{
-  "status": "needs_project_details",
-  "instruction": "Ask the user which region to create project \\"demo\\" in. After they pick one, re-run the next_command_template with the chosen --region-id value.",
-  "regions": [
-    {
-      "id": "aws-us-east-2",
-      "name": "AWS US East (Ohio)",
-      "default": true
-    },
-    {
-      "id": "aws-us-east-1",
-      "name": "AWS US East (N. Virginia)",
-      "default": false
-    },
-    {
-      "id": "aws-us-west-2",
-      "name": "AWS US West (Oregon)",
-      "default": false
-    },
-    {
-      "id": "aws-eu-central-1",
-      "name": "AWS Europe (Frankfurt)",
-      "default": false
-    }
-  ],
-  "next_command_template": "neon link --agent --org-id org-2 --project-name demo --region-id <region_id>"
-}
-"
-`;
-
 exports[`link > --no-checks (offline write) > fails when org-id or project-id is missing 1`] = `""`;
 
 exports[`link > --no-checks (offline write) > writes org+project with no API verification 1`] = `
@@ -354,80 +201,34 @@ exports[`link > non-interactive flag mode > re-linking the same project keeps th
 }"
 `;
 
-exports[`link > org-scoped API key behavior > agent mode auto-detects org from existing projects when org listing is forbidden 1`] = `
-"{
-  "status": "needs_project",
-  "instruction": "Ask the user whether to link to one of these 1 existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).",
-  "options": [
-    {
-      "id": "detected-project-12345",
-      "name": "detected_project",
-      "region_id": "aws-us-east-2"
-    }
-  ],
-  "create_option": {
-    "instruction": "To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
-    "next_command_template": "neon link --agent --org-id org-detected-99887766 --project-name <name> --region-id <region_id>"
-  },
-  "next_command_template": "neon link --agent --org-id org-detected-99887766 --project-id <project_id>"
-}
+exports[`link > org-scoped API key behavior > links an existing project when org listing is forbidden 1`] = `
+"Linked <TMP>/orgkey_project/.neon:
+  orgId:     org-detected-99887766
+  projectId: detected-project-12345
+
+No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
+
 "
 `;
 
-exports[`link > org-scoped API key behavior > agent mode falls back to static regions when getActiveRegions is forbidden 1`] = `
+exports[`link > org-scoped API key behavior > links an existing project when org listing is forbidden 2`] = `
 "{
-  "status": "needs_project_details",
-  "instruction": "Ask the user which region to create project \\"whatever\\" in. After they pick one, re-run the next_command_template with the chosen --region-id value.",
-  "regions": [
-    {
-      "id": "aws-us-west-2",
-      "name": "aws-us-west-2",
-      "default": false
-    },
-    {
-      "id": "aws-ap-southeast-1",
-      "name": "aws-ap-southeast-1",
-      "default": false
-    },
-    {
-      "id": "aws-ap-southeast-2",
-      "name": "aws-ap-southeast-2",
-      "default": false
-    },
-    {
-      "id": "aws-eu-central-1",
-      "name": "aws-eu-central-1",
-      "default": false
-    },
-    {
-      "id": "aws-us-east-2",
-      "name": "aws-us-east-2",
-      "default": true
-    },
-    {
-      "id": "aws-us-east-1",
-      "name": "aws-us-east-1",
-      "default": false
-    },
-    {
-      "id": "azure-eastus2",
-      "name": "azure-eastus2",
-      "default": false
-    }
-  ],
-  "next_command_template": "neon link --agent --org-id org-detected-99887766 --project-name whatever --region-id <region_id>"
-}
+  "orgId": "org-detected-99887766",
+  "projectId": "detected-project-12345"
+}"
+`;
+
+exports[`link > org-scoped API key behavior > records --org-id when org listing is forbidden and no projects exist 1`] = `
+"Updated <TMP>/orgkey_empty_org/.neon:
+  orgId:     org-from-console
+
 "
 `;
 
-exports[`link > org-scoped API key behavior > agent mode with no orgs available and no projects emits orgKeyLimited needs_org 1`] = `
+exports[`link > org-scoped API key behavior > records --org-id when org listing is forbidden and no projects exist 2`] = `
 "{
-  "status": "needs_org",
-  "instruction": "This Neon API key is organization-scoped, so the CLI cannot list the user's organizations and no existing project was found to auto-detect the org ID. Ask the user for their Neon organization ID (visible in the Neon Console under the org's Settings page, formatted like \`org-bitter-breeze-12345678\`) and re-run the next_command_template with that --org-id.",
-  "options": [],
-  "next_command_template": "neon link --agent --org-id <org_id>"
-}
-"
+  "orgId": "org-from-console"
+}"
 `;
 
 exports[`link > overwrites an existing .neon when re-linking non-interactively 1`] = `

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -207,11 +207,6 @@ const NEON_OWNED_ENV_KEYS: readonly EnvPullKey[] = [
 	...Object.values(NEON_ENV_VAR_KEYS.aiGateway),
 ];
 
-/**
- * What an env pull actually did, so callers (notably `link --agent`) can report it precisely
- * instead of guessing. `written` lists the keys merged into `file`; `empty` means the branch
- * has no Neon vars to pull yet (no DATABASE_URL / Auth / Data API).
- */
 export type PullOutcome =
 	| {
 			status: "written";
@@ -460,8 +455,7 @@ export type AutoPullResult =
  * On by default; `--no-env-pull` opts out (e.g. when env is injected at runtime via
  * `neon-env run` / `neon dev`, or to keep secrets out of the working tree). The pin is the
  * command's primary effect and has already succeeded by the time this runs, so a pull failure
- * degrades to a warning rather than failing the command. Returns what happened so
- * `link --agent` can fold an accurate note into its JSON message.
+ * degrades to a warning rather than failing the command.
  */
 export const autoPullEnvAfterPin = async (
 	props: EnvPullProps & { envPull: boolean },
@@ -481,36 +475,6 @@ export const autoPullEnvAfterPin = async (
 			message,
 		);
 		return { status: "failed", message };
-	}
-};
-
-/**
- * Render the one-line env-pull note appended to `link --agent`'s JSON `message`, so an agent
- * reading the structured output knows whether its branch env is already on disk.
- */
-export const renderAgentPullNote = (result: AutoPullResult): string => {
-	switch (result.status) {
-		case "written": {
-			// Call out a re-issued credential: an agent that already wrote the old storage /
-			// gateway values somewhere else has to update them.
-			const credential = result.credential?.issued
-				? ` Issued a new branch credential, so ${result.credential.keys.join(", ")} changed.`
-				: "";
-			// No `skipped` note: only the implied AI Gateway can be skipped, and the auto-pull
-			// this renders never implies it.
-			return ` Pulled ${result.written.length} Neon env var${
-				result.written.length === 1 ? "" : "s"
-			} into ${result.file}.${credential}`;
-		}
-		case "empty":
-			return " No Neon env vars to pull for this branch yet.";
-		case "skipped":
-			return (
-				` Skipped env pull (--no-env-pull); run \`${getCliName()} env pull\` later, ` +
-				"or inject env at runtime with `neon-env run -- <your dev command>`."
-			);
-		case "failed":
-			return ` Could not pull env vars (${result.message}); run \`${getCliName()} env pull\` once resolved.`;
 	}
 };
 

--- a/packages/cli/src/commands/link.test.ts
+++ b/packages/cli/src/commands/link.test.ts
@@ -15,7 +15,7 @@ import { test as originalTest } from "../test_utils/fixtures";
 
 // All tests in this file share a single temporary directory whose path is
 // normalized in snapshots to `<TMP>` so that absolute paths in command output
-// (both human summaries and agent JSON) remain stable across runs and machines.
+// remain stable across runs and machines.
 const TEST_TMP = mkdtempSync(join(tmpdir(), "neonctl-link-"));
 
 const TMP_TOKEN = "<TMP>";
@@ -39,7 +39,6 @@ beforeAll(() => {
 const test = originalTest.extend<{
 	cleanupFile: (name: string) => void;
 	readFile: (name: string) => string;
-	removeFile: (name: string) => void;
 	tmpContext: (label: string) => string;
 	runLinkInCi: (args: string[]) => Promise<{
 		code: number;
@@ -63,15 +62,6 @@ const test = originalTest.extend<{
 			const content = readFileSync(name, "utf-8");
 			cleanupFile(name);
 			return content;
-		});
-	},
-	removeFile: async ({}, use) => {
-		await use((name) => {
-			try {
-				rmSync(name);
-			} catch {
-				// ignore
-			}
 		});
 	},
 	// Each test gets its OWN sub-directory under TEST_TMP so the
@@ -125,6 +115,18 @@ const test = originalTest.extend<{
 		});
 	},
 });
+
+const expectNonInteractiveHelp = (text: string) => {
+	expect(text).toContain("neon orgs list --output json");
+	expect(text).toContain(
+		"neon projects list --org-id <org-id> --output json",
+	);
+	expect(text).toContain("neon link --project-id <project-id>");
+	expect(text).toContain(
+		"neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2",
+	);
+	expect(text).toContain("Organization-scoped API keys cannot list orgs");
+};
 
 describe("link", () => {
 	describe("non-interactive flag mode", () => {
@@ -325,6 +327,28 @@ describe("link", () => {
 				},
 			);
 		});
+
+		test("invalid --params JSON fails with a parse error", async ({
+			testCliCommand,
+			tmpContext,
+		}) => {
+			await testCliCommand(
+				[
+					"link",
+					"--params",
+					"not-valid-json",
+					"--context-file",
+					tmpContext("flag_bad_params"),
+				],
+				{
+					code: 1,
+					snapshot: false,
+					stderr: expect.stringContaining(
+						"Failed to parse --params JSON",
+					),
+				},
+			);
+		});
 	});
 
 	describe("input verification", () => {
@@ -395,241 +419,76 @@ describe("link", () => {
 		});
 	});
 
-	describe("--agent mode", () => {
-		test("with no flags emits needs_org JSON", async ({
+	describe("--agent", () => {
+		test("is refused and points at list + link commands", async ({
 			testCliCommand,
-			removeFile,
 			tmpContext,
 		}) => {
-			const ctx = tmpContext("agent_needs_org");
-			await testCliCommand(["link", "--agent", "--context-file", ctx]);
-			removeFile(ctx);
-		});
-
-		test("with only --org-id emits needs_project JSON", async ({
-			testCliCommand,
-			removeFile,
-			tmpContext,
-		}) => {
-			const ctx = tmpContext("agent_needs_project");
-			await testCliCommand([
-				"link",
-				"--agent",
-				"--org-id",
-				"org-2",
-				"--context-file",
-				ctx,
-			]);
-			removeFile(ctx);
-		});
-
-		test("with org+project emits linked JSON (no branch) and writes .neon", async ({
-			testCliCommand,
-			readFile,
-			tmpContext,
-		}) => {
-			const ctx = tmpContext("agent_linked_existing");
-			await testCliCommand([
-				"link",
-				"--agent",
-				"--org-id",
-				"org-2",
-				"--project-id",
-				"test",
-				"--no-env-pull",
-				"--context-file",
-				ctx,
-			]);
-			expect(readFile(ctx)).toMatchSnapshot();
-		});
-
-		test("with only --project-id infers the org and emits linked JSON", async ({
-			testCliCommand,
-			readFile,
-			tmpContext,
-		}) => {
-			const ctx = tmpContext("agent_linked_infer");
-			await testCliCommand([
-				"link",
-				"--agent",
-				"--project-id",
-				"proj-in-org",
-				"--no-env-pull",
-				"--context-file",
-				ctx,
-			]);
-			expect(readFile(ctx)).toMatchSnapshot();
-		});
-
-		test("with an unknown --project-id emits an error JSON, exit 1", async ({
-			runLinkInCi,
-			tmpContext,
-		}) => {
-			const result = await runLinkInCi([
-				"link",
-				"--agent",
-				"--project-id",
-				"ghost-project",
-				"--no-env-pull",
-				"--context-file",
-				tmpContext("agent_bad_project"),
-			]);
-			expect(result.code).toBe(1);
-			const parsed = JSON.parse(result.stdout) as {
-				status: string;
-				code: string;
-				message: string;
-			};
-			expect(parsed.status).toBe("error");
-			expect(parsed.code).toBe("NOT_FOUND");
-			expect(parsed.message).toContain(
-				"Project 'ghost-project' not found",
+			const { code, stdout, stderr } = await testCliCommand(
+				[
+					"link",
+					"--agent",
+					"--context-file",
+					tmpContext("agent_refused"),
+				],
+				{ code: 1, snapshot: false },
 			);
+			expect(code).toBe(1);
+			expect(stdout.trim()).toBe("");
+			expect(stderr).toContain("link --agent");
+			expectNonInteractiveHelp(stderr);
 		});
 
-		test("with org+projectName but no region emits needs_project_details JSON", async ({
+		test("help omits --agent and lists the non-interactive commands", async ({
 			testCliCommand,
-			removeFile,
-			tmpContext,
 		}) => {
-			const ctx = tmpContext("agent_needs_region");
-			await testCliCommand([
-				"link",
-				"--agent",
-				"--org-id",
-				"org-2",
-				"--project-name",
-				"demo",
-				"--context-file",
-				ctx,
-			]);
-			removeFile(ctx);
-		});
-
-		test("with full project details creates project and emits linked JSON", async ({
-			testCliCommand,
-			readFile,
-			tmpContext,
-		}) => {
-			const ctx = tmpContext("agent_linked_create");
-			await testCliCommand([
-				"link",
-				"--agent",
-				"--org-id",
-				"org-2",
-				"--project-name",
-				"test_project",
-				"--region-id",
-				"aws-us-east-2",
-				"--no-env-pull",
-				"--context-file",
-				ctx,
-			]);
-			expect(readFile(ctx)).toMatchSnapshot();
+			const { stdout, stderr } = await testCliCommand(
+				["link", "--help"],
+				{ snapshot: false },
+			);
+			const text = `${stdout}\n${stderr}`;
+			expect(text).not.toContain("--agent");
+			expectNonInteractiveHelp(text);
 		});
 	});
 
 	describe("org-scoped API key behavior", () => {
-		test("agent mode with no orgs available and no projects emits orgKeyLimited needs_org", async ({
+		test("links an existing project when org listing is forbidden", async ({
 			testCliCommand,
-			removeFile,
+			readFile,
 			tmpContext,
 		}) => {
-			const ctx = tmpContext("orgkey_empty");
-			await testCliCommand(["link", "--agent", "--context-file", ctx], {
-				mockDir: "org-key-empty",
-			});
-			removeFile(ctx);
-		});
-
-		test("agent mode auto-detects org from existing projects when org listing is forbidden", async ({
-			testCliCommand,
-			removeFile,
-			tmpContext,
-		}) => {
-			const ctx = tmpContext("orgkey_autodetect");
-			await testCliCommand(["link", "--agent", "--context-file", ctx], {
-				mockDir: "org-key",
-			});
-			removeFile(ctx);
-		});
-
-		test("agent mode falls back to static regions when getActiveRegions is forbidden", async ({
-			testCliCommand,
-			removeFile,
-			tmpContext,
-		}) => {
-			const ctx = tmpContext("orgkey_regions_fallback");
+			const ctx = tmpContext("orgkey_project");
 			await testCliCommand(
 				[
 					"link",
-					"--agent",
-					"--org-id",
-					"org-detected-99887766",
-					"--project-name",
-					"whatever",
+					"--project-id",
+					"detected-project-12345",
+					"--no-env-pull",
 					"--context-file",
 					ctx,
 				],
 				{ mockDir: "org-key" },
 			);
-			removeFile(ctx);
+			expect(readFile(ctx)).toMatchSnapshot();
+		});
+
+		test("records --org-id when org listing is forbidden and no projects exist", async ({
+			testCliCommand,
+			readFile,
+			tmpContext,
+		}) => {
+			const ctx = tmpContext("orgkey_empty_org");
+			await testCliCommand(
+				["link", "--org-id", "org-from-console", "--context-file", ctx],
+				{ mockDir: "org-key-empty" },
+			);
+			expect(readFile(ctx)).toMatchSnapshot();
 		});
 	});
 
-	describe("agent error responses", () => {
-		test("invalid --params JSON yields error JSON, exit 1", async ({
-			runLinkInCi,
-			tmpContext,
-		}) => {
-			const result = await runLinkInCi([
-				"link",
-				"--agent",
-				"--params",
-				"not-valid-json",
-				"--context-file",
-				tmpContext("agent_bad_params"),
-			]);
-			expect(result.code).toBe(1);
-			const parsed = JSON.parse(result.stdout) as {
-				status: string;
-				code: string;
-				message: string;
-			};
-			expect(parsed.status).toBe("error");
-			expect(parsed.code).toBe("INTERNAL_ERROR");
-			expect(parsed.message).toContain("Failed to parse --params JSON");
-		});
-
-		test("conflicting flags in agent mode yields error JSON, exit 1", async ({
-			runLinkInCi,
-			tmpContext,
-		}) => {
-			const result = await runLinkInCi([
-				"link",
-				"--agent",
-				"--org-id",
-				"org-2",
-				"--project-id",
-				"test",
-				"--project-name",
-				"x",
-				"--context-file",
-				tmpContext("agent_conflict"),
-			]);
-			expect(result.code).toBe(1);
-			const parsed = JSON.parse(result.stdout) as {
-				status: string;
-				code: string;
-				message: string;
-			};
-			expect(parsed.status).toBe("error");
-			expect(parsed.message).toContain("Conflicting inputs");
-		});
-	});
-
-	describe("CI guard", () => {
-		test("errors out with helpful message when no inputs provided in CI", async ({
+	describe("non-interactive missing inputs", () => {
+		test("errors with the replacement commands in CI", async ({
 			runLinkInCi,
 			tmpContext,
 		}) => {
@@ -639,8 +498,24 @@ describe("link", () => {
 				tmpContext("ci_guard"),
 			]);
 			expect(result.code).toBe(1);
-			expect(result.stderr).toContain("CI environment detected");
-			expect(result.stderr).toContain("neon link --agent");
+			expect(result.stdout.trim()).toBe("");
+			expect(result.stderr).toContain("no interactive terminal");
+			expect(result.stderr).not.toContain("link --agent");
+			expectNonInteractiveHelp(result.stderr);
+		});
+
+		test("errors with the replacement commands when there is no TTY", async ({
+			testCliCommand,
+			tmpContext,
+		}) => {
+			const { stdout, stderr } = await testCliCommand(
+				["link", "--context-file", tmpContext("no_tty_guard")],
+				{ code: 1, snapshot: false },
+			);
+			expect(stdout.trim()).toBe("");
+			expect(stderr).toContain("no interactive terminal");
+			expect(stderr).not.toContain("link --agent");
+			expectNonInteractiveHelp(stderr);
 		});
 	});
 

--- a/packages/cli/src/commands/link.test.ts
+++ b/packages/cli/src/commands/link.test.ts
@@ -117,14 +117,15 @@ const test = originalTest.extend<{
 });
 
 const expectNonInteractiveHelp = (text: string) => {
-	expect(text).toContain("neon orgs list --output json");
-	expect(text).toContain(
+	const commands = [
+		"neon orgs list --output json",
 		"neon projects list --org-id <org-id> --output json",
-	);
-	expect(text).toContain("neon link --project-id <project-id>");
-	expect(text).toContain(
+		"neon link --project-id <project-id>",
 		"neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2",
-	);
+	];
+	for (const command of commands) {
+		expect(text.split(command)).toHaveLength(2);
+	}
 	expect(text).toContain("Organization-scoped API keys cannot list orgs");
 };
 

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -155,14 +155,6 @@ export const builder = (argv: yargs.Argv) =>
 		})
 		.example([
 			[
-				"$0 orgs list --output json",
-				"List organizations as JSON (scripts and agents)",
-			],
-			[
-				"$0 projects list --org-id org-… --output json",
-				"List projects in an org as JSON (scripts and agents)",
-			],
-			[
 				"$0 link --project-id polished-snowflake-12345678",
 				`Link an existing project (org is inferred); pin a branch later with '${getCliName()} checkout'`,
 			],

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -25,8 +25,9 @@ import {
 	pickBranchInteractively,
 } from "../utils/branch_picker.js";
 import { getCliName } from "../utils/cli_name.js";
+import { helpEpilogue } from "../utils/help_text.js";
 import { hasNeonConfigFile, initCmd } from "./config.js";
-import { autoPullEnvAfterPin, renderAgentPullNote } from "./env.js";
+import { autoPullEnvAfterPin } from "./env.js";
 import { REGIONS } from "./projects.js";
 
 const PROJECTS_LIST_LIMIT = 100;
@@ -40,7 +41,7 @@ type LinkProps = CommonProps & {
 	regionId?: string;
 	branch?: string;
 	params?: string;
-	agent: boolean;
+	agent?: boolean;
 	yes: boolean;
 	clear: boolean;
 	checks: boolean;
@@ -56,43 +57,29 @@ type Inputs = {
 	branch?: string;
 };
 
-type AgentOrgOption = { id: string; name: string };
-type AgentProjectOption = { id: string; name: string; region_id?: string };
-type AgentRegionOption = { id: string; name: string; default: boolean };
-type AgentContext = { orgId?: string; projectId: string; branch?: string };
-type AgentProject = { id: string; name?: string; region_id?: string };
+const canPromptInteractively = (): boolean =>
+	!isCi() && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
 
-type AgentResponse =
-	| {
-			status: "needs_org";
-			instruction: string;
-			options: AgentOrgOption[];
-			next_command_template: string;
-	  }
-	| {
-			status: "needs_project";
-			instruction: string;
-			options: AgentProjectOption[];
-			create_option: {
-				instruction: string;
-				next_command_template: string;
-			};
-			next_command_template: string;
-	  }
-	| {
-			status: "needs_project_details";
-			instruction: string;
-			regions: AgentRegionOption[];
-			next_command_template: string;
-	  }
-	| {
-			status: "linked";
-			context_file: string;
-			context: AgentContext;
-			project: AgentProject;
-			message: string;
-	  }
-	| { status: "error"; code: string; message: string };
+const nonInteractiveLinkCommands = (): string[] => {
+	const cli = getCliName();
+	return [
+		`${cli} orgs list --output json`,
+		`${cli} projects list --org-id <org-id> --output json`,
+		`${cli} link --project-id <project-id>`,
+		`${cli} link --org-id <org-id> --project-name <name> --region-id aws-us-east-2`,
+	];
+};
+
+const nonInteractiveLinkHelp = (): string =>
+	nonInteractiveLinkCommands()
+		.map((command) => `  ${command}`)
+		.join("\n");
+
+const orgScopedKeyHint =
+	"Organization-scoped API keys cannot list orgs; pass --org-id.";
+
+const removedAgent = (): string =>
+	`\`${getCliName()} link --agent\` was removed.\nUse:\n${nonInteractiveLinkHelp()}\n${orgScopedKeyHint}`;
 
 export const command = "link";
 export const describe = "Link the current directory to a Neon project";
@@ -132,10 +119,8 @@ export const builder = (argv: yargs.Argv) =>
 				type: "string",
 			},
 			agent: {
-				describe:
-					"Emit a JSON state-machine response designed for AI agents instead of prompting. The output is a single JSON object with a discriminated `status` field describing the next step.",
+				hidden: true,
 				type: "boolean",
-				default: false,
 			},
 			yes: {
 				alias: "y",
@@ -170,6 +155,14 @@ export const builder = (argv: yargs.Argv) =>
 		})
 		.example([
 			[
+				"$0 orgs list --output json",
+				"List organizations as JSON (scripts and agents)",
+			],
+			[
+				"$0 projects list --org-id org-… --output json",
+				"List projects in an org as JSON (scripts and agents)",
+			],
+			[
 				"$0 link --project-id polished-snowflake-12345678",
 				`Link an existing project (org is inferred); pin a branch later with '${getCliName()} checkout'`,
 			],
@@ -189,7 +182,22 @@ export const builder = (argv: yargs.Argv) =>
 				"$0 link --clear",
 				"Forget the current org/project/branch context",
 			],
-		]);
+		])
+		.epilogue(
+			helpEpilogue(
+				"Non-interactive (CI, scripts, agents):",
+				...nonInteractiveLinkCommands().map(
+					(command) => `  ${command}`,
+				),
+				orgScopedKeyHint,
+			),
+		)
+		.check((argv) => {
+			if (argv.agent === true) {
+				throw new Error(removedAgent());
+			}
+			return true;
+		});
 
 export const handler = async (props: LinkProps) => {
 	if (props.clear) {
@@ -202,11 +210,6 @@ export const handler = async (props: LinkProps) => {
 		return;
 	}
 
-	if (props.agent) {
-		await runAgentSafely(props);
-		return;
-	}
-
 	const inputs = parseInputs(props);
 	validateInputs(inputs);
 	const existing = readContextFile(props.contextFile);
@@ -216,15 +219,14 @@ export const handler = async (props: LinkProps) => {
 		return;
 	}
 
-	if (isCi()) {
+	if (!canPromptInteractively()) {
 		log.error(
 			[
-				"Missing inputs and CI environment detected (no TTY for prompts).",
+				"Missing inputs and no interactive terminal for prompts.",
 				"",
-				"Use one of:",
-				`  ${getCliName()} link --agent                                                    (JSON state machine for agents)`,
-				`  ${getCliName()} link --project-id <project>                                     (link to an existing project; org is inferred)`,
-				`  ${getCliName()} link --org-id <org> --project-name <name> --region-id <region>  (create a new project and link)`,
+				"Use:",
+				nonInteractiveLinkHelp(),
+				orgScopedKeyHint,
 			].join("\n"),
 		);
 		process.exit(1);
@@ -354,20 +356,6 @@ const runWithoutChecks = (props: LinkProps): void => {
 		projectId: inputs.projectId,
 		branch: inputs.branch,
 	});
-	if (props.agent) {
-		emitAgent({
-			status: "linked",
-			context_file: props.contextFile,
-			context: {
-				orgId: inputs.orgId,
-				projectId: inputs.projectId,
-				branch: inputs.branch,
-			},
-			project: { id: inputs.projectId },
-			message: `Wrote ${props.contextFile} without checks (org ${inputs.orgId}, project ${inputs.projectId}${inputs.branch ? `, branch ${inputs.branch}` : ""}). No verification or env pull was performed.`,
-		});
-		return;
-	}
 	printSummary(props, {
 		contextFile: props.contextFile,
 		orgId: inputs.orgId,
@@ -378,29 +366,17 @@ const runWithoutChecks = (props: LinkProps): void => {
 	});
 };
 
-/**
- * A bad user-supplied identifier (project/org/branch that doesn't exist or
- * isn't accessible). Carries an `agentCode` so `--agent` mode can report a
- * precise `status: error` code instead of a generic INTERNAL_ERROR, while the
- * human path just prints the clear `message`.
- */
 class LinkInputError extends Error {
-	readonly agentCode: string;
-	constructor(message: string, agentCode: string) {
+	constructor(message: string) {
 		super(message);
 		this.name = "LinkInputError";
-		this.agentCode = agentCode;
 	}
 }
 
 const httpStatus = (err: unknown): number | undefined =>
 	isNeonApiError(err) ? err.status : undefined;
 
-/**
- * Fetch a project, turning the common failure modes into clear, actionable
- * errors. 401 is rethrown so the global handler can refresh credentials;
- * everything else surfaces as a `LinkInputError` the user (or agent) can act on.
- */
+/** 401 must reach the global handler so it can refresh credentials. */
 const fetchProjectOrThrow = async (props: CommonProps, projectId: string) => {
 	try {
 		const { data } = await props.apiClient.getProject(projectId);
@@ -413,13 +389,11 @@ const fetchProjectOrThrow = async (props: CommonProps, projectId: string) => {
 		if (status === 403) {
 			throw new LinkInputError(
 				`You don't have access to project '${projectId}'. Check that your API key's account or organization can see it.`,
-				"NO_ACCESS",
 			);
 		}
 		if (status === 404) {
 			throw new LinkInputError(
 				`Project '${projectId}' not found. Double-check the project ID — or that your API key has access to it.`,
-				"NOT_FOUND",
 			);
 		}
 		throw err;
@@ -448,7 +422,6 @@ const verifyOrgAccess = async (
 		if (status === 403 || status === 404) {
 			throw new LinkInputError(
 				`Organization '${orgId}' not found, or your API key doesn't have access to it. Find your org ID in the Neon Console under Settings.`,
-				status === 403 ? "NO_ACCESS" : "NOT_FOUND",
 			);
 		}
 		throw err;
@@ -484,7 +457,6 @@ const resolveBranchRef = async (
 			: "(none)";
 	throw new LinkInputError(
 		`Branch '${branchRef}' not found in project '${projectId}'. Available branches: ${available}. Pin one with \`${getCliName()} checkout <branch>\`.`,
-		"NOT_FOUND",
 	);
 };
 
@@ -520,7 +492,6 @@ const resolveOrgForProject = async (
 		if (projectOrg && projectOrg !== inputs.orgId) {
 			throw new LinkInputError(
 				`Project '${projectId}' belongs to organization '${projectOrg}', not '${inputs.orgId}'. Omit --org-id to use the project's own org, or pass the matching ID.`,
-				"ORG_MISMATCH",
 			);
 		}
 		if (!projectOrg) {
@@ -899,166 +870,6 @@ const promptRegion = async (props: LinkProps): Promise<string> => {
 };
 
 // ----------------------------------------------------------------------------
-// Agent mode (JSON state machine)
-// ----------------------------------------------------------------------------
-
-const runAgentSafely = async (props: LinkProps) => {
-	try {
-		const inputs = parseInputs(props);
-		validateInputs(inputs);
-		await runAgent(props, inputs);
-	} catch (err) {
-		emitAgent(toAgentError(err));
-		process.exit(1);
-	}
-};
-
-const runAgent = async (props: LinkProps, inputs: Inputs) => {
-	const { projectId, projectName, regionId, branch } = inputs;
-	const existing = readContextFile(props.contextFile);
-
-	// Existing project: infer the org and link it. The branch is left to an
-	// explicit `checkout` unless one was passed or is already pinned.
-	if (projectId) {
-		const orgId = await resolveOrgForProject(
-			props,
-			inputs,
-			existing,
-			projectId,
-		);
-		const pinnedBranch = await resolvePinnedBranch(
-			props,
-			inputs,
-			existing,
-			projectId,
-		);
-		applyContext(props.contextFile, {
-			orgId,
-			projectId,
-			branch: pinnedBranch,
-		});
-		const orgSuffix = orgId ? ` (org ${orgId})` : "";
-		if (pinnedBranch) {
-			const pullNote = renderAgentPullNote(
-				await autoPullEnvAfterPin({
-					...props,
-					projectId,
-					branch: pinnedBranch,
-					envPull: props.envPull,
-				}),
-			);
-			emitAgent({
-				status: "linked",
-				context_file: props.contextFile,
-				context: { orgId, projectId, branch: pinnedBranch },
-				project: { id: projectId },
-				message: `Linked ${props.contextFile} to project ${projectId}${orgSuffix} on branch ${pinnedBranch}.${pullNote}`,
-			});
-			return;
-		}
-		emitAgent({
-			status: "linked",
-			context_file: props.contextFile,
-			context: { orgId, projectId },
-			project: { id: projectId },
-			message: `Linked ${props.contextFile} to project ${projectId}${orgSuffix}. No branch pinned — run \`${getCliName()} checkout <branch>\` (omit the branch to list options) to pin one and pull its env vars.`,
-		});
-		return;
-	}
-
-	const orgResolution = await resolveOrg(props, inputs.orgId);
-	if (orgResolution.kind === "needs_selection") {
-		emitAgent(buildNeedsOrgResponse(orgResolution));
-		return;
-	}
-	const orgId = orgResolution.orgId;
-
-	if (projectName && !regionId) {
-		const regions = await fetchRegions(props);
-		emitAgent({
-			status: "needs_project_details",
-			instruction: `Ask the user which region to create project "${projectName}" in. After they pick one, re-run the next_command_template with the chosen --region-id value.`,
-			regions: regions.map((region) => ({
-				id: region.region_id,
-				name: region.name,
-				default: region.default,
-			})),
-			next_command_template: `${getCliName()} link --agent --org-id ${shellArg(orgId)} --project-name ${shellArg(projectName)} --region-id <region_id>`,
-		});
-		return;
-	}
-
-	if (projectName && regionId) {
-		await verifyOrgAccess(props, orgId);
-		const created = await createProject(props, {
-			orgId,
-			name: projectName,
-			regionId,
-		});
-		applyContext(props.contextFile, {
-			orgId,
-			projectId: created.project.id,
-			branch: created.branchName,
-		});
-		const pullNote = renderAgentPullNote(
-			await autoPullEnvAfterPin({
-				...props,
-				projectId: created.project.id,
-				branch: created.branchName,
-				envPull: props.envPull,
-			}),
-		);
-		emitAgent({
-			status: "linked",
-			context_file: props.contextFile,
-			context: {
-				orgId,
-				projectId: created.project.id,
-				branch: created.branchName,
-			},
-			project: {
-				id: created.project.id,
-				name: created.project.name,
-				region_id: created.project.region_id,
-			},
-			message: `Created project ${created.project.id} ("${created.project.name ?? projectName}") in ${created.project.region_id ?? regionId} and linked ${props.contextFile} on branch ${created.branchName}.${pullNote}`,
-		});
-		return;
-	}
-
-	// orgId is set but no project info — list projects to choose from. A pending
-	// --branch can't be applied until a project is chosen, so it's surfaced in
-	// the instruction rather than silently dropped.
-	const projects = await listAllProjects(props, orgId);
-	const branchNote = branch
-		? ` A branch was requested (--branch ${branch}) but a branch can only be pinned once a project is chosen — re-run with --project-id first, then \`${getCliName()} checkout ${branch}\`.`
-		: "";
-	emitAgent({
-		status: "needs_project",
-		instruction:
-			(projects.length === 0
-				? `Organization ${orgId} has no projects yet. Ask the user for a name for the new project, then re-run the create_option.next_command_template.`
-				: `Ask the user whether to link to one of these ${projects.length} existing projects (use next_command_template with --project-id) or create a new project (use create_option.next_command_template).`) +
-			branchNote,
-		options: projects.map((project) => ({
-			id: project.id,
-			name: project.name,
-			region_id: project.region_id,
-		})),
-		create_option: {
-			instruction:
-				"To create a new project, ask the user for a project name. The region can be omitted to receive a follow-up needs_project_details response that lists available regions.",
-			next_command_template: `${getCliName()} link --agent --org-id ${shellArg(orgId)} --project-name <name> --region-id <region_id>`,
-		},
-		next_command_template: `${getCliName()} link --agent --org-id ${shellArg(orgId)} --project-id <project_id>`,
-	});
-};
-
-const emitAgent = (response: AgentResponse) => {
-	process.stdout.write(`${JSON.stringify(response, null, 2)}\n`);
-};
-
-// ----------------------------------------------------------------------------
 // API helpers
 // ----------------------------------------------------------------------------
 
@@ -1133,69 +944,6 @@ const detectOrgIdFromProjects = async (
 		log.debug("detectOrgIdFromProjects failed: %s", message);
 		return undefined;
 	}
-};
-
-const buildNeedsOrgResponse = (
-	resolution: Extract<OrgResolution, { kind: "needs_selection" }>,
-): AgentResponse => {
-	if (resolution.orgKeyLimited) {
-		return {
-			status: "needs_org",
-			instruction:
-				"This Neon API key is organization-scoped, so the CLI cannot list the user's organizations and no existing project was found to auto-detect the org ID. Ask the user for their Neon organization ID (visible in the Neon Console under the org's Settings page, formatted like `org-bitter-breeze-12345678`) and re-run the next_command_template with that --org-id.",
-			options: [],
-			next_command_template: `${getCliName()} link --agent --org-id <org_id>`,
-		};
-	}
-	const orgs = resolution.orgs;
-	return {
-		status: "needs_org",
-		instruction:
-			orgs.length === 0
-				? "The user does not belong to any organizations. Ask them to create one in the Neon Console (https://console.neon.tech/) before linking."
-				: `Ask the user which of these ${orgs.length} organization${orgs.length === 1 ? "" : "s"} they want to link the current directory to. After they pick one, re-run the next_command_template with the chosen --org-id value.`,
-		options: orgs.map((org) => ({ id: org.id, name: org.name })),
-		next_command_template: `${getCliName()} link --agent --org-id <org_id>`,
-	};
-};
-
-const toAgentError = (
-	err: unknown,
-): Extract<AgentResponse, { status: "error" }> => {
-	if (err instanceof LinkInputError) {
-		return { status: "error", code: err.agentCode, message: err.message };
-	}
-	if (isNeonApiError(err)) {
-		const status = err.status;
-		const apiMessage = messageFromBody(err.data);
-		const message =
-			apiMessage !== undefined && apiMessage.length > 0
-				? apiMessage
-				: err.message;
-		let code = "API_ERROR";
-		if (status === 401 || status === 403) {
-			code = "AUTH_ERROR";
-		} else if (status !== undefined && status >= 400 && status < 500) {
-			code = "CLIENT_ERROR";
-		} else if (status !== undefined && status >= 500) {
-			code = "SERVER_ERROR";
-		} else if (err.code === "ECONNABORTED") {
-			code = "TIMEOUT";
-		}
-		return { status: "error", code, message };
-	}
-	if (err instanceof Error) {
-		return {
-			status: "error",
-			code: "INTERNAL_ERROR",
-			message: err.message,
-		};
-	}
-	return {
-		status: "error",
-		code: "INTERNAL_ERROR",
-		message: String(err),
-	};
 };
 
 const listAllProjects = async (
@@ -1463,13 +1211,6 @@ const onPromptState = (state: {
 		process.stdout.write("\n");
 		process.exit(1);
 	}
-};
-
-const shellArg = (value: string): string => {
-	if (/^[A-Za-z0-9._:/-]+$/.test(value)) {
-		return value;
-	}
-	return `'${value.replace(/'/g, `'\\''`)}'`;
 };
 
 const mustString = <T>(value: T | undefined, name: string): T => {

--- a/packages/cli/src/utils/cli_name.ts
+++ b/packages/cli/src/utils/cli_name.ts
@@ -1,16 +1,5 @@
 import { basename } from "node:path";
 
-/**
- * The name this CLI was invoked as: `neon` (current) or `neonctl` (legacy alias).
- *
- * Use this for any user-facing string that suggests a command to run — help text,
- * error hints, and especially `--agent` `next_command_template` values, which an agent
- * executes verbatim. Hardcoding `neonctl` breaks those on installs of the `neon` package,
- * which no longer ships a `neonctl` binary (removed in `neon@2.38.0`).
- *
- * Derived from `process.argv[1]`, which is fixed for the process lifetime, so the result
- * is stable whether this is called at module load or per invocation. Mirrors the name used
- * for yargs `.scriptName()` in `index.ts`.
- */
+/** Command hints must use the invoked binary so users can run them verbatim. */
 export const getCliName = (): string =>
 	basename(process.argv[1] ?? "") === "neonctl" ? "neonctl" : "neon";


### PR DESCRIPTION
## Problem

`neon link --agent` used a command-specific JSON state machine with `needs_org`, `needs_project`, `needs_project_details` and `linked` responses. Agents and scripts needed a separate protocol for linking even though the CLI already exposes machine-readable list commands and flag-driven linking.

## Diagnosis

The existing commands already provide the required operations. Organization and project lists support JSON output. `link --project-id` verifies the project and infers its organization. The existing creation flags fully describe a new project.

## User-facing interface

Agents and scripts list resources and then link:

```bash
neon orgs list --output json
neon projects list --org-id <org-id> --output json
neon link --project-id <project-id>
neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2
```

`neon link --help` includes this recipe. A `neon link` invocation with missing inputs and no interactive terminal exits 1 with the same commands.

`--agent` is hidden from `link --help`. Existing invocations exit 1 with empty stdout and this guidance on stderr:

```console
$ neon link --agent
ERROR: `neon link --agent` was removed.
Use:
  neon orgs list --output json
  neon projects list --org-id <org-id> --output json
  neon link --project-id <project-id>
  neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2
Organization-scoped API keys cannot list orgs; pass --org-id.
```

The `--agent <name>` selector on these commands is unchanged:

```bash
neon skills --agent <name>
neon mcp --agent <name>
neon plugins --agent <name>
```

## Also in here

- Removes the link-specific JSON response types, error mapping and env-pull message renderer.
- Updates the CLI README with the list-and-link workflow and organization-scoped key guidance.
- Adds a minor changeset for `neon` and `neonctl`.

## Verification

```bash
pnpm --filter neon exec vitest run src/commands/link.test.ts src/commands/env.test.ts src/utils/cli_name.test.ts
node packages/cli/dist/cli.js link --help --no-analytics
node packages/cli/dist/cli.js link --agent --no-analytics
git diff --check origin/main...HEAD
```

The CLI build passed. Those tests passed (75).

Tests cover the refusal, hidden help option, CI and no-TTY guidance, organization-scoped keys with and without existing projects, and invalid `--params` JSON.

Live API verification was not run. The changed refusal and help paths make no API requests; API-dependent link behavior is covered by fixtures.

## For your attention

- Callers using the JSON state machine must migrate to the listed commands.
- Organization-scoped keys must provide `--org-id` when organizations cannot be listed, or provide `--project-id` so `link` can infer the organization.