### PR TITLE
chore: release pending changesets

### DIFF
--- a/.changeset/pluggable-function-bundlers.md
+++ b/.changeset/pluggable-function-bundlers.md
@@ -1,9 +1,0 @@
----
-"@neon/config": minor
-"@neon/config-runtime": minor
-"neon": minor
----
-
-Add a per-function `bundler` option so a function's `source` can be shipped without esbuild.
-
-`neon.ts` functions accept `bundler`, defaulting to `"esbuild"`. A directory source is bundled from the first of `index.ts`, `index.js`, `index.mjs`. Set `"none"` to zip a prebuilt directory (or a single `index.mjs` / `index.js` file) as-is. `neon function deploy --no-bundle` is the CLI form. An inline `(fn) => Promise<FunctionBundle>` returns a file map. `externalPackages` remains esbuild-only.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neon-internals/env-core
 
+## 0.0.6
+
+### Patch Changes
+
+- Updated dependencies [59a05ea]
+  - @neon/config@1.1.0
+
 ## 0.0.5
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # neon
 
+## 4.12.0
+
+### Minor Changes
+
+- 59a05ea: Add a per-function `bundler` option so a function's `source` can be shipped without esbuild.
+
+  `neon.ts` functions accept `bundler`, defaulting to `"esbuild"`. A directory source is bundled from the first of `index.ts`, `index.js`, `index.mjs`. Set `"none"` to zip a prebuilt directory (or a single `index.mjs` / `index.js` file) as-is. `neon function deploy --no-bundle` is the CLI form. An inline `(fn) => Promise<FunctionBundle>` returns a file map. `externalPackages` remains esbuild-only.
+
+### Patch Changes
+
+- Updated dependencies [59a05ea]
+  - @neon/config@1.1.0
+  - @neon/config-runtime@1.1.0
+
 ## 4.11.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.11.1",
+	"version": "4.12.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @neondatabase/config-runtime
 
+## 1.1.0
+
+### Minor Changes
+
+- 59a05ea: Add a per-function `bundler` option so a function's `source` can be shipped without esbuild.
+
+  `neon.ts` functions accept `bundler`, defaulting to `"esbuild"`. A directory source is bundled from the first of `index.ts`, `index.js`, `index.mjs`. Set `"none"` to zip a prebuilt directory (or a single `index.mjs` / `index.js` file) as-is. `neon function deploy --no-bundle` is the CLI form. An inline `(fn) => Promise<FunctionBundle>` returns a file map. `externalPackages` remains esbuild-only.
+
+### Patch Changes
+
+- Updated dependencies [59a05ea]
+  - @neon/config@1.1.0
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.0.5",
+	"version": "1.1.0",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @neondatabase/config
 
+## 1.1.0
+
+### Minor Changes
+
+- 59a05ea: Add a per-function `bundler` option so a function's `source` can be shipped without esbuild.
+
+  `neon.ts` functions accept `bundler`, defaulting to `"esbuild"`. A directory source is bundled from the first of `index.ts`, `index.js`, `index.mjs`. Set `"none"` to zip a prebuilt directory (or a single `index.mjs` / `index.js` file) as-is. `neon function deploy --no-bundle` is the CLI form. An inline `(fn) => Promise<FunctionBundle>` returns a file map. `externalPackages` remains esbuild-only.
+
 ## 1.0.5
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.0.5",
+	"version": "1.1.0",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/env
 
+## 1.1.6
+
+### Patch Changes
+
+- Updated dependencies [59a05ea]
+  - @neon/config@1.1.0
+
 ## 1.1.5
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.1.5",
+	"version": "1.1.6",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.12.0
+
+### Patch Changes
+
+- Updated dependencies [59a05ea]
+  - neon@4.12.0
+
 ## 4.11.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.11.1",
+  "version": "4.12.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
Version bump after merging pluggable function bundlers.

- `@neon/config` 1.0.5 → 1.1.0
- `@neon/config-runtime` 1.0.5 → 1.1.0
- `neon` / `neonctl` 4.11.1 → 4.12.0
- `@neon/env` 1.1.5 → 1.1.6 (dependent cascade)
- `@neon-internals/env-core` 0.0.5 → 0.0.6 (dependent cascade, unpublished)

Nothing publishes on merge. Dispatch `neon-pkgs.yml` in `databricks/secure-public-registry-releases-eng` per package after this lands: `@neon/config`, `@neon/config-runtime`, `neon`, `neonctl`.