### PR TITLE
chore: release neon@4.9.0, neonctl@4.9.0

### DIFF
--- a/.changeset/cli-no-secrets.md
+++ b/.changeset/cli-no-secrets.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-`projects create` and `branches create` accept `--no-secrets` to omit connection URIs from command output.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.9.0
+
+### Minor Changes
+
+- 64d0333: `projects create` and `branches create` accept `--no-secrets` to omit connection URIs from command output.
+
 ## 4.8.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.8.0",
+	"version": "4.9.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.9.0
+
+### Patch Changes
+
+- Updated dependencies [64d0333]
+  - neon@4.9.0
+
 ## 4.8.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Bumped

- `neon`: 4.8.0 → 4.9.0
- `neonctl`: 4.8.0 → 4.9.0 (Changesets fixed group)

## Changelog

`projects create` and `branches create` accept `--no-secrets` to omit connection URIs from command output.

Version bump and CHANGELOG only. Source landed in https://github.com/neondatabase/neon-pkgs/pull/496.