### PR TITLE
Alias neon skill and neon plugin to the plural commands

### DIFF
--- a/.changeset/skill-plugin-aliases.md
+++ b/.changeset/skill-plugin-aliases.md
@@ -1,0 +1,6 @@
+---
+"neon": patch
+"neonctl": patch
+---
+
+`neon skill` and `neon plugin` are aliases of `neon skills` and `neon plugins`.

--- a/packages/cli/src/commands/plugins.test.ts
+++ b/packages/cli/src/commands/plugins.test.ts
@@ -202,10 +202,12 @@ describe("neon plugins", () => {
 		testCliCommand,
 	}) => {
 		const { home, cwd, bin, argvFile } = scratch();
-		const { stdout } = await testCliCommand(
+		const { stdout, stderr } = await testCliCommand(
 			["plugin", "-y"],
-			runOptions(home, cwd, bin),
+			runOptions(home, cwd, bin, { NEON_API_KEY: "" }),
 		);
+		expect(stderr).not.toMatch(/Cannot run interactive auth/);
+		expect(stderr).not.toMatch(/Authentication required/);
 		expect(JSON.parse(stdout)[0]).toMatchObject({
 			plugin: "neon-postgres",
 			agent: "cursor",
@@ -221,7 +223,7 @@ describe("neon plugins", () => {
 	}) => {
 		const { home, cwd, bin, argvFile } = scratch();
 		const { stderr } = await testCliCommand(["plugin"], {
-			...runOptions(home, cwd, bin),
+			...runOptions(home, cwd, bin, { NEON_API_KEY: "" }),
 			code: 1,
 		});
 		expect(stderr).toMatch(/Pass -y to install into detected agents/);

--- a/packages/cli/src/commands/plugins.test.ts
+++ b/packages/cli/src/commands/plugins.test.ts
@@ -198,6 +198,36 @@ describe("neon plugins", () => {
 		expect(() => readFileSync(argvFile, "utf8")).toThrow();
 	});
 
+	test("plugin alias installs into detected project agents", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stdout } = await testCliCommand(
+			["plugin", "-y"],
+			runOptions(home, cwd, bin),
+		);
+		expect(JSON.parse(stdout)[0]).toMatchObject({
+			plugin: "neon-postgres",
+			agent: "cursor",
+			status: "installed",
+		});
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))[0]).toEqual(
+			expect.arrayContaining(["-t", "cursor"]),
+		);
+	});
+
+	test("plugin alias does not spawn without -y", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stderr } = await testCliCommand(["plugin"], {
+			...runOptions(home, cwd, bin),
+			code: 1,
+		});
+		expect(stderr).toMatch(/Pass -y to install into detected agents/);
+		expect(() => readFileSync(argvFile, "utf8")).toThrow();
+	});
+
 	test("spawns once per detected target", async ({ testCliCommand }) => {
 		const { home, cwd, bin, argvFile } = scratch();
 		mkdirSync(join(cwd, ".claude"));

--- a/packages/cli/src/commands/plugins.ts
+++ b/packages/cli/src/commands/plugins.ts
@@ -56,6 +56,7 @@ const scopeLabel = (scope: "global" | "project"): string =>
 	scope === "project" ? "project" : "user";
 
 export const command = "plugins";
+export const aliases = ["plugin"];
 export const describe = "Install the Neon plugin into coding agents";
 
 const pluginProjectAgents = pluginsInstallableAgents("project");

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -195,6 +195,35 @@ describe("neon skills", () => {
 		expect(() => readFileSync(argvFile, "utf8")).toThrow();
 	});
 
+	test("skill alias installs default skills into detected project agents", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stdout } = await testCliCommand(
+			["skill", "-y"],
+			runOptions(home, cwd, bin),
+		);
+		expect(JSON.parse(stdout)[0]).toMatchObject({
+			agents: "cursor",
+			status: "installed",
+		});
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))[0]).toEqual(
+			expect.arrayContaining(["--agent", "cursor"]),
+		);
+	});
+
+	test("skill alias does not spawn without -y", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stderr } = await testCliCommand(["skill"], {
+			...runOptions(home, cwd, bin),
+			code: 1,
+		});
+		expect(stderr).toMatch(/Pass -y to install the default skills/);
+		expect(() => readFileSync(argvFile, "utf8")).toThrow();
+	});
+
 	test("installs named skills and routes platforms to its repo", async ({
 		testCliCommand,
 	}) => {
@@ -290,6 +319,22 @@ describe("neon skills", () => {
 		const { home, cwd, bin, argvFile } = scratch();
 		const { stdout } = await testCliCommand(
 			["skills", "update", "-y"],
+			runOptions(home, cwd, bin),
+		);
+		expect(JSON.parse(stdout)).toEqual([
+			{ scope: "this directory", status: "updated" },
+		]);
+		expect(JSON.parse(readFileSync(argvFile, "utf8"))).toEqual([
+			["-y", "skills", "update", "-p", "-y"],
+		]);
+	});
+
+	test("skill update alias routes to npx skills update -p", async ({
+		testCliCommand,
+	}) => {
+		const { home, cwd, bin, argvFile } = scratch();
+		const { stdout } = await testCliCommand(
+			["skill", "update", "-y"],
 			runOptions(home, cwd, bin),
 		);
 		expect(JSON.parse(stdout)).toEqual([

--- a/packages/cli/src/commands/skills.test.ts
+++ b/packages/cli/src/commands/skills.test.ts
@@ -199,10 +199,12 @@ describe("neon skills", () => {
 		testCliCommand,
 	}) => {
 		const { home, cwd, bin, argvFile } = scratch();
-		const { stdout } = await testCliCommand(
+		const { stdout, stderr } = await testCliCommand(
 			["skill", "-y"],
-			runOptions(home, cwd, bin),
+			runOptions(home, cwd, bin, { NEON_API_KEY: "" }),
 		);
+		expect(stderr).not.toMatch(/Cannot run interactive auth/);
+		expect(stderr).not.toMatch(/Authentication required/);
 		expect(JSON.parse(stdout)[0]).toMatchObject({
 			agents: "cursor",
 			status: "installed",
@@ -217,7 +219,7 @@ describe("neon skills", () => {
 	}) => {
 		const { home, cwd, bin, argvFile } = scratch();
 		const { stderr } = await testCliCommand(["skill"], {
-			...runOptions(home, cwd, bin),
+			...runOptions(home, cwd, bin, { NEON_API_KEY: "" }),
 			code: 1,
 		});
 		expect(stderr).toMatch(/Pass -y to install the default skills/);
@@ -333,10 +335,12 @@ describe("neon skills", () => {
 		testCliCommand,
 	}) => {
 		const { home, cwd, bin, argvFile } = scratch();
-		const { stdout } = await testCliCommand(
+		const { stdout, stderr } = await testCliCommand(
 			["skill", "update", "-y"],
-			runOptions(home, cwd, bin),
+			runOptions(home, cwd, bin, { NEON_API_KEY: "" }),
 		);
+		expect(stderr).not.toMatch(/Cannot run interactive auth/);
+		expect(stderr).not.toMatch(/Authentication required/);
 		expect(JSON.parse(stdout)).toEqual([
 			{ scope: "this directory", status: "updated" },
 		]);

--- a/packages/cli/src/commands/skills.ts
+++ b/packages/cli/src/commands/skills.ts
@@ -88,6 +88,7 @@ const coerceSkills = (value: unknown): string[] => {
 };
 
 export const command = "skills";
+export const aliases = ["skill"];
 export const describe = "Install Neon agent skills into coding agents";
 
 export const builder = (argv: yargs.Argv) =>

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -80,6 +80,8 @@ describe("isSkillsCommand", () => {
 	test("true for skills and skills update", () => {
 		expect(isSkillsCommand({ _: ["skills"] })).toBe(true);
 		expect(isSkillsCommand({ _: ["skills", "update"] })).toBe(true);
+		expect(isSkillsCommand({ _: ["skill"] })).toBe(true);
+		expect(isSkillsCommand({ _: ["skill", "update"] })).toBe(true);
 	});
 
 	test("false for other commands", () => {
@@ -92,6 +94,7 @@ describe("isSkillsCommand", () => {
 describe("isPluginsCommand", () => {
 	test("true for plugins", () => {
 		expect(isPluginsCommand({ _: ["plugins"] })).toBe(true);
+		expect(isPluginsCommand({ _: ["plugin"] })).toBe(true);
 	});
 
 	test("false for other commands", () => {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -104,10 +104,10 @@ export const isMcpCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "mcp";
 
 export const isSkillsCommand = (args: { _: (string | number)[] }): boolean =>
-	args._[0] === "skills";
+	args._[0] === "skills" || args._[0] === "skill";
 
 export const isPluginsCommand = (args: { _: (string | number)[] }): boolean =>
-	args._[0] === "plugins";
+	args._[0] === "plugins" || args._[0] === "plugin";
 
 /** Raw argv is required because auth middleware runs before MCP flags are parsed. */
 export const isMcpOauth = (args: { _: (string | number)[] }): boolean =>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,9 +59,13 @@ const NO_SUBCOMMANDS_VERBS = [
 
 	"mcp",
 
+	// aliases
 	"plugins",
+	"plugin",
 
+	// aliases
 	"skills",
+	"skill",
 
 	"dev",
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -59,11 +59,9 @@ const NO_SUBCOMMANDS_VERBS = [
 
 	"mcp",
 
-	// aliases
 	"plugins",
 	"plugin",
 
-	// aliases
 	"skills",
 	"skill",
 


### PR DESCRIPTION
## Problem

`neon plugin` and `neon skill` exit with `Unknown command`. Every other plural resource command already accepts the singular (`projects`/`project`, `functions`/`function`, `orgs`/`org`).

```
$ neon plugin
ERROR: Unknown command: plugin
```

The help strings already describe a singular product: "Install the Neon plugin into coding agents."

## Diagnosis

yargs leaves the typed verb in `args._[0]`. A command alias that is not also named in `NO_SUBCOMMANDS_VERBS` dumps top-level help instead of running the handler. `isPluginsCommand` / `isSkillsCommand` skip auth and `.neon` enrichment; they have to match the typed verb or `neon plugin` would try to sign in.

The same pairing already exists for `auth`/`login` and `api-keys`/`api-key`.

## The command

Plural stays canonical. The singulars are aliases:

```
$ neon plugin -y
$ neon skill -y
$ neon skill update -y
```

`--help` lists them:

```
neon plugins
└────────────────>    Install the Neon plugin into coding agents [aliases: plugin]
neon skills
└────────────────>    Install Neon agent skills into coding agents [aliases: skill]
```

`neon plugins` and `neon skills` are unchanged. Retry lines and usage stay plural.

## Also in here

Patch changeset for `neon` and `neonctl`.

## Verification

- `plugin -y` and `skill -y` install the same way as the plurals, with no credentials
- Bare `plugin` / `skill` refuse with the no-TTY prompt instead of dumping top-level help
- `skill update -y` routes to the same `npx skills update` as `skills update -y`
- `isPluginsCommand` / `isSkillsCommand` treat both spellings as the same command
- `pnpm exec vitest run src/context.test.ts src/commands/plugins.test.ts src/commands/skills.test.ts`: 80 passed
- Built CLI: `neon plugin` and `neon skill` print the no-TTY error, not `Unknown command`

Not verified: a real interactive TTY session, or a live `npx` marketplace install under the alias (the `-y` tests use a fake npx).

## For your attention

- neon.com docs still show only the plural. The CLI help is the interface that changed.
- `mcp` is already singular. No alias added.
- Canonical names are not flipped. `neon plugins` remains the documented command.