### PR TITLE
chore: release neon@4.10.1, neonctl@4.10.1

### DIFF
--- a/.changeset/stalled-queries-oldest-first.md
+++ b/.changeset/stalled-queries-oldest-first.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-Rank `inspect db stalled-queries` by the oldest query group first.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.10.1
+
+### Patch Changes
+
+- 7c6ec56: Rank `inspect db stalled-queries` by the oldest query group first.
+
 ## 4.10.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.10.0",
+	"version": "4.10.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.10.1
+
+### Patch Changes
+
+- Updated dependencies [7c6ec56]
+  - neon@4.10.1
+
 ## 4.10.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.10.0",
+  "version": "4.10.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Bumped

- `neon`: 4.10.0 → 4.10.1
- `neonctl`: 4.10.0 → 4.10.1 (fixed group)

Patch: rank `inspect db stalled-queries` by the oldest query group first.

Publish after merge: `neon`, then `neonctl`.