### PR TITLE
Split create from createAndConnect; attach compute on branch create by default

### DIFF
--- a/.changeset/create-and-connect.md
+++ b/.changeset/create-and-connect.md
@@ -1,0 +1,6 @@
+---
+"@neon/sdk": major
+"@neon/tools": major
+---
+
+`branches.create` attaches a read-write endpoint by default; pass `noCompute: true` (tools: `no_compute`) to skip it. `createWithCompute` is now `createAndConnect`. `create` returns the resource without a connection string; `createAndConnect` returns a URI.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,7 @@ written against. `packages/sdk/e2e/` targets exactly that gap across three files
   can only confirm whichever the author picked), and `postgres.connectionString`
   auto-resolving branch, role, and database.
 - **`resources`** — the CRUD spine on one shared project: branch create/get/update/
-  delete, `createWithCompute`, roles (including that `password` returns a bare string
+  delete, `createAndConnect`, roles (including that `password` returns a bare string
   while `resetPassword` returns a `Role`), databases, endpoints, and
   `operations.waitFor` recognising terminal states.
 - **`errors`** — `toNeonError` against real 404 and 401 envelopes, `throwOnError`

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -189,7 +189,7 @@ consuming it twice gets a fresh deadline each time.
 
 ## Readiness & workflows
 
-Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle; the **workflow** methods (`createAndConnect`, `createWithCompute`) default it on and hand back a connection string in one call. The primitive is `neon.operations.waitFor(operations)`.
+Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
 
 ---
 
@@ -203,7 +203,7 @@ Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→
 | --- | --- | --- |
 | `list(query?)` | **[P]** `ProjectListItem` | `query`: `{ search?, org_id?, limit? }` (cursor managed for you) |
 | `get(id)` | `Project` | |
-| `create(input?)` | `Project` | `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
+| `create(input?)` | `Project` | API always provisions default-branch compute. No connection string. Readiness polling on by default. `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
 | `createAndConnect(input?, { pooled? })` | **[W]** `{ project, connectionString }` | one call + readiness; `pooled` default `true` |
 | `update(id, input)` | `Project` | `input`: `{ name?, settings? }` |
 | `delete(id)` | `Project` | |
@@ -232,10 +232,10 @@ await neon.projects.transfer({
 | --- | --- | --- |
 | `list(projectId, query?)` | **[P]** `Branch` | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }` |
 | `get(projectId, branchId)` | `Branch` | |
-| `create(projectId, input?)` | `Branch` | `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected? }` |
+| `create(projectId, input?)` | `Branch` | RW compute on by default. `noCompute: true` skips the endpoint. No connection string. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
 | `update(projectId, branchId, input)` | `Branch` | `input`: `{ name?, protected?, expires_at? }` |
 | `delete(projectId, branchId)` | **→void** | |
-| `createWithCompute(projectId, input, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
+| `createAndConnect(projectId, input?, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
 | `getDefault(projectId)` | `Branch` | resolves the default branch by the `default` flag |
 | `setDefault(projectId, branchId)` | `Branch` | |
 | `resetFromParent(projectId, branchId, { preserveUnderName? }?)` | `Branch` | parent HEAD only; discards writes since the branch diverged. `preserveUnderName` is required when the branch has children. Pass `{ waitForReadiness: true }` before using the branch |
@@ -260,8 +260,21 @@ const branch = data?.branch;
 // Resolve the project's default ("production") branch
 const { data: prod } = await neon.branches.getDefault(projectId);
 
+// Branch off production with compute, without a connection string
+await neon.branches.create(projectId, {
+  name: "preview/pr-123",
+  parent_id: prod?.id,
+});
+
+// Skip compute when the branch only needs a schema
+await neon.branches.create(projectId, {
+  name: "schema-only",
+  parent_id: prod?.id,
+  noCompute: true,
+});
+
 // Branch off it with its own compute — returns a ready connection string
-const { data } = await neon.branches.createWithCompute(projectId, {
+const { data } = await neon.branches.createAndConnect(projectId, {
   name: "preview/pr-123",
   parentId: prod?.id,
   compute: { minCu: 0.25, maxCu: 2 },

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -260,13 +260,11 @@ const branch = data?.branch;
 // Resolve the project's default ("production") branch
 const { data: prod } = await neon.branches.getDefault(projectId);
 
-// Branch off production with compute, without a connection string
 await neon.branches.create(projectId, {
   name: "preview/pr-123",
   parent_id: prod?.id,
 });
 
-// Skip compute when the branch only needs a schema
 await neon.branches.create(projectId, {
   name: "schema-only",
   parent_id: prod?.id,

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -36,11 +36,11 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 	it("round-trips a branch through create, get, update and delete", async () => {
 		const created = expectOk(
-			await neon.branches.create(
-				projectId,
-				{ name: "crud", parent_id: defaultBranchId },
-				{ waitForReadiness: true },
-			),
+			await neon.branches.create(projectId, {
+				name: "crud",
+				parent_id: defaultBranchId,
+				noCompute: true,
+			}),
 		);
 		expect(created.name).toBe("crud");
 
@@ -64,7 +64,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 	it("compares schemas and resets a child back to its parent", async () => {
 		const child = expectOk(
-			await neon.branches.createWithCompute(projectId, {
+			await neon.branches.createAndConnect(projectId, {
 				name: "reset-child",
 				parentId: defaultBranchId,
 			}),
@@ -122,7 +122,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 	it("creates a branch with its compute and a connection string in one call", async () => {
 		const created = expectOk(
-			await neon.branches.createWithCompute(projectId, {
+			await neon.branches.createAndConnect(projectId, {
 				name: "with-compute",
 				parentId: defaultBranchId,
 			}),
@@ -144,6 +144,39 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		);
 
 		expectOk(await neon.branches.delete(projectId, created.branch.id));
+	});
+
+	it("attaches a read-write endpoint unless noCompute is true", async () => {
+		const withCompute = expectOk(
+			await neon.branches.create(projectId, {
+				name: "with-endpoint",
+				parent_id: defaultBranchId,
+			}),
+		);
+		const attached = expectOk(
+			await neon.postgres.endpoints.listByBranch(
+				projectId,
+				withCompute.id,
+			),
+		);
+		expect(
+			attached.filter((endpoint) => endpoint.type === "read_write"),
+		).toHaveLength(1);
+
+		const bare = expectOk(
+			await neon.branches.create(projectId, {
+				name: "bare",
+				parent_id: defaultBranchId,
+				noCompute: true,
+			}),
+		);
+		const none = expectOk(
+			await neon.postgres.endpoints.listByBranch(projectId, bare.id),
+		);
+		expect(none).toEqual([]);
+
+		expectOk(await neon.branches.delete(projectId, withCompute.id));
+		expectOk(await neon.branches.delete(projectId, bare.id));
 	});
 
 	it("manages roles, including the two different password shapes", async () => {

--- a/packages/sdk/e2e/workflows.e2e.test.ts
+++ b/packages/sdk/e2e/workflows.e2e.test.ts
@@ -70,16 +70,13 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			if (scope.kind !== "org-or-user") return;
 			const neon = makeClient();
 
-			// Without `waitForReadiness` the branch create below races the project's own
-			// provisioning operations and Neon rejects it as conflicting.
+			// create waits by default so the branch create below does not race the
+			// project's own provisioning operations.
 			const project = expectOk(
-				await neon.projects.create(
-					{
-						name: uniqueProjectName("sdk-page"),
-						region_id: DEFAULT_REGION,
-					},
-					{ waitForReadiness: true },
-				),
+				await neon.projects.create({
+					name: uniqueProjectName("sdk-page"),
+					region_id: DEFAULT_REGION,
+				}),
 			);
 			track(project.id);
 
@@ -88,6 +85,7 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 				await neon.branches.create(project.id, {
 					name: "dev",
 					parent_id: main.id,
+					noCompute: true,
 				}),
 			);
 
@@ -121,13 +119,10 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			const neon = makeClient();
 
 			const project = expectOk(
-				await neon.projects.create(
-					{
-						name: uniqueProjectName("sdk-conn"),
-						region_id: DEFAULT_REGION,
-					},
-					{ waitForReadiness: true },
-				),
+				await neon.projects.create({
+					name: uniqueProjectName("sdk-conn"),
+					region_id: DEFAULT_REGION,
+				}),
 			);
 			track(project.id);
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -38,9 +38,10 @@ export {
 } from "./neon/errors.js";
 export type { Page, Paginated } from "./neon/paginate.js";
 export type {
-	BranchWithCompute,
+	BranchConnection,
 	CompareSchemaInput,
-	CreateWithComputeInput,
+	ComputeSettings,
+	CreateAndConnectInput,
 	ResetFromParentInput,
 } from "./neon/resources/branches.js";
 export type {

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -12,7 +12,7 @@ import type {
 } from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
 import type { Paginated } from "./paginate.js";
-import type { BranchWithCompute } from "./resources/branches.js";
+import type { BranchConnection } from "./resources/branches.js";
 import type { ProjectConnection } from "./resources/projects.js";
 import type { NeonResult } from "./result.js";
 
@@ -50,16 +50,30 @@ it("branches + workflows carry the envelope and narrow under throwOnError", () =
 		NeonResult<Branch>
 	>();
 	expectTypeOf(
-		neon.branches.createWithCompute("p", { name: "x" }),
-	).resolves.toEqualTypeOf<NeonResult<BranchWithCompute>>();
+		neon.branches.create("p", { name: "x" }),
+	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	expectTypeOf(
+		neon.branches.create("p", { name: "x", noCompute: true }),
+	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	neon.branches.create("p", {
+		noCompute: true,
+		// @ts-expect-error compute is invalid when noCompute is true
+		compute: { minCu: 1 },
+	});
+	expectTypeOf(neon.branches.createAndConnect("p")).resolves.toEqualTypeOf<
+		NeonResult<BranchConnection>
+	>();
+	expectTypeOf(
+		neon.branches.createAndConnect("p", { name: "x" }),
+	).resolves.toEqualTypeOf<NeonResult<BranchConnection>>();
 	expectTypeOf(
 		neon.projects.createAndConnect({ name: "x" }),
 	).resolves.toEqualTypeOf<NeonResult<ProjectConnection>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
-		throwing.branches.createWithCompute("p", { name: "x" }),
-	).resolves.toEqualTypeOf<BranchWithCompute>();
+		throwing.branches.createAndConnect("p", { name: "x" }),
+	).resolves.toEqualTypeOf<BranchConnection>();
 	expectTypeOf(
 		throwing.branches.delete("p", "br"),
 	).resolves.toEqualTypeOf<void>();

--- a/packages/sdk/src/neon/resources/branches.test.ts
+++ b/packages/sdk/src/neon/resources/branches.test.ts
@@ -39,6 +39,145 @@ function neonRouting(
 	return { neon, calls };
 }
 
+describe("branches.create", () => {
+	it("posts a read-write endpoint by default and unwraps the branch", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: {
+				branch: { id: "br-1", name: "feature" },
+				endpoints: [{ id: "ep-1", type: "read_write" }],
+			},
+		}));
+
+		const { data, error } = await neon.branches.create("p-1", {
+			name: "feature",
+			parent_id: "br-parent",
+			compute: { minCu: 0.5, maxCu: 2, suspendTimeoutSeconds: 300 },
+		});
+
+		expect(error).toBeUndefined();
+		expect(data).toEqual({ id: "br-1", name: "feature" });
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.body).toEqual({
+			branch: { name: "feature", parent_id: "br-parent" },
+			endpoints: [
+				{
+					type: "read_write",
+					autoscaling_limit_min_cu: 0.5,
+					autoscaling_limit_max_cu: 2,
+					suspend_timeout_seconds: 300,
+				},
+			],
+		});
+	});
+
+	it("posts a read-write endpoint when compute is omitted", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { branch: { id: "br-1", name: "feature" } },
+		}));
+
+		await neon.branches.create("p-1", { name: "feature" });
+
+		expect(calls[0]?.body).toEqual({
+			branch: { name: "feature" },
+			endpoints: [{ type: "read_write" }],
+		});
+	});
+
+	it("omits endpoints when noCompute is true", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { branch: { id: "br-1", name: "bare" } },
+		}));
+
+		const { data, error } = await neon.branches.create("p-1", {
+			name: "bare",
+			noCompute: true,
+		});
+
+		expect(error).toBeUndefined();
+		expect(data).toEqual({ id: "br-1", name: "bare" });
+		expect(calls[0]?.body).toEqual({ branch: { name: "bare" } });
+	});
+
+	it("rejects noCompute together with compute settings without fetching", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 500,
+			body: { message: "should not be called" },
+		}));
+
+		const { data, error } = await neon.branches.create("p-1", {
+			noCompute: true,
+			// @ts-expect-error runtime guard for JS callers
+			compute: { minCu: 1 },
+		});
+
+		expect(data).toBeUndefined();
+		expect(error?.kind).toBe("client");
+		expect(error?.message).toBe(
+			"Pass compute settings or noCompute, not both.",
+		);
+		expect(calls).toHaveLength(0);
+
+		const throwing = createNeonClient({
+			apiKey: "test",
+			retries: 0,
+			throwOnError: true,
+			fetch: async () => {
+				throw new Error("should not be called");
+			},
+		});
+		await expect(
+			throwing.branches.create("p-1", {
+				noCompute: true,
+				// @ts-expect-error runtime guard for JS callers
+				compute: { minCu: 1 },
+			}),
+		).rejects.toMatchObject({
+			kind: "client",
+			message: "Pass compute settings or noCompute, not both.",
+		});
+	});
+});
+
+describe("branches.createAndConnect", () => {
+	it("posts a read-write endpoint and returns a pooled connection string", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: {
+				branch: { id: "br-1", name: "feature" },
+				endpoints: [{ id: "ep-1", type: "read_write" }],
+				connection_uris: [
+					{
+						connection_uri: "postgresql://user:pass@ep-host/neondb",
+						connection_parameters: {
+							host: "ep-host",
+							pooler_host: "ep-pooler-host",
+						},
+					},
+				],
+			},
+		}));
+
+		const { data, error } = await neon.branches.createAndConnect("p-1", {
+			name: "feature",
+			parentId: "br-parent",
+		});
+
+		expect(error).toBeUndefined();
+		expect(data).toEqual({
+			branch: { id: "br-1", name: "feature" },
+			endpoint: { id: "ep-1", type: "read_write" },
+			connectionString: "postgresql://user:pass@ep-pooler-host/neondb",
+		});
+		expect(calls[0]?.body).toEqual({
+			branch: { name: "feature", parent_id: "br-parent" },
+			endpoints: [{ type: "read_write" }],
+		});
+	});
+});
+
 describe("branches.resetFromParent", () => {
 	it("restores from the parent HEAD and unwraps the branch", async () => {
 		const { neon, calls } = neonRouting(({ url }) => {

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -27,13 +27,11 @@ type ListQuery = Omit<NonNullable<ListProjectBranchesData["query"]>, "cursor">;
 type BranchFields = NonNullable<BranchCreateRequest["branch"]>;
 type UpdateInput = BranchUpdateRequest["branch"];
 
-/** Per-call options for {@link Branches.createAndConnect}. */
 interface WorkflowOptions<Throw extends boolean> extends CallOptions<Throw> {
 	/** Return a pooled connection string (default `true`). */
 	pooled?: boolean;
 }
 
-/** Autoscaling settings for the branch's read-write endpoint. */
 export interface ComputeSettings {
 	minCu?: number;
 	maxCu?: number;
@@ -44,12 +42,10 @@ type CreateInputBase = BranchFields & {
 	compute?: ComputeSettings;
 };
 
-/** Input for {@link Branches.create}. `noCompute: true` cannot carry `compute`. */
 export type CreateInput =
 	| (CreateInputBase & { noCompute?: false })
 	| (BranchFields & { noCompute: true; compute?: never });
 
-/** Input for {@link Branches.createAndConnect}. */
 export interface CreateAndConnectInput {
 	name?: string;
 	/** Parent branch id. Defaults to the project's default branch. */
@@ -143,15 +139,12 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/**
-	 * Create a branch with a read-write endpoint by default. Does not return a
-	 * connection string; use {@link Branches.createAndConnect} or
-	 * `postgres.connectionString` for that.
+	 * This method retains its branch-only result even when it provisions compute;
+	 * use {@link Branches.createAndConnect} or `postgres.connectionString` when a
+	 * connection string is needed.
 	 *
-	 * Pass `noCompute: true` to skip the endpoint (the Management API default).
-	 * Readiness polling stays on unless `waitForReadiness` is set false — a
+	 * Readiness polling stays on for `noCompute` branches because a
 	 * compute-less branch still has provisioning operations.
-	 *
-	 * @workflow createProjectBranch + waitForReadiness
 	 */
 	create(
 		projectId: string,
@@ -253,12 +246,6 @@ export class Branches<DThrow extends boolean> {
 		);
 	}
 
-	/**
-	 * Create a branch with a read-write endpoint and return a ready-to-use connection
-	 * string. One API call plus readiness polling.
-	 *
-	 * @workflow createProjectBranch (with endpoint) + waitForReadiness
-	 */
 	createAndConnect(
 		projectId: string,
 		input?: CreateAndConnectInput,

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -24,34 +24,54 @@ import { type Paginated, paginate } from "../paginate.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 type ListQuery = Omit<NonNullable<ListProjectBranchesData["query"]>, "cursor">;
-type CreateInput = NonNullable<BranchCreateRequest["branch"]>;
+type BranchFields = NonNullable<BranchCreateRequest["branch"]>;
 type UpdateInput = BranchUpdateRequest["branch"];
 
-/** Per-call options for the connect/compute workflows. */
+/** Per-call options for {@link Branches.createAndConnect}. */
 interface WorkflowOptions<Throw extends boolean> extends CallOptions<Throw> {
 	/** Return a pooled connection string (default `true`). */
 	pooled?: boolean;
 }
 
-/** Input for {@link Branches.createWithCompute}. */
-export interface CreateWithComputeInput {
+/** Autoscaling settings for the branch's read-write endpoint. */
+export interface ComputeSettings {
+	minCu?: number;
+	maxCu?: number;
+	suspendTimeoutSeconds?: number;
+}
+
+type CreateInputBase = BranchFields & {
+	compute?: ComputeSettings;
+};
+
+/** Input for {@link Branches.create}. `noCompute: true` cannot carry `compute`. */
+export type CreateInput =
+	| (CreateInputBase & { noCompute?: false })
+	| (BranchFields & { noCompute: true; compute?: never });
+
+/** Input for {@link Branches.createAndConnect}. */
+export interface CreateAndConnectInput {
 	name?: string;
 	/** Parent branch id. Defaults to the project's default branch. */
 	parentId?: string;
-	/** Autoscaling settings for the branch's read-write endpoint. */
-	compute?: {
-		minCu?: number;
-		maxCu?: number;
-		suspendTimeoutSeconds?: number;
-	};
+	compute?: ComputeSettings;
 }
 
 /** A branch with its read-write endpoint and a ready-to-use connection string. */
-export interface BranchWithCompute {
+export interface BranchConnection {
 	branch: Branch;
 	endpoint: Endpoint;
 	connectionString: string;
 }
+
+const NO_COMPUTE_WITH_COMPUTE = "Pass compute settings or noCompute, not both.";
+
+const readWriteEndpoint = (compute?: ComputeSettings) => ({
+	type: "read_write" as const,
+	autoscaling_limit_min_cu: compute?.minCu,
+	autoscaling_limit_max_cu: compute?.maxCu,
+	suspend_timeout_seconds: compute?.suspendTimeoutSeconds,
+});
 
 export interface ResetFromParentInput {
 	/** Required when the branch has children so they can move to the preserved branch. */
@@ -122,7 +142,17 @@ export class Branches<DThrow extends boolean> {
 		);
 	}
 
-	/** @apiCall POST /projects/{project_id}/branches */
+	/**
+	 * Create a branch with a read-write endpoint by default. Does not return a
+	 * connection string; use {@link Branches.createAndConnect} or
+	 * `postgres.connectionString` for that.
+	 *
+	 * Pass `noCompute: true` to skip the endpoint (the Management API default).
+	 * Readiness polling stays on unless `waitForReadiness` is set false — a
+	 * compute-less branch still has provisioning operations.
+	 *
+	 * @workflow createProjectBranch + waitForReadiness
+	 */
 	create(
 		projectId: string,
 		input?: CreateInput,
@@ -132,18 +162,36 @@ export class Branches<DThrow extends boolean> {
 		input: CreateInput | undefined,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
-	create(
+	async create(
 		projectId: string,
 		input?: CreateInput,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const shouldThrow =
+			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
+		const parsed = parseCreateInput(input);
+		if (parsed.error) {
+			return finalize(err<Branch>(parsed.error), shouldThrow);
+		}
 		return this.#ctx.run(
-			opts,
+			{
+				...opts,
+				waitForReadiness: opts?.waitForReadiness ?? true,
+			},
 			(client, signal) =>
 				createProjectBranch({
 					client,
 					path: { project_id: projectId },
-					body: { branch: input },
+					body: {
+						branch: parsed.branch,
+						...(parsed.noCompute
+							? {}
+							: {
+									endpoints: [
+										readWriteEndpoint(parsed.compute),
+									],
+								}),
+					},
 					throwOnError: false,
 					signal,
 				}),
@@ -206,25 +254,25 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/**
-	 * Create a branch **with a read-write endpoint** and return a ready-to-use connection
-	 * string. One API call (Neon creates the endpoint inline) plus readiness polling.
+	 * Create a branch with a read-write endpoint and return a ready-to-use connection
+	 * string. One API call plus readiness polling.
 	 *
 	 * @workflow createProjectBranch (with endpoint) + waitForReadiness
 	 */
-	createWithCompute(
+	createAndConnect(
 		projectId: string,
-		input: CreateWithComputeInput,
-	): Promise<Outcome<BranchWithCompute, DThrow>>;
-	createWithCompute<Throw extends boolean = DThrow>(
+		input?: CreateAndConnectInput,
+	): Promise<Outcome<BranchConnection, DThrow>>;
+	createAndConnect<Throw extends boolean = DThrow>(
 		projectId: string,
-		input: CreateWithComputeInput,
+		input: CreateAndConnectInput | undefined,
 		opts: WorkflowOptions<Throw>,
-	): Promise<Outcome<BranchWithCompute, Throw>>;
-	async createWithCompute(
+	): Promise<Outcome<BranchConnection, Throw>>;
+	async createAndConnect(
 		projectId: string,
-		input: CreateWithComputeInput,
+		input?: CreateAndConnectInput,
 		opts?: WorkflowOptions<boolean>,
-	): Promise<BranchWithCompute | NeonResult<BranchWithCompute>> {
+	): Promise<BranchConnection | NeonResult<BranchConnection>> {
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
@@ -234,16 +282,11 @@ export class Branches<DThrow extends boolean> {
 					client,
 					path: { project_id: projectId },
 					body: {
-						branch: { name: input.name, parent_id: input.parentId },
-						endpoints: [
-							{
-								type: "read_write",
-								autoscaling_limit_min_cu: input.compute?.minCu,
-								autoscaling_limit_max_cu: input.compute?.maxCu,
-								suspend_timeout_seconds:
-									input.compute?.suspendTimeoutSeconds,
-							},
-						],
+						branch: {
+							name: input?.name,
+							parent_id: input?.parentId,
+						},
+						endpoints: [readWriteEndpoint(input?.compute)],
 					},
 					throwOnError: false,
 					signal,
@@ -494,4 +537,30 @@ export class Branches<DThrow extends boolean> {
 			() => undefined,
 		);
 	}
+}
+
+function parseCreateInput(input?: CreateInput):
+	| {
+			error: NeonError;
+	  }
+	| {
+			error?: undefined;
+			branch: BranchFields;
+			noCompute: boolean;
+			compute?: ComputeSettings;
+	  } {
+	if (input === undefined) {
+		return { branch: {}, noCompute: false };
+	}
+	if (input.noCompute === true) {
+		if ("compute" in input && input.compute !== undefined) {
+			return {
+				error: new NeonError(NO_COMPUTE_WITH_COMPUTE, "client"),
+			};
+		}
+		const { noCompute: _noCompute, compute: _compute, ...branch } = input;
+		return { branch, noCompute: true };
+	}
+	const { noCompute: _noCompute, compute, ...branch } = input;
+	return { branch, noCompute: false, compute };
 }

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -366,13 +366,10 @@ export class Projects<DThrow extends boolean> {
 	}
 
 	/**
-	 * Create a project. The API always provisions a default branch with read-write
-	 * compute; there is no opt-out. Does not return a connection string; use
-	 * {@link Projects.createAndConnect} or `postgres.connectionString` for that.
-	 *
-	 * Readiness polling is on by default.
-	 *
-	 * @apiCall POST /projects
+	 * The API provides no way to skip the default branch or read-write compute.
+	 * This method retains its project-only result; use
+	 * {@link Projects.createAndConnect} or `postgres.connectionString` when a
+	 * connection string is needed.
 	 */
 	create(input?: CreateInput): Promise<Outcome<Project, DThrow>>;
 	create<Throw extends boolean = DThrow>(

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -365,7 +365,15 @@ export class Projects<DThrow extends boolean> {
 		);
 	}
 
-	/** @apiCall POST /projects */
+	/**
+	 * Create a project. The API always provisions a default branch with read-write
+	 * compute; there is no opt-out. Does not return a connection string; use
+	 * {@link Projects.createAndConnect} or `postgres.connectionString` for that.
+	 *
+	 * Readiness polling is on by default.
+	 *
+	 * @apiCall POST /projects
+	 */
 	create(input?: CreateInput): Promise<Outcome<Project, DThrow>>;
 	create<Throw extends boolean = DThrow>(
 		input: CreateInput | undefined,
@@ -376,7 +384,10 @@ export class Projects<DThrow extends boolean> {
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
-			opts,
+			{
+				...opts,
+				waitForReadiness: opts?.waitForReadiness ?? true,
+			},
 			(client, signal) =>
 				createProject({
 					client,

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -24,7 +24,7 @@ const tools = createNeonTools({
 	tools: [
 		"projects.list",
 		"projects.createAndConnect",
-		"branches.createWithCompute",
+		"branches.createAndConnect",
 		"branches.resetFromParent",
 		"branches.compareSchema",
 	],
@@ -70,7 +70,7 @@ Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, 
 Paginated lists call `.all()` and return the item array. Do not pass a cursor; those fields are omitted from the input schema.
 
 ```ts
-const createBranch = createNeonTool("branches.createWithCompute", { apiKey });
+const createBranch = createNeonTool("branches.createAndConnect", { apiKey });
 ```
 
 ## Writes and waiting
@@ -83,7 +83,7 @@ An abort `signal` on `execute` or a wait timeout stops the poll, not the create:
 
 `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there.
 
-These public client methods are not tools: `projects.create`, `branches.create`, `operations.waitFor`, `postgres.roles.password`, and `storage.objects.get`. Use `projects.createAndConnect` and `branches.createWithCompute` for creates that attach compute and return a connection string. Waiting is what the write tools already do.
+These public client methods are not tools: `operations.waitFor`, `postgres.roles.password`, and `storage.objects.get`. Waiting is what the write tools already do. `projects.create` and `branches.create` return the created resource without a connection string; `createAndConnect` returns a URI.
 
 ## Optional host add-ons
 
@@ -127,17 +127,17 @@ This package does not send analytics. Mutating `event.input` does not change a g
 ```ts
 const tools = createNeonTools({
 	apiKey,
-	tools: ["branches.createWithCompute", "projects.list"] as const,
-	names: { "branches.createWithCompute": "create_branch" },
+	tools: ["branches.createAndConnect", "projects.list"] as const,
+	names: { "branches.createAndConnect": "create_branch" },
 	name: (id) => `neon_${id}`,
 });
 ```
 
-Those tools publish as `neon_create_branch` and `neon_list_projects`. The record is still keyed by SDK path (`tools["branches.createWithCompute"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
+Those tools publish as `neon_create_branch` and `neon_list_projects`. The record is still keyed by SDK path (`tools["branches.createAndConnect"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
 
 ### Project and branch injection
 
-Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.createWithCompute`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
+Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.createAndConnect`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
 
 ```ts
 const tools = createNeonTools({

--- a/packages/tools/src/catalog.test.ts
+++ b/packages/tools/src/catalog.test.ts
@@ -46,12 +46,6 @@ describe("ergonomic catalog coverage", () => {
 				]),
 			).toThrow(`Neon tool "${id}" is not published`);
 		}
-		expect(() =>
-			Reflect.apply(createNeonTool, undefined, [
-				"projects.create",
-				{ apiKey: "test-key" },
-			]),
-		).toThrow("projects.createAndConnect");
 	});
 });
 

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -738,7 +738,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.delete", "branches.createWithCompute"] as const,
+			tools: ["branches.delete", "branches.createAndConnect"] as const,
 			inject: { projectId: "granted-project", omitFromSchema: true },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -749,7 +749,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		await tools["branches.delete"].execute({
 			branch_id: "br-id",
 		});
-		await tools["branches.createWithCompute"].execute({
+		await tools["branches.createAndConnect"].execute({
 			name: "feature",
 		});
 
@@ -907,20 +907,35 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		);
 	});
 
+	test("drops path from create when project_id is omitted", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["branches.create"] as const,
+			inject: { projectId: "granted-project", omitFromSchema: true },
+		});
+
+		const schema = z.toJSONSchema(tools["branches.create"].inputSchema);
+		expect(schema.properties).not.toHaveProperty("project_id");
+		expect(schema.properties).toHaveProperty("no_compute");
+		expect(tools["branches.create"].inputSchema.safeParse({}).success).toBe(
+			true,
+		);
+	});
+
 	test("drops path from createProjectBranch when project_id is omitted", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute"] as const,
+			tools: ["branches.createAndConnect"] as const,
 			inject: { projectId: "granted-project", omitFromSchema: true },
 		});
 
 		const schema = z.toJSONSchema(
-			tools["branches.createWithCompute"].inputSchema,
+			tools["branches.createAndConnect"].inputSchema,
 		);
 		expect(schema.properties).not.toHaveProperty("project_id");
 		expect(schema.properties).toHaveProperty("name");
 		expect(
-			tools["branches.createWithCompute"].inputSchema.safeParse({})
+			tools["branches.createAndConnect"].inputSchema.safeParse({})
 				.success,
 		).toBe(true);
 	});
@@ -962,22 +977,22 @@ describe("tool names", () => {
 	test("renames one tool and then applies a global prefix", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute", "projects.list"] as const,
-			names: { "branches.createWithCompute": "create_branch" },
+			tools: ["branches.createAndConnect", "projects.list"] as const,
+			names: { "branches.createAndConnect": "create_branch" },
 			name: (id) => `neon_${id}`,
 		});
 
-		expect(tools["branches.createWithCompute"].id).toBe(
+		expect(tools["branches.createAndConnect"].id).toBe(
 			"neon_create_branch",
 		);
 		expect(tools["projects.list"].id).toBe("neon_list_projects");
 	});
 
 	test("lets a function rename from the generated id", () => {
-		const tool = createNeonTool("branches.createWithCompute", {
+		const tool = createNeonTool("branches.createAndConnect", {
 			apiKey: "test-key",
 			names: ({ id }) =>
-				id === "create_with_compute_branches" ? "create_branch" : id,
+				id === "create_and_connect_branches" ? "create_branch" : id,
 		});
 
 		expect(tool.id).toBe("create_branch");
@@ -1012,7 +1027,7 @@ describe("tool names", () => {
 		expect(() =>
 			createNeonTools({
 				apiKey: "test-key",
-				tools: ["branches.createWithCompute"] as const,
+				tools: ["branches.createAndConnect"] as const,
 				names: { createProjectBrunch: "create_branch" },
 			}),
 		).toThrow("Unknown Neon tool name override: createProjectBrunch");

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -175,21 +175,21 @@ uninjectedProject.execute({});
 
 const renamed = createNeonTools({
 	apiKey: "test-key",
-	tools: ["projects.list", "branches.createWithCompute"] as const,
-	names: { "branches.createWithCompute": "create_branch" },
+	tools: ["projects.list", "branches.createAndConnect"] as const,
+	names: { "branches.createAndConnect": "create_branch" },
 	name: (id) => `neon_${id}`,
 });
 expectTypeOf(renamed["projects.list"].id).toEqualTypeOf<string>();
-expectTypeOf(renamed["branches.createWithCompute"].id).toEqualTypeOf<string>();
+expectTypeOf(renamed["branches.createAndConnect"].id).toEqualTypeOf<string>();
 expectTypeOf(tools["projects.list"].id).toEqualTypeOf<"list_projects">();
 
 const mastraRenamed = toMastraTools(renamed);
 expectTypeOf(mastraRenamed.neon_create_branch.id).toEqualTypeOf<string>();
 expectTypeOf(mastraRenamed.neon_list_projects.id).toEqualTypeOf<string>();
 
-const renamedOne = createNeonTool("branches.createWithCompute", {
+const renamedOne = createNeonTool("branches.createAndConnect", {
 	apiKey: "test-key",
-	names: { "branches.createWithCompute": "create_branch" },
+	names: { "branches.createAndConnect": "create_branch" },
 });
 expectTypeOf(renamedOne.id).toEqualTypeOf<string>();
 
@@ -218,17 +218,17 @@ expectTypeOf(createNeonTools(annotatedTools)).toHaveProperty("projects.list");
 
 const createBranch = createNeonTools({
 	apiKey: "test-key",
-	tools: ["branches.createWithCompute"] as const,
+	tools: ["branches.createAndConnect"] as const,
 });
-expectTypeOf(createBranch).toHaveProperty("branches.createWithCompute");
+expectTypeOf(createBranch).toHaveProperty("branches.createAndConnect");
 // @ts-expect-error unselected tools are absent
 createBranch["projects.list"];
-createBranch["branches.createWithCompute"].execute({
+createBranch["branches.createAndConnect"].execute({
 	project_id: "project-id",
 });
 // @ts-expect-error project_id is required without inject
-createBranch["branches.createWithCompute"].execute({});
-createBranch["branches.createWithCompute"]
+createBranch["branches.createAndConnect"].execute({});
+createBranch["branches.createAndConnect"]
 	.execute({ project_id: "project-id" })
 	.then((result) => {
 		expectTypeOf(result.data.connectionString).toEqualTypeOf<string>();
@@ -237,21 +237,21 @@ createBranch["branches.createWithCompute"]
 
 declare const unionOpts:
 	| { apiKey: "test-key"; tools: ["projects.list"] }
-	| { apiKey: "test-key"; tools: ["branches.createWithCompute"] };
+	| { apiKey: "test-key"; tools: ["branches.createAndConnect"] };
 const unionTools = createNeonTools(unionOpts);
 // @ts-expect-error union options do not share projects.list
 unionTools["projects.list"];
-// @ts-expect-error union options do not share branches.createWithCompute
-unionTools["branches.createWithCompute"];
+// @ts-expect-error union options do not share branches.createAndConnect
+unionTools["branches.createAndConnect"];
 
-const createBranchWithCompute = createNeonTool("branches.createWithCompute", {
+const createBranchAndConnect = createNeonTool("branches.createAndConnect", {
 	apiKey: "test-key",
 });
-createBranchWithCompute.execute({
+createBranchAndConnect.execute({
 	project_id: "project-id",
 	name: "feature-x",
 });
-createBranchWithCompute.execute({
+createBranchAndConnect.execute({
 	project_id: "project-id",
 	// @ts-expect-error parentId is not the tool field name
 	parentId: "br-id",
@@ -259,10 +259,38 @@ createBranchWithCompute.execute({
 
 const omittedWorkflow = createNeonTools({
 	apiKey: "test-key",
-	tools: ["branches.createWithCompute"] as const,
+	tools: ["branches.createAndConnect"] as const,
 	inject: { projectId: "granted-project", omitFromSchema: true },
 });
-omittedWorkflow["branches.createWithCompute"].execute({ name: "feature-x" });
+omittedWorkflow["branches.createAndConnect"].execute({ name: "feature-x" });
+
+const createBranchOnly = createNeonTool("branches.create", {
+	apiKey: "test-key",
+});
+createBranchOnly.execute({ project_id: "project-id", no_compute: true });
+createBranchOnly.execute({ project_id: "project-id" }).then((result) => {
+	expectTypeOf(result.data.id).toEqualTypeOf<string>();
+	// @ts-expect-error create does not return a connection string
+	result.data.connectionString;
+});
+// @ts-expect-error pooled is not on create
+createBranchOnly.execute({ project_id: "project-id", pooled: false });
+createBranchAndConnect.execute({
+	project_id: "project-id",
+	// @ts-expect-error no_compute is not on createAndConnect
+	no_compute: true,
+});
+
+const createProjectOnly = createNeonTool("projects.create", {
+	apiKey: "test-key",
+});
+createProjectOnly.execute({ name: "x" }).then((result) => {
+	expectTypeOf(result.data.id).toEqualTypeOf<string>();
+	// @ts-expect-error create does not return a connection string
+	result.data.connectionString;
+});
+// @ts-expect-error no_compute is not on projects.create
+createProjectOnly.execute({ name: "x", no_compute: true });
 
 // @ts-expect-error tools is required
 createNeonTools({ apiKey: "test-key" });

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -11,8 +11,10 @@ import {
 import {
 	compareSchemaTool,
 	connectionStringTool,
-	createBranchWithComputeTool,
+	createBranchAndConnectTool,
+	createBranchTool,
 	createProjectAndConnectTool,
+	createProjectTool,
 	getDefaultTool,
 	resetFromParentTool,
 	restoreSnapshotTool,
@@ -58,6 +60,7 @@ export const toolFactories = {
 			run: (neon, input, signal) =>
 				neon.projects.get(input.project_id, { signal }),
 		}),
+	"projects.create": createProjectTool,
 	"projects.createAndConnect": createProjectAndConnectTool,
 	"projects.update": (options) =>
 		fromGenerated(options, {
@@ -225,7 +228,8 @@ export const toolFactories = {
 					signal,
 				}),
 		}),
-	"branches.createWithCompute": createBranchWithComputeTool,
+	"branches.create": createBranchTool,
+	"branches.createAndConnect": createBranchAndConnectTool,
 	"branches.update": (options) =>
 		fromGenerated(options, {
 			id: "branches.update",

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -23,18 +23,67 @@ const pooledField = z
 const branchCreateFields = zod.zBranchCreateRequest.shape.branch.unwrap().shape;
 const projectCreateFields = zod.zCreateProjectBody.shape.project.shape;
 
-export const createBranchWithComputeInputSchema = z.strictObject({
+const computeSettingsSchema = z
+	.strictObject({
+		min_cu: zod.zComputeUnit.optional(),
+		max_cu: zod.zComputeUnit.optional(),
+		suspend_timeout_seconds: zod.zSuspendTimeoutSeconds.optional(),
+	})
+	.optional();
+
+const mapCompute = (
+	compute:
+		| {
+				min_cu?: number;
+				max_cu?: number;
+				suspend_timeout_seconds?: number;
+		  }
+		| undefined,
+) =>
+	compute === undefined
+		? undefined
+		: {
+				minCu: compute.min_cu,
+				maxCu: compute.max_cu,
+				suspendTimeoutSeconds: compute.suspend_timeout_seconds,
+			};
+
+const NO_COMPUTE_WITH_COMPUTE =
+	"Pass compute settings or no_compute, not both.";
+
+export const createBranchInputSchema = z
+	.strictObject({
+		project_id: zod.zCreateProjectBranchPath.shape.project_id,
+		name: branchCreateFields.name,
+		parent_id: branchCreateFields.parent_id,
+		compute: computeSettingsSchema,
+		no_compute: z
+			.boolean()
+			.describe(
+				"Skip the read-write endpoint. Default false. Cannot be combined with compute.",
+			)
+			.optional(),
+	})
+	.superRefine((value, ctx) => {
+		if (value.no_compute === true && value.compute !== undefined) {
+			ctx.addIssue({
+				code: "custom",
+				message: NO_COMPUTE_WITH_COMPUTE,
+				path: ["no_compute"],
+			});
+		}
+	});
+
+export const createBranchAndConnectInputSchema = z.strictObject({
 	project_id: zod.zCreateProjectBranchPath.shape.project_id,
 	name: branchCreateFields.name,
 	parent_id: branchCreateFields.parent_id,
-	compute: z
-		.strictObject({
-			min_cu: zod.zComputeUnit.optional(),
-			max_cu: zod.zComputeUnit.optional(),
-			suspend_timeout_seconds: zod.zSuspendTimeoutSeconds.optional(),
-		})
-		.optional(),
+	compute: computeSettingsSchema,
 	pooled: pooledField,
+});
+
+export const createProjectInputSchema = z.strictObject({
+	...projectCreateFields,
 });
 
 export const createProjectAndConnectInputSchema = z.strictObject({
@@ -103,16 +152,60 @@ export const setScheduleInputSchema = z.strictObject({
 	),
 });
 
-export const createBranchWithComputeTool = (options: ToolClientOptions) =>
+export const createBranchTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "branches.createWithCompute",
-			id: publishedId("branches.createWithCompute"),
-			title: "Create branch with compute",
+			operationId: "branches.create",
+			id: publishedId("branches.create"),
+			title: "Create branch",
+			description:
+				"Create a branch with a read-write endpoint by default. Pass no_compute to skip the endpoint. The call waits until operation-backed provisioning finishes, up to five minutes by default. Does not return a connection string; use branches.createAndConnect or postgres.connectionString for that.",
+			inputSchema: createBranchInputSchema,
+			annotations: writeAnnotations,
+			requiresApproval: true,
+			metadata: {
+				method: "POST",
+				path: "/projects/{project_id}/branches",
+				stability: "stable",
+				deprecated: false,
+				tags: ["Branch"],
+			},
+		},
+		(neon, input, signal) => {
+			if (input.no_compute === true) {
+				return neon.branches.create(
+					input.project_id,
+					{
+						name: input.name,
+						parent_id: input.parent_id,
+						noCompute: true,
+					},
+					{ signal },
+				);
+			}
+			return neon.branches.create(
+				input.project_id,
+				{
+					name: input.name,
+					parent_id: input.parent_id,
+					compute: mapCompute(input.compute),
+				},
+				{ signal },
+			);
+		},
+	);
+
+export const createBranchAndConnectTool = (options: ToolClientOptions) =>
+	bindTool(
+		options,
+		{
+			operationId: "branches.createAndConnect",
+			id: publishedId("branches.createAndConnect"),
+			title: "Create branch and connect",
 			description:
 				"Create a branch with a read-write endpoint and return its connection string. The call waits until operation-backed provisioning finishes, up to five minutes by default.",
-			inputSchema: createBranchWithComputeInputSchema,
+			inputSchema: createBranchAndConnectInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,
 			metadata: {
@@ -124,20 +217,12 @@ export const createBranchWithComputeTool = (options: ToolClientOptions) =>
 			},
 		},
 		(neon, input, signal) =>
-			neon.branches.createWithCompute(
+			neon.branches.createAndConnect(
 				input.project_id,
 				{
 					name: input.name,
 					parentId: input.parent_id,
-					compute:
-						input.compute === undefined
-							? undefined
-							: {
-									minCu: input.compute.min_cu,
-									maxCu: input.compute.max_cu,
-									suspendTimeoutSeconds:
-										input.compute.suspend_timeout_seconds,
-								},
+					compute: mapCompute(input.compute),
 				},
 				{
 					signal,
@@ -146,6 +231,29 @@ export const createBranchWithComputeTool = (options: ToolClientOptions) =>
 						: { pooled: input.pooled }),
 				},
 			),
+	);
+
+export const createProjectTool = (options: ToolClientOptions) =>
+	bindTool(
+		options,
+		{
+			operationId: "projects.create",
+			id: publishedId("projects.create"),
+			title: "Create project",
+			description:
+				"Create a project. The API always provisions a default branch with read-write compute. The call waits until operation-backed provisioning finishes, up to five minutes by default. Does not return a connection string; use projects.createAndConnect or postgres.connectionString for that.",
+			inputSchema: createProjectInputSchema,
+			annotations: writeAnnotations,
+			requiresApproval: true,
+			metadata: {
+				method: "POST",
+				path: "/projects",
+				stability: "stable",
+				deprecated: false,
+				tags: ["Project"],
+			},
+		},
+		(neon, input, signal) => neon.projects.create(input, { signal }),
 	);
 
 export const createProjectAndConnectTool = (options: ToolClientOptions) =>

--- a/packages/tools/src/lib/ergonomic/ids.ts
+++ b/packages/tools/src/lib/ergonomic/ids.ts
@@ -1,7 +1,5 @@
 export const hiddenToolIds = [
 	"operations.waitFor",
-	"branches.create",
-	"projects.create",
 	"postgres.roles.password",
 	"storage.objects.get",
 ] as const;
@@ -11,6 +9,7 @@ export type HiddenToolId = (typeof hiddenToolIds)[number];
 export const toolIds = [
 	"projects.list",
 	"projects.get",
+	"projects.create",
 	"projects.createAndConnect",
 	"projects.update",
 	"projects.delete",
@@ -25,7 +24,8 @@ export const toolIds = [
 	"projects.members.removeRole",
 	"branches.list",
 	"branches.get",
-	"branches.createWithCompute",
+	"branches.create",
+	"branches.createAndConnect",
 	"branches.update",
 	"branches.delete",
 	"branches.getDefault",
@@ -117,10 +117,6 @@ export const isNeonToolId = (id: string): id is NeonToolId =>
 	(toolIds as readonly string[]).includes(id);
 
 const hiddenToolHint: Record<HiddenToolId, string> = {
-	"projects.create":
-		'Use "projects.createAndConnect", which attaches compute and returns a connection string.',
-	"branches.create":
-		'Use "branches.createWithCompute", which attaches compute and returns a connection string.',
 	"operations.waitFor":
 		"Write tools wait for readiness. operations.waitFor is not a tool.",
 	"postgres.roles.password": "Role passwords are not published as a tool.",

--- a/packages/tools/src/published-id.test.ts
+++ b/packages/tools/src/published-id.test.ts
@@ -9,8 +9,8 @@ describe("publishedId", () => {
 		expect(publishedId("projects.createAndConnect")).toBe(
 			"create_and_connect_projects",
 		);
-		expect(publishedId("branches.createWithCompute")).toBe(
-			"create_with_compute_branches",
+		expect(publishedId("branches.createAndConnect")).toBe(
+			"create_and_connect_branches",
 		);
 		expect(publishedId("postgres.roles.resetPassword")).toBe(
 			"reset_password_postgres_roles",

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -39,12 +39,12 @@ const projectWithUriBody = {
 	],
 };
 
-const createBranchTools = (options: NeonToolsClientOptions = {}) => {
+const createBranchOnlyTools = (options: NeonToolsClientOptions = {}) => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({
 		apiKey: "test-key",
 		...options,
-		tools: ["branches.createWithCompute"] as const,
+		tools: ["branches.create"] as const,
 		fetch: async (input, init) => {
 			requests.push(new Request(input, init));
 			return jsonResponse(branchWithComputeBody);
@@ -53,22 +53,146 @@ const createBranchTools = (options: NeonToolsClientOptions = {}) => {
 	return { requests, tools };
 };
 
-describe("branches.createWithCompute", () => {
+const createBranchTools = (options: NeonToolsClientOptions = {}) => {
+	const requests: Request[] = [];
+	const tools = createNeonTools({
+		apiKey: "test-key",
+		...options,
+		tools: ["branches.createAndConnect"] as const,
+		fetch: async (input, init) => {
+			requests.push(new Request(input, init));
+			return jsonResponse(branchWithComputeBody);
+		},
+	});
+	return { requests, tools };
+};
+
+describe("branches.create", () => {
+	test("posts a read-write endpoint and returns the branch without a connection string", async () => {
+		const { requests, tools } = createBranchOnlyTools();
+
+		const result = await tools["branches.create"].execute({
+			project_id: "project-id",
+			name: "feature-x",
+			parent_id: "br-parent",
+			compute: {
+				min_cu: 0.5,
+				max_cu: 2,
+				suspend_timeout_seconds: 300,
+			},
+		});
+
+		expect(requests).toHaveLength(1);
+		expect(await requests[0].json()).toEqual({
+			branch: { name: "feature-x", parent_id: "br-parent" },
+			endpoints: [
+				{
+					type: "read_write",
+					autoscaling_limit_min_cu: 0.5,
+					autoscaling_limit_max_cu: 2,
+					suspend_timeout_seconds: 300,
+				},
+			],
+		});
+		expect(result).toEqual({
+			data: { id: "br-id", name: "feature-x" },
+		});
+		expect(result.data).not.toHaveProperty("connectionString");
+	});
+
+	test("omits endpoints when no_compute is true", async () => {
+		const { requests, tools } = createBranchOnlyTools();
+
+		await tools["branches.create"].execute({
+			project_id: "project-id",
+			name: "bare",
+			no_compute: true,
+		});
+
+		expect(await requests[0].json()).toEqual({
+			branch: { name: "bare" },
+		});
+	});
+
+	test("rejects no_compute together with compute", () => {
+		const { tools } = createBranchOnlyTools();
+
+		expect(
+			tools["branches.create"].inputSchema.safeParse({
+				project_id: "project-id",
+				no_compute: true,
+				compute: { min_cu: 1 },
+			}).success,
+		).toBe(false);
+	});
+
+	test("does not publish pooled", () => {
+		const { tools } = createBranchOnlyTools();
+		const schema = z.toJSONSchema(tools["branches.create"].inputSchema);
+
+		expect(schema.properties).not.toHaveProperty("pooled");
+		expect(schema.properties).toHaveProperty("no_compute");
+		expect(schema.properties).toHaveProperty("compute");
+	});
+});
+
+describe("projects.create", () => {
+	test("posts the project body and returns the project without a connection string", async () => {
+		const requests: Request[] = [];
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.create"] as const,
+			fetch: async (input, init) => {
+				requests.push(new Request(input, init));
+				return jsonResponse(projectWithUriBody);
+			},
+		});
+
+		const result = await tools["projects.create"].execute({
+			name: "tool-created",
+			region_id: "aws-us-east-1",
+		});
+
+		expect(await requests[0].json()).toEqual({
+			project: {
+				name: "tool-created",
+				region_id: "aws-us-east-1",
+			},
+		});
+		expect(result).toEqual({
+			data: { id: "project-id", name: "tool-created" },
+		});
+		expect(result.data).not.toHaveProperty("connectionString");
+	});
+
+	test("does not publish pooled or no_compute", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.create"] as const,
+		});
+		const schema = z.toJSONSchema(tools["projects.create"].inputSchema);
+
+		expect(schema.properties).not.toHaveProperty("pooled");
+		expect(schema.properties).not.toHaveProperty("no_compute");
+	});
+});
+
+describe("branches.createAndConnect", () => {
 	test("creates only the selected tool", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute"] as const,
+			tools: ["branches.createAndConnect"] as const,
 		});
 
-		expect(Object.keys(tools)).toEqual(["branches.createWithCompute"]);
-		expect(tools["branches.createWithCompute"].id).toBe(
-			"create_with_compute_branches",
+		expect(Object.keys(tools)).toEqual(["branches.createAndConnect"]);
+		expect(tools["branches.createAndConnect"].id).toBe(
+			"create_and_connect_branches",
 		);
-		expect(tools["branches.createWithCompute"].operationId).toBe(
-			"branches.createWithCompute",
+		expect(tools["branches.createAndConnect"].operationId).toBe(
+			"branches.createAndConnect",
 		);
-		expect(tools["branches.createWithCompute"].requiresApproval).toBe(true);
-		expect(tools["branches.createWithCompute"].annotations).toEqual({
+		expect(tools["branches.createAndConnect"].requiresApproval).toBe(true);
+		expect(tools["branches.createAndConnect"].annotations).toEqual({
 			readOnlyHint: false,
 			destructiveHint: true,
 			openWorldHint: true,
@@ -78,7 +202,7 @@ describe("branches.createWithCompute", () => {
 	test("posts a read-write endpoint and returns the SDK workflow result", async () => {
 		const { requests, tools } = createBranchTools();
 
-		const result = await tools["branches.createWithCompute"].execute({
+		const result = await tools["branches.createAndConnect"].execute({
 			project_id: "project-id",
 			name: "feature-x",
 			parent_id: "br-parent",
@@ -118,7 +242,7 @@ describe("branches.createWithCompute", () => {
 	test("forwards pooled: false to the SDK connection-string picker", async () => {
 		const { tools } = createBranchTools();
 
-		const result = await tools["branches.createWithCompute"].execute({
+		const result = await tools["branches.createAndConnect"].execute({
 			project_id: "project-id",
 			pooled: false,
 		});
@@ -134,7 +258,7 @@ describe("branches.createWithCompute", () => {
 		const { tools } = createBranchTools();
 
 		await expect(
-			tools["branches.createWithCompute"].execute(
+			tools["branches.createAndConnect"].execute(
 				{ project_id: "project-id" },
 				{ signal: controller.signal },
 			),
@@ -144,7 +268,7 @@ describe("branches.createWithCompute", () => {
 	test("describes pooled on the published schema", () => {
 		const { tools } = createBranchTools();
 		const schema = z.toJSONSchema(
-			tools["branches.createWithCompute"].inputSchema,
+			tools["branches.createAndConnect"].inputSchema,
 		);
 		const pooled = schema.properties?.pooled;
 
@@ -158,7 +282,7 @@ describe("branches.createWithCompute", () => {
 		const { tools } = createBranchTools();
 
 		expect(
-			tools["branches.createWithCompute"].inputSchema.safeParse({
+			tools["branches.createAndConnect"].inputSchema.safeParse({
 				project_id: "project-id",
 				parentId: "br-parent",
 			}).success,
@@ -170,7 +294,7 @@ describe("branches.createWithCompute", () => {
 			inject: { projectId: "granted-project", omitFromSchema: true },
 		});
 
-		await tools["branches.createWithCompute"].execute({
+		await tools["branches.createAndConnect"].execute({
 			name: "feature-x",
 		});
 
@@ -182,11 +306,11 @@ describe("branches.createWithCompute", () => {
 	test("renames the published id", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
-			tools: ["branches.createWithCompute"] as const,
-			names: { "branches.createWithCompute": "create_branch" },
+			tools: ["branches.createAndConnect"] as const,
+			names: { "branches.createAndConnect": "create_branch" },
 		});
 
-		expect(tools["branches.createWithCompute"].id).toBe("create_branch");
+		expect(tools["branches.createAndConnect"].id).toBe("create_branch");
 	});
 
 	test("uses an execute-time credential instead of the constructor credential", async () => {
@@ -194,7 +318,7 @@ describe("branches.createWithCompute", () => {
 			apiKey: "constructor-key",
 		});
 
-		await tools["branches.createWithCompute"].execute(
+		await tools["branches.createAndConnect"].execute(
 			{ project_id: "project-id" },
 			{ apiKey: "oauth-access-token" },
 		);
@@ -210,7 +334,7 @@ describe("branches.createWithCompute", () => {
 		});
 
 		await expect(
-			tools["branches.createWithCompute"].execute(
+			tools["branches.createAndConnect"].execute(
 				{ project_id: "project-id" },
 				{ apiKey: "" },
 			),
@@ -276,7 +400,7 @@ describe("projects.createAndConnect", () => {
 describe("createNeonTool", () => {
 	test("creates a single ergonomic tool", async () => {
 		const requests: Request[] = [];
-		const tool = createNeonTool("branches.createWithCompute", {
+		const tool = createNeonTool("branches.createAndConnect", {
 			apiKey: "test-key",
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -286,7 +410,7 @@ describe("createNeonTool", () => {
 
 		await tool.execute({ project_id: "project-id", name: "feature-x" });
 
-		expect(tool.id).toBe("create_with_compute_branches");
+		expect(tool.id).toBe("create_and_connect_branches");
 		expect(requests[0].url).toBe(
 			"https://console.neon.tech/api/v2/projects/project-id/branches",
 		);


### PR DESCRIPTION
## Problem

`branches.create` followed the Management API default and created a branch with no compute. The method that actually provisioned an endpoint and returned a URI was `createWithCompute`. Agents that wanted a usable branch had to call the URI workflow, which put a connection string into model context.

`projects.create` already provisioned compute (the API has no skip-compute field) but still defaulted readiness polling off, and `@neon/tools` hid both `create` methods in favor of the URI workflows.

## Diagnosis

The create call is the right place to attach compute. The connection string is a separate job. Those were glued together on `createWithCompute`, so dropping the URI meant dropping the endpoint too.

The Management API always attaches a default-branch endpoint on `POST /projects`. There is no request field to skip it, so `projects.create({ noCompute: true })` would be a dead API. Branch create is the one call that can omit `endpoints`.

## Solution

`create` returns the resource. `createAndConnect` returns the resource plus a connection string. Branch create attaches a read-write endpoint unless `noCompute: true`. Readiness polling is on by default for both create methods, including compute-less branch create, because the API still returns provisioning operations.

`createWithCompute` is removed. `@neon/tools` publishes `projects.create` and `branches.create` next to the connect tools.

## User-facing API

SDK:

```ts
const { data: project } = await neon.projects.create({ name: "my-app" });
// Project. No connection string. Wait on by default.

const { data: connected } = await neon.projects.createAndConnect({ name: "my-app" });
// { project, connectionString }

const { data: branch } = await neon.branches.create(projectId, {
  name: "preview",
  parent_id: parentId,
  // compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }
});
// Branch with a read-write endpoint. No connection string.

await neon.branches.create(projectId, {
  name: "schema-only",
  noCompute: true,
});
// No endpoint. `noCompute: true` cannot carry `compute`.

const { data: withUri } = await neon.branches.createAndConnect(projectId, {
  name: "preview",
  parentId: parentId,
  compute: { minCu: 0.25, maxCu: 2 },
});
// { branch, endpoint, connectionString }
```

Tools (selectors, published ids):

| Selector | Published id | Result |
| --- | --- | --- |
| `projects.create` | `create_projects` | Project. No `pooled`. No `no_compute`. |
| `projects.createAndConnect` | `create_and_connect_projects` | `{ project, connectionString }`. `pooled` default true. |
| `branches.create` | `create_branches` | Branch. `compute` and `no_compute`. No `pooled`. |
| `branches.createAndConnect` | `create_and_connect_branches` | `{ branch, endpoint, connectionString }`. Replaces `branches.createWithCompute`. |

```ts
await tools["branches.create"].execute({
  project_id: projectId,
  name: "preview",
  compute: { min_cu: 0.25, max_cu: 2 },
});

await tools["branches.create"].execute({
  project_id: projectId,
  name: "schema-only",
  no_compute: true,
});
```

Existing `createAndConnect` callers on projects keep the same method name and result shape. Callers of `branches.createWithCompute` or of the old compute-less `branches.create` need to move.

Types `CreateWithComputeInput` and `BranchWithCompute` are now `CreateAndConnectInput` and `BranchConnection`.

## Also in here

Major changeset for `@neon/sdk` and `@neon/tools`. README and the SDK e2e notes in `AGENTS.md` follow the rename. CLI create flags are unchanged.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 138 tests, including default branch create posting `endpoints: [{ type: "read_write" }]`, `noCompute: true` omitting endpoints, `noCompute` + `compute` returning a client error with zero fetch, and `createAndConnect` still returning a pooled URI.
- `pnpm --filter @neon/sdk test:types`
- `pnpm --filter @neon/tools test:ci` — 131 tests, including create tools returning the resource without `connectionString`, rejecting `no_compute` + `compute`, omitting `pooled` from create schemas, and inject still dropping `project_id` on `branches.create`.

Not run locally: live SDK e2e (`pnpm --filter @neon/sdk test:e2e`). No `NEON_API_KEY` in this worktree. CI `e2e-live.yml` covers it. Those tests now assert a default create has one read-write endpoint and `noCompute: true` has none.

## For your attention

- [neondatabase/neon-pkgs#489](https://github.com/neondatabase/neon-pkgs/pull/489) publishes compute-less `branches.create`. This PR is the intended ergonomic shape if both are open.
- [neondatabase/mcp-server-neon#324](https://github.com/neondatabase/mcp-server-neon/pull/324) maps `branches.createWithCompute`. It will need a follow-up to select `branches.create` / `projects.create` for MCP create tools once this lands.
- `projects.create` has no `noCompute`. Faking it by deleting the default endpoint after create is out of scope.
- CLI `branches create` already has `--compute` / `--no-compute`. This PR does not add `--no-compute` to `projects create`.