### PR TITLE
`neon link --project-id` pins a branch when the project has one

### DIFF
--- a/.changeset/link-auto-pin-branch.md
+++ b/.changeset/link-auto-pin-branch.md
@@ -1,0 +1,6 @@
+---
+"neon": minor
+"neonctl": minor
+---
+
+`neon link --project-id` pins the project's only branch. Several branches prompt in a TTY, pin the default with `-y`, or stay unpinned for `neon checkout`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -282,13 +282,21 @@ Linked .neon:
 
 When you link an **existing** project that has more than one branch, the interactive flow adds a
 final step to pick which branch to pin — the same `＋ Create a new branch…` + list selector used by
-`neon checkout` (a single-branch project is pinned automatically, no prompt). `link --project-id …`
-uses the same rule: one branch is pinned, several prompt in a TTY, `-y` pins the default, and
-no TTY leaves the pin empty for `neon checkout`:
+`neon checkout` (a single-branch project is pinned automatically, no prompt):
 
 ```bash
+$ neon link
 ? Which organization would you like to link? › Personal Org (org-abc123)
 ? Which project would you like to link? › my-app (polished-snowflake-12345678)
+? Which branch would you like to link? › [default] main (br-main-branch-87654321)
+```
+
+`link --project-id …` skips org and project. One branch is pinned with no prompt. Several branches
+in a TTY show the branch prompt; `-y` pins the default; no TTY leaves the pin empty for
+`neon checkout`:
+
+```bash
+$ neon link --project-id polished-snowflake-12345678
 ? Which branch would you like to link? › [default] main (br-main-branch-87654321)
 ```
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -257,7 +257,7 @@ The Neon CLI supports autocompletion, which you can configure in a few easy step
 
 - **org** is inferred from the project (so `--project-id` alone is enough); it's omitted only when the project has no organization (personal account).
 - **project** is taken from `--project-id` (or chosen interactively).
