### PR TITLE
chore: release neon-new@0.15.2 / vite-plugin-neon-new@0.9.2

### DIFF
--- a/.changeset/deprecate-neon-new.md
+++ b/.changeset/deprecate-neon-new.md
@@ -1,6 +1,0 @@
----
-"neon-new": patch
-"vite-plugin-neon-new": patch
----
-
-Deprecate neon-new and vite-plugin-neon-new. The successor is Claimable Neon in the Neon CLI: `npx neon@latest claim create`.

--- a/packages/get-db/CHANGELOG.md
+++ b/packages/get-db/CHANGELOG.md
@@ -1,5 +1,12 @@
 # get-db
 
+## 0.14.3
+
+### Patch Changes
+
+- Updated dependencies [8c482b4]
+  - neon-new@0.15.2
+
 ## 0.14.2
 
 ### Patch Changes

--- a/packages/get-db/package.json
+++ b/packages/get-db/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "get-db",
-	"version": "0.14.2",
+	"version": "0.14.3",
 	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",

--- a/packages/neon-new/CHANGELOG.md
+++ b/packages/neon-new/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon-new
 
+## 0.15.2
+
+### Patch Changes
+
+- 8c482b4: Deprecate neon-new and vite-plugin-neon-new. The successor is Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
+
 ## 0.15.1
 
 ### Patch Changes

--- a/packages/neon-new/package.json
+++ b/packages/neon-new/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon-new",
-	"version": "0.15.1",
+	"version": "0.15.2",
 	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [

--- a/packages/neondb/CHANGELOG.md
+++ b/packages/neondb/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neondb
 
+## 0.14.3
+
+### Patch Changes
+
+- Updated dependencies [8c482b4]
+  - neon-new@0.15.2
+
 ## 0.14.2
 
 ### Patch Changes

--- a/packages/neondb/package.json
+++ b/packages/neondb/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neondb",
-	"version": "0.14.2",
+	"version": "0.14.3",
 	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",

--- a/packages/vite-plugin-db/CHANGELOG.md
+++ b/packages/vite-plugin-db/CHANGELOG.md
@@ -1,5 +1,12 @@
 # vite-plugin-db
 
+## 0.8.3
+
+### Patch Changes
+
+- Updated dependencies [8c482b4]
+  - vite-plugin-neon-new@0.9.2
+
 ## 0.8.2
 
 ### Patch Changes

--- a/packages/vite-plugin-db/package.json
+++ b/packages/vite-plugin-db/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-db",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",

--- a/packages/vite-plugin-neon-new/CHANGELOG.md
+++ b/packages/vite-plugin-neon-new/CHANGELOG.md
@@ -1,5 +1,13 @@
 # vite-plugin-neon-new
 
+## 0.9.2
+
+### Patch Changes
+
+- 8c482b4: Deprecate neon-new and vite-plugin-neon-new. The successor is Claimable Neon in the Neon CLI: `npx neon@latest claim create`.
+- Updated dependencies [8c482b4]
+  - neon-new@0.15.2
+
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/vite-plugin-neon-new/package.json
+++ b/packages/vite-plugin-neon-new/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vite-plugin-neon-new",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"deprecated": "Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [

--- a/packages/vite-plugin-postgres/CHANGELOG.md
+++ b/packages/vite-plugin-postgres/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/vite-plugin-postgres
 
+## 0.8.3
+
+### Patch Changes
+
+- Updated dependencies [8c482b4]
+  - vite-plugin-neon-new@0.9.2
+
 ## 0.8.2
 
 ### Patch Changes

--- a/packages/vite-plugin-postgres/package.json
+++ b/packages/vite-plugin-postgres/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neondatabase/vite-plugin-postgres",
-	"version": "0.8.2",
+	"version": "0.8.3",
 	"description": "[DEPRECATED] Use Claimable Neon in the Neon CLI: npx neon@latest claim create",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Problem

Deprecation of `neon-new` and `vite-plugin-neon-new` is on `main` from [#519](https://github.com/neondatabase/neon-pkgs/pull/519). npm still serves the versions that do not carry that deprecation:

```console
$ npm view neon-new version
0.15.1

$ npm view vite-plugin-neon-new version
0.9.1
```

Those packages need release metadata on `main` before the separate npm publish workflow can ship them.

## Diagnosis

The feature changeset marked both packages for a patch release. This branch consumes that changeset, sets `neon-new` to 0.15.2 and `vite-plugin-neon-new` to 0.9.2, and writes their changelog entries. The deprecation implementation remains in the merged feature PR.

## User-facing interface

After 0.15.2 / 0.9.2 are published, installing either package still provisions a neon.new database, and prints this once per process:

```text
Deprecated. Use Claimable Neon in the Neon CLI: npx neon@latest claim create
```

The successor command:

```console
npx neon@latest claim create
```

## Also in here

- Consumes `.changeset/deprecate-neon-new.md`.
- Records `neon-new@0.15.2` as the dependency version for `vite-plugin-neon-new`.
- Changesets also patch-bumped the deprecated aliases (`get-db` 0.14.2 → 0.14.3, `neondb` 0.14.2 → 0.14.3, `vite-plugin-db` 0.8.2 → 0.8.3, `@neondatabase/vite-plugin-postgres` 0.8.2 → 0.8.3). Those aliases are not published from this release.

## Verification

- `pnpm lint:ci`: checked 720 files with no fixes.
- Confirmed npm still serves `neon-new@0.15.1` and `vite-plugin-neon-new@0.9.1`.

Installing 0.15.2 / 0.9.2 from npm remains unverified because the packages have not been published.

## For your attention

Merging this PR lands package versions and changelogs. The manual publish workflow must then publish `neon-new` first, then `vite-plugin-neon-new`.