### PR TITLE
Add neon api --describe for OpenAPI request fields

### DIFF
--- a/.changeset/api-describe.md
+++ b/.changeset/api-describe.md
@@ -1,0 +1,5 @@
+---
+"neon": minor
+---
+
+`neon api <path> --describe` prints the OpenAPI request shape for a route. Body field names are dotted for `-F`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1120,7 +1120,7 @@ neon api /projects/{project_id}/branches -X POST --describe
 neon api /projects/foo-bar-123/branches -X POST -F branch.name=dev
 ```
 
-`--describe` does not call the API. `-X` defaults to GET; if that method is missing, the error names the methods that exist.
+`--describe` does not send the selected API request. It uses the same CLI authentication as `--list`. `-X` defaults to GET; if that method is missing, the error names the methods that exist.
 
 ## API keys (`api-keys`)
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1108,6 +1108,20 @@ When both are only environment variables the key wins, which keeps a CI pipeline
 
 `neon init` forwards `--profile` and `--config-dir` to the commands it runs. An explicit `--api-key` is passed to those children through `NEON_API_KEY`, not argv.
 
+## API passthrough (`api`)
+
+`neon api` sends an authenticated request to any Neon API route. `neon api --list` catalogs the routes. `neon api <path> --describe` prints the OpenAPI request shape for one operation so you can fill `-F` and `-Q` without guessing. Body field names are dotted to match `-F`.
+
+```bash
+neon api --list
+neon api /projects --describe
+neon api /projects -X POST --describe -o json
+neon api /projects/{project_id}/branches -X POST --describe
+neon api /projects/foo-bar-123/branches -X POST -F branch.name=dev
+```
+
+`--describe` does not call the API. `-X` defaults to GET; if that method is missing, the error names the methods that exist.
+
 ## API keys (`api-keys`)
 
 ```bash
@@ -1182,6 +1196,7 @@ Id   Name      Project         Created At            Last Used At          Last 
 | claim (`claimable`)                                                        | `create`, `status`, `accept`, `list`, `delete`                                                               | Manage claimable projects          |
 | profile                                                                    | `list`, `create`, `rotate-key`, `remove`                                                                     | Manage named sets of credentials   |
 | api-keys                                                                   | `list`, `create`, `revoke`                                                                                   | Manage API keys                    |
+| api                                                                        |                                                                                                              | Call any Neon API route            |
 | [projects](https://neon.com/docs/reference/cli-projects)                   | `list`, `create`, `update`, `delete`, `get`                                                                  | Manage projects                    |
 | [ip-allow](https://neon.com/docs/reference/cli-ip-allow)                   | `list`, `add`, `remove`, `reset`                                                                             | Manage IP Allow                    |
 | [me](https://neon.com/docs/reference/cli-me)                               |                                                                                                              | Show current user                  |

--- a/packages/cli/src/commands/__snapshots__/api.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api.test.ts.snap
@@ -41,7 +41,7 @@ query  category  optional  string (SECURITY, PERFORMANCE)  Filter by category
 `;
 
 exports[`api --describe > prints POST array item fields in the table type column 1`] = `
-"POST /projects - Create project
+"POST /projects - Create project (body required)
 In    Name               Required  Type                                  Description
 body  project.name       optional  string                                The project name
 body  project.endpoints  optional  array (type (read_write, read_only))

--- a/packages/cli/src/commands/__snapshots__/api.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api.test.ts.snap
@@ -16,6 +16,17 @@ exports[`api --describe > prints GET query fields as JSON without calling the AP
       "required": false,
       "type": "integer",
       "description": "Page size"
+    },
+    {
+      "in": "query",
+      "name": "category",
+      "required": false,
+      "type": "string",
+      "description": "Filter by category",
+      "enum": [
+        "SECURITY",
+        "PERFORMANCE"
+      ]
     }
   ]
 }"
@@ -23,8 +34,9 @@ exports[`api --describe > prints GET query fields as JSON without calling the AP
 
 exports[`api --describe > prints GET query fields as a table 1`] = `
 "GET /projects - List projects
-In     Name   Required  Type     Description
-query  limit  optional  integer  Page size
+In     Name      Required  Type                            Description
+query  limit     optional  integer                         Page size
+query  category  optional  string (SECURITY, PERFORMANCE)  Filter by category
 "
 `;
 

--- a/packages/cli/src/commands/__snapshots__/api.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api.test.ts.snap
@@ -1,5 +1,64 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`api --describe > prints GET query fields as JSON without calling the API 1`] = `
+"{
+  "endpoint": {
+    "method": "GET",
+    "path": "/projects",
+    "summary": "List projects",
+    "operationId": "listProjects",
+    "bodyRequired": false
+  },
+  "parameters": [
+    {
+      "in": "query",
+      "name": "limit",
+      "required": false,
+      "type": "integer",
+      "description": "Page size"
+    }
+  ]
+}"
+`;
+
+exports[`api --describe > prints GET query fields as a table 1`] = `
+"GET /projects - List projects
+In     Name   Required  Type     Description
+query  limit  optional  integer  Page size
+"
+`;
+
+exports[`api --describe > prints POST body fields dotted for -F 1`] = `
+"{
+  "endpoint": {
+    "method": "POST",
+    "path": "/projects",
+    "summary": "Create project",
+    "operationId": "createProject",
+    "bodyRequired": true
+  },
+  "parameters": [
+    {
+      "in": "body",
+      "name": "project.name",
+      "required": false,
+      "type": "string",
+      "description": "The project name"
+    }
+  ]
+}"
+`;
+
+exports[`api --describe > rejects --describe without a path 1`] = `""`;
+
+exports[`api --describe > rejects --list and --describe together 1`] = `""`;
+
+exports[`api --describe > rejects an unknown path 1`] = `""`;
+
+exports[`api --describe > rejects api ls --describe 1`] = `""`;
+
+exports[`api --describe > rejects request flags with --describe 1`] = `""`;
+
 exports[`api command (e2e passthrough) > GET single resource by path 1`] = `
 "{
   "project": {

--- a/packages/cli/src/commands/__snapshots__/api.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/api.test.ts.snap
@@ -40,6 +40,14 @@ query  category  optional  string (SECURITY, PERFORMANCE)  Filter by category
 "
 `;
 
+exports[`api --describe > prints POST array item fields in the table type column 1`] = `
+"POST /projects - Create project
+In    Name               Required  Type                                  Description
+body  project.name       optional  string                                The project name
+body  project.endpoints  optional  array (type (read_write, read_only))
+"
+`;
+
 exports[`api --describe > prints POST body fields dotted for -F 1`] = `
 "{
   "endpoint": {
@@ -56,6 +64,28 @@ exports[`api --describe > prints POST body fields dotted for -F 1`] = `
       "required": false,
       "type": "string",
       "description": "The project name"
+    },
+    {
+      "in": "body",
+      "name": "project.endpoints",
+      "required": false,
+      "type": "array",
+      "description": "",
+      "items": {
+        "type": "object",
+        "properties": [
+          {
+            "name": "type",
+            "type": "string",
+            "required": true,
+            "description": "",
+            "enum": [
+              "read_write",
+              "read_only"
+            ]
+          }
+        ]
+      }
     }
   ]
 }"

--- a/packages/cli/src/commands/api.test.ts
+++ b/packages/cli/src/commands/api.test.ts
@@ -58,6 +58,22 @@ const DESCRIBE_SPEC = {
 												type: "string",
 												description: "The project name",
 											},
+											endpoints: {
+												type: "array",
+												items: {
+													type: "object",
+													required: ["type"],
+													properties: {
+														type: {
+															type: "string",
+															enum: [
+																"read_write",
+																"read_only",
+															],
+														},
+													},
+												},
+											},
 										},
 									},
 								},
@@ -242,6 +258,26 @@ describe("api --describe", () => {
 		}
 	});
 