-- **branch** is left to an explicit [`neon checkout <branch>`](#checkout) — `link` never silently pins a project's default branch (that would make later commands quietly target, say, production). It only records a branch when you pass `--branch`, when one is already pinned for the same project (preserved), when you pick one in the interactive picker, or for a freshly **created** project (whose single branch is unambiguous).
+- **branch** is taken from `--branch`, an existing pin for the same project, or the project's branch list: one branch is pinned automatically; several prompt in a TTY, pin the default with `-y`, or stay unpinned for [`neon checkout <branch>`](#checkout). A project with no branches is linked without a pin and says so.
 
 When a branch ends up pinned, `link` also runs [`env pull`](#env-pull) so the branch's Neon env vars (`DATABASE_URL`, …) land in a local `.env`. With no branch pinned there is nothing to pull, so `link` instead nudges you to run `neon checkout`. Pass `--no-env-pull` to skip the pull (for example when injecting env at runtime with `neon-env run` or `neon dev`).
 
@@ -282,9 +282,9 @@ Linked .neon:
 
 When you link an **existing** project that has more than one branch, the interactive flow adds a
 final step to pick which branch to pin — the same `＋ Create a new branch…` + list selector used by
-`neon checkout` (a single-branch project is pinned automatically, no prompt). Non-interactive
-`link --project-id …` does **not** prompt or default a branch; it links org + project and leaves
-branch selection to `neon checkout`:
+`neon checkout` (a single-branch project is pinned automatically, no prompt). `link --project-id …`
+uses the same rule: one branch is pinned, several prompt in a TTY, `-y` pins the default, and
+no TTY leaves the pin empty for `neon checkout`:
 
 ```bash
 ? Which organization would you like to link? › Personal Org (org-abc123)
@@ -295,8 +295,12 @@ branch selection to `neon checkout`:
 **Non-interactive (flags or `--params` JSON)** — for scripts and CI:
 
 ```bash
-# Link to an existing project (org is inferred from the project; no branch pinned)
+# Link to an existing project (org is inferred). Pins the only branch;
+# several branches prompt in a TTY, or stay unpinned without one.
 neon link --project-id polished-snowflake-12345678
+
+# Same, pin the project's default branch when several exist
+neon link --project-id polished-snowflake-12345678 -y
 
 # Same, but also pin a branch (name or id — resolved and stored as its name)
 neon link --project-id polished-snowflake-12345678 --branch main
@@ -327,7 +331,7 @@ Every supplied identifier is checked before anything is written, with actionable
 ```bash
 neon orgs list --output json
 neon projects list --org-id <org-id> --output json
-neon link --project-id <project-id>
+neon link --project-id <project-id> [--branch <name> | -y]
 neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2
 ```
 
@@ -352,7 +356,7 @@ How today's `set-context` uses map onto `link`:
 
 | `set-context` (deprecated)              | Recommended `link` equivalent                                                 |
 | --------------------------------------- | ----------------------------------------------------------------------------- |
-| `neon set-context --project-id <id>` | `neon link --project-id <id>` (infers org + verifies; branch via checkout) |
+| `neon set-context --project-id <id>` | `neon link --project-id <id>` (infers org + verifies; pins the only branch) |
 | `neon set-context --org-id <id>`     | `neon link --org-id <id>`                                                  |
 | `neon set-context --branch-id <id>`  | `neon link --branch <name\|id>`                                            |
 | `neon set-context` (clear)           | `neon link --clear`                                                        |

--- a/packages/cli/mocks/main/projects/proj-in-org/branches/GET.json
+++ b/packages/cli/mocks/main/projects/proj-in-org/branches/GET.json
@@ -1,0 +1,20 @@
+{
+  "annotations": {},
+  "branches": [
+    {
+      "id": "br-dev-branch-123456",
+      "name": "dev",
+      "created_at": "2021-01-01T00:00:00.000Z",
+      "updated_at": "2021-01-01T00:00:00.000Z",
+      "current_state": "ready"
+    },
+    {
+      "id": "br-main-branch-654321",
+      "name": "main",
+      "default": true,
+      "created_at": "2021-01-01T00:00:00.000Z",
+      "updated_at": "2021-01-01T00:00:00.000Z",
+      "current_state": "ready"
+    }
+  ]
+}

--- a/packages/cli/mocks/main/projects/proj-no-branches/GET.json
+++ b/packages/cli/mocks/main/projects/proj-no-branches/GET.json
@@ -1,0 +1,9 @@
+{
+  "project": {
+    "id": "proj-no-branches",
+    "name": "No Branches",
+    "org_id": "org-7",
+    "region_id": "aws-us-east-2",
+    "created_at": "2019-01-01T00:00:00Z"
+  }
+}

--- a/packages/cli/mocks/main/projects/proj-no-branches/branches/GET.json
+++ b/packages/cli/mocks/main/projects/proj-no-branches/branches/GET.json
@@ -1,0 +1,4 @@
+{
+  "annotations": {},
+  "branches": []
+}

--- a/packages/cli/mocks/main/projects/proj-no-default/GET.json
+++ b/packages/cli/mocks/main/projects/proj-no-default/GET.json
@@ -1,0 +1,9 @@
+{
+  "project": {
+    "id": "proj-no-default",
+    "name": "No Default",
+    "org_id": "org-7",
+    "region_id": "aws-us-east-2",
+    "created_at": "2019-01-01T00:00:00Z"
+  }
+}

--- a/packages/cli/mocks/main/projects/proj-no-default/branches/GET.json
+++ b/packages/cli/mocks/main/projects/proj-no-default/branches/GET.json
@@ -1,0 +1,19 @@
+{
+  "annotations": {},
+  "branches": [
+    {
+      "id": "br-alpha-branch-123456",
+      "name": "alpha",
+      "created_at": "2021-01-01T00:00:00.000Z",
+      "updated_at": "2021-01-01T00:00:00.000Z",
+      "current_state": "ready"
+    },
+    {
+      "id": "br-beta-branch-123456",
+      "name": "beta",
+      "created_at": "2021-01-01T00:00:00.000Z",
+      "updated_at": "2021-01-01T00:00:00.000Z",
+      "current_state": "ready"
+    }
+  ]
+}

--- a/packages/cli/mocks/main/projects/proj-one-branch/GET.json
+++ b/packages/cli/mocks/main/projects/proj-one-branch/GET.json
@@ -1,0 +1,9 @@
+{
+  "project": {
+    "id": "proj-one-branch",
+    "name": "One Branch",
+    "org_id": "org-7",
+    "region_id": "aws-us-east-2",
+    "created_at": "2019-01-01T00:00:00Z"
+  }
+}

--- a/packages/cli/mocks/main/projects/proj-one-branch/branches/GET.json
+++ b/packages/cli/mocks/main/projects/proj-one-branch/branches/GET.json
@@ -1,0 +1,13 @@
+{
+  "annotations": {},
+  "branches": [
+    {
+      "id": "br-only-branch-123456",
+      "name": "main",
+      "default": true,
+      "created_at": "2021-01-01T00:00:00.000Z",
+      "updated_at": "2021-01-01T00:00:00.000Z",
+      "current_state": "ready"
+    }
+  ]
+}

--- a/packages/cli/src/commands/__snapshots__/link.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/link.test.ts.snap
@@ -132,6 +132,23 @@ exports[`link > non-interactive flag mode > link --params JSON behaves like flag
 }"
 `;
 
+exports[`link > non-interactive flag mode > link --project-id -y pins the default branch, not the first listed 1`] = `
+"Linked <TMP>/flag_yes_default/.neon:
+  orgId:     org-7
+  projectId: proj-in-org
+  branch:    main
+
+"
+`;
+
+exports[`link > non-interactive flag mode > link --project-id -y pins the default branch, not the first listed 2`] = `
+"{
+  "orgId": "org-7",
+  "projectId": "proj-in-org",
+  "branch": "main"
+}"
+`;
+
 exports[`link > non-interactive flag mode > link --project-id alone infers the org from the project 1`] = `
 "Linked <TMP>/flag_infer_org/.neon:
   orgId:     org-7
@@ -146,6 +163,40 @@ exports[`link > non-interactive flag mode > link --project-id alone infers the o
 "{
   "orgId": "org-7",
   "projectId": "proj-in-org"
+}"
+`;
+
+exports[`link > non-interactive flag mode > link --project-id pins the only branch 1`] = `
+"Linked <TMP>/flag_one_branch/.neon:
+  orgId:     org-7
+  projectId: proj-one-branch
+  branch:    main
+
+"
+`;
+
+exports[`link > non-interactive flag mode > link --project-id pins the only branch 2`] = `
+"{
+  "orgId": "org-7",
+  "projectId": "proj-one-branch",
+  "branch": "main"
+}"
+`;
+
+exports[`link > non-interactive flag mode > link --project-id with no branches warns and does not pin 1`] = `
+"Linked <TMP>/flag_no_branches/.neon:
+  orgId:     org-7
+  projectId: proj-no-branches
+
+This project has no branches, so none was pinned. Create a branch, then run \`neon checkout <branch>\` to pin it and pull its env vars.
+
+"
+`;
+
+exports[`link > non-interactive flag mode > link --project-id with no branches warns and does not pin 2`] = `
+"{
+  "orgId": "org-7",
+  "projectId": "proj-no-branches"
 }"
 `;
 
@@ -201,12 +252,28 @@ exports[`link > non-interactive flag mode > re-linking the same project keeps th
 }"
 `;
 
+exports[`link > non-interactive flag mode > re-linking the same project with -y keeps the already-pinned branch 1`] = `
+"Linked <TMP>/flag_keep_branch_yes/.neon:
+  orgId:     org-2
+  projectId: test
+  branch:    test_branch
+
+"
+`;
+
+exports[`link > non-interactive flag mode > re-linking the same project with -y keeps the already-pinned branch 2`] = `
+"{
+  "orgId": "org-2",
+  "projectId": "test",
+  "branch": "test_branch"
+}"
+`;
+
 exports[`link > org-scoped API key behavior > links an existing project when org listing is forbidden 1`] = `
 "Linked <TMP>/orgkey_project/.neon:
   orgId:     org-detected-99887766
   projectId: detected-project-12345
-
-No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its env vars.
+  branch:    main
 
 "
 `;
@@ -214,7 +281,8 @@ No branch pinned. Run \`neon checkout <branch>\` to pin a branch and pull its en
 exports[`link > org-scoped API key behavior > links an existing project when org listing is forbidden 2`] = `
 "{
   "orgId": "org-detected-99887766",
-  "projectId": "detected-project-12345"
+  "projectId": "detected-project-12345",
+  "branch": "main"
 }"
 `;
 

--- a/packages/cli/src/commands/link.test.ts
+++ b/packages/cli/src/commands/link.test.ts
@@ -1,5 +1,6 @@
 import { fork } from "node:child_process";
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
 	readFileSync,
@@ -120,7 +121,7 @@ const expectNonInteractiveHelp = (text: string) => {
 	const commands = [
 		"neon orgs list --output json",
 		"neon projects list --org-id <org-id> --output json",
-		"neon link --project-id <project-id>",
+		"neon link --project-id <project-id> [--branch <name> | -y]",
 		"neon link --org-id <org-id> --project-name <name> --region-id aws-us-east-2",
 	];
 	for (const command of commands) {
@@ -160,6 +161,110 @@ describe("link", () => {
 				"link",
 				"--project-id",
 				"proj-in-org",
+				"--no-env-pull",
+				"--context-file",
+				ctx,
+			]);
+			expect(readFile(ctx)).toMatchSnapshot();
+		});
+
+		test("link --project-id pins the only branch", async ({
+			testCliCommand,
+			readFile,
+			tmpContext,
+		}) => {
+			const ctx = tmpContext("flag_one_branch");
+			await testCliCommand([
+				"link",
+				"--project-id",
+				"proj-one-branch",
+				"--no-env-pull",
+				"--context-file",
+				ctx,
+			]);
+			expect(readFile(ctx)).toMatchSnapshot();
+		});
+
+		test("link --project-id -y pins the default branch, not the first listed", async ({
+			testCliCommand,
+			readFile,
+			tmpContext,
+		}) => {
+			const ctx = tmpContext("flag_yes_default");
+			await testCliCommand([
+				"link",
+				"--project-id",
+				"proj-in-org",
+				"-y",
+				"--no-env-pull",
+				"--context-file",
+				ctx,
+			]);
+			expect(readFile(ctx)).toMatchSnapshot();
+		});
+
+		test("link --project-id with no branches warns and does not pin", async ({
+			testCliCommand,
+			readFile,
+			tmpContext,
+		}) => {
+			const ctx = tmpContext("flag_no_branches");
+			await testCliCommand([
+				"link",
+				"--project-id",
+				"proj-no-branches",
+				"--no-env-pull",
+				"--context-file",
+				ctx,
+			]);
+			expect(readFile(ctx)).toMatchSnapshot();
+		});
+
+		test("link --project-id -y with no default branch fails without writing .neon", async ({
+			testCliCommand,
+			tmpContext,
+		}) => {
+			const ctx = tmpContext("flag_no_default");
+			await testCliCommand(
+				[
+					"link",
+					"--project-id",
+					"proj-no-default",
+					"-y",
+					"--no-env-pull",
+					"--context-file",
+					ctx,
+				],
+				{
+					code: 1,
+					snapshot: false,
+					stderr: expect.stringContaining(
+						"Project 'proj-no-default' has no default branch. Pass --branch <name> to pin one.",
+					),
+				},
+			);
+			expect(existsSync(ctx)).toBe(false);
+		});
+
+		test("re-linking the same project with -y keeps the already-pinned branch", async ({
+			testCliCommand,
+			readFile,
+			tmpContext,
+		}) => {
+			const ctx = tmpContext("flag_keep_branch_yes");
+			writeFileSync(
+				ctx,
+				JSON.stringify({
+					orgId: "org-2",
+					projectId: "test",
+					branch: "test_branch",
+				}),
+			);
+			await testCliCommand([
+				"link",
+				"--project-id",
+				"test",
+				"-y",
 				"--no-env-pull",
 				"--context-file",
 				ctx,

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -65,7 +65,7 @@ const nonInteractiveLinkCommands = (): string[] => {
 	return [
 		`${cli} orgs list --output json`,
 		`${cli} projects list --org-id <org-id> --output json`,
-		`${cli} link --project-id <project-id>`,
+		`${cli} link --project-id <project-id> [--branch <name> | -y]`,
 		`${cli} link --org-id <org-id> --project-name <name> --region-id aws-us-east-2`,
 	];
 };
@@ -108,9 +108,10 @@ export const builder = (argv: yargs.Argv) =>
 			branch: {
 				alias: "branch-id",
 				describe:
-					"Branch name or ID to pin in the context (resolved to its ID before writing). " +
-					"Without it, link only resolves the org and project — pin a branch with " +
-					`\`${getCliName()} checkout <branch>\` (link never guesses a default).`,
+					"Branch name or ID to pin in the context (resolved to its name before writing). " +
+					"Without it, a project with one branch is pinned automatically; several branches " +
+					"prompt in a TTY, pin the default with -y, or stay unpinned for " +
+					`\`${getCliName()} checkout <branch>\`.`,
 				type: "string",
 			},
 			params: {
@@ -125,7 +126,7 @@ export const builder = (argv: yargs.Argv) =>
 			yes: {
 				alias: "y",
 				describe:
-					'Skip the "already linked" confirmation in interactive mode and re-link anyway.',
+					'Skip the "already linked" confirmation, and pin the project\'s default branch when linking a project that has more than one.',
 				type: "boolean",
 				default: false,
 			},
@@ -156,7 +157,11 @@ export const builder = (argv: yargs.Argv) =>
 		.example([
 			[
 				"$0 link --project-id polished-snowflake-12345678",
-				`Link an existing project (org is inferred); pin a branch later with '${getCliName()} checkout'`,
+				"Link an existing project (org is inferred). Pins the only branch; several prompt in a TTY",
+			],
+			[
+				"$0 link --project-id polished-snowflake-12345678 -y",
+				"Same, pinning the project's default branch when several exist",
 			],
 			[
 				"$0 link --org-id org-… --project-name my-app --region-id aws-us-east-2",
@@ -289,16 +294,8 @@ const validateInputs = (inputs: Inputs): void => {
 };
 
 /**
- * Whether the inputs (combined with the existing `.neon`) fully determine what
- * to write without prompting the user. Everything else falls back to the
- * interactive picker (TTY) or the CI guard.
- *
- * - `--project-id` is always enough: the org is inferred from the project and
- *   the branch is left to an explicit `checkout` (never auto-defaulted).
- * - `--org-id --project-name --region-id` fully describes a project to create.
- * - `--branch-id` needs a project, which it takes from the existing `.neon`.
- * - `--org-id` on its own just records the default org (merged into any
- *   existing context).
+ * Branch selection may still prompt after org and project resolve without the
+ * org/project wizard.
  */
 const canResolveNonInteractively = (
 	inputs: Inputs,
@@ -501,29 +498,81 @@ const resolveOrgForProject = async (
 	return undefined;
 };
 
+type BranchResolution = {
+	branch?: string;
+	empty: boolean;
+};
+
 /**
- * Resolve the branch to persist alongside a project in non-interactive mode.
- *
- * `link` never guesses the project's default branch — that's `checkout`'s job —
- * so the only sources are an explicit `--branch` (name or id, verified and
- * normalized to its name) or a branch already pinned for the *same* project (so
- * re-linking it doesn't drop your checked-out branch). Reading the existing
- * branch via {@link contextBranch} also recovers a legacy `branchId` field.
+ * Keep an existing pin when re-linking the same project so `-y` does not reset
+ * a checkout.
  */
 const resolvePinnedBranch = async (
-	props: CommonProps,
+	props: LinkProps,
 	inputs: Inputs,
 	existing: Context,
 	projectId: string,
-): Promise<string | undefined> => {
+): Promise<BranchResolution> => {
 	if (inputs.branch) {
 		const branch = await resolveBranchRef(props, projectId, inputs.branch);
-		return branchPersistValue(branch);
+		return { branch: branchPersistValue(branch), empty: false };
 	}
 	if (projectId === existing.projectId) {
-		return contextBranch(existing);
+		const pinned = contextBranch(existing);
+		if (pinned) {
+			return { branch: pinned, empty: false };
+		}
 	}
-	return undefined;
+	return resolveBranchFromList(props, projectId);
+};
+
+const resolveBranchFromList = async (
+	props: LinkProps,
+	projectId: string,
+): Promise<BranchResolution> => {
+	const { data } = await props.apiClient.listProjectBranches({ projectId });
+	const branches = data.branches;
+	if (branches.length === 0) {
+		return { empty: true };
+	}
+	if (branches.length === 1) {
+		const [only] = branches;
+		if (!only) {
+			return { empty: true };
+		}
+		return { branch: branchPersistValue(only), empty: false };
+	}
+	if (props.yes) {
+		const def = branches.find((b: Branch) => b.default);
+		if (!def) {
+			throw new Error(
+				`Project '${projectId}' has no default branch. Pass --branch <name> to pin one.`,
+			);
+		}
+		return { branch: branchPersistValue(def), empty: false };
+	}
+	if (canPromptInteractively()) {
+		const picked = await pickBranchInteractively(branches, {
+			message: "Which branch would you like to link?",
+			nonInteractiveMessage:
+				"No branch could be selected without an interactive terminal. " +
+				`Re-run \`${getCliName()} link\` interactively, or \`${getCliName()} checkout <branch>\` to pin one.`,
+		});
+		if (picked.kind === "existing") {
+			const existing = branches.find(
+				(b: Branch) => b.id === picked.branchId,
+			);
+			return {
+				branch: existing
+					? branchPersistValue(existing)
+					: picked.branchId,
+				empty: false,
+			};
+		}
+		await createBranch(props.apiClient, projectId, picked.name, branches);
+		return { branch: picked.name, empty: false };
+	}
+	return { empty: false };
 };
 
 // ----------------------------------------------------------------------------
@@ -569,7 +618,7 @@ const runNonInteractive = async (
 			existing,
 			inputs.projectId,
 		);
-		const branch = await resolvePinnedBranch(
+		const resolved = await resolvePinnedBranch(
 			props,
 			inputs,
 			existing,
@@ -578,14 +627,15 @@ const runNonInteractive = async (
 		applyContext(props.contextFile, {
 			orgId,
 			projectId: inputs.projectId,
-			branch,
+			branch: resolved.branch,
 		});
 		await finalizeLink(props, {
 			contextFile: props.contextFile,
 			orgId,
 			projectId: inputs.projectId,
-			branch,
+			branch: resolved.branch,
 			created: false,
+			empty: resolved.empty,
 		});
 		return;
 	}
@@ -599,7 +649,7 @@ const runNonInteractive = async (
 			existing,
 			projectId,
 		);
-		const branch = await resolvePinnedBranch(
+		const resolved = await resolvePinnedBranch(
 			props,
 			inputs,
 			existing,
@@ -608,14 +658,15 @@ const runNonInteractive = async (
 		applyContext(props.contextFile, {
 			orgId,
 			projectId,
-			branch,
+			branch: resolved.branch,
 		});
 		await finalizeLink(props, {
 			contextFile: props.contextFile,
 			orgId,
 			projectId,
-			branch,
+			branch: resolved.branch,
 			created: false,
+			empty: resolved.empty,
 		});
 		return;
 	}
@@ -695,20 +746,21 @@ const runInteractive = async (props: LinkProps, inputs: Inputs) => {
 	const action = await promptProjectChoice(projects, inputs.projectName);
 
 	if (action.type === "existing") {
-		const branch = await resolveInteractiveBranch(props, action.projectId);
+		const resolved = await resolveBranchFromList(props, action.projectId);
 		applyContext(props.contextFile, {
 			orgId,
 			projectId: action.projectId,
-			branch,
+			branch: resolved.branch,
 		});
 		await finalizeInteractiveLink(props, {
 			contextFile: props.contextFile,
 			orgId,
 			projectId: action.projectId,
-			branch,
+			branch: resolved.branch,
 			created: false,
 			projectName: action.name,
 			regionId: action.regionId,
+			empty: resolved.empty,
 		});
 		return;
 	}
@@ -959,44 +1011,6 @@ const listAllProjects = async (
 	return result;
 };
 
-/**
- * Resolve which branch to pin for an interactively-chosen project, returned as the value to
- * persist (its name when known, see {@link branchPersistValue}). When the project has a
- * single branch there is nothing to choose, so we pin it silently. Otherwise we offer the
- * shared branch picker (the same "＋ Create a new branch…" + list as `neonctl checkout`),
- * creating the branch when the user opts to. This makes interactive `link` a full org →
- * project → branch flow; non-interactive `link` instead defers the branch to `checkout`.
- */
-const resolveInteractiveBranch = async (
-	props: CommonProps,
-	projectId: string,
-): Promise<string> => {
-	const { data } = await props.apiClient.listProjectBranches({ projectId });
-	const branches = data.branches;
-	if (branches.length <= 1) {
-		const only = branches.find((b: Branch) => b.default) ?? branches[0];
-		if (!only) {
-			throw new Error(
-				`Could not find a default branch for project ${projectId}.`,
-			);
-		}
-		return branchPersistValue(only);
-	}
-	const picked = await pickBranchInteractively(branches, {
-		message: "Which branch would you like to link?",
-		nonInteractiveMessage:
-			"No branch could be selected without an interactive terminal. " +
-			`Re-run \`${getCliName()} link\` interactively, or \`${getCliName()} checkout <branch>\` to pin one.`,
-	});
-	if (picked.kind === "existing") {
-		const existing = branches.find((b: Branch) => b.id === picked.branchId);
-		return existing ? branchPersistValue(existing) : picked.branchId;
-	}
-	// A freshly-created branch: we already know the name the user typed.
-	await createBranch(props.apiClient, projectId, picked.name, branches);
-	return picked.name;
-};
-
 const fetchRegions = async (props: CommonProps): Promise<RegionResponse[]> => {
 	try {
 		const { data } = await props.apiClient.getActiveRegions();
@@ -1079,6 +1093,7 @@ type HumanSummary = {
 	orgOnly?: boolean;
 	/** True for the `--no-checks` path: written offline, so suppress the checkout nudge. */
 	noChecks?: boolean;
+	empty?: boolean;
 };
 
 const printSummary = (_props: LinkProps, summary: HumanSummary): void => {
@@ -1105,9 +1120,15 @@ const printSummary = (_props: LinkProps, summary: HumanSummary): void => {
 		lines.push("Written offline (--no-checks): nothing was verified.");
 	} else if (summary.projectId && !summary.branch && !summary.orgOnly) {
 		lines.push("");
-		lines.push(
-			`No branch pinned. Run \`${getCliName()} checkout <branch>\` to pin a branch and pull its env vars.`,
-		);
+		if (summary.empty) {
+			lines.push(
+				`This project has no branches, so none was pinned. Create a branch, then run \`${getCliName()} checkout <branch>\` to pin it and pull its env vars.`,
+			);
+		} else {
+			lines.push(
+				`No branch pinned. Run \`${getCliName()} checkout <branch>\` to pin a branch and pull its env vars.`,
+			);
+		}
 	}
 	lines.push("");
 	process.stdout.write(`${lines.join("\n")}\n`);

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -108,10 +108,7 @@ export const builder = (argv: yargs.Argv) =>
 			branch: {
 				alias: "branch-id",
 				describe:
-					"Branch name or ID to pin in the context (resolved to its name before writing). " +
-					"Without it, a project with one branch is pinned automatically; several branches " +
-					"prompt in a TTY, pin the default with -y, or stay unpinned for " +
-					`\`${getCliName()} checkout <branch>\`.`,
+					"Branch name or ID to pin in the context (resolved to its name before writing).",
 				type: "string",
 			},
 			params: {


### PR DESCRIPTION
## Problem

`neon link --project-id <id>` inferred the org, wrote the project and left `branch` empty. The next command still needed `neon checkout`. `env pull` did not run, because there was nothing to pull.

Interactive `neon link` already pinned a project that has one branch. Creating a project pinned the new branch too. The gap is an existing project you name by id.

## Diagnosis

The `--project-id` path skipped the branch list on purpose. The comment on that path was that guessing the default would make later commands target production. That constraint applies when the list has several branches.

`--project-id` already skips the org and project wizard (`canResolveNonInteractively` returns true). The list can be fetched on that same path. A TTY then only asks which branch to pin.

`-y` already means do not ask. When several branches exist, it pins the one marked `default`.

## User-facing interface

Resolution order: `--branch`, then an existing pin for the same project, then the list.

`--branch` is unchanged. `--no-checks` still writes offline with no list. Creating a project still pins the new branch. Env pull still runs after a pin unless `--no-env-pull`.

| Branches | How you run it | What gets pinned |
| --- | --- | --- |
| One | `neon link --project-id <id>` | that branch |
| Several | TTY, no `-y` | prompt: `Which branch would you like to link?` (same picker as `neon checkout`, including create) |
| Several | no TTY, or CI (`isCi()`), no `-y` | none; checkout nudge |
| Several | `-y` | the default branch |
| Several | `-y`, no default | error; `.neon` not written |
| None | `neon link --project-id <id>` | none; empty-project warning |

Copied from the mock CLI suite. Invocations pass `--no-env-pull` so the summaries are the pin only. Without that flag, a pin still runs `env pull`.

One branch:

```bash
$ neon link --project-id proj-one-branch --no-env-pull
Linked .neon:
  orgId:     org-7
  projectId: proj-one-branch
  branch:    main
```

```json
{
  "orgId": "org-7",
  "projectId": "proj-one-branch",
  "branch": "main"
}
```

Several branches, no TTY. The list is `dev` then `main` (`default: true`):

```bash
$ neon link --project-id proj-in-org --no-env-pull
Linked .neon:
  orgId:     org-7
  projectId: proj-in-org

No branch pinned. Run `neon checkout <branch>` to pin a branch and pull its env vars.
```

Same project with `-y` pins `main`:

```bash
$ neon link --project-id proj-in-org -y --no-env-pull
Linked .neon:
  orgId:     org-7
  projectId: proj-in-org
  branch:    main
```

No branches:

```bash
$ neon link --project-id proj-no-branches --no-env-pull
Linked .neon:
  orgId:     org-7
  projectId: proj-no-branches

This project has no branches, so none was pinned. Create a branch, then run `neon checkout <branch>` to pin it and pull its env vars.
```

`-y` when none of the branches is default (list is `alpha`, `beta`):

```bash
$ neon link --project-id proj-no-default -y --no-env-pull
Project 'proj-no-default' has no default branch. Pass --branch <name> to pin one.
```

Exit 1. `.neon` is not created.

Re-link the same project with `-y` keeps the pin that is already there (`test_branch`), so `-y` does not reset a checkout.

TTY, several branches. Same picker as `neon checkout`. Not captured from a live TTY:

```bash
$ neon link --project-id polished-snowflake-12345678
? Which branch would you like to link? › [default] main (br-main-branch-87654321)
```

Help epilogue:

```bash
neon link --project-id <project-id> [--branch <name> | -y]
```

`-y` describe: Skip the "already linked" confirmation, and pin the project's default branch when linking a project that has more than one.

## Also in here

- CLI README, `--help` examples and the `set-context` mapping row.
- Minor changeset on `neon` and `neonctl`.
- Mocks for one branch, several with the default listed second, an empty list and two branches with no default.
- Interactive existing-project `link` uses the same list resolver. A project with no branches used to throw `Could not find a default branch for project …`. It now writes the link and prints the empty-project warning.

## Verification

Mock API, vitest snapshots in `link.test.ts`:

- one branch pins `main`
- several, no TTY, stay unpinned (`proj-in-org`)
- `-y` on that project pins `main`
- no branches warn and omit `branch`
- `-y` with no default fails with the stderr above and does not write `.neon`
- re-link same project with `-y` keeps `test_branch`
- existing org-scoped `--project-id` snapshot now includes `branch: main` (that fixture has one branch)

Live projects (created then deleted): one-branch `link --project-id` pinned `main` and wrote `NEON_BRANCH`, `DATABASE_URL`, and `DATABASE_URL_UNPOOLED` into `.env.local`. After adding a second branch, `CI=true link --project-id` stayed unpinned; `-y` pinned `main`.

Not verified: a real TTY prompt; `-y` on a project with no branches (the empty warning returns before the default lookup).

## For your attention

- Scripts that ran `neon link --project-id <id>` on a one-branch project now get a `branch` in `.neon` and, without `--no-env-pull`, a `.env` from `env pull`.
- Non-interactive `-y` did not choose a branch before. On several branches it now pins the default.
- Interactive `neon link -y` uses the same resolver, so several branches pin the default with no picker. Org and project prompts still run.
- The TTY prompt is the checkout picker, including create. This PR does not add a TTY test for that path.
