### PR TITLE
chore: release neon@4.10.0, neonctl@4.10.0

### DIFF
--- a/.changeset/api-describe.md
+++ b/.changeset/api-describe.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-`neon api <path> --describe` prints the OpenAPI request shape for a route. Body field names are dotted for `-F`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.10.0
+
+### Minor Changes
+
+- 33aac59: `neon api <path> --describe` prints the OpenAPI request shape for a route. Body field names are dotted for `-F`.
+
 ## 4.9.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.9.0",
+	"version": "4.10.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.10.0
+
+### Patch Changes
+
+- Updated dependencies [33aac59]
+  - neon@4.10.0
+
 ## 4.9.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.9.0",
+  "version": "4.10.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Bumped

- `neon`: 4.9.0 → 4.10.0
- `neonctl`: 4.9.0 → 4.10.0 (Changesets fixed group)

## Changelog

`neon api <path> --describe` prints the OpenAPI request shape for a route. Body field names are dotted for `-F`.

Version bump and CHANGELOG only. Source landed in https://github.com/neondatabase/neon-pkgs/pull/501.