### PR TITLE
chore: release neon@4.8.0, neonctl@4.8.0

### DIFF
--- a/.changeset/link-auto-pin-branch.md
+++ b/.changeset/link-auto-pin-branch.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-`neon link --project-id` pins the project's only branch. Several branches prompt in a TTY, pin the default with `-y`, or stay unpinned for `neon checkout`.

--- a/.changeset/simple-neon-init.md
+++ b/.changeset/simple-neon-init.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-`neon init` in an empty directory is `neon bootstrap` (scaffold, agent tooling, link). In an existing app it installs a plugin or skills+MCP, links, then writes neon.ts. `neon bootstrap` offers the same agent tooling after scaffolding; `--default` also runs `link --yes`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neon
 
+## 4.8.0
+
+### Minor Changes
+
+- 599c69c: `neon link --project-id` pins the project's only branch. Several branches prompt in a TTY, pin the default with `-y`, or stay unpinned for `neon checkout`.
+- 53b2e72: `neon init` in an empty directory is `neon bootstrap` (scaffold, agent tooling, link). In an existing app it installs a plugin or skills+MCP, links, then writes neon.ts. `neon bootstrap` offers the same agent tooling after scaffolding; `--default` also runs `link --yes`.
+
 ## 4.7.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.7.1",
+	"version": "4.8.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,18 @@
 # neonctl
 
+## 4.8.0
+
+### Minor Changes
+
+- 599c69c: `neon link --project-id` pins the project's only branch. Several branches prompt in a TTY, pin the default with `-y`, or stay unpinned for `neon checkout`.
+- 53b2e72: `neon init` in an empty directory is `neon bootstrap` (scaffold, agent tooling, link). In an existing app it installs a plugin or skills+MCP, links, then writes neon.ts. `neon bootstrap` offers the same agent tooling after scaffolding; `--default` also runs `link --yes`.
+
+### Patch Changes
+
+- Updated dependencies [599c69c]
+- Updated dependencies [53b2e72]
+  - neon@4.8.0
+
 ## 4.7.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

[#494](https://github.com/neondatabase/neon-pkgs/pull/494) and [#485](https://github.com/neondatabase/neon-pkgs/pull/485) are on `main`. npm is still at 4.7.0:

```console
$ npm view neon version
4.7.0
$ npm view neonctl version
4.7.0
```

`main` already has 4.7.1 from the `@neon/sdk@3.0.0` dependent cascade in [#495](https://github.com/neondatabase/neon-pkgs/pull/495). This PR prepares 4.8.0 for both CLI packages.

## User-facing interface

`neon link --project-id` pins a branch from the project list:

```bash
neon link --project-id <project-id>              # pins the only branch
neon link --project-id <project-id> -y           # pins the default when several exist
neon link --project-id <project-id> --branch main
```

Empty `neon init` is `neon bootstrap` (scaffold, agent tooling, link). In an existing app it installs a plugin or skills+MCP, links, then writes `neon.ts`.

```bash
neon init
neon init -y
neon bootstrap --default
```

## Release metadata

- Bumps `neon` and `neonctl` from 4.7.1 to 4.8.0.
- Adds the 4.8.0 changelog entries from both feature PRs.
- Consumes `.changeset/link-auto-pin-branch.md` and `.changeset/simple-neon-init.md`.

## Verification

- `pnpm lint:ci` checked 696 files with no errors.
- The diff is version and changelog metadata only.
- `.changeset/` contains only `README.md` and `config.json`.

## For your attention

- This PR only lands version and changelog metadata. The private mirror publishes to npm after merge.
- `neon` must publish before `neonctl` because the compatibility package depends on the matching `neon` version.
- `@neon/tools@1.0.0` is already on `main` from #495 and is not yet on npm (`npm view` still reports 0.8.0). It is not bumped here.