### PR TITLE
Pass waitForReadiness on SDK e2e deletes

### DIFF
--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -56,7 +56,11 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		);
 		expect(renamed.name).toBe("crud-renamed");
 
-		expectOk(await neon.branches.delete(projectId, created.id));
+		expectOk(
+			await neon.branches.delete(projectId, created.id, {
+				waitForReadiness: true,
+			}),
+		);
 
 		const { error } = await neon.branches.get(projectId, created.id);
 		expect(error).toBeInstanceOf(NeonNotFoundError);
@@ -219,6 +223,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				projectId,
 				defaultBranchId,
 				"e2e_role",
+				{ waitForReadiness: true },
 			),
 		);
 		const after = expectOk(
@@ -256,6 +261,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				projectId,
 				defaultBranchId,
 				"e2e_db",
+				{ waitForReadiness: true },
 			),
 		);
 		const after = expectOk(


### PR DESCRIPTION
## Problem

The live `@neon/sdk` e2e creates `e2e_role`, deletes it, then lists roles and expects that name gone. The list still included it. CI failed with:

```text
expected [ 'neondb_owner', 'e2e_role' ] to not include 'e2e_role'
```

[Live e2e run](https://github.com/neondatabase/neon-pkgs/actions/runs/33092195936)

## Diagnosis

`DELETE /projects/{project_id}/branches/{branch_id}/roles/{role_name}` returns 200 with a `RoleOperations` body. The OpenAPI example still has work in flight:

```json
{
  "operations": [
    { "action": "apply_config", "status": "running" },
    { "action": "suspend_compute", "status": "scheduling" }
  ]
}
```

A list issued before those operations finish still contains the role.

`roles.delete` already goes through `RequestContext.runVoid`, which calls `#maybeWait` when `waitForReadiness` is true. The e2e client is `createNeonClient({ apiKey, orgId, baseUrl })`, so the documented client default (`false`) applies. The delete HTTP call returned and the test listed immediately.

The same file already passes `{ waitForReadiness: true }` on `databases.create` and `branches.resetFromParent` before asserting the follow-up list. These deletes did not.

## Change

Pass `{ waitForReadiness: true }` on the three `runVoid` deletes that then assert the resource is gone:

- `neon.postgres.roles.delete` before listing roles
- `neon.postgres.databases.delete` before listing databases
- `neon.branches.delete` in the create/get/update/delete round-trip, before `get` expecting `NeonNotFoundError`

`#maybeWait` polls the `operations` array until each is `finished` or `skipped` (or the wait budget expires).

The OpenAPI 200 examples for the other two deletes are the same shape: database delete returns `apply_config` `running` and `suspend_compute` `scheduling`; branch delete returns `suspend_compute` `running` and `delete_timeline` `scheduling`.

## User-facing API

Published `@neon/sdk` methods, defaults and types are unchanged. `waitForReadiness` stays client-default `false` and remains overridable per call.

```ts
await neon.postgres.roles.delete(projectId, branchId, "e2e_role", {
  waitForReadiness: true, // default false
});
```

README contract, unchanged:

| Option | Default | Meaning |
| --- | --- | --- |
| `waitForReadiness` | `false` | When `true`, mutations block until their provisioning `operations` finish, so the returned resource is ready to use. |

`projects.create`, `branches.create` and the `createAndConnect` workflows still default it on. Role and database delete do not.

## Also in here

No changeset. The published package is unchanged.

## Verification

`pnpm --filter @neon/sdk test:e2e` against a throwaway org, twice. 18 tests passed both times.

The e2e now asserts:

- after `roles.delete` with `waitForReadiness: true`, `roles.list` does not contain `e2e_role`
- after `databases.delete` with `waitForReadiness: true`, `databases.list` does not contain `e2e_db`
- after `branches.delete` with `waitForReadiness: true`, `branches.get` returns `NeonNotFoundError`

## For your attention

- Callers who delete without `waitForReadiness` and immediately list or get can still see the resource. That is the documented default.
- These three tests now poll until the operations finish, or until `wait.timeoutMs` (default five minutes). A stuck `apply_config` becomes a timeout instead of a list assertion failure.