### PR TITLE
Add neon ask --prompt for the hosted Neon assistant

### DIFF
--- a/.changeset/cli-ask-prompt.md
+++ b/.changeset/cli-ask-prompt.md
@@ -3,4 +3,4 @@
 "neonctl": minor
 ---
 
-Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login. A TTY shows a spinner, then streams the reply.
+Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login. A TTY shows a spinner, then streams the reply. CLI analytics includes that prompt text.

--- a/.changeset/cli-ask-prompt.md
+++ b/.changeset/cli-ask-prompt.md
@@ -1,0 +1,6 @@
+---
+"neon": minor
+"neonctl": minor
+---
+
+Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login.

--- a/.changeset/cli-ask-prompt.md
+++ b/.changeset/cli-ask-prompt.md
@@ -3,4 +3,4 @@
 "neonctl": minor
 ---
 
-Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login.
+Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login. A TTY shows a spinner, then streams the reply.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1304,7 +1304,7 @@ Global options are supported with any Neon CLI command.
 
 - <a id="analytics"></a>`--analytics`
 
-  Analytics are enabled by default to gather information about the CLI commands and options that are used by our customers. This data collection assists in offering support, and allows for a better understanding of typical usage patterns so that we can improve user experience. Neon does not collect user-defined data, such as project IDs or command payloads. To opt-out of analytics data collection, specify `--no-analytics` or `--analytics false`.
+  Analytics are enabled by default to gather information about the CLI commands and options that are used by our customers. This data collection assists in offering support, and allows for a better understanding of typical usage patterns so that we can improve user experience. Neon does not collect user-defined data, such as project IDs or command payloads, except the question passed to `neon ask --prompt`. To opt-out of analytics data collection, specify `--no-analytics` or `--analytics false`.
 
 - <a id="version"></a>`-v, --version`
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -806,6 +806,19 @@ On a TTY the command asks which agents and which skills, then shows a summary to
 
 Supported agents match `neon mcp`, minus agents that cannot install skills: `antigravity`, `cline`, `cline-cli`, `claude-code`, `claude-desktop`, `codex`, `cursor`, `gemini-cli`, `goose`, `github-copilot-cli`, `grok-build`, `opencode`, `vscode`, `windsurf`, `zed`. `mcporter` is a known MCP name that is then skipped. `neon skills --help` lists the same skill and agent values, and that `-y` leaves out `neon-postgres-agent-platforms`.
 
+## Ask the Neon assistant (`ask`)
+
+`neon ask --prompt` asks the hosted Neon assistant a question about Neon. It does not log in and does not use your Neon account.
+
+```bash
+neon ask --prompt "How do schema-only branches work?"
+neon ask --prompt "How do schema-only branches work?" --output json
+```
+
+Default table output is the assistant's text. `--output json` and `--output yaml` print `{ "text": "…" }`.
+
+The hosted assistant URL can be overridden with `NEON_ASK_URL` (the full `/ask` URL).
+
 ## Install the Neon plugin (`plugins`)
 
 `neon plugins` installs the Neon agent plugin (`neon-postgres`) by running `npx plugins add`. It does not call the Neon API.
@@ -1234,6 +1247,7 @@ Id   Name      Project         Created At            Last Used At          Last 
 | mcp                                                                        |                                                                                                              | Install the Neon MCP server         |
 | plugins                                                                    |                                                                                                              | Install the Neon plugin             |
 | skills                                                                     | `update`                                                                                                     | Install Neon agent skills           |
