### PR TITLE
Deprecate neon-new toward neon claim create

### DIFF
--- a/.changeset/deprecate-neon-new.md
+++ b/.changeset/deprecate-neon-new.md
@@ -1,0 +1,6 @@
+---
+"neon-new": patch
+"vite-plugin-neon-new": patch
+---
+
+Deprecate neon-new and vite-plugin-neon-new. The successor is Claimable Neon in the Neon CLI: `npx neon@latest claim create`.

--- a/README.md
+++ b/README.md
@@ -13,13 +13,6 @@ If you're looking for a single package's docs, see its own `README.md` under `pa
 | `neon` | The Neon CLI. Install this package for the `neon` command. |
 | `neonctl` | Compatibility package that delegates to `neon`. Provides the legacy `neonctl` command (plus `neon`) and is what Homebrew builds from. |
 
-### Provisioning & project setup
-
-| Package | Description |
-| --- | --- |
-| `neon-new` | A CLI tool and SDK for creating claimable Neon databases instantly. |
-| `vite-plugin-neon-new` | A Vite plugin that automatically provisions databases during development. |
-
 ### Config-as-Code (`neon.ts`)
 
 | Package | Description |
@@ -37,7 +30,9 @@ If you're looking for a single package's docs, see its own `README.md` under `pa
 | `@neon/functions` | Runtime helpers for Neon Functions (e.g. a `waitUntil` primitive for deferring work past a response). |
 | `@neon/ai-sdk-provider` | Community [Vercel AI SDK](https://ai-sdk.dev) provider for the Neon AI Gateway. |
 
-A few renamed packages are still published as deprecated aliases (`get-db` / `neondb` → `neon-new`; `vite-plugin-db` / `@neondatabase/vite-plugin-postgres` → `vite-plugin-neon-new`); they re-export the new package and print a deprecation warning. `neonctl` is not deprecated: it is a supported compatibility package that installs and runs `neon`.
+`neon-new` and `vite-plugin-neon-new` are **deprecated**. Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`. The old alias packages (`get-db`, `neondb`, `vite-plugin-db`, `@neondatabase/vite-plugin-postgres`) still re-export them.
+
+`neonctl` is not deprecated: it is a supported compatibility package that installs and runs `neon`.
 
 `neon-init` is **deprecated and no longer built from this repo**. Everything it did is the
 `neon init` command, so the command is `npx neon init`. There is no alias package: it was a

--- a/packages/get-db/README.md
+++ b/packages/get-db/README.md
@@ -6,6 +6,6 @@
 npx neon@latest claim create
 ```
 
-It still works as an alias of `neon-new` and prints a deprecation warning.
+It still works as an alias of `neon-new`. Loading it prints the `neon-new` deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).

--- a/packages/get-db/README.md
+++ b/packages/get-db/README.md
@@ -1,32 +1,11 @@
 # ⚠️ DEPRECATED: get-db
 
