### PR TITLE
chore: release neon@4.10.2, neonctl@4.10.2

### DIFF
--- a/.changeset/init-questions-then-install.md
+++ b/.changeset/init-questions-then-install.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-Group the top-level `neon init` and `neon bootstrap` setup questions before running the selected steps. Install dependencies last unless `neon.ts` must be evaluated for linking. Restore the NEON banner, remove `claimable-postgres` from skill selection, and print a completion summary.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.10.2
+
+### Patch Changes
+
+- 19b64a8: Group the top-level `neon init` and `neon bootstrap` setup questions before running the selected steps. Install dependencies last unless `neon.ts` must be evaluated for linking. Restore the NEON banner, remove `claimable-postgres` from skill selection, and print a completion summary.
+
 ## 4.10.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.10.1",
+	"version": "4.10.2",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.10.2
+
+### Patch Changes
+
+- Updated dependencies [19b64a8]
+  - neon@4.10.2
+
 ## 4.10.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.10.1",
+  "version": "4.10.2",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Bumped

- `neon`: 4.10.1 → 4.10.2
- `neonctl`: 4.10.1 → 4.10.2 (fixed group)

Patch: group the top-level `neon init` and `neon bootstrap` setup questions before running the selected steps. Install dependencies last unless `neon.ts` must be evaluated for linking. Restore the NEON banner, remove `claimable-postgres` from skill selection, and print a completion summary.

Publish after merge: `neon`, then `neonctl`.