+| ask                                                                        |                                                                                                              | Ask a question about Neon          |
 | bucket                                                                     | `create`, `list`, `delete`, `object list`, `object get`, `object put`, `object delete` (incl. `--recursive`) | Manage buckets and their objects   |
 | [completion](https://neon.com/docs/reference/cli-completion)               |                                                                                                              | Generate a completion script       |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -817,8 +817,6 @@ neon ask --prompt "How do schema-only branches work?" --output json
 
 Default table output is the assistant's text. `--output json` and `--output yaml` print `{ "text": "…" }`.
 
-The hosted assistant URL can be overridden with `NEON_ASK_URL` (the full `/ask` URL).
-
 ## Install the Neon plugin (`plugins`)
 
 `neon plugins` installs the Neon agent plugin (`neon-postgres`) by running `npx plugins add`. It does not call the Neon API.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -815,7 +815,7 @@ neon ask --prompt "How do schema-only branches work?"
 neon ask --prompt "How do schema-only branches work?" --output json
 ```
 
-Default table output is the assistant's text. `--output json` and `--output yaml` print `{ "text": "…" }`.
+Default table output is the assistant's text. On a TTY that is a spinner, then the streamed reply. `--output json` and `--output yaml` print `{ "text": "…" }` after the full response.
 
 ## Install the Neon plugin (`plugins`)
 

--- a/packages/cli/src/analytics.test.ts
+++ b/packages/cli/src/analytics.test.ts
@@ -175,6 +175,47 @@ describe("getAnalyticsEventProperties", () => {
 		).toBe("secret-value");
 	});
 
+	it("puts the ask prompt on command so existing CLI telemetry can list it", () => {
+		expect(
+			getAnalyticsEventProperties({
+				_: ["ask"],
+				prompt: "How do schema-only branches work?",
+			}).command,
+		).toBe("ask How do schema-only branches work?");
+	});
+
+	it("does not append prompt on a command that is not ask", () => {
+		expect(
+			getAnalyticsEventProperties({
+				_: ["branches", "list"],
+				prompt: "How do schema-only branches work?",
+			}).command,
+		).toBe("branches list");
+	});
+
+	it("does not put the assistant URL on the event", () => {
+		expect(
+			getAnalyticsEventProperties({
+				_: ["ask"],
+				prompt: "How do schema-only branches work?",
+				url: "https://example.invalid/ask",
+			}),
+		).toEqual(
+			expect.not.objectContaining({
+				url: expect.anything(),
+			}),
+		);
+		expect(
+			JSON.stringify(
+				getAnalyticsEventProperties({
+					_: ["ask"],
+					prompt: "How do schema-only branches work?",
+					url: "https://example.invalid/ask",
+				}),
+			),
+		).not.toContain("example.invalid");
+	});
+
 	it("attributes commands run by a coding agent", () => {
 		vi.stubEnv("CODEX_CI", undefined);
 		vi.stubEnv("CODEX_THREAD_ID", undefined);

--- a/packages/cli/src/analytics.ts
+++ b/packages/cli/src/analytics.ts
@@ -115,6 +115,8 @@ type AnalyticsEventArgs = {
 	_: (string | number)[];
 	output?: string;
 	currentBranch?: boolean;
+	prompt?: string;
+	url?: string;
 };
 
 type AnalyticsEventProperties = {
@@ -336,11 +338,19 @@ const getErrorAnalyticsEventContext = (
 	agent: getCliAgent(process.env),
 });
 
+const analyticsCommand = (args: AnalyticsEventArgs): string => {
+	const command = args._.join(" ");
+	if (args._[0] !== "ask" || typeof args.prompt !== "string") {
+		return command;
+	}
+	return `${command} ${args.prompt}`;
+};
+
 export const getAnalyticsEventProperties = (
 	args: AnalyticsEventArgs,
 ): AnalyticsEventProperties => ({
 	version: pkg.version,
-	command: args._.join(" "),
+	command: analyticsCommand(args),
 	flags: {
 		output: args.output,
 	},

--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -116,6 +116,7 @@ describe("neon ask", () => {
 				expect(stdout).toBe(
 					"Schema-only branches copy schema, not data.\n",
 				);
+				expect(stderr).toMatch(/Asking the Neon assistant/);
 				expect(stderr).not.toMatch(/Cannot run interactive auth in CI/);
 				expect(stderr).not.toMatch(/Not Found/);
 			},

--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -248,6 +248,63 @@ describe("neon ask", () => {
 		);
 	});
 
+	test("fails when the sse stream ends without done", async ({
+		testCliCommand,
+	}) => {
+		await withAskServer(
+			(_req, res) => {
+				res.statusCode = 200;
+				res.setHeader("Content-Type", "text/event-stream");
+				res.write('event: text\ndata: {"text":"truncated"}\n\n');
+				res.end();
+			},
+			async (url) => {
+				const { stdout, stderr } = await testCliCommand(
+					["ask", "--prompt", "What is Neon?", "--url", url],
+					{
+						apiKey: false,
+						outputTable: true,
+						snapshot: false,
+						code: 1,
+						env: ASK_ENV,
+					},
+				);
+				expect(stdout).toBe("truncated\n");
+				expect(stderr).toMatch(/unexpected response/);
+			},
+		);
+	});
+
+	test("ends stdout with a newline after a partial sse error", async ({
+		testCliCommand,
+	}) => {
+		await withAskServer(
+			(_req, res) => {
+				res.statusCode = 200;
+				res.setHeader("Content-Type", "text/event-stream");
+				res.write('event: text\ndata: {"text":"partial"}\n\n');
+				res.write(
+					'event: error\ndata: {"error":"The assistant failed."}\n\n',
+				);
+				res.end();
+			},
+			async (url) => {
+				const { stdout, stderr } = await testCliCommand(
+					["ask", "--prompt", "What is Neon?", "--url", url],
+					{
+						apiKey: false,
+						outputTable: true,
+						snapshot: false,
+						code: 1,
+						env: ASK_ENV,
+					},
+				);
+				expect(stdout).toBe("partial\n");
+				expect(stderr).toMatch(/The assistant failed/);
+			},
+		);
+	});
+
 	test("prints the server error on 4xx", async ({ testCliCommand }) => {
 		await withAskServer(
 			(_req, res) => {

--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -80,6 +80,7 @@ describe("neon ask", () => {
 		const seen: Array<{
 			method?: string;
 			authorization: string | undefined;
+			accept: string | undefined;
 			body: unknown;
 		}> = [];
 		await withAskServer(
@@ -87,6 +88,7 @@ describe("neon ask", () => {
 				seen.push({
 					method: req.method,
 					authorization: req.headers.authorization,
+					accept: req.headers.accept,
 					body,
 				});
 				res.statusCode = 200;
@@ -116,7 +118,7 @@ describe("neon ask", () => {
 				expect(stdout).toBe(
 					"Schema-only branches copy schema, not data.\n",
 				);
-				expect(stderr).toMatch(/Asking the Neon assistant/);
+				expect(stderr).not.toMatch(/Asking the Neon assistant/);
 				expect(stderr).not.toMatch(/Cannot run interactive auth in CI/);
 				expect(stderr).not.toMatch(/Not Found/);
 			},
@@ -125,14 +127,17 @@ describe("neon ask", () => {
 			{
 				method: "POST",
 				authorization: undefined,
+				accept: "text/event-stream",
 				body: { prompt: "How do schema-only branches work?" },
 			},
 		]);
 	});
 
 	test("prints json as { text }", async ({ testCliCommand }) => {
+		const seen: string[] = [];
 		await withAskServer(
-			(_req, res) => {
+			(req, res) => {
+				seen.push(String(req.headers.accept));
 				res.statusCode = 200;
 				res.setHeader("Content-Type", "application/json");
 				res.end(JSON.stringify({ text: "A Neon branch is a copy." }));
@@ -152,6 +157,7 @@ describe("neon ask", () => {
 				});
 			},
 		);
+		expect(seen).toEqual(["application/json"]);
 	});
 
 	test("uses NEON_ASK_URL when --url is omitted", async ({
@@ -174,6 +180,70 @@ describe("neon ask", () => {
 					},
 				);
 				expect(stdout).toBe("from-env\n");
+			},
+		);
+	});
+
+	test("streams sse text to stdout", async ({ testCliCommand }) => {
+		await withAskServer(
+			(_req, res) => {
+				res.statusCode = 200;
+				res.setHeader(
+					"Content-Type",
+					"text/event-stream; charset=utf-8",
+				);
+				res.write('event: status\ndata: {"message":"Thinking"}\n\n');
+				res.write("event: ping\ndata: \n\n");
+				res.write('event: text\ndata: {"text":"Schema-only"}\n\n');
+				res.write('event: text\ndata: {"text":" branches."}\n\n');
+				res.write("event: done\ndata: {}\n\n");
+				res.end();
+			},
+			async (url) => {
+				const { stdout, stderr } = await testCliCommand(
+					[
+						"ask",
+						"--prompt",
+						"How do schema-only branches work?",
+						"--url",
+						url,
+					],
+					{
+						apiKey: false,
+						outputTable: true,
+						snapshot: false,
+						env: ASK_ENV,
+					},
+				);
+				expect(stdout).toBe("Schema-only branches.\n");
+				expect(stderr).not.toMatch(/Asking the Neon assistant/);
+			},
+		);
+	});
+
+	test("prints an sse error event", async ({ testCliCommand }) => {
+		await withAskServer(
+			(_req, res) => {
+				res.statusCode = 200;
+				res.setHeader("Content-Type", "text/event-stream");
+				res.write(
+					'event: error\ndata: {"error":"The assistant failed."}\n\n',
+				);
+				res.end();
+			},
+			async (url) => {
+				const { stdout, stderr } = await testCliCommand(
+					["ask", "--prompt", "What is Neon?", "--url", url],
+					{
+						apiKey: false,
+						outputTable: true,
+						snapshot: false,
+						code: 1,
+						env: ASK_ENV,
+					},
+				);
+				expect(stdout).toBe("");
+				expect(stderr).toMatch(/The assistant failed/);
 			},
 		);
 	});

--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -1,0 +1,237 @@
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect } from "vitest";
+
+import { test } from "../test_utils/fixtures.js";
+import { DEFAULT_ASK_URL, resolveAskUrl } from "./ask.js";
+
+const ASK_ENV = { CI: "1" };
+
+async function withAskServer(
+	handler: (req: IncomingMessage, res: ServerResponse, body: unknown) => void,
+	run: (url: string) => Promise<void>,
+): Promise<void> {
+	const server = createServer((req, res) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (chunk: Buffer) => {
+			chunks.push(chunk);
+		});
+		req.on("end", () => {
+			const raw = Buffer.concat(chunks).toString("utf8");
+			let body: unknown;
+			if (raw.trim() !== "") {
+				try {
+					body = JSON.parse(raw);
+				} catch {
+					res.statusCode = 400;
+					res.setHeader("Content-Type", "application/json");
+					res.end(JSON.stringify({ error: "invalid json" }));
+					return;
+				}
+			}
+			handler(req, res, body);
+		});
+	});
+
+	await new Promise<void>((resolve, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolve());
+	});
+	const { port } = server.address() as AddressInfo;
+	try {
+		await run(`http://127.0.0.1:${port}/ask`);
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((err) => (err ? reject(err) : resolve()));
+		});
+	}
+}
+
+describe("resolveAskUrl", () => {
+	test("uses the hosted assistant by default", () => {
+		expect(resolveAskUrl({})).toBe(DEFAULT_ASK_URL);
+		expect(DEFAULT_ASK_URL).toMatch(/\/ask$/);
+	});
+
+	test("prefers --url over NEON_ASK_URL", () => {
+		expect(
+			resolveAskUrl({
+				url: " http://127.0.0.1:9/ask ",
+				envUrl: "https://example.test/ask",
+			}),
+		).toBe("http://127.0.0.1:9/ask");
+	});
+
+	test("uses NEON_ASK_URL when --url is omitted", () => {
+		expect(resolveAskUrl({ envUrl: " https://example.test/ask " })).toBe(
+			"https://example.test/ask",
+		);
+	});
+});
+
+describe("neon ask", () => {
+	test("prints the assistant text without logging in", async ({
+		testCliCommand,
+	}) => {
+		const seen: Array<{
+			method?: string;
+			authorization: string | undefined;
+			body: unknown;
+		}> = [];
+		await withAskServer(
+			(req, res, body) => {
+				seen.push({
+					method: req.method,
+					authorization: req.headers.authorization,
+					body,
+				});
+				res.statusCode = 200;
+				res.setHeader("Content-Type", "application/json");
+				res.end(
+					JSON.stringify({
+						text: "Schema-only branches copy schema, not data.",
+					}),
+				);
+			},
+			async (url) => {
+				const { stdout, stderr } = await testCliCommand(
+					[
+						"ask",
+						"--prompt",
+						"How do schema-only branches work?",
+						"--url",
+						url,
+					],
+					{
+						apiKey: false,
+						outputTable: true,
+						snapshot: false,
+						env: ASK_ENV,
+					},
+				);
+				expect(stdout).toBe(
+					"Schema-only branches copy schema, not data.\n",
+				);
+				expect(stderr).not.toMatch(/Cannot run interactive auth in CI/);
+				expect(stderr).not.toMatch(/Not Found/);
+			},
+		);
+		expect(seen).toEqual([
+			{
+				method: "POST",
+				authorization: undefined,
+				body: { prompt: "How do schema-only branches work?" },
+			},
+		]);
+	});
+
+	test("prints json as { text }", async ({ testCliCommand }) => {
+		await withAskServer(
+			(_req, res) => {
+				res.statusCode = 200;
+				res.setHeader("Content-Type", "application/json");
+				res.end(JSON.stringify({ text: "A Neon branch is a copy." }));
+			},
+			async (url) => {
+				const { stdout } = await testCliCommand(
+					["ask", "--prompt", "What is a branch?", "--url", url],
+					{
+						apiKey: false,
+						output: "json",
+						snapshot: false,
+						env: ASK_ENV,
+					},
+				);
+				expect(JSON.parse(stdout)).toEqual({
+					text: "A Neon branch is a copy.",
+				});
+			},
+		);
+	});
+
+	test("uses NEON_ASK_URL when --url is omitted", async ({
+		testCliCommand,
+	}) => {
+		await withAskServer(
+			(_req, res) => {
+				res.statusCode = 200;
+				res.setHeader("Content-Type", "application/json");
+				res.end(JSON.stringify({ text: "from-env" }));
+			},
+			async (url) => {
+				const { stdout } = await testCliCommand(
+					["ask", "--prompt", "What is Neon?"],
+					{
+						apiKey: false,
+						outputTable: true,
+						snapshot: false,
+						env: { ...ASK_ENV, NEON_ASK_URL: url },
+					},
+				);
+				expect(stdout).toBe("from-env\n");
+			},
+		);
+	});
+
+	test("prints the server error on 4xx", async ({ testCliCommand }) => {
+		await withAskServer(
+			(_req, res) => {
+				res.statusCode = 400;
+				res.setHeader("Content-Type", "application/json");
+				res.end(JSON.stringify({ error: "prompt is required" }));
+			},
+			async (url) => {
+				const { stdout, stderr } = await testCliCommand(
+					["ask", "--prompt", "hello", "--url", url],
+					{
+						apiKey: false,
+						outputTable: true,
+						snapshot: false,
+						code: 1,
+						env: ASK_ENV,
+					},
+				);
+				expect(stdout).toBe("");
+				expect(stderr).toMatch(/prompt is required/);
+			},
+		);
+	});
+
+	test("fails without --prompt", async ({ testCliCommand }) => {
+		const { stdout, stderr } = await testCliCommand(["ask"], {
+			apiKey: false,
+			snapshot: false,
+			code: 1,
+			env: ASK_ENV,
+		});
+		expect(stdout).toBe("");
+		expect(stderr).toMatch(/prompt/i);
+	});
+
+	test("fails on empty --prompt", async ({ testCliCommand }) => {
+		const { stderr } = await testCliCommand(["ask", "--prompt", ""], {
+			apiKey: false,
+			snapshot: false,
+			code: 1,
+			env: ASK_ENV,
+		});
+		expect(stderr).toMatch(/--prompt needs a value/);
+	});
+
+	test("help lists --prompt and not the hosted URL", async ({
+		testCliCommand,
+	}) => {
+		const { stderr } = await testCliCommand(["ask", "--help"], {
+			apiKey: false,
+			snapshot: false,
+			env: ASK_ENV,
+		});
+		expect(stderr).toMatch(/--prompt/);
+		expect(stderr).not.toMatch(/br-frosty-cell/);
+		expect(stderr).not.toMatch(/--url/);
+	});
+});

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -65,7 +65,7 @@ export const handler = async (props: AskProps) => {
 		out: process.stderr,
 		isTty: Boolean(process.stderr.isTTY) && !isCi() && human,
 	});
