### PR TITLE
chore: release @neon/tools@1.1.0

### DIFF
--- a/.changeset/mcp-compact-tool-catalog.md
+++ b/.changeset/mcp-compact-tool-catalog.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": minor
----
-
-Generated tool descriptions are the OpenAPI first sentence. Generated Zod has no OpenAPI field essays. MCP 2 keeps handwritten `.describe()` copy and drops `$schema`.

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 1.1.0
+
+### Minor Changes
+
+- f218eb7: Generated tool descriptions are the OpenAPI first sentence. Generated Zod has no OpenAPI field essays. MCP 2 keeps handwritten `.describe()` copy and drops `$schema`.
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Bumped

- `@neon/tools`: 1.0.0 → 1.1.0

Minor: generated tool descriptions are the OpenAPI first sentence. Generated Zod has no OpenAPI field essays. MCP 2 keeps handwritten `.describe()` copy and drops `$schema`.

Publish after merge: `@neon/tools`.