### PR TITLE
chore: release neon@4.11.0 / neonctl@4.11.0

### DIFF
--- a/.changeset/init-agent-fallback.md
+++ b/.changeset/init-agent-fallback.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-`neon init -y` / `neon bootstrap --default`, `neon skills -y`, `neon plugins -y`, and `neon mcp -y` install into detected agents: project folders (or installed apps with `--global` / default `mcp -y`), else the host CLI agent. `--agent <name>` on `skills`, `plugins`, `mcp`, `init`, and `bootstrap` names coding agents and skips agent selection. `init` and `bootstrap` pass `--agent` to plugins, or to skills and mcp, not both. If `skills` / `plugins` / `mcp` `-y` finds none, the command names `--agent`. `link` has no `--agent`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.11.0
+
+### Minor Changes
+
+- 2e7c936: `neon init -y` / `neon bootstrap --default`, `neon skills -y`, `neon plugins -y`, and `neon mcp -y` install into detected agents: project folders (or installed apps with `--global` / default `mcp -y`), else the host CLI agent. `--agent <name>` on `skills`, `plugins`, `mcp`, `init`, and `bootstrap` names coding agents and skips agent selection. `init` and `bootstrap` pass `--agent` to plugins, or to skills and mcp, not both. If `skills` / `plugins` / `mcp` `-y` finds none, the command names `--agent`. `link` has no `--agent`.
+
 ## 4.10.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.10.2",
+	"version": "4.11.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.11.0
+
+### Minor Changes
+
+- 2e7c936: `neon init -y` / `neon bootstrap --default`, `neon skills -y`, `neon plugins -y`, and `neon mcp -y` install into detected agents: project folders (or installed apps with `--global` / default `mcp -y`), else the host CLI agent. `--agent <name>` on `skills`, `plugins`, `mcp`, `init`, and `bootstrap` names coding agents and skips agent selection. `init` and `bootstrap` pass `--agent` to plugins, or to skills and mcp, not both. If `skills` / `plugins` / `mcp` `-y` finds none, the command names `--agent`. `link` has no `--agent`.
+
+### Patch Changes
+
+- Updated dependencies [2e7c936]
+  - neon@4.11.0
+
 ## 4.10.2
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.10.2",
+  "version": "4.11.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

#503 put `--agent` on `skills`, `plugins`, `mcp`, `init` and `bootstrap` on `main`. npm still serves `neon@4.10.2` and `neonctl@4.10.2`.

This PR bumps both packages 4.10.2 → 4.11.0 so that minor can publish. The diff is versions, CHANGELOGs and the consumed changeset file.

## Diagnosis

#503 merged with `.changeset/init-agent-fallback.md` (`"neon": minor`, `"neonctl": minor`). `changeset version` consumed it and wrote the 4.11.0 CHANGELOG entries. Publish is the post-merge npm workflow.

## The user-facing interface

```
neon skills -s neon -s neon-ai-gateway --agent cursor
neon plugins --agent cursor --agent claude-code
neon mcp --agent cursor --agent claude-code
neon init --agent cursor --agent claude-code
neon bootstrap my-app --agent cursor --agent claude-code
```

`--agent` / `-a` is repeatable. It names coding agents and skips the agent picker.

Without `--agent`, non-interactive install still detects agents:

```
neon init -y
neon bootstrap --default
neon skills -y
neon plugins -y
neon mcp -y
```

Those install into project folders (or installed apps with `--global` / default `mcp -y`), else the host CLI agent. If `skills` / `plugins` / `mcp` `-y` finds none, the error names `--agent`.

`init` and `bootstrap` forward `--agent` to one tooling path: plugins, or skills and mcp.

`neon link` rejects `--agent`. Callers that omit `--agent` still get the picker in a TTY and detection with `-y`.

## Also in here

- `neonctl@4.11.0` tracks `neon@4.11.0` (`workspace:*`)
- Both CHANGELOGs copy the changeset text, hashed to 2e7c936 (#503)
- `.changeset/init-agent-fallback.md` is deleted

## Verification

- `git diff origin/main...HEAD --stat`: 5 files, +19 −8
- `npm view neon version` and `npm view neonctl version`: 4.10.2
- `packages/cli/package.json` and `packages/neonctl/package.json`: 4.11.0
- `.changeset/`: `README.md` and `config.json` only

No tests in this diff. `packages/cli/dist` is not in the worktree, so `--help` was not run here. The invocations above are the yargs examples on `main` from #503.

4.11.0 is live when `npm view neon version` is 4.11.0 and `npm i -g neon@latest` then `neon --version` print 4.11.0.

## For your attention

- Merge lands versions on `main`. It does not publish.
- This PR only versions #503.