-	let streamed = false;
+	let streamed = "";
 	try {
 		spinner.start();
 		const text = await askAssistant({
@@ -80,7 +80,7 @@ export const handler = async (props: AskProps) => {
 					return;
 				}
 				spinner.stop();
-				streamed = true;
+				streamed += chunk;
 				writer(props).text(chunk);
 			},
 		});
@@ -89,13 +89,19 @@ export const handler = async (props: AskProps) => {
 			writer(props).end({ text }, { fields: ["text"] });
 			return;
 		}
-		if (!streamed) {
+		if (streamed === "") {
 			writer(props).text(`${text}\n`);
 			return;
 		}
-		if (!text.endsWith("\n")) {
+		if (!streamed.endsWith("\n")) {
 			writer(props).text("\n");
 		}
+	} catch (error) {
+		spinner.stop();
+		if (human && streamed !== "" && !streamed.endsWith("\n")) {
+			writer(props).text("\n");
+		}
+		throw error;
 	} finally {
 		spinner.stop();
 	}
@@ -170,7 +176,7 @@ async function readStreamedAsk(
 				break;
 		}
 	}
-	if (text === "" && !sawDone) {
+	if (!sawDone) {
 		throw new Error("The Neon assistant returned an unexpected response.");
 	}
 	return text;

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -1,10 +1,12 @@
 import type yargs from "yargs";
 
+import { isCi } from "../env.js";
 import { isNetworkError } from "../errors.js";
-import { log } from "../log.js";
 import type { CommonProps } from "../types.js";
 import { noPassthrough, single } from "../utils/flags.js";
 import { writer } from "../writer.js";
+import { isEventStreamContentType, readAskSse } from "./ask_sse.js";
+import { createThinkingSpinner } from "./thinking_spinner.js";
 
 export const DEFAULT_ASK_URL =
 	"https://br-frosty-cell-a5smzg39-assistant.compute.c-1.us-east-2.aws.neon.tech/ask";
@@ -49,18 +51,54 @@ export function resolveAskUrl(opts: { url?: string; envUrl?: string }): string {
 	return DEFAULT_ASK_URL;
 }
 
+function isMachineOutput(output: AskProps["output"]): boolean {
+	return output === "json" || output === "yaml";
+}
+
 export const handler = async (props: AskProps) => {
 	const url = resolveAskUrl({
 		url: props.url,
 		envUrl: process.env.NEON_ASK_URL,
 	});
-	log.info("Asking the Neon assistant.");
-	const text = await askAssistant({ prompt: props.prompt, url });
-	if (props.output === "json" || props.output === "yaml") {
-		writer(props).end({ text }, { fields: ["text"] });
-		return;
+	const human = !isMachineOutput(props.output);
+	const spinner = createThinkingSpinner({
+		out: process.stderr,
+		isTty: Boolean(process.stderr.isTTY) && !isCi() && human,
+	});
+	let streamed = false;
+	try {
+		spinner.start();
+		const text = await askAssistant({
+			prompt: props.prompt,
+			url,
+			acceptEventStream: human,
+			onStatus: (message) => {
+				spinner.setMessage(message);
+			},
+			onText: (chunk) => {
+				if (!human) {
+					return;
+				}
+				spinner.stop();
+				streamed = true;
+				writer(props).text(chunk);
+			},
+		});
+		spinner.stop();
+		if (!human) {
+			writer(props).end({ text }, { fields: ["text"] });
+			return;
+		}
+		if (!streamed) {
+			writer(props).text(`${text}\n`);
+			return;
+		}
+		if (!text.endsWith("\n")) {
+			writer(props).text("\n");
+		}
+	} finally {
+		spinner.stop();
 	}
-	writer(props).text(`${text}\n`);
 };
 
 function isAskTimeout(error: unknown): boolean {
@@ -107,15 +145,54 @@ async function readJsonBody(response: Response): Promise<unknown> {
 	}
 }
 
+async function readStreamedAsk(
+	body: ReadableStream<Uint8Array>,
+	opts: {
+		onStatus?: (message: string) => void;
+		onText?: (text: string) => void;
+	},
+): Promise<string> {
+	let text = "";
+	let sawDone = false;
+	for await (const event of readAskSse(body)) {
+		switch (event.type) {
+			case "status":
+				opts.onStatus?.(event.message);
+				break;
+			case "text":
+				text += event.text;
+				opts.onText?.(event.text);
+				break;
+			case "error":
+				throw new Error(event.error);
+			case "done":
+				sawDone = true;
+				break;
+		}
+	}
+	if (text === "" && !sawDone) {
+		throw new Error("The Neon assistant returned an unexpected response.");
+	}
+	return text;
+}
+
 async function askAssistant(opts: {
 	prompt: string;
 	url: string;
+	acceptEventStream: boolean;
+	onStatus?: (message: string) => void;
+	onText?: (text: string) => void;
 }): Promise<string> {
 	let response: Response;
 	try {
 		response = await fetch(opts.url, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: {
+				"Content-Type": "application/json",
+				Accept: opts.acceptEventStream
+					? "text/event-stream"
+					: "application/json",
+			},
 			body: JSON.stringify({ prompt: opts.prompt }),
 			signal: AbortSignal.timeout(ASK_TIMEOUT_MS),
 		});
@@ -131,9 +208,25 @@ async function askAssistant(opts: {
 		throw error;
 	}
 
-	const body = await readJsonBody(response);
 	if (!response.ok) {
+		const body = await readJsonBody(response);
 		throw new Error(askErrorMessage(body, response.status));
 	}
+
+	if (
+		opts.acceptEventStream &&
+		isEventStreamContentType(
+			response.headers.get("content-type") ?? undefined,
+		)
+	) {
+		if (!response.body) {
+			throw new Error(
+				"The Neon assistant returned an unexpected response.",
+			);
+		}
+		return readStreamedAsk(response.body, opts);
+	}
+
+	const body = await readJsonBody(response);
 	return askText(body);
 }

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -1,0 +1,137 @@
+import type yargs from "yargs";
+
+import { isNetworkError } from "../errors.js";
+import type { CommonProps } from "../types.js";
+import { noPassthrough, single } from "../utils/flags.js";
+import { writer } from "../writer.js";
+
+export const DEFAULT_ASK_URL =
+	"https://br-frosty-cell-a5smzg39-assistant.compute.c-1.us-east-2.aws.neon.tech/ask";
+
+const ASK_TIMEOUT_MS = 120_000;
+
+type AskProps = CommonProps & {
+	prompt: string;
+	url?: string;
+};
+
+export const command = "ask";
+export const describe = "Ask a question about Neon";
+
+export const builder = (argv: yargs.Argv) =>
+	argv
+		.usage("$0 ask --prompt <question>")
+		.option("prompt", {
+			describe: "The question to ask",
+			type: "string",
+			demandOption: true,
+			coerce: single("prompt", { required: true }),
+		})
+		.option("url", {
+			describe: "Override the assistant URL",
+			type: "string",
+			hidden: true,
+			coerce: single("url"),
+		})
+		.strict()
+		.check(noPassthrough("ask"))
+		.example(
+			'$0 ask --prompt "How do schema-only branches work?"',
+			describe,
+		);
+
+export function resolveAskUrl(opts: { url?: string; envUrl?: string }): string {
+	const fromFlag = opts.url?.trim();
+	if (fromFlag) return fromFlag;
+	const fromEnv = opts.envUrl?.trim();
+	if (fromEnv) return fromEnv;
+	return DEFAULT_ASK_URL;
+}
+
+export const handler = async (props: AskProps) => {
+	const url = resolveAskUrl({
+		url: props.url,
+		envUrl: process.env.NEON_ASK_URL,
+	});
+	const text = await askAssistant({ prompt: props.prompt, url });
+	if (props.output === "json" || props.output === "yaml") {
+		writer(props).end({ text }, { fields: ["text"] });
+		return;
+	}
+	writer(props).text(`${text}\n`);
+};
+
+function isAskTimeout(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error.name === "TimeoutError" || error.name === "AbortError")
+	);
+}
+
+function askErrorMessage(body: unknown, status: number): string {
+	if (
+		typeof body === "object" &&
+		body !== null &&
+		"error" in body &&
+		typeof body.error === "string" &&
+		body.error.trim() !== ""
+	) {
+		return body.error;
+	}
+	return `The Neon assistant returned ${status}.`;
+}
+
+function askText(body: unknown): string {
+	if (
+		typeof body === "object" &&
+		body !== null &&
+		"text" in body &&
+		typeof body.text === "string"
+	) {
+		return body.text;
+	}
+	throw new Error("The Neon assistant returned an unexpected response.");
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+	const raw = await response.text();
+	if (raw.trim() === "") {
+		return undefined;
+	}
+	try {
+		return JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+async function askAssistant(opts: {
+	prompt: string;
+	url: string;
+}): Promise<string> {
+	let response: Response;
+	try {
+		response = await fetch(opts.url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ prompt: opts.prompt }),
+			signal: AbortSignal.timeout(ASK_TIMEOUT_MS),
+		});
+	} catch (error) {
+		if (isAskTimeout(error)) {
+			throw new Error("The Neon assistant did not respond in time.");
+		}
+		if (isNetworkError(error)) {
+			throw new Error(
+				"Could not reach the Neon assistant. Check your internet connection and try again.",
+			);
+		}
+		throw error;
+	}
+
+	const body = await readJsonBody(response);
+	if (!response.ok) {
+		throw new Error(askErrorMessage(body, response.status));
+	}
+	return askText(body);
+}

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -1,6 +1,7 @@
 import type yargs from "yargs";
 
 import { isNetworkError } from "../errors.js";