-> **This package is deprecated and no longer maintained.** It has been renamed to
-> [`neon-new`](https://www.npmjs.com/package/neon-new). It still works as an alias but prints a
-> deprecation warning at runtime — please migrate.
+> **This package is deprecated and no longer maintained.** Use Claimable Neon in the Neon CLI:
+
+```sh
+npx neon@latest claim create
+```
+
+It still works as an alias of `neon-new` and prints a deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
-
-## Migration
-
-Update your dependency:
-
-```diff
-- "get-db": "^0.x.x"
-+ "neon-new": "^0.x.x"
-```
-
-Update your imports:
-
-```diff
-- import { instantPostgres } from "get-db/sdk";
-+ import { instantPostgres } from "neon-new/sdk";
-```
-
-CLI usage:
-
-```diff
-- npx get-db
-+ npx neon-new
-```
-
-For documentation, see the [`neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/neon-new).

--- a/packages/get-db/package.json
+++ b/packages/get-db/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "get-db",
 	"version": "0.14.2",
-	"description": "[DEPRECATED] This package has been renamed to 'neon-new'. Please use 'neon-new' instead.",
+	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",
 		"database",
@@ -65,5 +65,5 @@
 	"dependencies": {
 		"neon-new": "workspace:*"
 	},
-	"deprecated": "This package has been renamed to 'neon-new'. Please update your dependencies."
+	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create"
 }

--- a/packages/get-db/src/cli.ts
+++ b/packages/get-db/src/cli.ts
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
 
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	"DEPRECATION: get-db is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
-);
-console.warn("");
-
 import { dirname, resolve } from "node:path";
 // Import and run the CLI from neon-new
 import { fileURLToPath } from "node:url";

--- a/packages/get-db/src/cli.ts
+++ b/packages/get-db/src/cli.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
-console.warn("");
 console.warn(
 	"\x1b[33m%s\x1b[0m",
-	'⚠️  DEPRECATION WARNING: The "get-db" package has been renamed to "neon-new".',
+	"DEPRECATION: get-db is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 );
-console.warn("\x1b[33m%s\x1b[0m", '   Please use "neon-new" instead.');
+console.warn("");
 
 import { dirname, resolve } from "node:path";
 // Import and run the CLI from neon-new

--- a/packages/get-db/src/index.ts
+++ b/packages/get-db/src/index.ts
@@ -1,6 +1,5 @@
 /**
- * @deprecated This package has been renamed to "neon-new".
- * Please update your imports: import { instantPostgres } from 'neon-new/sdk'
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 
 // Re-export everything from the lib module

--- a/packages/get-db/src/lib/index.ts
+++ b/packages/get-db/src/lib/index.ts
@@ -2,11 +2,5 @@
  * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	"DEPRECATION: get-db is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
-);
-console.warn("");
-
 // Re-export everything from neon-new
 export * from "neon-new/sdk";

--- a/packages/get-db/src/lib/index.ts
+++ b/packages/get-db/src/lib/index.ts
@@ -1,15 +1,10 @@
 /**
- * @deprecated This package has been renamed to "neon-new".
- * Please update your imports: import { instantPostgres } from 'neon-new/sdk'
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 
 console.warn(
 	"\x1b[33m%s\x1b[0m",
-	'⚠️  DEPRECATION WARNING: The "get-db" package has been renamed to "neon-new".',
-);
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	'   Please update your imports to use "neon-new/sdk" or "neon-new/launchpad" instead.',
+	"DEPRECATION: get-db is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 );
 console.warn("");
 

--- a/packages/neon-new/README.md
+++ b/packages/neon-new/README.md
@@ -14,7 +14,7 @@ Running this package still provisions a neon.new database and prints a deprecati
 npx neon@latest claim create
 ```
 
-Remove the `neon-new` dependency. `claim create` writes `DATABASE_URL` (see `--file`). It does not take `referrer` or `seed`.
+Remove the `neon-new` dependency. `claim create` writes `DATABASE_URL` (see `--file`). It does not take `referrer`, `seed`, `envKey`, or `envPrefix`.
 
 > **Requirements:** Node.js >= 20.19.
 

--- a/packages/neon-new/README.md
+++ b/packages/neon-new/README.md
@@ -14,7 +14,7 @@ Running this package still provisions a neon.new database and prints a deprecati
 npx neon@latest claim create
 ```
 
-Remove the `neon-new` dependency. `claim create` writes `DATABASE_URL` (see `--file`). It does not take `referrer`, `seed`, `envKey`, or `envPrefix`.
+Remove the `neon-new` dependency. `claim create` writes `DATABASE_URL` (see `--file`). It does not take `referrer`, `seed`, `envKey`, `envPrefix`, or `--logical-replication`, and it does not write `DATABASE_URL_DIRECT` or a claim URL env var.
 
 > **Requirements:** Node.js >= 20.19.
 

--- a/packages/neon-new/README.md
+++ b/packages/neon-new/README.md
@@ -8,6 +8,14 @@ npx neon@latest claim create
 
 Running this package still provisions a neon.new database and prints a deprecation warning.
 
+## Migration
+
+```sh
+npx neon@latest claim create
+```
+
+Remove the `neon-new` dependency. `claim create` writes `DATABASE_URL` (see `--file`). It does not take `referrer` or `seed`.
+
 > **Requirements:** Node.js >= 20.19.
 
 ## CLI Usage

--- a/packages/neon-new/README.md
+++ b/packages/neon-new/README.md
@@ -1,8 +1,12 @@
-<h1 align="center">neon-new</h1>
+# ⚠️ DEPRECATED: neon-new
 
-<p align="center">CLI to help you hit the ground running without any sign-up. Instantiate a database with a single-command!</p>
+> **This package is deprecated and no longer maintained.** Use Claimable Neon in the Neon CLI:
 
----
+```sh
+npx neon@latest claim create
+```
+
+Running this package still provisions a neon.new database and prints a deprecation warning.
 
 > **Requirements:** Node.js >= 20.19.
 
@@ -72,7 +76,7 @@ await instantPostgres({
 ### settings Options
 
 | Property            | Type    | Description                    | Default |
-| ------------------- | ------- | ------------------------------ | ------- |
+| -------------------- | ------- | ------------------------------ | ------- |
 | `logicalReplication`| boolean | Enable logical replication     | `false` |
 
 > **Note**: The Vite plugin uses `VITE_` as the default `envPrefix` to match Vite's convention for client-side environment variables.

--- a/packages/neon-new/package.json
+++ b/packages/neon-new/package.json
@@ -1,12 +1,14 @@
 {
 	"name": "neon-new",
 	"version": "0.15.1",
-	"description": "create a claimable Neon database in seconds!",
+	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
+	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",
 		"database",
 		"postgres",
-		"cli"
+		"cli",
+		"deprecated"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/neon-new/src/lib/deprecation.test.ts
+++ b/packages/neon-new/src/lib/deprecation.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { DEPRECATION_MESSAGE, warnDeprecatedOnce } from "./deprecation.js";
+
+describe("deprecation warning", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	test("names the Claimable Neon CLI successor", () => {
+		expect(DEPRECATION_MESSAGE).toContain("npx neon@latest claim create");
+	});
+
+	test("SDK import prints the successor command once", async () => {
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+		await import("./instant-postgres.js");
+		const text = warn.mock.calls.flat().map(String).join("\n");
+		expect(text).toContain("npx neon@latest claim create");
+		const n = warn.mock.calls.length;
+		warnDeprecatedOnce();
+		expect(warn.mock.calls.length).toBe(n);
+	});
+});

--- a/packages/neon-new/src/lib/deprecation.ts
+++ b/packages/neon-new/src/lib/deprecation.ts
@@ -1,0 +1,12 @@
+export const DEPRECATION_MESSAGE =
+	"neon-new and vite-plugin-neon-new are deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create";
+
+let warned = false;
+
+export function warnDeprecatedOnce(): void {
+	if (warned) {
+		return;
+	}
+	warned = true;
+	console.warn(DEPRECATION_MESSAGE);
+}

--- a/packages/neon-new/src/lib/instant-postgres.ts
+++ b/packages/neon-new/src/lib/instant-postgres.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "node:crypto";
 import { log } from "@clack/prompts";
+import { warnDeprecatedOnce } from "./deprecation.js";
 import { seedDatabase } from "./seed-database.js";
 import { messages } from "./texts.js";
 import type { InstantPostgresParams } from "./types.js";
@@ -8,7 +9,10 @@ import { getConnectionStrings } from "./utils/format.js";
 import { writeToEnv } from "./utils/fs.js";
 import { CLAIMABLE_POSTGRES_URLS } from "./utils/urls.js";
 
+warnDeprecatedOnce();
+
 /**
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  * Creates an instant Postgres connection string from Claimable Postgres by Neon
  * if not already set in the specified .env file.
  * Prompts the user to optionally generate a connection string,
@@ -72,13 +76,13 @@ export const instantPostgres = async ({
 };
 
 /**
- * @deprecated Use `instantPostgres` instead
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 export const instantNeon = instantPostgres;
 
 export type { InstantPostgresParams };
 
 /**
- * @deprecated Use `InstantPostgresParams` instead
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 export type InstantNeonParams = InstantPostgresParams;

--- a/packages/neon-new/src/lib/types.ts
+++ b/packages/neon-new/src/lib/types.ts
@@ -4,6 +4,7 @@ export type SqlScript = {
 };
 
 /**
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  * Parameters for configuring Postgres database connection
  * @param {string} dotEnvFile - Path to the .env file where the connection string will be saved
  * @param {string} dotEnvKey - Environment variable name to store the connection string

--- a/packages/neondb/README.md
+++ b/packages/neondb/README.md
@@ -6,6 +6,6 @@
 npx neon@latest claim create
 ```
 
-It still works as an alias of `neon-new` and prints a deprecation warning.
+It still works as an alias of `neon-new`. Loading it prints the `neon-new` deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).

--- a/packages/neondb/README.md
+++ b/packages/neondb/README.md
@@ -1,32 +1,11 @@
 # ⚠️ DEPRECATED: neondb
 
-> **This package is deprecated and no longer maintained.** It has been renamed to
-> [`neon-new`](https://www.npmjs.com/package/neon-new). It still works as an alias but prints a
-> deprecation warning at runtime — please migrate.
+> **This package is deprecated and no longer maintained.** Use Claimable Neon in the Neon CLI:
+
+```sh
+npx neon@latest claim create
+```
+
+It still works as an alias of `neon-new` and prints a deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
-
-## Migration
-
-Update your dependency:
-
-```diff
-- "neondb": "^0.x.x"
-+ "neon-new": "^0.x.x"
-```
-
-CLI usage:
-
-```diff
-- npx neondb
-+ npx neon-new
-```
-
-Update your imports:
-
-```diff
-- import { instantNeon } from "neondb/sdk";
-+ import { instantNeon } from "neon-new/sdk";
-```
-
-For documentation, see the [`neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/neon-new).

--- a/packages/neondb/package.json
+++ b/packages/neondb/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "neondb",
 	"version": "0.14.2",
-	"description": "[DEPRECATED] This package has been renamed to 'neon-new'. Please use 'neon-new' instead.",
+	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",
 		"database",
@@ -65,5 +65,5 @@
 	"dependencies": {
 		"neon-new": "workspace:*"
 	},
-	"deprecated": "This package has been renamed to 'neon-new'. Please update your dependencies."
+	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create"
 }

--- a/packages/neondb/src/cli.ts
+++ b/packages/neondb/src/cli.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
-console.warn("");
 console.warn(
 	"\x1b[33m%s\x1b[0m",
-	'⚠️  DEPRECATION WARNING: The "neondb" package has been renamed to "neon-new".',
+	"DEPRECATION: neondb is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 );
-console.warn("\x1b[33m%s\x1b[0m", '   Please use "neon-new" instead.');
+console.warn("");
 
 import { dirname, resolve } from "node:path";
 // Import and run the CLI from neon-new

--- a/packages/neondb/src/cli.ts
+++ b/packages/neondb/src/cli.ts
@@ -1,11 +1,5 @@
 #!/usr/bin/env node
 
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	"DEPRECATION: neondb is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
-);
-console.warn("");
-
 import { dirname, resolve } from "node:path";
 // Import and run the CLI from neon-new
 import { fileURLToPath } from "node:url";

--- a/packages/neondb/src/index.ts
+++ b/packages/neondb/src/index.ts
@@ -1,6 +1,5 @@
 /**
- * @deprecated This package has been renamed to "neon-new".
- * Please update your imports: import { instantPostgres } from 'neon-new/sdk'
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 
 // Re-export everything from the lib module

--- a/packages/neondb/src/lib/index.ts
+++ b/packages/neondb/src/lib/index.ts
@@ -2,11 +2,5 @@
  * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	"DEPRECATION: neondb is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
-);
-console.warn("");
-
 // Re-export everything from neon-new
 export * from "neon-new/sdk";

--- a/packages/neondb/src/lib/index.ts
+++ b/packages/neondb/src/lib/index.ts
@@ -1,15 +1,10 @@
 /**
- * @deprecated This package has been renamed to "neon-new".
- * Please update your imports: import { instantPostgres } from 'neon-new/sdk'
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 
 console.warn(
 	"\x1b[33m%s\x1b[0m",
-	'⚠️  DEPRECATION WARNING: The "neondb" package has been renamed to "neon-new".',
-);
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	'   Please update your imports to use "neon-new/sdk" or "neon-new/launchpad" instead.',
+	"DEPRECATION: neondb is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 );
 console.warn("");
 

--- a/packages/vite-plugin-db/README.md
+++ b/packages/vite-plugin-db/README.md
@@ -1,25 +1,11 @@
 # ⚠️ DEPRECATED: vite-plugin-db
 
-> **This package is deprecated and no longer maintained.** It has been renamed to
-> [`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new). It still works as an
-> alias but prints a deprecation warning at runtime — please migrate.
+> **This package is deprecated and no longer maintained.** Use Claimable Neon in the Neon CLI:
+
+```sh
+npx neon@latest claim create
+```
+
+It still works as an alias of `vite-plugin-neon-new` and prints a deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
-
-## Migration
-
-Update your dependency:
-
-```diff
-- "vite-plugin-db": "^0.x.x"
-+ "vite-plugin-neon-new": "^0.x.x"
-```
-
-Update your imports:
-
-```diff
-- import { postgres } from "vite-plugin-db";
-+ import { postgres } from "vite-plugin-neon-new";
-```
-
-For documentation, see the [`vite-plugin-neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/vite-plugin-neon-new).

--- a/packages/vite-plugin-db/README.md
+++ b/packages/vite-plugin-db/README.md
@@ -6,6 +6,6 @@
 npx neon@latest claim create
 ```
 
-It still works as an alias of `vite-plugin-neon-new` and prints a deprecation warning.
+It still works as an alias of `vite-plugin-neon-new`. Loading it prints the `neon-new` deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).

--- a/packages/vite-plugin-db/package.json
+++ b/packages/vite-plugin-db/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "vite-plugin-db",
 	"version": "0.8.2",
-	"description": "[DEPRECATED] This package has been renamed to 'vite-plugin-neon-new'. Please use 'vite-plugin-neon-new' instead.",
+	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",
 		"database",
@@ -44,5 +44,5 @@
 	"dependencies": {
 		"vite-plugin-neon-new": "workspace:*"
 	},
-	"deprecated": "This package has been renamed to 'vite-plugin-neon-new'. Please update your dependencies."
+	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create"
 }

--- a/packages/vite-plugin-db/src/index.ts
+++ b/packages/vite-plugin-db/src/index.ts
@@ -1,9 +1,3 @@
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	"DEPRECATION: vite-plugin-db is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
-);
-console.warn("");
-
 /**
  * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */

