### PR TITLE
chore: release @neon/tools@1.1.1

### DIFF
--- a/.changeset/tools-closed-world-hint.md
+++ b/.changeset/tools-closed-world-hint.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": patch
----
-
-Management API tools now publish `openWorldHint: false`. They operate on the authenticated Neon account. Operations that send or schedule mail stay `true`.

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 1.1.1
+
+### Patch Changes
+
+- 0c29080: Management API tools now publish `openWorldHint: false`. They operate on the authenticated Neon account. Operations that send or schedule mail stay `true`.
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Bumped

- `@neon/tools`: 1.1.0 → 1.1.1

Patch: Management API tools now publish `openWorldHint: false`. They operate on the authenticated Neon account. Operations that send or schedule mail stay `true`.

Publish after merge: `@neon/tools`.