+import { log } from "../log.js";
 import type { CommonProps } from "../types.js";
 import { noPassthrough, single } from "../utils/flags.js";
 import { writer } from "../writer.js";
@@ -53,6 +54,7 @@ export const handler = async (props: AskProps) => {
 		url: props.url,
 		envUrl: process.env.NEON_ASK_URL,
 	});
+	log.info("Asking the Neon assistant.");
 	const text = await askAssistant({ prompt: props.prompt, url });
 	if (props.output === "json" || props.output === "yaml") {
 		writer(props).end({ text }, { fields: ["text"] });

--- a/packages/cli/src/commands/ask_sse.test.ts
+++ b/packages/cli/src/commands/ask_sse.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+
+import { isEventStreamContentType, readAskSse } from "./ask_sse.js";
+
+function streamOf(parts: string[]): ReadableStream<Uint8Array> {
+	const encoder = new TextEncoder();
+	return new ReadableStream({
+		start(controller) {
+			for (const part of parts) {
+				controller.enqueue(encoder.encode(part));
+			}
+			controller.close();
+		},
+	});
+}
+
+async function collect(parts: string[]) {
+	const events = [];
+	for await (const event of readAskSse(streamOf(parts))) {
+		events.push(event);
+	}
+	return events;
+}
+
+describe("isEventStreamContentType", () => {
+	test("matches text/event-stream with parameters", () => {
+		expect(isEventStreamContentType("text/event-stream")).toBe(true);
+		expect(
+			isEventStreamContentType("text/event-stream; charset=utf-8"),
+		).toBe(true);
+		expect(isEventStreamContentType("application/json")).toBe(false);
+		expect(
+			isEventStreamContentType("application/json; charset=utf-8"),
+		).toBe(false);
+		expect(isEventStreamContentType(undefined)).toBe(false);
+	});
+});
+
+describe("readAskSse", () => {
+	test("parses status, text, and done across fragmented chunks", async () => {
+		expect(
+			await collect([
+				'event: status\ndata: {"message":"Thinking"}\n\n',
+				"event: te",
+				'xt\ndata: {"text":"Hello"}\n\n',
+				'event: text\ndata: {"text":" world"}\n\n',
+				"event: done\ndata: {}\n\n",
+			]),
+		).toEqual([
+			{ type: "status", message: "Thinking" },
+			{ type: "text", text: "Hello" },
+			{ type: "text", text: " world" },
+			{ type: "done" },
+		]);
+	});
+
+	test("parses CRLF and ignores ping heartbeats", async () => {
+		expect(
+			await collect([
+				'event: status\r\ndata: {"message":"Thinking"}\r\n\r\n',
+				"event: ping\r\ndata: \r\n\r\n",
+				'event: text\r\ndata: {"text":"ok"}\r\n\r\n',
+				"event: done\r\ndata: {}\r\n\r\n",
+			]),
+		).toEqual([
+			{ type: "status", message: "Thinking" },
+			{ type: "text", text: "ok" },
+			{ type: "done" },
+		]);
+	});
+
+	test("stops on error and redacts empty error text", async () => {
+		expect(
+			await collect([
+				'event: text\ndata: {"text":"partial"}\n\n',
+				'event: error\ndata: {"error":"The assistant failed."}\n\n',
+				'event: text\ndata: {"text":"after"}\n\n',
+			]),
+		).toEqual([
+			{ type: "text", text: "partial" },
+			{ type: "error", error: "The assistant failed." },
+		]);
+	});
+
+	test("decodes UTF-8 split across chunks", async () => {
+		const json = '{"text":"é"}';
+		const encoded = new TextEncoder().encode(
+			`event: text\ndata: ${json}\n\nevent: done\ndata: {}\n\n`,
+		);
+		const splitAt = encoded.indexOf(0xc3) + 1;
+		const first = encoded.slice(0, splitAt);
+		const second = encoded.slice(splitAt);
+		const events = [];
+		for await (const event of readAskSse(
+			new ReadableStream({
+				start(controller) {
+					controller.enqueue(first);
+					controller.enqueue(second);
+					controller.close();
+				},
+			}),
+		)) {
+			events.push(event);
+		}
+		expect(events).toEqual([{ type: "text", text: "é" }, { type: "done" }]);
+	});
+});

--- a/packages/cli/src/commands/ask_sse.ts
+++ b/packages/cli/src/commands/ask_sse.ts
@@ -1,0 +1,148 @@
+export type AskStreamEvent =
+	| { type: "status"; message: string }
+	| { type: "text"; text: string }
+	| { type: "error"; error: string }
+	| { type: "done" };
+
+export function isEventStreamContentType(header: string | undefined): boolean {
+	const media = header?.split(";")[0]?.trim().toLowerCase();
+	return media === "text/event-stream";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}
+
+function parseSseBlock(
+	block: string,
+): { event: string; data: string } | undefined {
+	let event = "message";
+	const dataLines: string[] = [];
+	for (const line of block.split(/\r?\n/)) {
+		if (line === "" || line.startsWith(":")) {
+			continue;
+		}
+		if (line.startsWith("event:")) {
+			event = line.slice("event:".length).trim();
+			continue;
+		}
+		if (line.startsWith("data:")) {
+			dataLines.push(line.slice("data:".length).replace(/^ /, ""));
+		}
+	}
+	if (event === "ping") {
+		return undefined;
+	}
+	if (event === "message" && dataLines.length === 0) {
+		return undefined;
+	}
+	return { event, data: dataLines.join("\n") };
+}
+
+function takeSseBlocks(pending: string): {
+	events: Array<{ event: string; data: string }>;
+	rest: string;
+} {
+	const events: Array<{ event: string; data: string }> = [];
+	let rest = pending;
+	while (true) {
+		const lf = rest.indexOf("\n\n");
+		const crlf = rest.indexOf("\r\n\r\n");
+		let at = -1;
+		let sep = 0;
+		if (lf === -1 && crlf === -1) {
+			break;
+		}
+		if (crlf !== -1 && (lf === -1 || crlf < lf)) {
+			at = crlf;
+			sep = 4;
+		} else {
+			at = lf;
+			sep = 2;
+		}
+		const parsed = parseSseBlock(rest.slice(0, at));
+		rest = rest.slice(at + sep);
+		if (parsed) {
+			events.push(parsed);
+		}
+	}
+	return { events, rest };
+}
+
+function mapAskEvent(raw: {
+	event: string;
+	data: string;
+}): AskStreamEvent | undefined {
+	if (raw.event === "done") {
+		return { type: "done" };
+	}
+	let parsed: unknown;
+	try {
+		parsed = raw.data === "" ? undefined : JSON.parse(raw.data);
+	} catch {
+		return undefined;
+	}
+	if (raw.event === "status") {
+		if (
+			!isRecord(parsed) ||
+			typeof parsed.message !== "string" ||
+			parsed.message === ""
+		) {
+			return undefined;
+		}
+		return { type: "status", message: parsed.message };
+	}
+	if (raw.event === "text") {
+		if (
+			!isRecord(parsed) ||
+			typeof parsed.text !== "string" ||
+			parsed.text === ""
+		) {
+			return undefined;
+		}
+		return { type: "text", text: parsed.text };
+	}
+	if (raw.event === "error") {
+		const error =
+			isRecord(parsed) &&
+			typeof parsed.error === "string" &&
+			parsed.error.trim() !== ""
+				? parsed.error
+				: "The assistant failed.";
+		return { type: "error", error };
+	}
+	return undefined;
+}
+
+export async function* readAskSse(
+	body: ReadableStream<Uint8Array>,
+): AsyncGenerator<AskStreamEvent> {
+	const decoder = new TextDecoder();
+	const reader = body.getReader();
+	let pending = "";
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			pending += decoder.decode(value ?? new Uint8Array(), {
+				stream: !done,
+			});
+			const taken = takeSseBlocks(pending);
+			pending = taken.rest;
+			for (const raw of taken.events) {
+				const event = mapAskEvent(raw);
+				if (!event) {
+					continue;
+				}
+				yield event;
+				if (event.type === "error" || event.type === "done") {
+					return;
+				}
+			}
+			if (done) {
+				break;
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -829,6 +829,44 @@ describe("ensureAuth", () => {
 		expect(props.apiKey).toBe("valid-token");
 	});
 
+	test("should skip global auth for ask command", async ({
+		runMockServer,
+	}) => {
+		const server = await runMockServer("main");
+
+		const credentialsPath = join(configDir, "credentials.json");
+		if (existsSync(credentialsPath)) {
+			rmSync(credentialsPath);
+		}
+
+		const props = {
+			...setupTestProps(server),
+			_: ["ask"],
+		};
+
+		await ensureAuth(props);
+
+		expect(authSpy).not.toHaveBeenCalled();
+		expect(refreshTokenSpy).not.toHaveBeenCalled();
+	});
+
+	test("ask does not refresh or refuse broken stored credentials", async ({
+		runMockServer,
+	}) => {
+		const server = await runMockServer("main");
+		writeFileSync(join(configDir, "credentials.json"), "invalid json", {
+			mode: 0o700,
+		});
+
+		await ensureAuth({
+			...setupTestProps(server),
+			_: ["ask"],
+		});
+
+		expect(authSpy).not.toHaveBeenCalled();
+		expect(refreshTokenSpy).not.toHaveBeenCalled();
+	});
+
 	test("should skip global auth for init command", async ({
 		runMockServer,
 	}) => {

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -450,7 +450,6 @@ export const ensureAuth = async (
 		return;
 	}
 
-	// Public Q&A against the hosted assistant. No Neon account.
 	if (isAskCommand(props)) {
 		return;
 	}

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -45,6 +45,7 @@ import {
 } from "../claimable/state.js";
 import {
 	currentContextFile,
+	isAskCommand,
 	isClaimCommand,
 	isConfigInit,
 	isCurrentBranchProbe,
@@ -446,6 +447,11 @@ export const ensureAuth = async (
 
 	// Neon authentication is unrelated to the child skills and plugins CLIs.
 	if (isSkillsCommand(props) || isPluginsCommand(props)) {
+		return;
+	}
+
+	// Public Q&A against the hosted assistant. No Neon account.
+	if (isAskCommand(props)) {
 		return;
 	}
 

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,5 +1,6 @@
 import * as api from "./api.js";
 import * as apiKeys from "./api_keys.js";
+import * as ask from "./ask.js";
 import * as auth from "./auth.js";
 import * as bootstrap from "./bootstrap.js";
 import * as branches from "./branches.js";
@@ -66,6 +67,7 @@ export default [
 	mcp,
 	plugins,
 	skills,
+	ask,
 	dataApi,
 	functions,
 	dev,

--- a/packages/cli/src/commands/thinking_spinner.test.ts
+++ b/packages/cli/src/commands/thinking_spinner.test.ts
@@ -1,0 +1,47 @@
+import { Writable } from "node:stream";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+import { createThinkingSpinner } from "./thinking_spinner.js";
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+function capture() {
+	const chunks: string[] = [];
+	const out = new Writable({
+		write(chunk, _encoding, callback) {
+			chunks.push(String(chunk));
+			callback();
+		},
+	});
+	return { chunks, out };
+}
+
+describe("createThinkingSpinner", () => {
+	test("paints a TTY line, updates it, and erases on stop", () => {
+		vi.useFakeTimers();
+		const { chunks, out } = capture();
+		const spinner = createThinkingSpinner({ out, isTty: true });
+		spinner.start();
+		expect(chunks.join("")).toMatch(/Thinking/);
+		spinner.setMessage("Searching Neon docs");
+		expect(chunks.join("")).toMatch(/Searching Neon docs/);
+		vi.advanceTimersByTime(80);
+		expect(chunks.join("")).toMatch(/Searching Neon docs/);
+		spinner.stop();
+		expect(chunks.at(-1)).toBe("\r\x1b[2K");
+		const writes = chunks.length;
+		spinner.stop();
+		expect(chunks).toHaveLength(writes);
+	});
+
+	test("writes nothing when the stream is not a TTY", () => {
+		const { chunks, out } = capture();
+		const spinner = createThinkingSpinner({ out, isTty: false });
+		spinner.start();
+		spinner.setMessage("Thinking");
+		spinner.stop();
+		expect(chunks).toEqual([]);
+	});
+});

--- a/packages/cli/src/commands/thinking_spinner.ts
+++ b/packages/cli/src/commands/thinking_spinner.ts
@@ -1,0 +1,49 @@
+const FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const INTERVAL_MS = 80;
+const CLEAR_LINE = "\r\x1b[2K";
+
+export function createThinkingSpinner(opts: {
+	out: NodeJS.WritableStream;
+	isTty: boolean;
+}) {
+	let message = "Thinking";
+	let frame = 0;
+	let timer: ReturnType<typeof setInterval> | undefined;
+	let stopped = false;
+
+	const paint = () => {
+		if (!opts.isTty || stopped) {
+			return;
+		}
+		const glyph = FRAMES[frame % FRAMES.length];
+		frame += 1;
+		opts.out.write(`${CLEAR_LINE}${glyph} ${message}`);
+	};
+
+	return {
+		start() {
+			if (!opts.isTty || stopped) {
+				return;
+			}
+			paint();
+			timer = setInterval(paint, INTERVAL_MS);
+			timer.unref();
+		},
+		setMessage(next: string) {
+			message = next;
+			paint();
+		},
+		stop() {
+			if (stopped) {
+				return;
+			}
+			stopped = true;
+			if (timer) {
+				clearInterval(timer);
+			}
+			if (opts.isTty) {
+				opts.out.write(CLEAR_LINE);
+			}
+		},
+	};
+}

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -13,6 +13,7 @@ import {
 	applyContext,
 	currentContextFile,
 	ensureGitignored,
+	isAskCommand,
 	isCurrentBranchProbe,
 	isMcpOauth,
 	isPluginsCommand,
@@ -88,6 +89,19 @@ describe("isSkillsCommand", () => {
 		expect(isSkillsCommand({ _: ["mcp"] })).toBe(false);
 		expect(isSkillsCommand({ _: ["init"] })).toBe(false);
 		expect(isSkillsCommand({ _: ["plugins"] })).toBe(false);
+	});
+});
+
+describe("isAskCommand", () => {
+	test("true for ask", () => {
+		expect(isAskCommand({ _: ["ask"] })).toBe(true);
+		expect(isAskCommand({ _: ["ask", "extra"] })).toBe(true);
+	});
+
+	test("false for other commands", () => {
+		expect(isAskCommand({ _: ["skills"] })).toBe(false);
+		expect(isAskCommand({ _: ["mcp"] })).toBe(false);
+		expect(isAskCommand({ _: ["init"] })).toBe(false);
 	});
 });
 

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -109,6 +109,9 @@ export const isSkillsCommand = (args: { _: (string | number)[] }): boolean =>
 export const isPluginsCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "plugins" || args._[0] === "plugin";
 
+export const isAskCommand = (args: { _: (string | number)[] }): boolean =>
+	args._[0] === "ask";
+
 /** Raw argv is required because auth middleware runs before MCP flags are parsed. */
 export const isMcpOauth = (args: { _: (string | number)[] }): boolean =>
 	isMcpCommand(args) && argvEnablesMcpOauth(process.argv);
@@ -238,6 +241,10 @@ export const enrichFromContext = (
 		return;
 	}
 	if (isSkillsCommand(args) || isPluginsCommand(args)) {
+		return;
+	}
+	// `ask` is public Q&A. A linked `.neon` must not fill flags it does not have.
+	if (isAskCommand(args)) {
 		return;
 	}
 	// Claim commands bypass enrichment so `claim list` never targets the current directory.

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -243,7 +243,6 @@ export const enrichFromContext = (
 	if (isSkillsCommand(args) || isPluginsCommand(args)) {
 		return;
 	}
-	// `ask` is public Q&A. A linked `.neon` must not fill flags it does not have.
 	if (isAskCommand(args)) {
 		return;
 	}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -65,6 +65,8 @@ const NO_SUBCOMMANDS_VERBS = [
 	"skills",
 	"skill",
 
+	"ask",
+
 	"dev",
 
 	"deploy",


### PR DESCRIPTION
## Problem

People in a terminal need a way to ask the hosted Neon assistant a question about Neon without signing in. Agents that already invoke `neon` need the same.

`neon ask --prompt` POSTs the question to that assistant and prints the reply.

## Diagnosis

Most CLI commands run `ensureAuth` then enrich from `.neon`. The assistant call is a `POST` of `{ "prompt": "<question>" }` to a hosted `/ask` URL, so `ask` returns from those middlewares the same way `skills` and `plugins` do. Tests recorded this request (no login, local server via the hidden URL override):

```
method: POST
authorization: undefined
accept: text/event-stream
body: { prompt: "How do schema-only branches work?" }
```

Invalid `credentials.json` does not start a refresh or refuse the command.

CLI analytics already sends a `command` string on `CLI Started` and `cli_command_success` (for example `branches list`). `ask` writes the question onto that same property:

```
ask How do schema-only branches work?
```

Anything that already lists `command` sees the prompt. `--url` is a hidden override for tests and `NEON_ASK_URL`. It is on the argv type so the payload builder can ignore it; it is not copied onto the event.

## The user-facing interface

```bash
neon ask --prompt "How do schema-only branches work?"
neon ask --prompt "How do schema-only branches work?" --output json
```

| Input | Behavior |
| --- | --- |
| `--prompt` | Required question. Empty or whitespace fails with `--prompt needs a value.` |
| default / table output | Assistant text. Human `Accept: text/event-stream`. |
| `--output json` / `--output yaml` | `{ text }` after the full response. `Accept: application/json`. |
| `--url` | Hidden URL override. Wins over `NEON_ASK_URL`. Not in `--help`. |
| `NEON_ASK_URL` | Override when `--url` is omitted. Not in `--help` or the README `ask` section. |

On a TTY, with table output and not CI, stderr shows a spinner (starts as `Thinking`, then SSE `status` messages) and stdout streams `text` chunks. CI, non-TTY stderr and json/yaml skip the spinner.

Default output from the local-server tests (CI, so no spinner). JSON body from the assistant:

```
Schema-only branches copy schema, not data.
```

SSE `text` chunks `"Schema-only"` then `" branches."`:

```
Schema-only branches.
```

`--output json`:

```json
{
  "text": "A Neon branch is a copy."
}
```

`--output yaml` uses the same `{ text }` object through the existing writer.

SSE: `status` updates the spinner, `text` goes to stdout, `ping` is ignored, a `done` event is required, `error` fails the command. A stream that ends without `done` prints whatever text already arrived, then exits 1 with `The Neon assistant returned an unexpected response.` A `text` chunk followed by `error` also ends stdout with a newline before the failure.

Other errors:

- HTTP 4xx: the server `error` string (test: `prompt is required`)
- missing `--prompt`: yargs, stderr matches `prompt`
- 120s timeout: `The Neon assistant did not respond in time.`
- unreachable host: `Could not reach the Neon assistant. Check your internet connection and try again.`

`--help` lists `--prompt`. It does not list `--url` or the compiled default host (`DEFAULT_ASK_URL` in source).

Existing commands keep the same `command` property. A `prompt` argv on `branches list` stays `branches list`. The README analytics paragraph now states that Neon collects the question passed to `neon ask --prompt`. `--no-analytics` / `--analytics false` opt out.

## Also in here

- SSE reader for `text/event-stream` (LF and CRLF, chunked UTF-8, pings)
- stderr TTY spinner; no writes when the stream is not a TTY
- `ask` on the command list, in `NO_SUBCOMMANDS_VERBS` and in the README command table
- minor changeset for `neon` and `neonctl`

## Verification

Behaviors covered against a local HTTP server, unless noted:

- unauthenticated POST of `{ prompt }`, `Accept: text/event-stream` for default output
- `--output json` is `{ text }` and `Accept: application/json`
- `NEON_ASK_URL` when `--url` is omitted
- SSE text concatenated to stdout with a trailing newline
- SSE `error` exits 1
- SSE without `done` prints the partial text then fails
- partial text plus SSE `error` ends stdout with a newline
- 4xx prints the server `error`
- missing and empty `--prompt` fail
- `--help` includes `--prompt` and leaves out `--url` and the default host
- spinner paints `Thinking`, updates the message and clears the line on a TTY; writes nothing otherwise
- `command` is `ask <question>`; serialized analytics properties do not contain the `--url` value
- `ensureAuth` is a no-op for `ask`, including invalid `credentials.json`

```
pnpm exec vitest run src/analytics.test.ts src/help.test.ts
```

24 passed. The ask, SSE and spinner cases above are the tests added in this diff.

Not run: a live TTY against the hosted assistant, `--output yaml` (same `writer.end({ text })` path as json), delivery of analytics events beyond the property shape.

## For your attention

- The full `--prompt` string becomes `command`, with no truncation. That is user-defined question text. The README discloses it.
- `CLI Error` still has no `command` field. A failed `ask` can already have sent `CLI Started` with the prompt and then an error event without it.
- `--url` and `NEON_ASK_URL` retarget the POST. Both are undocumented in `--help` and the README `ask` section. The default host is `DEFAULT_ASK_URL` in source.