+	test("prints POST array item fields in the table type column", async ({
+		testCliCommand,
+	}) => {
+		const spec = await listenSpec(DESCRIBE_SPEC);
+		try {
+			await testCliCommand(
+				describeArgs(spec.url, [
+					"api",
+					"/projects",
+					"-X",
+					"POST",
+					"--describe",
+				]),
+				{ output: "table", unreachableHost: true },
+			);
+		} finally {
+			await spec.close();
+		}
+	});
+
 	test("rejects --describe without a path", async ({ testCliCommand }) => {
 		const spec = await listenSpec(DESCRIBE_SPEC);
 		try {
@@ -308,7 +344,7 @@ describe("api --describe", () => {
 				{
 					code: 1,
 					unreachableHost: true,
-					stderr: "ERROR: --describe prints the field list; it does not send a request. Drop -F, -f, -d, -Q, and -H.",
+					stderr: "ERROR: --describe prints the field list; it does not send a request. Drop -F, -f, -d, -Q, -H, and -i.",
 				},
 			);
 		} finally {

--- a/packages/cli/src/commands/api.test.ts
+++ b/packages/cli/src/commands/api.test.ts
@@ -29,6 +29,15 @@ const DESCRIBE_SPEC = {
 						schema: { type: "integer" },
 						description: "Page size",
 					},
+					{
+						name: "category",
+						in: "query",
+						schema: {
+							type: "string",
+							enum: ["SECURITY", "PERFORMANCE"],
+						},
+						description: "Filter by category",
+					},
 				],
 			},
 			post: {

--- a/packages/cli/src/commands/api.test.ts
+++ b/packages/cli/src/commands/api.test.ts
@@ -1,3 +1,9 @@
+import { mkdtempSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { test } from "../test_utils/fixtures";
@@ -9,6 +15,77 @@ import {
 	parseTypedValue,
 	setDeep,
 } from "./api";
+
+const DESCRIBE_SPEC = {
+	paths: {
+		"/projects": {
+			get: {
+				operationId: "listProjects",
+				summary: "List projects",
+				parameters: [
+					{
+						name: "limit",
+						in: "query",
+						schema: { type: "integer" },
+						description: "Page size",
+					},
+				],
+			},
+			post: {
+				operationId: "createProject",
+				summary: "Create project",
+				requestBody: {
+					required: true,
+					content: {
+						"application/json": {
+							schema: {
+								type: "object",
+								required: ["project"],
+								properties: {
+									project: {
+										type: "object",
+										properties: {
+											name: {
+												type: "string",
+												description: "The project name",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	},
+};
+
+const listenSpec = async (
+	spec: unknown,
+): Promise<{ url: string; close: () => Promise<void> }> => {
+	const server: Server = createServer((_req, res) => {
+		res.setHeader("content-type", "application/json");
+		res.end(JSON.stringify(spec));
+	});
+	await new Promise<void>((resolve) => {
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const { port } = server.address() as AddressInfo;
+	return {
+		url: `http://127.0.0.1:${port}/`,
+		close: () =>
+			new Promise<void>((resolve, reject) => {
+				server.close((err) => {
+					if (err) {
+						reject(err);
+					} else {
+						resolve();
+					}
+				});
+			}),
+	};
+};
 
 describe("api arg mapping", () => {
 	it("types scalar and JSON values", () => {
@@ -101,5 +178,132 @@ describe("api command (e2e passthrough)", () => {
 			code: 1,
 			stderr: 'ERROR: Invalid path "projects". API paths must start with "/". Run `neon api --list` to see available routes.',
 		});
+	});
+});
+
+describe("api --describe", () => {
+	const describeArgs = (url: string, args: string[]) => {
+		const configDir = mkdtempSync(join(tmpdir(), "neon-api-describe-"));
+		return [...args, "--spec-url", url, "--config-dir", configDir];
+	};
+
+	test("prints GET query fields as JSON without calling the API", async ({
+		testCliCommand,
+	}) => {
+		const spec = await listenSpec(DESCRIBE_SPEC);
+		try {
+			await testCliCommand(
+				describeArgs(spec.url, ["api", "/projects", "--describe"]),
+				{ output: "json", unreachableHost: true },
+			);
+		} finally {
+			await spec.close();
+		}
+	});
+
+	test("prints GET query fields as a table", async ({ testCliCommand }) => {
+		const spec = await listenSpec(DESCRIBE_SPEC);
+		try {
+			await testCliCommand(
+				describeArgs(spec.url, ["api", "/projects", "--describe"]),
+				{ output: "table", unreachableHost: true },
+			);
+		} finally {
+			await spec.close();
+		}
+	});
+
+	test("prints POST body fields dotted for -F", async ({
+		testCliCommand,
+	}) => {
+		const spec = await listenSpec(DESCRIBE_SPEC);
+		try {
+			await testCliCommand(
+				describeArgs(spec.url, [
+					"api",
+					"/projects",
+					"-X",
+					"POST",
+					"--describe",
+				]),
+				{ output: "json", unreachableHost: true },
+			);
+		} finally {
+			await spec.close();
+		}
+	});
+
+	test("rejects --describe without a path", async ({ testCliCommand }) => {
+		const spec = await listenSpec(DESCRIBE_SPEC);
+		try {
+			await testCliCommand(
+				describeArgs(spec.url, ["api", "--describe"]),
+				{
+					code: 1,
+					unreachableHost: true,
+					stderr: "ERROR: Missing API path. Usage: neon api <path> --describe (e.g. neon api /projects --describe). Run `neon api --list` to see available routes.",
+				},
+			);
+		} finally {
+			await spec.close();
+		}
+	});
+
+	test("rejects --list and --describe together", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["api", "--list", "--describe"], {
+			code: 1,
+			unreachableHost: true,
+			stderr: "ERROR: Pass either --list or --describe, not both.",
+		});
+	});
+
+	test("rejects api ls --describe", async ({ testCliCommand }) => {
+		await testCliCommand(["api", "ls", "--describe"], {
+			code: 1,
+			unreachableHost: true,
+			stderr: "ERROR: Pass either --list or --describe, not both.",
+		});
+	});
+
+	test("rejects an unknown path", async ({ testCliCommand }) => {
+		const spec = await listenSpec(DESCRIBE_SPEC);
+		try {
+			await testCliCommand(
+				describeArgs(spec.url, ["api", "/nope", "--describe"]),
+				{
+					code: 1,
+					unreachableHost: true,
+					stderr: 'ERROR: No route matches "/nope". Run `neon api --list` to see available routes.',
+				},
+			);
+		} finally {
+			await spec.close();
+		}
+	});
+
+	test("rejects request flags with --describe", async ({
+		testCliCommand,
+	}) => {
+		const spec = await listenSpec(DESCRIBE_SPEC);
+		try {
+			await testCliCommand(
+				describeArgs(spec.url, [
+					"api",
+					"/projects",
+					"--describe",
+					"-F",
+					"project.name=x",
+				]),
+				{
+					code: 1,
+					unreachableHost: true,
+					stderr: "ERROR: --describe prints the field list; it does not send a request. Drop -F, -f, -d, -Q, and -H.",
+				},
+			);
+		} finally {
+			await spec.close();
+		}
 	});
 });

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -6,7 +6,12 @@ import type yargs from "yargs";
 
 import type { RequestParams } from "../api.js";
 import type { CommonProps } from "../types.js";
-import { DEFAULT_SPEC_URL, getEndpoints, loadSpec } from "../utils/openapi.js";
+import {
+	DEFAULT_SPEC_URL,
+	describeOperation,
+	getEndpoints,
+	loadSpec,
+} from "../utils/openapi.js";
 import { writer } from "../writer.js";
 
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
@@ -156,6 +161,7 @@ type ApiArgs = CommonProps & {
 	header?: (string | number)[];
 	include: boolean;
 	list: boolean;
+	describe: boolean;
 	refresh: boolean;
 	specUrl: string;
 };
@@ -184,6 +190,89 @@ async function listEndpoints(args: ApiArgs): Promise<void> {
 		fields: ["method", "path", "summary"],
 		title: `Neon API endpoints (${endpoints.length})`,
 		emptyMessage: "No endpoints found in the spec.",
+	});
+}
+
+function isListing(args: ApiArgs): boolean {
+	return args.list || args.path === "list" || args.path === "ls";
+}
+
+async function describeRoute(args: ApiArgs): Promise<void> {
+	const path = args.path;
+	if (!path) {
+		throw new Error(
+			"Missing API path. Usage: neon api <path> --describe " +
+				"(e.g. neon api /projects --describe). " +
+				"Run `neon api --list` to see available routes.",
+		);
+	}
+	if (!path.startsWith("/")) {
+		throw new Error(
+			`Invalid path "${path}". API paths must start with "/". ` +
+				"Run `neon api --list` to see available routes.",
+		);
+	}
+	const unused = [
+		...toStrings(args.field),
+		...toStrings(args.rawField),
+		...toStrings(args.query),
+		...toStrings(args.header),
+	];
+	if (unused.length > 0 || args.data !== undefined) {
+		throw new Error(
+			"--describe prints the field list; it does not send a request. " +
+				"Drop -F, -f, -d, -Q, and -H.",
+		);
+	}
+	const spec = await loadSpec({
+		configDir: args.configDir,
+		specUrl: args.specUrl,
+		refresh: args.refresh,
+	});
+	if (!spec) {
+		throw new Error(
+			`Could not load the Neon OpenAPI spec from ${args.specUrl}. ` +
+				"Check your network connection or pass --spec-url.",
+		);
+	}
+	const method = String(args.method ?? "GET").toUpperCase();
+	assertMethod(method);
+	const description = describeOperation(spec, path, method);
+	const endpoint = {
+		method: description.method,
+		path: description.path,
+		summary: description.summary,
+		operationId: description.operationId,
+		bodyRequired: description.bodyRequired,
+	};
+	const title = description.summary
+		? `${description.method} ${description.path} - ${description.summary}`
+		: `${description.method} ${description.path}`;
+	if (args.output === "json" || args.output === "yaml") {
+		writer(args)
+			.write(endpoint, {
+				fields: [
+					"method",
+					"path",
+					"summary",
+					"operationId",
+					"bodyRequired",
+				],
+				title: "Endpoint",
+			})
+			.end(description.fields, {
+				fields: ["in", "name", "required", "type", "description"],
+				title: "Parameters",
+			});
+		return;
+	}
+	writer(args).end(description.fields, {
+		fields: ["in", "name", "required", "type", "description"],
+		title,
+		emptyMessage: "No path, query, or body fields in the spec.",
+		renderColumns: {
+			required: (field) => (field.required ? "required" : "optional"),
+		},
 	});
 }
 
@@ -318,16 +407,23 @@ export const builder = (argv: yargs.Argv) =>
 				default: false,
 				describe: "List available API endpoints from the OpenAPI spec.",
 			},
+			describe: {
+				type: "boolean",
+				default: false,
+				describe:
+					"Print path, query, and body fields from the OpenAPI spec without calling the API. Body names are dotted for -F.",
+			},
 			refresh: {
 				type: "boolean",
 				default: false,
-				describe: "Refresh the cached OpenAPI spec (used with --list).",
+				describe:
+					"Refresh the cached OpenAPI spec (used with --list and --describe).",
 			},
 			"spec-url": {
 				type: "string",
 				default: process.env.NEON_API_SPEC_URL ?? DEFAULT_SPEC_URL,
 				hidden: true,
-				describe: "OpenAPI spec URL used by --list.",
+				describe: "OpenAPI spec URL used by --list and --describe.",
 			},
 		})
 		.example("$0 api /projects", "List your projects")
@@ -335,12 +431,27 @@ export const builder = (argv: yargs.Argv) =>
 			"$0 api /projects/{id}/branches -X POST -F branch.name=dev",
 			"Create a branch",
 		)
-		.example("$0 api --list", "List every available API route");
+		.example("$0 api --list", "List every available API route")
+		.example(
+			"$0 api /projects --describe",
+			"Show GET /projects query parameters",
+		)
+		.example(
+			"$0 api /projects -X POST --describe",
+			"Show the create-project body fields",
+		);
 
 export const handler = async (args: yargs.Arguments) => {
 	const apiArgs = args as unknown as ApiArgs;
-	if (apiArgs.list || apiArgs.path === "list" || apiArgs.path === "ls") {
+	if (isListing(apiArgs) && apiArgs.describe) {
+		throw new Error("Pass either --list or --describe, not both.");
+	}
+	if (isListing(apiArgs)) {
 		await listEndpoints(apiArgs);
+		return;
+	}
+	if (apiArgs.describe) {
+		await describeRoute(apiArgs);
 		return;
 	}
 	await runRequest(apiArgs);

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -270,10 +270,20 @@ async function describeRoute(args: ApiArgs): Promise<void> {
 		summary: description.summary,
 		operationId: description.operationId,
 		bodyRequired: description.bodyRequired,
+		...(description.contentType !== "" &&
+		description.contentType !== "application/json"
+			? { contentType: description.contentType }
+			: {}),
 	};
-	const title = description.summary
+	let title = description.summary
 		? `${description.method} ${description.path} - ${description.summary}`
 		: `${description.method} ${description.path}`;
+	if (
+		description.contentType !== "" &&
+		description.contentType !== "application/json"
+	) {
+		title = `${title} (${description.contentType})`;
+	}
 	if (args.output === "json" || args.output === "yaml") {
 		writer(args)
 			.write(endpoint, {

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -197,6 +197,31 @@ function isListing(args: ApiArgs): boolean {
 	return args.list || args.path === "list" || args.path === "ls";
 }
 
+function describeType(field: {
+	type: string;
+	enum?: unknown[];
+	items?: {
+		type: string;
+		properties?: { name: string; enum?: unknown[] }[];
+	};
+}): string {
+	const enumText = (values: unknown[] | undefined): string =>
+		Array.isArray(values) && values.length > 0
+			? ` (${values.map(String).join(", ")})`
+			: "";
+	if (field.type === "array" && field.items) {
+		const props = field.items.properties;
+		if (props && props.length > 0) {
+			const inner = props
+				.map((prop) => `${prop.name}${enumText(prop.enum)}`)
+				.join(", ");
+			return `array (${inner})`;
+		}
+		return `array of ${field.items.type}`;
+	}
+	return `${field.type}${enumText(field.enum)}`;
+}
+
 async function describeRoute(args: ApiArgs): Promise<void> {
 	const path = args.path;
 	if (!path) {
@@ -218,10 +243,10 @@ async function describeRoute(args: ApiArgs): Promise<void> {
 		...toStrings(args.query),
 		...toStrings(args.header),
 	];
-	if (unused.length > 0 || args.data !== undefined) {
+	if (unused.length > 0 || args.data !== undefined || args.include) {
 		throw new Error(
 			"--describe prints the field list; it does not send a request. " +
-				"Drop -F, -f, -d, -Q, and -H.",
+				"Drop -F, -f, -d, -Q, -H, and -i.",
 		);
 	}
 	const spec = await loadSpec({
@@ -272,13 +297,7 @@ async function describeRoute(args: ApiArgs): Promise<void> {
 		emptyMessage: "No path, query, or body fields in the spec.",
 		renderColumns: {
 			required: (field) => (field.required ? "required" : "optional"),
-			type: (field) => {
-				const values = field.enum;
-				if (!Array.isArray(values) || values.length === 0) {
-					return String(field.type);
-				}
-				return `${field.type} (${values.map(String).join(", ")})`;
-			},
+			type: (field) => describeType(field),
 		},
 	});
 }

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -272,6 +272,13 @@ async function describeRoute(args: ApiArgs): Promise<void> {
 		emptyMessage: "No path, query, or body fields in the spec.",
 		renderColumns: {
 			required: (field) => (field.required ? "required" : "optional"),
+			type: (field) => {
+				const values = field.enum;
+				if (!Array.isArray(values) || values.length === 0) {
+					return String(field.type);
+				}
+				return `${field.type} (${values.map(String).join(", ")})`;
+			},
 		},
 	});
 }

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -278,6 +278,9 @@ async function describeRoute(args: ApiArgs): Promise<void> {
 	let title = description.summary
 		? `${description.method} ${description.path} - ${description.summary}`
 		: `${description.method} ${description.path}`;
+	if (description.bodyRequired) {
+		title = `${title} (body required)`;
+	}
 	if (
 		description.contentType !== "" &&
 		description.contentType !== "application/json"

--- a/packages/cli/src/commands/api.ts
+++ b/packages/cli/src/commands/api.ts
@@ -202,6 +202,7 @@ function describeType(field: {
 	enum?: unknown[];
 	items?: {
 		type: string;
+		enum?: unknown[];
 		properties?: { name: string; enum?: unknown[] }[];
 	};
 }): string {
@@ -217,7 +218,7 @@ function describeType(field: {
 				.join(", ");
 			return `array (${inner})`;
 		}
-		return `array of ${field.items.type}`;
+		return `array of ${field.items.type}${enumText(field.items.enum)}`;
 	}
 	return `${field.type}${enumText(field.enum)}`;
 }

--- a/packages/cli/src/utils/openapi.test.ts
+++ b/packages/cli/src/utils/openapi.test.ts
@@ -240,6 +240,13 @@ const miniSpec = {
 								type: "string",
 								description: "The project name",
 							},
+							tags: {
+								type: "array",
+								items: {
+									type: "string",
+									enum: ["prod", "dev"],
+								},
+							},
 							provisioner: {
 								$ref: "#/components/schemas/Provisioner",
 								description:
@@ -385,6 +392,7 @@ describe("describeOperation", () => {
 		expect(result.fields.map((field) => field.name)).toEqual([
 			"org_id",
 			"project.name",
+			"project.tags",
 			"project.provisioner",
 			"project.settings.quota.logical_size_bytes",
 			"project.settings.maintenance_window.weekdays",
@@ -402,6 +410,12 @@ describe("describeOperation", () => {
 			required: false,
 			type: "string",
 			description: "The project name",
+		});
+		expect(
+			result.fields.find((field) => field.name === "project.tags"),
+		).toMatchObject({
+			type: "array",
+			items: { type: "string", enum: ["prod", "dev"] },
 		});
 		expect(
 			result.fields.find((field) => field.name === "project.provisioner"),
@@ -662,5 +676,37 @@ describe("describeOperation against the vendored Neon spec", () => {
 		expect(
 			result.fields.find((field) => field.name === "project_id"),
 		).toMatchObject({ in: "path" });
+	});
+
+	it("keeps primitive array item enums", () => {
+		const webhooks = describeOperation(
+			neonSpec,
+			"/projects/p/branches/b/auth/webhooks",
+			"PUT",
+		);
+		expect(
+			webhooks.fields.find((field) => field.name === "enabled_events"),
+		).toMatchObject({
+			type: "array",
+			items: {
+				type: "string",
+				enum: expect.arrayContaining(["user.created", "send.otp"]),
+			},
+		});
+		const credentials = describeOperation(
+			neonSpec,
+			"/projects/p/branches/b/credentials",
+			"POST",
+		);
+		expect(
+			credentials.fields.find((field) => field.name === "scopes"),
+		).toMatchObject({
+			type: "array",
+			items: { type: "string" },
+		});
+		expect(
+			credentials.fields.find((field) => field.name === "scopes")?.items
+				?.enum,
+		).toEqual(expect.arrayContaining(["storage:read", "functions:invoke"]));
 	});
 });

--- a/packages/cli/src/utils/openapi.test.ts
+++ b/packages/cli/src/utils/openapi.test.ts
@@ -543,6 +543,7 @@ describe("describeOperation", () => {
 
 	it("describes a multipart JSON-shaped body when application/json is absent", () => {
 		const result = describeOperation(spec, "/deploy", "POST");
+		expect(result.contentType).toBe("multipart/form-data");
 		expect(result.fields.map((field) => field.name)).toEqual([
 			"zip",
 			"runtime",

--- a/packages/cli/src/utils/openapi.test.ts
+++ b/packages/cli/src/utils/openapi.test.ts
@@ -85,6 +85,45 @@ const miniSpec = {
 				summary: "POST only",
 			},
 		},
+		"/email": {
+			patch: {
+				operationId: "updateEmail",
+				summary: "Update email",
+				requestBody: {
+					required: true,
+					content: {
+						"application/json": {
+							schema: {
+								$ref: "#/components/schemas/EmailConfig",
+							},
+						},
+					},
+				},
+			},
+		},
+		"/deploy": {
+			post: {
+				operationId: "deployFn",
+				summary: "Deploy",
+				requestBody: {
+					required: true,
+					content: {
+						"multipart/form-data": {
+							schema: {
+								type: "object",
+								properties: {
+									zip: { type: "string" },
+									runtime: {
+										type: "string",
+										enum: ["nodejs24"],
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	},
 	components: {
 		parameters: {
@@ -107,6 +146,33 @@ const miniSpec = {
 			EndpointType: {
 				type: "string",
 				enum: ["read_write", "read_only"],
+			},
+			EmailConfig: {
+				type: "object",
+				discriminator: {
+					propertyName: "type",
+					mapping: {
+						standard: "#/components/schemas/StandardEmail",
+						shared: "#/components/schemas/SharedEmail",
+					},
+				},
+				oneOf: [
+					{ $ref: "#/components/schemas/StandardEmail" },
+					{ $ref: "#/components/schemas/SharedEmail" },
+				],
+			},
+			StandardEmail: {
+				type: "object",
+				properties: {
+					host: { type: "string", description: "SMTP host" },
+					sender_email: { type: "string" },
+				},
+			},
+			SharedEmail: {
+				type: "object",
+				properties: {
+					sender_email: { type: "string" },
+				},
 			},
 			ProjectCreateRequest: {
 				type: "object",
@@ -366,6 +432,49 @@ describe("describeOperation", () => {
 			'No route matches "/nope". Run `neon api --list` to see available routes.',
 		);
 	});
+
+	it("flattens oneOf bodies and injects the discriminator", () => {
+		const result = describeOperation(spec, "/email", "PATCH");
+		expect(result.bodyRequired).toBe(true);
+		expect(result.fields.map((field) => field.name)).toEqual([
+			"type",
+			"host",
+			"sender_email",
+		]);
+		expect(
+			result.fields.find((field) => field.name === "type"),
+		).toMatchObject({
+			in: "body",
+			required: true,
+			type: "string",
+			enum: ["standard", "shared"],
+		});
+		expect(
+			result.fields.find((field) => field.name === "host"),
+		).toMatchObject({
+			required: false,
+			type: "string",
+			description: "SMTP host",
+		});
+		expect(
+			result.fields.find((field) => field.name === "sender_email")
+				?.required,
+		).toBe(false);
+	});
+
+	it("describes a multipart JSON-shaped body when application/json is absent", () => {
+		const result = describeOperation(spec, "/deploy", "POST");
+		expect(result.fields.map((field) => field.name)).toEqual([
+			"zip",
+			"runtime",
+		]);
+		expect(
+			result.fields.find((field) => field.name === "runtime"),
+		).toMatchObject({
+			type: "string",
+			enum: ["nodejs24"],
+		});
+	});
 });
 
 describe("describeOperation against the vendored Neon spec", () => {
@@ -442,5 +551,27 @@ describe("describeOperation against the vendored Neon spec", () => {
 			type: "string",
 			enum: ["SECURITY", "PERFORMANCE"],
 		});
+	});
+
+	it("flattens the email-provider oneOf body", () => {
+		const result = describeOperation(
+			neonSpec,
+			"/projects/p/branches/b/auth/email_provider",
+			"PATCH",
+		);
+		const names = result.fields.map((field) => field.name);
+		expect(names).toContain("type");
+		expect(names).toContain("host");
+		expect(names).toContain("sender_email");
+		expect(
+			result.fields.find((field) => field.name === "type"),
+		).toMatchObject({
+			in: "body",
+			required: true,
+			enum: ["standard", "shared"],
+		});
+		expect(
+			result.fields.find((field) => field.name === "project_id"),
+		).toMatchObject({ in: "path" });
 	});
 });

--- a/packages/cli/src/utils/openapi.test.ts
+++ b/packages/cli/src/utils/openapi.test.ts
@@ -124,6 +124,34 @@ const miniSpec = {
 				},
 			},
 		},
+		"/items/me": {
+			get: {
+				operationId: "getMe",
+				summary: "Current item",
+			},
+		},
+		"/items/{id}": {
+			get: {
+				operationId: "getItem",
+				summary: "One item",
+			},
+		},
+		"/cycle": {
+			post: {
+				operationId: "createCycle",
+				summary: "Cycle",
+				requestBody: {
+					required: true,
+					content: {
+						"application/json": {
+							schema: {
+								$ref: "#/components/schemas/Cycle",
+							},
+						},
+					},
+				},
+			},
+		},
 	},
 	components: {
 		parameters: {
@@ -172,6 +200,13 @@ const miniSpec = {
 				type: "object",
 				properties: {
 					sender_email: { type: "string" },
+				},
+			},
+			Cycle: {
+				type: "object",
+				properties: {
+					name: { type: "string" },
+					child: { $ref: "#/components/schemas/Cycle" },
 				},
 			},
 			ProjectCreateRequest: {
@@ -473,6 +508,30 @@ describe("describeOperation", () => {
 		).toMatchObject({
 			type: "string",
 			enum: ["nodejs24"],
+		});
+	});
+
+	it("prefers the template with more static segments", () => {
+		expect(describeOperation(spec, "/items/me", "GET").operationId).toBe(
+			"getMe",
+		);
+		expect(describeOperation(spec, "/items/other", "GET").operationId).toBe(
+			"getItem",
+		);
+	});
+
+	it("stops a circular $ref at an object leaf", () => {
+		const result = describeOperation(spec, "/cycle", "POST");
+		expect(result.fields.map((field) => field.name)).toEqual([
+			"name",
+			"child",
+		]);
+		expect(
+			result.fields.find((field) => field.name === "child"),
+		).toMatchObject({
+			in: "body",
+			type: "object",
+			required: false,
 		});
 	});
 });

--- a/packages/cli/src/utils/openapi.test.ts
+++ b/packages/cli/src/utils/openapi.test.ts
@@ -79,6 +79,18 @@ const miniSpec = {
 				},
 			},
 		},
+		"/need-org": {
+			get: {
+				operationId: "needOrg",
+				summary: "Needs org",
+				parameters: [
+					{
+						$ref: "#/components/parameters/RequiredOrg",
+						description: "Must pass org",
+					},
+				],
+			},
+		},
 		"/only-post": {
 			post: {
 				operationId: "onlyPost",
@@ -160,6 +172,13 @@ const miniSpec = {
 				in: "query",
 				description: "Timeout in milliseconds",
 				schema: { type: "integer" },
+			},
+			RequiredOrg: {
+				name: "org_id",
+				in: "query",
+				required: true,
+				description: "Organization id",
+				schema: { type: "string" },
 			},
 		},
 		schemas: {
@@ -340,6 +359,17 @@ describe("describeOperation", () => {
 				enum: ["SECURITY", "PERFORMANCE"],
 			},
 		]);
+	});
+
+	it("keeps required on a parameter $ref", () => {
+		const orgId = describeOperation(spec, "/need-org", "GET").fields.find(
+			(field) => field.name === "org_id",
+		);
+		expect(orgId).toMatchObject({
+			in: "query",
+			required: true,
+			description: "Must pass org",
+		});
 	});
 
 	it("overrides path-item parameters with the same name and in", () => {

--- a/packages/cli/src/utils/openapi.test.ts
+++ b/packages/cli/src/utils/openapi.test.ts
@@ -1,0 +1,446 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import { describeOperation, type OpenApiSpec } from "./openapi";
+
+const miniSpec = {
+	paths: {
+		"/projects": {
+			parameters: [
+				{
+					name: "org_id",
+					in: "query",
+					schema: { type: "string" },
+					description: "path-item org_id",
+				},
+			],
+			get: {
+				operationId: "listProjects",
+				summary: "List projects",
+				parameters: [
+					{
+						name: "limit",
+						in: "query",
+						schema: { type: "integer" },
+						description: "Page size",
+					},
+					{
+						name: "org_id",
+						in: "query",
+						schema: { type: "string" },
+						description: "operation org_id",
+					},
+					{ $ref: "#/components/parameters/TimeoutParam" },
+					{
+						name: "category",
+						in: "query",
+						schema: {
+							$ref: "#/components/schemas/AdvisorCategory",
+						},
+						description: "Filter by category",
+					},
+				],
+			},
+			post: {
+				operationId: "createProject",
+				summary: "Create project",
+				requestBody: {
+					required: true,
+					content: {
+						"application/json": {
+							schema: {
+								$ref: "#/components/schemas/ProjectCreateRequest",
+							},
+						},
+					},
+				},
+			},
+		},
+		"/projects/{project_id}/branches": {
+			post: {
+				operationId: "createProjectBranch",
+				summary: "Create branch",
+				requestBody: {
+					required: false,
+					content: {
+						"application/json": {
+							schema: {
+								allOf: [
+									{
+										$ref: "#/components/schemas/BranchCreateRequest",
+									},
+								],
+							},
+						},
+					},
+				},
+			},
+		},
+		"/only-post": {
+			post: {
+				operationId: "onlyPost",
+				summary: "POST only",
+			},
+		},
+	},
+	components: {
+		parameters: {
+			TimeoutParam: {
+				name: "timeout",
+				in: "query",
+				description: "Timeout in milliseconds",
+				schema: { type: "integer" },
+			},
+		},
+		schemas: {
+			AdvisorCategory: {
+				type: "string",
+				enum: ["SECURITY", "PERFORMANCE"],
+			},
+			Provisioner: {
+				type: "string",
+				enum: ["k8s-neonvm", "k8s-pod"],
+			},
+			EndpointType: {
+				type: "string",
+				enum: ["read_write", "read_only"],
+			},
+			ProjectCreateRequest: {
+				type: "object",
+				required: ["project"],
+				properties: {
+					project: {
+						type: "object",
+						description: "New project",
+						properties: {
+							name: {
+								type: "string",
+								description: "The project name",
+							},
+							provisioner: {
+								$ref: "#/components/schemas/Provisioner",
+								description:
+									"Compute provisioner. k8s-neonvm supports Autoscaling.",
+							},
+							settings: {
+								type: "object",
+								properties: {
+									quota: {
+										type: "object",
+										properties: {
+											logical_size_bytes: {
+												type: "integer",
+												description:
+													"Per-branch size cap",
+											},
+										},
+									},
+									maintenance_window: {
+										type: "object",
+										required: [
+											"weekdays",
+											"start_time",
+											"end_time",
+										],
+										properties: {
+											weekdays: { type: "array" },
+											start_time: { type: "string" },
+											end_time: { type: "string" },
+										},
+									},
+								},
+							},
+							annotations: {
+								type: "object",
+								additionalProperties: { type: "string" },
+								description: "Free-form metadata",
+							},
+						},
+					},
+				},
+			},
+			BranchCreateRequest: {
+				type: "object",
+				properties: {
+					branch: {
+						type: "object",
+						properties: {
+							name: {
+								type: "string",
+								description: "The branch name",
+							},
+							parent_id: { type: "string" },
+						},
+					},
+					endpoints: {
+						type: "array",
+						description: "Computes to create with the branch",
+						items: {
+							$ref: "#/components/schemas/BranchCreateRequestEndpointOptions",
+						},
+					},
+				},
+			},
+			BranchCreateRequestEndpointOptions: {
+				type: "object",
+				required: ["type"],
+				properties: {
+					type: { $ref: "#/components/schemas/EndpointType" },
+					settings: { type: "object" },
+				},
+			},
+		},
+	},
+} satisfies OpenApiSpec;
+
+const spec: OpenApiSpec = miniSpec;
+
+describe("describeOperation", () => {
+	it("lists query params, resolving parameter and schema $refs", () => {
+		const result = describeOperation(spec, "/projects", "GET");
+		expect(result).toMatchObject({
+			method: "GET",
+			path: "/projects",
+			summary: "List projects",
+			operationId: "listProjects",
+			bodyRequired: false,
+		});
+		expect(result.fields).toEqual([
+			{
+				in: "query",
+				name: "org_id",
+				required: false,
+				type: "string",
+				description: "operation org_id",
+			},
+			{
+				in: "query",
+				name: "limit",
+				required: false,
+				type: "integer",
+				description: "Page size",
+			},
+			{
+				in: "query",
+				name: "timeout",
+				required: false,
+				type: "integer",
+				description: "Timeout in milliseconds",
+			},
+			{
+				in: "query",
+				name: "category",
+				required: false,
+				type: "string",
+				description: "Filter by category",
+				enum: ["SECURITY", "PERFORMANCE"],
+			},
+		]);
+	});
+
+	it("overrides path-item parameters with the same name and in", () => {
+		const orgId = describeOperation(spec, "/projects", "GET").fields.find(
+			(field) => field.name === "org_id",
+		);
+		expect(orgId?.description).toBe("operation org_id");
+	});
+
+	it("flattens nested body keys and keeps $ref sibling descriptions", () => {
+		const result = describeOperation(spec, "/projects", "POST");
+		expect(result.bodyRequired).toBe(true);
+		expect(result.fields.map((field) => field.name)).toEqual([
+			"org_id",
+			"project.name",
+			"project.provisioner",
+			"project.settings.quota.logical_size_bytes",
+			"project.settings.maintenance_window.weekdays",
+			"project.settings.maintenance_window.start_time",
+			"project.settings.maintenance_window.end_time",
+			"project.annotations",
+		]);
+		expect(
+			result.fields.find((field) => field.name === "project"),
+		).toBeUndefined();
+		expect(
+			result.fields.find((field) => field.name === "project.name"),
+		).toMatchObject({
+			in: "body",
+			required: false,
+			type: "string",
+			description: "The project name",
+		});
+		expect(
+			result.fields.find((field) => field.name === "project.provisioner"),
+		).toMatchObject({
+			type: "string",
+			description:
+				"Compute provisioner. k8s-neonvm supports Autoscaling.",
+			enum: ["k8s-neonvm", "k8s-pod"],
+		});
+		expect(
+			result.fields.find(
+				(field) =>
+					field.name ===
+					"project.settings.maintenance_window.weekdays",
+			),
+		).toMatchObject({ required: true, type: "array" });
+		expect(
+			result.fields.find((field) => field.name === "project.annotations"),
+		).toMatchObject({
+			required: false,
+			type: "object",
+			description: "Free-form metadata",
+		});
+	});
+
+	it("keeps arrays as -F leaves and exposes item properties", () => {
+		const result = describeOperation(
+			spec,
+			"/projects/{project_id}/branches",
+			"POST",
+		);
+		expect(result.bodyRequired).toBe(false);
+		expect(
+			result.fields.find((field) => field.name === "project_id"),
+		).toMatchObject({
+			in: "path",
+			required: true,
+			type: "string",
+		});
+		expect(
+			result.fields.find((field) => field.name === "branch.name"),
+		).toMatchObject({
+			in: "body",
+			type: "string",
+			description: "The branch name",
+		});
+		expect(
+			result.fields.find((field) => field.name === "endpoints"),
+		).toMatchObject({
+			in: "body",
+			required: false,
+			type: "array",
+			description: "Computes to create with the branch",
+			items: {
+				type: "object",
+				properties: [
+					{
+						name: "type",
+						type: "string",
+						required: true,
+						description: "",
+						enum: ["read_write", "read_only"],
+					},
+					{
+						name: "settings",
+						type: "object",
+						required: false,
+						description: "",
+					},
+				],
+			},
+		});
+	});
+
+	it("matches a concrete id against a path template", () => {
+		const result = describeOperation(
+			spec,
+			"/projects/foo-bar-123/branches",
+			"POST",
+		);
+		expect(result.path).toBe("/projects/{project_id}/branches");
+		expect(result.operationId).toBe("createProjectBranch");
+	});
+
+	it("errors when GET is missing and names the methods that exist", () => {
+		expect(() => describeOperation(spec, "/only-post", "GET")).toThrow(
+			"No GET /only-post in the spec. Available: POST. Pass -X POST.",
+		);
+	});
+
+	it("errors for an unknown path", () => {
+		expect(() => describeOperation(spec, "/nope", "GET")).toThrow(
+			'No route matches "/nope". Run `neon api --list` to see available routes.',
+		);
+	});
+});
+
+describe("describeOperation against the vendored Neon spec", () => {
+	const neonSpec = JSON.parse(
+		readFileSync(
+			join(
+				dirname(fileURLToPath(import.meta.url)),
+				"../../../sdk/spec/neon-openapi.json",
+			),
+			"utf8",
+		),
+	) as OpenApiSpec;
+
+	it("describes GET /projects query params including TimeoutParam", () => {
+		const result = describeOperation(neonSpec, "/projects", "GET");
+		const names = result.fields.map((field) => field.name);
+		expect(names).toEqual(
+			expect.arrayContaining([
+				"cursor",
+				"limit",
+				"search",
+				"org_id",
+				"timeout",
+			]),
+		);
+		expect(result.fields.every((field) => field.in === "query")).toBe(true);
+	});
+
+	it("describes POST /projects as a required body of dotted project fields", () => {
+		const result = describeOperation(neonSpec, "/projects", "POST");
+		expect(result.bodyRequired).toBe(true);
+		expect(result.operationId).toBe("createProject");
+		const names = result.fields.map((field) => field.name);
+		expect(names).toContain("project.name");
+		expect(names).toContain("project.region_id");
+		expect(names).not.toContain("project");
+		expect(
+			result.fields.find((field) => field.name === "project.provisioner")
+				?.description,
+		).toMatch(/provisioner/i);
+	});
+
+	it("describes POST .../branches array items for -F endpoints=", () => {
+		const result = describeOperation(
+			neonSpec,
+			"/projects/proj-1/branches",
+			"POST",
+		);
+		expect(result.path).toBe("/projects/{project_id}/branches");
+		const endpoints = result.fields.find(
+			(field) => field.name === "endpoints",
+		);
+		expect(endpoints?.type).toBe("array");
+		expect(
+			endpoints?.items?.properties?.some(
+				(p) => p.name === "type" && p.required,
+			),
+		).toBe(true);
+		expect(
+			result.fields.find((field) => field.name === "branch.name"),
+		).toMatchObject({ in: "body", type: "string" });
+	});
+
+	it("resolves query enum $refs", () => {
+		const result = describeOperation(
+			neonSpec,
+			"/projects/{project_id}/advisors",
+			"GET",
+		);
+		expect(
+			result.fields.find((field) => field.name === "category"),
+		).toMatchObject({
+			in: "query",
+			type: "string",
+			enum: ["SECURITY", "PERFORMANCE"],
+		});
+	});
+});

--- a/packages/cli/src/utils/openapi.ts
+++ b/packages/cli/src/utils/openapi.ts
@@ -559,7 +559,12 @@ function resolveParameter(
 			throw new Error(`Unresolved $ref ${parameter.$ref}.`);
 		}
 		const { $ref: _ref, ...siblings } = parameter;
-		return mergeSchema(resolved, siblings);
+		const description = stringDesc(siblings) || stringDesc(resolved);
+		return {
+			...resolved,
+			...siblings,
+			...(description ? { description } : {}),
+		};
 	}
 	return parameter;
 }

--- a/packages/cli/src/utils/openapi.ts
+++ b/packages/cli/src/utils/openapi.ts
@@ -405,12 +405,93 @@ function arrayField(
 	return field;
 }
 
+function unionMembers(schema: Record<string, unknown>): unknown[] {
+	if (Array.isArray(schema.oneOf)) {
+		return schema.oneOf;
+	}
+	if (Array.isArray(schema.anyOf)) {
+		return schema.anyOf;
+	}
+	return [];
+}
+
+function discriminatorField(
+	schema: Record<string, unknown>,
+	prefix: string,
+): DescribedField | null {
+	if (!isRecord(schema.discriminator)) {
+		return null;
+	}
+	const propertyName = schema.discriminator.propertyName;
+	if (typeof propertyName !== "string") {
+		return null;
+	}
+	const mapping = schema.discriminator.mapping;
+	const values = isRecord(mapping) ? Object.keys(mapping) : [];
+	return {
+		in: "body",
+		name: prefix ? `${prefix}.${propertyName}` : propertyName,
+		required: true,
+		type: "string",
+		description: "",
+		...(values.length > 0 ? { enum: values } : {}),
+	};
+}
+
+function flattenUnion(
+	spec: OpenApiSpec,
+	schema: Record<string, unknown>,
+	prefix: string,
+): DescribedField[] {
+	const members = unionMembers(schema);
+	const byName = new Map<string, DescribedField[]>();
+	for (const member of members) {
+		const seen = new Set<string>();
+		for (const field of flattenBody(spec, member, prefix)) {
+			if (seen.has(field.name)) {
+				continue;
+			}
+			seen.add(field.name);
+			const copies = byName.get(field.name) ?? [];
+			copies.push(field);
+			byName.set(field.name, copies);
+		}
+	}
+	const fields: DescribedField[] = [];
+	for (const copies of byName.values()) {
+		fields.push({
+			...copies[0],
+			required:
+				copies.length === members.length &&
+				copies.every((field) => field.required),
+		});
+	}
+	const discriminator = discriminatorField(schema, prefix);
+	if (discriminator && !byName.has(discriminator.name)) {
+		fields.unshift(discriminator);
+	} else if (discriminator) {
+		const existing = fields.find(
+			(field) => field.name === discriminator.name,
+		);
+		if (existing) {
+			existing.required = true;
+			if (!existing.enum && discriminator.enum) {
+				existing.enum = discriminator.enum;
+			}
+		}
+	}
+	return fields;
+}
+
 function flattenBody(
 	spec: OpenApiSpec,
 	schema: unknown,
 	prefix: string,
 ): DescribedField[] {
 	const resolved = resolveSchema(spec, schema, []);
+	if (unionMembers(resolved).length > 0) {
+		return flattenUnion(spec, resolved, prefix);
+	}
 	const properties = isRecord(resolved.properties)
 		? resolved.properties
 		: undefined;
@@ -607,10 +688,16 @@ function jsonBodySchema(
 		return null;
 	}
 	const json = content["application/json"];
-	if (!isRecord(json) || json.schema === undefined) {
+	const selected = isRecord(json)
+		? json
+		: Object.values(content).find(isRecord);
+	if (!isRecord(selected) || selected.schema === undefined) {
 		return null;
 	}
-	return { schema: json.schema, required: requestBody.required === true };
+	return {
+		schema: selected.schema,
+		required: requestBody.required === true,
+	};
 }
 
 export function describeOperation(

--- a/packages/cli/src/utils/openapi.ts
+++ b/packages/cli/src/utils/openapi.ts
@@ -357,14 +357,31 @@ function fieldFromSchema(
 	};
 }
 
+function pushedRefs(schema: unknown, stack: string[]): string[] {
+	if (!isRecord(schema)) {
+		return stack;
+	}
+	let next = stack;
+	if (typeof schema.$ref === "string" && !next.includes(schema.$ref)) {
+		next = [...next, schema.$ref];
+	}
+	if (Array.isArray(schema.allOf)) {
+		for (const part of schema.allOf) {
+			next = pushedRefs(part, next);
+		}
+	}
+	return next;
+}
+
 function arrayField(
 	spec: OpenApiSpec,
 	name: string,
 	required: boolean,
 	schema: Record<string, unknown>,
+	stack: string[],
 ): DescribedField {
 	const items = isRecord(schema.items)
-		? resolveSchema(spec, schema.items, [])
+		? resolveSchema(spec, schema.items, stack)
 		: {};
 	const itemType = schemaType(items);
 	const properties = isRecord(items.properties)
@@ -386,7 +403,7 @@ function arrayField(
 								const resolved = resolveSchema(
 									spec,
 									propSchema,
-									[],
+									stack,
 								);
 								return {
 									name: propName,
@@ -442,12 +459,13 @@ function flattenUnion(
 	spec: OpenApiSpec,
 	schema: Record<string, unknown>,
 	prefix: string,
+	stack: string[],
 ): DescribedField[] {
 	const members = unionMembers(schema);
 	const byName = new Map<string, DescribedField[]>();
 	for (const member of members) {
 		const seen = new Set<string>();
-		for (const field of flattenBody(spec, member, prefix)) {
+		for (const field of flattenBody(spec, member, prefix, stack)) {
 			if (seen.has(field.name)) {
 				continue;
 			}
@@ -487,10 +505,12 @@ function flattenBody(
 	spec: OpenApiSpec,
 	schema: unknown,
 	prefix: string,
+	stack: string[] = [],
 ): DescribedField[] {
-	const resolved = resolveSchema(spec, schema, []);
+	const nextStack = pushedRefs(schema, stack);
+	const resolved = resolveSchema(spec, schema, stack);
 	if (unionMembers(resolved).length > 0) {
-		return flattenUnion(spec, resolved, prefix);
+		return flattenUnion(spec, resolved, prefix, nextStack);
 	}
 	const properties = isRecord(resolved.properties)
 		? resolved.properties
@@ -500,7 +520,7 @@ function flattenBody(
 			return [];
 		}
 		if (schemaType(resolved) === "array") {
-			return [arrayField(spec, prefix, false, resolved)];
+			return [arrayField(spec, prefix, false, resolved, nextStack)];
 		}
 		return [fieldFromSchema("body", prefix, false, resolved)];
 	}
@@ -509,14 +529,16 @@ function flattenBody(
 	for (const [key, prop] of Object.entries(properties)) {
 		const name = prefix ? `${prefix}.${key}` : key;
 		const required = requiredSet.has(key);
-		const resolvedProp = resolveSchema(spec, prop, []);
+		const resolvedProp = resolveSchema(spec, prop, nextStack);
 		const type = schemaType(resolvedProp);
 		if (type === "object" && isRecord(resolvedProp.properties)) {
-			fields.push(...flattenBody(spec, resolvedProp, name));
+			fields.push(...flattenBody(spec, prop, name, nextStack));
 			continue;
 		}
 		if (type === "array") {
-			fields.push(arrayField(spec, name, required, resolvedProp));
+			fields.push(
+				arrayField(spec, name, required, resolvedProp, nextStack),
+			);
 			continue;
 		}
 		fields.push(fieldFromSchema("body", name, required, resolvedProp));

--- a/packages/cli/src/utils/openapi.ts
+++ b/packages/cli/src/utils/openapi.ts
@@ -77,6 +77,8 @@ export type DescribedField = {
 	nullable?: boolean;
 	items?: {
 		type: string;
+		enum?: unknown[];
+		nullable?: boolean;
 		properties?: ItemProperty[];
 	};
 };
@@ -396,6 +398,8 @@ function arrayField(
 		description: stringDesc(schema),
 		items: {
 			type: itemType,
+			...optionalEnum(items),
+			...optionalNullable(items),
 			...(properties
 				? {
 						properties: Object.entries(properties).map(
@@ -587,14 +591,28 @@ function paramToField(
 		location === "path"
 			? param.required !== false
 			: param.required === true;
+	const type = schemaType(schema);
+	const itemSchema =
+		type === "array" && isRecord(schema.items)
+			? resolveSchema(spec, schema.items, [])
+			: null;
 	return {
 		in: location,
 		name: param.name,
 		required,
-		type: schemaType(schema),
+		type,
 		description: stringDesc(param) || stringDesc(schema),
 		...optionalEnum(schema),
 		...optionalNullable(schema),
+		...(itemSchema
+			? {
+					items: {
+						type: schemaType(itemSchema),
+						...optionalEnum(itemSchema),
+						...optionalNullable(itemSchema),
+					},
+				}
+			: {}),
 	};
 }
 

--- a/packages/cli/src/utils/openapi.ts
+++ b/packages/cli/src/utils/openapi.ts
@@ -1,8 +1,8 @@
-// Lightweight loader for the Neon OpenAPI spec, used by `neon api --list` to
-// enumerate the available routes. The `neon api <path>` request path does NOT
-// depend on this module — it is a pure passthrough — so a stale or unreachable
-// spec never blocks a real API call. Listing degrades gracefully: fresh cache →
-// live fetch → stale cache → clear error.
+// Spec loader for `neon api --list` and `neon api <path> --describe`.
+// `neon api <path>` request mode does not use this module — it is a pure
+// passthrough — so a stale or unreachable spec never blocks a real API call.
+// Listing and describe degrade gracefully: fresh cache → live fetch → stale
+// cache → clear error.
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
@@ -26,6 +26,8 @@ const HTTP_METHODS = new Set([
 	"options",
 ]);
 
+const DESCRIBE_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
+
 type Operation = {
 	operationId?: string;
 	summary?: string;
@@ -37,6 +39,10 @@ type PathItem = Record<string, unknown>;
 
 export type OpenApiSpec = {
 	paths?: Record<string, PathItem>;
+	components?: {
+		schemas?: Record<string, unknown>;
+		parameters?: Record<string, unknown>;
+	};
 	servers?: { url: string }[];
 	info?: { version?: string };
 };
@@ -48,6 +54,40 @@ export type EndpointInfo = {
 	summary?: string;
 	operationId?: string;
 	tags: string[];
+};
+
+export type ParameterLocation = "path" | "query" | "header" | "body";
+
+export type ItemProperty = {
+	name: string;
+	type: string;
+	required: boolean;
+	description: string;
+	enum?: unknown[];
+	nullable?: boolean;
+};
+
+export type DescribedField = {
+	in: ParameterLocation;
+	name: string;
+	required: boolean;
+	type: string;
+	description: string;
+	enum?: unknown[];
+	nullable?: boolean;
+	items?: {
+		type: string;
+		properties?: ItemProperty[];
+	};
+};
+
+export type OperationDescription = {
+	method: string;
+	path: string;
+	summary: string;
+	operationId: string;
+	bodyRequired: boolean;
+	fields: DescribedField[];
 };
 
 type CachedSpec = {
@@ -159,4 +199,450 @@ export function getEndpoints(spec: OpenApiSpec): EndpointInfo[] {
 			: a.path.localeCompare(b.path),
 	);
 	return endpoints;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+	return value.filter((item): item is string => typeof item === "string");
+}
+
+function stringDesc(value: unknown): string {
+	if (!isRecord(value) || typeof value.description !== "string") {
+		return "";
+	}
+	return value.description.trim();
+}
+
+function specRecord(spec: OpenApiSpec): Record<string, unknown> {
+	return spec;
+}
+
+function resolveRef(spec: OpenApiSpec, ref: string): unknown {
+	if (!ref.startsWith("#/")) {
+		throw new Error(
+			`Unsupported $ref "${ref}". Only document-local refs are resolved.`,
+		);
+	}
+	let node: unknown = specRecord(spec);
+	for (const part of ref.slice(2).split("/")) {
+		const key = part.replace(/~1/g, "/").replace(/~0/g, "~");
+		if (!isRecord(node) || !(key in node)) {
+			throw new Error(`Unresolved $ref ${ref}.`);
+		}
+		node = node[key];
+	}
+	return node;
+}
+
+function schemaType(schema: Record<string, unknown>): string {
+	const t = schema.type;
+	if (typeof t === "string") {
+		return t;
+	}
+	if (Array.isArray(t)) {
+		const first = t.find(
+			(item): item is string => typeof item === "string",
+		);
+		if (first) {
+			return first;
+		}
+	}
+	if (schema.items !== undefined) {
+		return "array";
+	}
+	if (
+		isRecord(schema.properties) ||
+		schema.additionalProperties !== undefined
+	) {
+		return "object";
+	}
+	if (Array.isArray(schema.enum)) {
+		return "string";
+	}
+	return "object";
+}
+
+function optionalEnum(
+	schema: Record<string, unknown>,
+): { enum: unknown[] } | Record<string, never> {
+	return Array.isArray(schema.enum) ? { enum: schema.enum } : {};
+}
+
+function optionalNullable(
+	schema: Record<string, unknown>,
+): { nullable: true } | Record<string, never> {
+	return schema.nullable === true ? { nullable: true } : {};
+}
+
+function mergeSchema(
+	base: Record<string, unknown>,
+	overlay: Record<string, unknown>,
+): Record<string, unknown> {
+	const properties = {
+		...(isRecord(base.properties) ? base.properties : {}),
+		...(isRecord(overlay.properties) ? overlay.properties : {}),
+	};
+	const required = [
+		...new Set([
+			...asStringArray(base.required),
+			...asStringArray(overlay.required),
+		]),
+	];
+	const overlayDesc = stringDesc(overlay);
+	const description = overlayDesc || stringDesc(base);
+	return {
+		...base,
+		...overlay,
+		properties,
+		required,
+		...(description ? { description } : {}),
+	};
+}
+
+function resolveSchema(
+	spec: OpenApiSpec,
+	schema: unknown,
+	stack: string[],
+): Record<string, unknown> {
+	if (!isRecord(schema)) {
+		return {};
+	}
+	if (typeof schema.$ref === "string") {
+		const ref = schema.$ref;
+		const { $ref: _ref, ...siblings } = schema;
+		if (stack.includes(ref)) {
+			return { type: "object", ...siblings };
+		}
+		const resolved = resolveSchema(spec, resolveRef(spec, ref), [
+			...stack,
+			ref,
+		]);
+		return mergeSchema(resolved, siblings);
+	}
+	if (Array.isArray(schema.allOf)) {
+		const { allOf, ...rest } = schema;
+		let merged: Record<string, unknown> = {
+			type: "object",
+			properties: {},
+			required: [],
+		};
+		for (const part of allOf) {
+			merged = mergeSchema(merged, resolveSchema(spec, part, stack));
+		}
+		return mergeSchema(merged, rest);
+	}
+	return schema;
+}
+
+function fieldFromSchema(
+	location: ParameterLocation,
+	name: string,
+	required: boolean,
+	schema: Record<string, unknown>,
+): DescribedField {
+	return {
+		in: location,
+		name,
+		required,
+		type: schemaType(schema),
+		description: stringDesc(schema),
+		...optionalEnum(schema),
+		...optionalNullable(schema),
+	};
+}
+
+function arrayField(
+	spec: OpenApiSpec,
+	name: string,
+	required: boolean,
+	schema: Record<string, unknown>,
+): DescribedField {
+	const items = isRecord(schema.items)
+		? resolveSchema(spec, schema.items, [])
+		: {};
+	const itemType = schemaType(items);
+	const properties = isRecord(items.properties)
+		? items.properties
+		: undefined;
+	const requiredItems = new Set(asStringArray(items.required));
+	const field: DescribedField = {
+		in: "body",
+		name,
+		required,
+		type: "array",
+		description: stringDesc(schema),
+		items: {
+			type: itemType,
+			...(properties
+				? {
+						properties: Object.entries(properties).map(
+							([propName, propSchema]) => {
+								const resolved = resolveSchema(
+									spec,
+									propSchema,
+									[],
+								);
+								return {
+									name: propName,
+									type: schemaType(resolved),
+									required: requiredItems.has(propName),
+									description: stringDesc(resolved),
+									...optionalEnum(resolved),
+									...optionalNullable(resolved),
+								};
+							},
+						),
+					}
+				: {}),
+		},
+	};
+	return field;
+}
+
+function flattenBody(
+	spec: OpenApiSpec,
+	schema: unknown,
+	prefix: string,
+): DescribedField[] {
+	const resolved = resolveSchema(spec, schema, []);
+	const properties = isRecord(resolved.properties)
+		? resolved.properties
+		: undefined;
+	if (!properties) {
+		if (prefix === "") {
+			return [];
+		}
+		if (schemaType(resolved) === "array") {
+			return [arrayField(spec, prefix, false, resolved)];
+		}
+		return [fieldFromSchema("body", prefix, false, resolved)];
+	}
+	const requiredSet = new Set(asStringArray(resolved.required));
+	const fields: DescribedField[] = [];
+	for (const [key, prop] of Object.entries(properties)) {
+		const name = prefix ? `${prefix}.${key}` : key;
+		const required = requiredSet.has(key);
+		const resolvedProp = resolveSchema(spec, prop, []);
+		const type = schemaType(resolvedProp);
+		if (type === "object" && isRecord(resolvedProp.properties)) {
+			fields.push(...flattenBody(spec, resolvedProp, name));
+			continue;
+		}
+		if (type === "array") {
+			fields.push(arrayField(spec, name, required, resolvedProp));
+			continue;
+		}
+		fields.push(fieldFromSchema("body", name, required, resolvedProp));
+	}
+	return fields;
+}
+
+function resolveParameter(
+	spec: OpenApiSpec,
+	parameter: unknown,
+): Record<string, unknown> | null {
+	if (!isRecord(parameter)) {
+		return null;
+	}
+	if (typeof parameter.$ref === "string") {
+		const resolved = resolveRef(spec, parameter.$ref);
+		if (!isRecord(resolved)) {
+			throw new Error(`Unresolved $ref ${parameter.$ref}.`);
+		}
+		const { $ref: _ref, ...siblings } = parameter;
+		return mergeSchema(resolved, siblings);
+	}
+	return parameter;
+}
+
+function paramToField(
+	spec: OpenApiSpec,
+	param: Record<string, unknown>,
+): DescribedField | null {
+	const location = param.in;
+	if (location !== "path" && location !== "query" && location !== "header") {
+		return null;
+	}
+	if (typeof param.name !== "string") {
+		return null;
+	}
+	const schema = isRecord(param.schema)
+		? resolveSchema(spec, param.schema, [])
+		: {};
+	const required =
+		location === "path"
+			? param.required !== false
+			: param.required === true;
+	return {
+		in: location,
+		name: param.name,
+		required,
+		type: schemaType(schema),
+		description: stringDesc(param) || stringDesc(schema),
+		...optionalEnum(schema),
+		...optionalNullable(schema),
+	};
+}
+
+function pathParamNames(template: string): string[] {
+	return [...template.matchAll(/\{([^}]+)\}/g)].map((match) => match[1]);
+}
+
+function pathMatchesTemplate(path: string, template: string): boolean {
+	const pathParts = path.split("/");
+	const templateParts = template.split("/");
+	if (pathParts.length !== templateParts.length) {
+		return false;
+	}
+	return templateParts.every((part, i) => {
+		if (part.startsWith("{") && part.endsWith("}")) {
+			return pathParts[i] !== "";
+		}
+		return part === pathParts[i];
+	});
+}
+
+function matchPath(
+	spec: OpenApiSpec,
+	requestPath: string,
+): { template: string; pathItem: Record<string, unknown> } {
+	const path = requestPath.split("?")[0] ?? requestPath;
+	const paths = spec.paths ?? {};
+	const exact = paths[path];
+	if (isRecord(exact)) {
+		return { template: path, pathItem: exact };
+	}
+	const matches = Object.entries(paths).filter(
+		([template, item]) =>
+			isRecord(item) && pathMatchesTemplate(path, template),
+	);
+	if (matches.length === 0) {
+		throw new Error(
+			`No route matches "${path}". Run \`neon api --list\` to see available routes.`,
+		);
+	}
+	matches.sort((a, b) => {
+		const staticA = a[0]
+			.split("/")
+			.filter((p) => !p.startsWith("{")).length;
+		const staticB = b[0]
+			.split("/")
+			.filter((p) => !p.startsWith("{")).length;
+		return staticB - staticA;
+	});
+	const [template, pathItem] = matches[0];
+	if (!isRecord(pathItem)) {
+		throw new Error(
+			`No route matches "${path}". Run \`neon api --list\` to see available routes.`,
+		);
+	}
+	return { template, pathItem };
+}
+
+function availableMethods(pathItem: Record<string, unknown>): string[] {
+	return DESCRIBE_METHODS.filter((method) =>
+		isRecord(pathItem[method.toLowerCase()]),
+	);
+}
+
+function collectParameters(
+	spec: OpenApiSpec,
+	pathItem: Record<string, unknown>,
+	operation: Record<string, unknown>,
+	template: string,
+): DescribedField[] {
+	const raw = [
+		...(Array.isArray(pathItem.parameters) ? pathItem.parameters : []),
+		...(Array.isArray(operation.parameters) ? operation.parameters : []),
+	];
+	const byKey = new Map<string, DescribedField>();
+	for (const entry of raw) {
+		const resolved = resolveParameter(spec, entry);
+		if (!resolved) {
+			continue;
+		}
+		const field = paramToField(spec, resolved);
+		if (!field) {
+			continue;
+		}
+		byKey.set(`${field.in}:${field.name}`, field);
+	}
+	const pathFields = pathParamNames(template).map((name) => {
+		const existing = byKey.get(`path:${name}`);
+		if (existing) {
+			return existing;
+		}
+		return {
+			in: "path" as const,
+			name,
+			required: true,
+			type: "string",
+			description: "",
+		};
+	});
+	const query = [...byKey.values()].filter((field) => field.in === "query");
+	const header = [...byKey.values()].filter((field) => field.in === "header");
+	return [...pathFields, ...query, ...header];
+}
+
+function jsonBodySchema(
+	spec: OpenApiSpec,
+	operation: Record<string, unknown>,
+): { schema: unknown; required: boolean } | null {
+	let requestBody = operation.requestBody;
+	if (isRecord(requestBody) && typeof requestBody.$ref === "string") {
+		requestBody = resolveRef(spec, requestBody.$ref);
+	}
+	if (!isRecord(requestBody)) {
+		return null;
+	}
+	const content = requestBody.content;
+	if (!isRecord(content)) {
+		return null;
+	}
+	const json = content["application/json"];
+	if (!isRecord(json) || json.schema === undefined) {
+		return null;
+	}
+	return { schema: json.schema, required: requestBody.required === true };
+}
+
+export function describeOperation(
+	spec: OpenApiSpec,
+	path: string,
+	method: string,
+): OperationDescription {
+	const methodUpper = method.toUpperCase();
+	const { template, pathItem } = matchPath(spec, path);
+	const available = availableMethods(pathItem);
+	const operation = pathItem[methodUpper.toLowerCase()];
+	if (!isRecord(operation)) {
+		const hint =
+			available.length > 0
+				? ` Available: ${available.join(", ")}. Pass -X ${available[0]}.`
+				: " Run `neon api --list` to see available routes.";
+		throw new Error(`No ${methodUpper} ${template} in the spec.${hint}`);
+	}
+	const body = jsonBodySchema(spec, operation);
+	const fields = [
+		...collectParameters(spec, pathItem, operation, template),
+		...(body ? flattenBody(spec, body.schema, "") : []),
+	];
+	return {
+		method: methodUpper,
+		path: template,
+		summary: typeof operation.summary === "string" ? operation.summary : "",
+		operationId:
+			typeof operation.operationId === "string"
+				? operation.operationId
+				: "",
+		bodyRequired: body?.required === true,
+		fields,
+	};
 }

--- a/packages/cli/src/utils/openapi.ts
+++ b/packages/cli/src/utils/openapi.ts
@@ -89,6 +89,7 @@ export type OperationDescription = {
 	summary: string;
 	operationId: string;
 	bodyRequired: boolean;
+	contentType: string;
 	fields: DescribedField[];
 };
 
@@ -720,7 +721,7 @@ function collectParameters(
 function jsonBodySchema(
 	spec: OpenApiSpec,
 	operation: Record<string, unknown>,
-): { schema: unknown; required: boolean } | null {
+): { schema: unknown; required: boolean; contentType: string } | null {
 	let requestBody = operation.requestBody;
 	if (isRecord(requestBody) && typeof requestBody.$ref === "string") {
 		requestBody = resolveRef(spec, requestBody.$ref);
@@ -733,15 +734,25 @@ function jsonBodySchema(
 		return null;
 	}
 	const json = content["application/json"];
-	const selected = isRecord(json)
-		? json
-		: Object.values(content).find(isRecord);
+	let contentType = "application/json";
+	let selected: unknown = json;
+	if (!isRecord(json)) {
+		const entry = Object.entries(content).find(([, value]) =>
+			isRecord(value),
+		);
+		if (!entry) {
+			return null;
+		}
+		contentType = entry[0];
+		selected = entry[1];
+	}
 	if (!isRecord(selected) || selected.schema === undefined) {
 		return null;
 	}
 	return {
 		schema: selected.schema,
 		required: requestBody.required === true,
+		contentType,
 	};
 }
 
@@ -775,6 +786,7 @@ export function describeOperation(
 				? operation.operationId
 				: "",
 		bodyRequired: body?.required === true,
+		contentType: body?.contentType ?? "",
 		fields,
 	};
 }


### PR DESCRIPTION
## Problem

`neon api --list` catalogs each operation's method, path and summary. It does not show query parameters or request bodies, so users have to inspect the OpenAPI spec or guess the names expected by `-Q` and `-F`.

## User-facing interface

`--describe` resolves one operation and prints its path, query, header and body parameters. Omitting `-X` selects `GET`.

Table output uses one parameters table titled `METHOD path - summary`. When the request body is required, the title includes `(body required)`. Required fields render as `required` or `optional`. Enum values appear in the Type column. Array bodies include item field names and enums:

```console
$ neon api /projects/p/advisors --describe
GET /projects/{project_id}/advisors - Get advisor issues
In     Name           Required  Type                            Description
path   project_id     required  string                          Neon project ID
query  branch_id      optional  string                          Branch ID to analyze. If not specified, the project's default branch is used.
query  database_name  optional  string                          Database name to analyze. Required if branch has multiple databases.
query  category       optional  string (SECURITY, PERFORMANCE)  Filter issues by category
query  min_severity   optional  string (INFO, WARN, ERROR)      Minimum severity level to include. For example, WARN returns WARN and ERROR issues, excluding INFO.
```

```console
$ neon api /projects/p/branches -X POST --describe
...
body  endpoints  optional  array (type (read_only, read_write), settings, autoscaling_limit_min_cu, autoscaling_limit_max_cu, provisioner, suspend_timeout_seconds)  ...
```

Concrete paths resolve to their templates. If multiple templates match, the one with more static segments wins.

JSON and YAML return an `endpoint` object plus a `parameters` array. Filtering the live JSON output shows the contract and dotted names accepted by `-F`:

```console
$ neon api /projects -X POST --describe -o json |
  jq '{endpoint, parameters: [.parameters[] | select(.name == "project.name" or .name == "project.region_id")]}'
{
  "endpoint": {
    "method": "POST",
    "path": "/projects",
    "summary": "Create project",
    "operationId": "createProject",
    "bodyRequired": true
  },
  "parameters": [
    {
      "in": "body",
      "name": "project.name",
      "required": false,
      "type": "string",
      "description": "The project name. If not specified, the name will be identical to the generated project ID"
    },
    {
      "in": "body",
      "name": "project.region_id",
      "required": false,
      "type": "string",
      "description": "The region identifier. Refer to our [Regions](https://neon.com/docs/introduction/regions) documentation for supported regions. Values are specified in this format: `aws-us-east-1`"
    }
  ]
}
```

The command loads the operation metadata and exits before passthrough request mode sends the selected API request.

## OpenAPI mapping

- Nested body objects flatten into dotted `-F` names.
- Arrays remain leaf fields. JSON and YAML include their item type, item enums, and `items.properties` when the item schema defines properties. Table Type renders those names and enums, including primitive arrays such as `array of string (storage:read, storage:write, ai_gateway:invoke, functions:invoke)`.
- `oneOf` and `anyOf` bodies flatten into one field list. A discriminator field is injected when the schema defines one. A union field is required only when every variant requires it.
- `application/json` is preferred for request bodies. When it is absent, the first content schema is described and the media type is shown: table titles append `(multipart/form-data)`, and JSON/YAML set `endpoint.contentType`. `neon api` still sends JSON.
- Parameter `required` follows the OpenAPI `required` list on the field's immediate parent. A parameter `$ref` keeps its boolean `required`. JSON and YAML expose `bodyRequired` separately from `requestBody.required`.
- Local `$ref` and `allOf` schemas are resolved. A circular `$ref` stops at an `object` leaf.

## Errors and compatibility

`--list` and `--describe` are mutually exclusive:

```console
$ neon api --list --describe
ERROR: Pass either --list or --describe, not both.
```

Request flags are rejected because describe mode does not send a request:

```console
$ neon api /projects --describe -Q limit=10
ERROR: --describe prints the field list; it does not send a request. Drop -F, -f, -d, -Q, -H, and -i.
```

Missing paths, unknown routes and paths without a leading slash fail with guidance to use `neon api --list`. When the default `GET` operation is absent, the error names the available methods and suggests the first matching `-X` value.

Existing passthrough request behavior and `--list` output stay unchanged.

## Also in here

- The CLI README now documents API passthrough, route listing and operation descriptions.
- A minor changeset adds this interface to the `neon` package.

## Verification

```console
$ pnpm --filter neon exec vitest run src/commands/api.test.ts src/utils/openapi.test.ts
Test Files  2 passed (2)
Tests       37 passed (37)
```

The focused tests cover:

- table and JSON output plus confirmation that describe mode does not call the selected API host
- missing paths, unknown paths, list/describe conflicts and request-flag rejection
- parameter and schema references, required parameter `$ref`s, parameter overrides, dotted nested bodies and array item metadata
- concrete path matching, static-segment priority, missing-method errors, discriminated `oneOf` bodies, multipart schemas and circular `$ref` leaves
- `/projects`, branch creation, advisors and email-provider operations against the vendored Neon spec

The built CLI was also run against the public spec with:

```console
node packages/cli/dist/cli.js api /projects --describe
node packages/cli/dist/cli.js api /projects -X POST --describe -o json
node packages/cli/dist/cli.js api /projects/p/advisors --describe
node packages/cli/dist/cli.js api /projects/p/branches -X POST --describe
node packages/cli/dist/cli.js api /projects/p/branches/b/auth/email_provider -X PATCH --describe -o json
```

The full workspace suite was not run.

## For your attention

- CLI authentication still runs before describe output, matching `--list`.
- Describing a multipart request body does not add multipart sending to `neon api`.
- Required nested fields stay required in the OpenAPI immediate-parent sense even when an ancestor object is optional.


