### PR TITLE
Send x-neon-source: cli on neon ask

### DIFF
--- a/packages/cli/src/commands/ask.test.ts
+++ b/packages/cli/src/commands/ask.test.ts
@@ -81,6 +81,7 @@ describe("neon ask", () => {
 			method?: string;
 			authorization: string | undefined;
 			accept: string | undefined;
+			source: string | undefined;
 			body: unknown;
 		}> = [];
 		await withAskServer(
@@ -89,6 +90,10 @@ describe("neon ask", () => {
 					method: req.method,
 					authorization: req.headers.authorization,
 					accept: req.headers.accept,
+					source:
+						typeof req.headers["x-neon-source"] === "string"
+							? req.headers["x-neon-source"]
+							: undefined,
 					body,
 				});
 				res.statusCode = 200;
@@ -128,6 +133,7 @@ describe("neon ask", () => {
 				method: "POST",
 				authorization: undefined,
 				accept: "text/event-stream",
+				source: "cli",
 				body: { prompt: "How do schema-only branches work?" },
 			},
 		]);

--- a/packages/cli/src/commands/ask.ts
+++ b/packages/cli/src/commands/ask.ts
@@ -198,6 +198,7 @@ async function askAssistant(opts: {
 				Accept: opts.acceptEventStream
 					? "text/event-stream"
 					: "application/json",
+				"x-neon-source": "cli",
 			},
 			body: JSON.stringify({ prompt: opts.prompt }),
 			signal: AbortSignal.timeout(ASK_TIMEOUT_MS),


### PR DESCRIPTION
## Problem

`neon ask` POSTs to the hosted assistant at `/ask`. Other HTTP clients can POST to the same path. The request never named the caller, so the assistant could not tell a CLI invocation from another HTTP client.

## Diagnosis

`askAssistant` already sends `Content-Type: application/json`, an `Accept` of `text/event-stream` or `application/json` and a `{ prompt }` JSON body. Those fields describe the payload. They don't name the client.

A request header is visible to whoever handles `POST /ask`. Setting `x-neon-source: cli` on that existing `fetch` is the change.

## The user-facing interface

Invocation is unchanged:

```bash
neon ask --prompt "How do schema-only branches work?"
```

The POST now includes this header on every call. Default (human) output:

```js
headers: {
  "Content-Type": "application/json",
  Accept: "text/event-stream",
  "x-neon-source": "cli",
}
body: JSON.stringify({ prompt: "How do schema-only branches work?" })
```

`-o json` and `-o yaml` use the same header with `Accept: "application/json"`.

```bash
curl -X POST "$ASK_URL" \
  -H "Content-Type: application/json" \
  -H "Accept: text/event-stream" \
  -H "x-neon-source: cli" \
  -d '{"prompt":"How do schema-only branches work?"}'
```

`--url` and `NEON_ASK_URL` still override the URL and still send `x-neon-source: cli`. Flags, stdout and exit codes match `main`.

## Verification

```bash
pnpm exec vitest run src/commands/ask.test.ts
```

Ran from `packages/cli` on `2626e00` (base `origin/main` `896aec9`). 14 passed.

Behaviors covered:

- `neon ask --prompt ... --url <local>` POSTs `{ prompt }` with `x-neon-source: cli` and `Accept: text/event-stream`
- `-o json` still sends `Accept: application/json`
- `NEON_ASK_URL` still selects the URL
- SSE text/status/done, SSE errors, 4xx, missing `--prompt`, empty `--prompt` and help still pass

The `-o json` test doesn't assert `x-neon-source`. The header is set on the shared `fetch`, so it is sent; that test only checks `Accept`.

Not verified against a live hosted `/ask`. The local server records what the CLI sent. What the production assistant does with the header is outside this repo.

## For your attention

- The value is the literal string `cli`. There is no flag to change it. URL overrides send the same header.
- No changeset. CLI users see the same command and output. The header ships in the next `neon` release that includes this commit.
- Other `/ask` clients are unchanged here. Their own `x-neon-source` values would be a change on those clients.