### PR TITLE
chore: release neon@4.7.0, neonctl@4.7.0

### DIFF
--- a/.changeset/link-no-agent.md
+++ b/.changeset/link-no-agent.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-`neon link --agent` is removed. List orgs with `orgs list --output json` and projects with `projects list --org-id <org-id> --output json`. Link with `--project-id`, or create with `--org-id --project-name --region-id`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.7.0
+
+### Minor Changes
+
+- 9530c77: `neon link --agent` is removed. List orgs with `orgs list --output json` and projects with `projects list --org-id <org-id> --output json`. Link with `--project-id`, or create with `--org-id --project-name --region-id`.
+
 ## 4.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.6.0",
+	"version": "4.7.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.7.0
+
+### Minor Changes
+
+- 9530c77: `neon link --agent` is removed. List orgs with `orgs list --output json` and projects with `projects list --org-id <org-id> --output json`. Link with `--project-id`, or create with `--org-id --project-name --region-id`.
+
+### Patch Changes
+
+- Updated dependencies [9530c77]
+  - neon@4.7.0
+
 ## 4.6.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

The CLI change in [#491](https://github.com/neondatabase/neon-pkgs/pull/491) is merged, but the published packages remain at 4.6.0:

```console
$ npm view neon version
4.6.0
$ npm view neonctl version
4.6.0
```

This PR prepares the 4.7.0 release metadata for both packages.

## User-facing interface

The release removes `neon link --agent`. Agents list resources as JSON, then link an existing project:

```bash
neon orgs list --output json
neon projects list --org-id <org-id> --output json
neon link --project-id <project-id>
```

Or create and link a project:

```bash
neon link \
  --org-id <org-id> \
  --project-name <project-name> \
  --region-id <region-id>
```

## Release metadata

- Bumps `neon` and `neonctl` from 4.6.0 to 4.7.0.
- Adds the 4.7.0 changelog entries.
- Consumes `.changeset/link-no-agent.md`.

## Verification

- `pnpm lint:ci` checked 729 files with no errors.
- `git diff --check origin/main...HEAD` passed.
- The diff contains five release metadata files.
- `.changeset/` contains only `README.md` and `config.json`.
- npm reports 4.6.0 for both packages before this release.

## For your attention

- This PR only lands version and changelog metadata. The private mirror publishes to npm after merge.
- `neon` must publish before `neonctl` because the compatibility package depends on the matching `neon` version.