### PR TITLE
chore: release @neon/sdk@3.0.0, @neon/tools@1.0.0

### DIFF
--- a/.changeset/create-and-connect.md
+++ b/.changeset/create-and-connect.md
@@ -1,6 +1,0 @@
----
-"@neon/sdk": major
-"@neon/tools": major
----
-
-`branches.create` attaches a read-write endpoint by default; pass `noCompute: true` (tools: `no_compute`) to skip it. `createWithCompute` is now `createAndConnect`. `create` returns the resource without a connection string; `createAndConnect` returns a URI.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon-internals/env-core
 
+## 0.0.5
+
+### Patch Changes
+
+- @neon/config@1.0.5
+
 ## 0.0.4
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # neon
 
+## 4.7.1
+
+### Patch Changes
+
+- Updated dependencies [4211669]
+  - @neon/sdk@3.0.0
+  - @neon/config@1.0.5
+  - @neon/config-runtime@1.0.5
+
 ## 4.7.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.7.0",
+	"version": "4.7.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 1.0.5
+
+### Patch Changes
+
+- @neon/config@1.0.5
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 1.0.5
+
+### Patch Changes
+
+- Updated dependencies [4211669]
+  - @neon/sdk@3.0.0
+
 ## 1.0.4
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.1.5
+
+### Patch Changes
+
+- @neon/config@1.0.5
+
 ## 1.1.4
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 4.7.1
+
+### Patch Changes
+
+- neon@4.7.1
+
 ## 4.7.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/sdk
 
+## 3.0.0
+
+### Major Changes
+
+- 4211669: `branches.create` attaches a read-write endpoint by default; pass `noCompute: true` (tools: `no_compute`) to skip it. `createWithCompute` is now `createAndConnect`. `create` returns the resource without a connection string; `createAndConnect` returns a URI.
+
 ## 2.3.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "2.3.0",
+	"version": "3.0.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @neon/tools
 
+## 1.0.0
+
+### Major Changes
+
+- 4211669: `branches.create` attaches a read-write endpoint by default; pass `noCompute: true` (tools: `no_compute`) to skip it. `createWithCompute` is now `createAndConnect`. `create` returns the resource without a connection string; `createAndConnect` returns a URI.
+
+### Patch Changes
+
+- Updated dependencies [4211669]
+  - @neon/sdk@3.0.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "0.8.0",
+	"version": "1.0.0",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Problem

[#493](https://github.com/neondatabase/neon-pkgs/pull/493) is on `main`. npm still serves the previous majors:

```console
$ npm view @neon/sdk version
2.3.0
$ npm view @neon/tools version
0.8.0
```

This PR is the version and changelog bump. Publish is the separate workflow after merge.

## User-facing interface

`@neon/sdk` 3.0.0 and `@neon/tools` 1.0.0:

```ts
const project = await neon.projects.create({ name: "demo" });
const { project, connectionString } = await neon.projects.createAndConnect({
  name: "demo",
});

const branch = await neon.branches.create(projectId, { name: "feat" });
const { branch, connectionString } = await neon.branches.createAndConnect(
  projectId,
  { name: "feat" },
);

await neon.branches.create(projectId, { name: "schema-only", noCompute: true });
```

Published tools: `create_projects`, `create_and_connect_projects`, `create_branches`, `create_and_connect_branches`. `createWithCompute` is gone.

Dependents cascade to pick up `@neon/sdk@3.0.0`.

## Release metadata

| Package | npm | this PR |
| --- | --- | --- |
| `@neon/sdk` | 2.3.0 | 3.0.0 |
| `@neon/tools` | 0.8.0 | 1.0.0 |
| `@neon/config` | 1.0.4 | 1.0.5 (cascade) |
| `@neon/config-runtime` | 1.0.4 | 1.0.5 (cascade) |
| `@neon/env` | 1.1.4 | 1.1.5 (cascade) |
| `neon` | 4.7.0 | 4.7.1 (cascade) |
| `neonctl` | 4.7.0 | 4.7.1 (cascade) |

`@neon-internals/env-core` 0.0.4 → 0.0.5 is private and is not published.

Consumes `.changeset/create-and-connect.md`.

## Verification

- `pnpm lint:ci` checked 729 files with no errors.
- Diff is version bumps, changelogs, and the consumed changeset.

## For your attention

Publish after merge, one package per run, sdk before tools, config before config-runtime and env, neon before neonctl:

```bash
gh workflow run neon-pkgs.yml --repo databricks/secure-public-registry-releases-eng -f package=@neon/sdk -f ref=main
```