### PR TITLE
docs(release): install neon@latest after every npm publish

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -185,12 +185,22 @@ you ran a dry-run (missing/`dry-run` `package` input); re-dispatch with the real
 This requires access to that repo — if you don't have it, hand the publish backlog list to someone
 who does.
 
+After every successful publish (any package, not only `neon`), install latest and run it:
+
+```bash
+npm i -g neon@latest
+neon --version
+```
+
+Don't claim the publish is done until that install succeeds. `npm view` does not catch a
+`neon@latest` dependency that was never published.
+
 ## Gotchas
 
 - **The publish workflow defaults to `dry-run` and publishes ONE package per run.** Always pass
   `-f package=<name>` (and `-f ref=main`), once per bumped package. A `dry-run` (or input-less)
   dispatch goes green and prints a "Publish …" step but lands nothing on npm — verify with
-  `npm view <pkg> version`, not the green check.
+  `npm view <pkg> version`, not the green check. Then `npm i -g neon@latest`.
 - **Never pin an internal package to a published version.** `packages/cli` pinned `neon-init`
   (since folded into `packages/cli/src/init`) that
   way through 2.39.0, and `changeset version` rewriting the pin without touching `pnpm-lock.yaml`

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -192,8 +192,8 @@ npm i -g neon@latest
 neon --version
 ```
 
-Don't claim the publish is done until that install succeeds. `npm view` does not catch a
-`neon@latest` dependency that was never published.
+Don't claim the publish is done until that install succeeds and `neon --version` prints. `npm view`
+does not catch a `neon@latest` dependency that was never published.
 
 ## Gotchas
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -200,7 +200,7 @@ Don't claim the publish is done until that install succeeds. `npm view` does not
 - **The publish workflow defaults to `dry-run` and publishes ONE package per run.** Always pass
   `-f package=<name>` (and `-f ref=main`), once per bumped package. A `dry-run` (or input-less)
   dispatch goes green and prints a "Publish …" step but lands nothing on npm — verify with
-  `npm view <pkg> version`, not the green check. Then `npm i -g neon@latest`.
+  `npm view <pkg> version`, not the green check.
 - **Never pin an internal package to a published version.** `packages/cli` pinned `neon-init`
   (since folded into `packages/cli/src/init`) that
   way through 2.39.0, and `changeset version` rewriting the pin without touching `pnpm-lock.yaml`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -575,7 +575,7 @@ including a git-vs-npm check that flags packages which changed but lack a change
 `@neon/config` → `@neon/config-runtime` / `@neon/env` → `neon` → `neonctl`.
 Publishing `neon` also ships the standalone binaries and the GitHub release; publish the
 compatibility package only after `npm view neon version` confirms the matching primary package.
-Verify each with `npm view <pkg> version`.
+Verify each with `npm view <pkg> version`. Then `npm i -g neon@latest`.
 
 Ordering is a courtesy to npm consumers, not a build constraint. Every internal dependency is
 `workspace:*`, so a package is always built and packed against workspace source and never makes a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -575,7 +575,7 @@ including a git-vs-npm check that flags packages which changed but lack a change
 `@neon/config` → `@neon/config-runtime` / `@neon/env` → `neon` → `neonctl`.
 Publishing `neon` also ships the standalone binaries and the GitHub release; publish the
 compatibility package only after `npm view neon version` confirms the matching primary package.
-Verify each with `npm view <pkg> version`. Then `npm i -g neon@latest`.
+Verify each with `npm view <pkg> version`. After every successful publish, `npm i -g neon@latest` and `neon --version`.
 
 Ordering is a courtesy to npm consumers, not a build constraint. Every internal dependency is
 `workspace:*`, so a package is always built and packed against workspace source and never makes a


### PR DESCRIPTION
## Problem

A successful publish workflow plus `npm view <pkg> version` can still leave `neon@latest` uninstallable.

`pnpm pack` rewrites each `workspace:*` dependency to the version on `main`. If that version of the dependency was never published, `npm i -g neon@latest` fails with `ETARGET` while `npm view neon version` already shows the new CLI.

That is the command users run. The release skill did not run it.

## Diagnosis

`npm view` reads one packument. It does not install `neon@latest` or resolve its dependency tree.

The check that matches the user path is a real global install, then `neon --version`.

## The user-facing interface

After every successful publish dispatch, including library packages, the release skill now requires:

```bash
npm i -g neon@latest
neon --version
```

The publish is not done until that install succeeds and `neon --version` prints.

`AGENTS.md` publish order has the same two commands so a repo agent that skips the skill still hits them.

## Verification

Read the skill and `AGENTS.md` publish-order section. No package code changed. Did not run a publish.

## For your attention

`npm i -g neon@latest` overwrites the machine's global `neon`. That is the command the skill is specifying, not a sandbox install.