--- a/packages/vite-plugin-db/src/index.ts
+++ b/packages/vite-plugin-db/src/index.ts
@@ -1,15 +1,10 @@
 console.warn(
 	"\x1b[33m%s\x1b[0m",
-	'⚠️  DEPRECATION WARNING: The "vite-plugin-db" package has been renamed to "vite-plugin-neon-new".',
-);
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	'   Please update your imports to use "vite-plugin-neon-new" instead.',
+	"DEPRECATION: vite-plugin-db is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 );
 console.warn("");
 
 /**
- * @deprecated This package has been renamed to "vite-plugin-neon-new".
- * @see https://www.npmjs.com/package/vite-plugin-neon-new
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 export * from "vite-plugin-neon-new";

--- a/packages/vite-plugin-neon-new/README.md
+++ b/packages/vite-plugin-neon-new/README.md
@@ -1,8 +1,16 @@
-# vite-plugin-neon-new
+# ⚠️ DEPRECATED: vite-plugin-neon-new
+
+> **This package is deprecated and no longer maintained.** Use Claimable Neon in the Neon CLI:
+
+```sh
+npx neon@latest claim create
+```
+
+Loading this plugin still provisions a neon.new database during `vite dev` and prints a deprecation warning.
+
+> **Note:** This package was previously named `vite-plugin-db`.
 
 This Vite plugin instantly provisions a Postgres instance (via Neon) and injects the connection string into your `.env` file, so you can start developing immediately.
-
-> **Note:** This package was previously named `vite-plugin-db`. The old package is now deprecated. If you're upgrading, simply replace it with `vite-plugin-neon-new` in your imports and package.json.
 
 ## How it works
 
@@ -143,6 +151,6 @@ Yes, this plugin is framework-agnostic. The example uses React, but you can use 
 
 ## Advanced
 
-If you want to generate claimable databases outside of Vite, use the [`neon-new`](https://github.com/neondatabase/neon-pkgs/tree/main/packages/neon-new) library directly.
+If you want to generate claimable databases outside of Vite, use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
 
 > See [documentation on Neon](https://neon.com/docs/reference/neon-launchpad) for more.

--- a/packages/vite-plugin-neon-new/README.md
+++ b/packages/vite-plugin-neon-new/README.md
@@ -8,6 +8,14 @@ npx neon@latest claim create
 
 Loading this plugin still provisions a neon.new database during `vite dev` and prints a deprecation warning.
 
+## Migration
+
+```sh
+npx neon@latest claim create
+```
+
+Remove `vite-plugin-neon-new` from `vite.config` and package.json. `vite dev` will not provision a database. `seed`, `envKey`, and `envPrefix` are not `claim create` flags; `--file` picks the dotenv path.
+
 > **Note:** This package was previously named `vite-plugin-db`.
 
 This Vite plugin instantly provisions a Postgres instance (via Neon) and injects the connection string into your `.env` file, so you can start developing immediately.

--- a/packages/vite-plugin-neon-new/README.md
+++ b/packages/vite-plugin-neon-new/README.md
@@ -14,7 +14,7 @@ Loading this plugin still provisions a neon.new database during `vite dev` and p
 npx neon@latest claim create
 ```
 
-Remove `vite-plugin-neon-new` from `vite.config` and package.json. `vite dev` will not provision a database. `referrer`, `seed`, `envKey`, and `envPrefix` are not `claim create` flags; `--file` picks the dotenv path.
+Remove `vite-plugin-neon-new` from `vite.config` and package.json. `vite dev` will not provision a database. `referrer`, `seed`, `envKey`, `envPrefix`, and `logicalReplication` are not `claim create` flags; `--file` picks the dotenv path. It does not write `DATABASE_URL_DIRECT` or a claim URL env var.
 
 > **Note:** This package was previously named `vite-plugin-db`.
 

--- a/packages/vite-plugin-neon-new/README.md
+++ b/packages/vite-plugin-neon-new/README.md
@@ -14,7 +14,7 @@ Loading this plugin still provisions a neon.new database during `vite dev` and p
 npx neon@latest claim create
 ```
 
-Remove `vite-plugin-neon-new` from `vite.config` and package.json. `vite dev` will not provision a database. `seed`, `envKey`, and `envPrefix` are not `claim create` flags; `--file` picks the dotenv path.
+Remove `vite-plugin-neon-new` from `vite.config` and package.json. `vite dev` will not provision a database. `referrer`, `seed`, `envKey`, and `envPrefix` are not `claim create` flags; `--file` picks the dotenv path.
 
 > **Note:** This package was previously named `vite-plugin-db`.
 

--- a/packages/vite-plugin-neon-new/package.json
+++ b/packages/vite-plugin-neon-new/package.json
@@ -1,12 +1,15 @@
 {
 	"name": "vite-plugin-neon-new",
 	"version": "0.9.1",
+	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
+	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",
 		"database",
 		"postgres",
 		"vite",
-		"neon-new"
+		"neon-new",
+		"deprecated"
 	],
 	"type": "module",
 	"license": "Apache-2.0",

--- a/packages/vite-plugin-neon-new/src/index.ts
+++ b/packages/vite-plugin-neon-new/src/index.ts
@@ -29,6 +29,9 @@ type PostgresPluginOptions = {
 
 let claimProcessStarted = false;
 
+/**
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
+ */
 function postgresPlugin(options: PostgresPluginOptions): Plugin {
 	if (!options?.referrer || options.referrer.trim() === "") {
 		throw new Error(

--- a/packages/vite-plugin-postgres/README.md
+++ b/packages/vite-plugin-postgres/README.md
@@ -1,25 +1,11 @@
 # ⚠️ DEPRECATED: @neondatabase/vite-plugin-postgres
 
-> **This package is deprecated and no longer maintained.** It has been renamed to
-> [`vite-plugin-neon-new`](https://www.npmjs.com/package/vite-plugin-neon-new). It still works as an
-> alias but prints a deprecation warning at runtime — please migrate.
+> **This package is deprecated and no longer maintained.** Use Claimable Neon in the Neon CLI:
+
+```sh
+npx neon@latest claim create
+```
+
+It still works as an alias of `vite-plugin-neon-new` and prints a deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).
-
-## Migration
-
-Update your dependency:
-
-```diff
-- "@neondatabase/vite-plugin-postgres": "^0.x.x"
-+ "vite-plugin-neon-new": "^0.x.x"
-```
-
-Update your imports:
-
-```diff
-- import { postgres } from "@neondatabase/vite-plugin-postgres";
-+ import { postgres } from "vite-plugin-neon-new";
-```
-
-For documentation, see the [`vite-plugin-neon-new` README](https://github.com/neondatabase/neon-pkgs/tree/main/packages/vite-plugin-neon-new).

--- a/packages/vite-plugin-postgres/README.md
+++ b/packages/vite-plugin-postgres/README.md
@@ -6,6 +6,6 @@
 npx neon@latest claim create
 ```
 
-It still works as an alias of `vite-plugin-neon-new` and prints a deprecation warning.
+It still works as an alias of `vite-plugin-neon-new`. Loading it prints the `neon-new` deprecation warning.
 
 > **Requirements:** Node.js >= 20.19 (same as the package it forwards to).

--- a/packages/vite-plugin-postgres/package.json
+++ b/packages/vite-plugin-postgres/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@neondatabase/vite-plugin-postgres",
 	"version": "0.8.2",
-	"description": "[DEPRECATED] This package has been renamed to 'vite-plugin-neon-new'. Please use 'vite-plugin-neon-new' instead.",
+	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",
 		"database",
@@ -44,5 +44,5 @@
 	"dependencies": {
 		"vite-plugin-neon-new": "workspace:*"
 	},
-	"deprecated": "This package has been renamed to 'vite-plugin-neon-new'. Please update your dependencies."
+	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create"
 }

--- a/packages/vite-plugin-postgres/src/index.ts
+++ b/packages/vite-plugin-postgres/src/index.ts
@@ -1,15 +1,10 @@
 console.warn(
 	"\x1b[33m%s\x1b[0m",
-	'⚠️  DEPRECATION WARNING: The "@neondatabase/vite-plugin-postgres" package has been renamed to "vite-plugin-neon-new".',
-);
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	'   Please update your imports to use "vite-plugin-neon-new" instead.',
+	"DEPRECATION: @neondatabase/vite-plugin-postgres is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 );
 console.warn("");
 
 /**
- * @deprecated This package has been renamed to "vite-plugin-neon-new".
- * @see https://www.npmjs.com/package/vite-plugin-neon-new
+ * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */
 export * from "vite-plugin-neon-new";

--- a/packages/vite-plugin-postgres/src/index.ts
+++ b/packages/vite-plugin-postgres/src/index.ts
@@ -1,9 +1,3 @@
-console.warn(
-	"\x1b[33m%s\x1b[0m",
-	"DEPRECATION: @neondatabase/vite-plugin-postgres is deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
-);
-console.warn("");
-
 /**
  * @deprecated Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
  */


### PR DESCRIPTION
## Problem

Claimable Neon lives in the Neon CLI (`neon claim create`). `npx neon-new`, `vite-plugin-neon-new`, and the four alias packages still present themselves as the current way to get a throwaway database. Anyone following those READMEs or npm pages lands on neon.new instead of the CLI.

## Diagnosis

`neon-new` and `vite-plugin-neon-new` were still listed as maintained packages. Their npm `deprecated` field was empty. The alias packages (`get-db`, `neondb`, `vite-plugin-db`, `@neondatabase/vite-plugin-postgres`) were already npm-deprecated, but the message told people to switch to `neon-new`.

The successor command on current `neon` is:

```sh
npx neon@latest claim create
```

`npx neon claim create` is not enough: older global installs do not have `claim`.

## Solution

Mark `neon-new` and `vite-plugin-neon-new` deprecated in git (README banner, `package.json` `deprecated` / description, `@deprecated` JSDoc). On load they print one warning per process and still provision a neon.new database.

Alias packages document the same CLI command and re-export without a second warning. Their published tarballs pin `neon-new@0.14.0` / `vite-plugin-neon-new@0.8.0`, so npm users of those aliases will not see the new runtime warning until `npm deprecate`. This PR does not publish aliases; they are not in the secure-publish workflow.

## User-facing API

```sh
npx neon-new --help
# neon-new and vite-plugin-neon-new are deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create
```

```ts
import { instantPostgres } from "neon-new/sdk";
// same warning on import; instantPostgres is @deprecated
```

```ts
import { postgres } from "vite-plugin-neon-new";
// postgres is @deprecated; loading the plugin imports neon-new and warns
```

Migration:

```diff
- npx neon-new --yes
+ npx neon@latest claim create
```

```diff
- postgres({ referrer: "my-app" })
+ // remove the plugin; run `npx neon@latest claim create`
```

`claim create` writes `DATABASE_URL` (`--file` picks the dotenv). It does not take `referrer`, `seed`, `envKey`, `envPrefix`, or logical replication, and it does not write `DATABASE_URL_DIRECT` or a claim URL env var. `vite dev` will not provision after the plugin is removed.

## Verification

- `pnpm --filter neon-new test:ci` (118 tests), including SDK import warning once per process.
- `pnpm --filter neon-new build && node packages/neon-new/dist/cli.js --help` prints the successor line, then yargs help.

## Risks

- This PR does not publish and does not run `npm deprecate`. After merge: dispatch `neon-pkgs.yml` with `package=neon-new` and `package=vite-plugin-neon-new` (explicit choice; dry-run skips packages with a `deprecated` field), then `npm deprecate <pkg>@'*' '...'` for those two, the four aliases, and `instagres`.
- `instagres` is not in this repo.