### PR TITLE
chore: release neon@4.13.0 / neonctl@4.13.0

### DIFF
--- a/.changeset/cli-ask-prompt.md
+++ b/.changeset/cli-ask-prompt.md
@@ -1,6 +1,0 @@
----
-"neon": minor
-"neonctl": minor
----
-
-Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login. A TTY shows a spinner, then streams the reply. CLI analytics includes that prompt text.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.13.0
+
+### Minor Changes
+
+- dab4540: Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login. A TTY shows a spinner, then streams the reply. CLI analytics includes that prompt text.
+
 ## 4.12.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.12.0",
+	"version": "4.13.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.13.0
+
+### Minor Changes
+
+- dab4540: Add `neon ask --prompt` to ask the hosted Neon assistant about Neon, with no login. A TTY shows a spinner, then streams the reply. CLI analytics includes that prompt text.
+
+### Patch Changes
+
+- Updated dependencies [dab4540]
+  - neon@4.13.0
+
 ## 4.12.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.12.0",
+  "version": "4.13.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

`neon ask --prompt` is on `main` from [#516](https://github.com/neondatabase/neon-pkgs/pull/516), while npm still serves version 4.12.0:

```console
$ npm view neon version
4.12.0

$ npm view neonctl version
4.12.0
```

The command needs release metadata on `main` before the separate npm publish workflow can ship it.

## Diagnosis

The feature changeset marked both `neon` and `neonctl` for a minor release. They are a fixed Changesets group and advance together.

This branch consumes that changeset, sets both package versions to 4.13.0 and writes their changelog entries. The CLI implementation remains in the merged feature PR.

## User-facing interface

After 4.13.0 is published:

```console
$ neon ask --prompt "How do schema-only branches work?"
⠋ Thinking
<reply streams as it arrives>
```

The command requires no login. The spinner appears on stderr and clears before the reply streams to stdout.

Machine-readable output waits for the complete reply:

```console
$ neon ask --prompt "How do schema-only branches work?" --output json
{
  "text": "<complete reply>"
}
```

`--output yaml` returns the same `text` field without streaming. CLI analytics includes the prompt text.

## Also in here

- Consumes `.changeset/cli-ask-prompt.md`.
- Records `neon@4.13.0` as the dependency version for the `neonctl` compatibility package.

## Verification

- `pnpm lint:ci`: checked 718 files with no fixes.
- `git diff --check origin/main...HEAD`: no whitespace errors.
- Confirmed npm still serves `neon@4.12.0` and `neonctl@4.12.0`.

Installing 4.13.0 from npm and running the published command remain unverified because the packages have not been published.

## For your attention

Merging this PR lands package versions and changelogs. The manual publish workflow must then publish `neon` first followed by `neonctl`.