### PR TITLE
chore: release neon@4.11.1 / neonctl@4.11.1

### DIFF
--- a/.changeset/skill-plugin-aliases.md
+++ b/.changeset/skill-plugin-aliases.md
@@ -1,6 +1,0 @@
----
-"neon": patch
-"neonctl": patch
----
-
-`neon skill` and `neon plugin` are aliases of `neon skills` and `neon plugins`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.11.1
+
+### Patch Changes
+
+- 4ddfe65: `neon skill` and `neon plugin` are aliases of `neon skills` and `neon plugins`.
+
 ## 4.11.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.11.0",
+	"version": "4.11.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.11.1
+
+### Patch Changes
+
+- 4ddfe65: `neon skill` and `neon plugin` are aliases of `neon skills` and `neon plugins`.
+- Updated dependencies [4ddfe65]
+  - neon@4.11.1
+
 ## 4.11.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

#514 put `neon skill` and `neon plugin` aliases of `neon skills` and `neon plugins` on `main`. npm still serves `neon@4.11.0` and `neonctl@4.11.0`.

This PR bumps both packages 4.11.0 → 4.11.1 so that patch can publish. The diff is versions, CHANGELOGs and the consumed changeset file.

## Diagnosis

#514 merged with `.changeset/skill-plugin-aliases.md` (`"neon": patch`, `"neonctl": patch`). `changeset version` consumed it and wrote the 4.11.1 CHANGELOG entries. Publish is the post-merge npm workflow.

## The user-facing interface

```
neon skill
neon plugin
neon skill update -y
neon plugin add <name>
```

Those are aliases of `neon skills` and `neon plugins`. Canonical names stay plural. `--plugin` is still a flag error.

## Also in here

- `neonctl@4.11.1` tracks `neon@4.11.1` (`workspace:*`)
- Both CHANGELOGs copy the changeset text, hashed to 4ddfe65 (#514)
- `.changeset/skill-plugin-aliases.md` is deleted

## Verification

- `git diff origin/main...HEAD --stat`: 5 files, +16 −8
- `npm view neon version` and `npm view neonctl version`: 4.11.0
- `packages/cli/package.json` and `packages/neonctl/package.json`: 4.11.1
- `.changeset/`: `README.md` and `config.json` only
- `pnpm lint:ci`: 705 files, no fixes

No tests in this diff. The invocations above are the yargs aliases on `main` from #514.

4.11.1 is live when `npm view neon version` is 4.11.1 and `npm i -g neon@latest` then `neon --version` print 4.11.1.

## For your attention

- Merge lands versions on `main`. It does not publish.
- This PR only versions #514.