### PR TITLE
Distinguish neon deploy from neon functions deploy in --help

### DIFF
--- a/.changeset/deploy-help-env.md
+++ b/.changeset/deploy-help-env.md
@@ -1,0 +1,7 @@
+---
+"neon": patch
+"neonctl": patch
+"@neon/config": patch
+---
+
+`neon deploy --help` and `neon functions deploy --help` now say which command is the neon.ts full deploy and which is the manual/targeted path, and that `neon deploy --env` is a .env file. An unset Function env value in neon.ts tells you to set it or omit the key, not to coerce with `?? ""`.

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -684,7 +684,7 @@ describe("config commands", () => {
 		const config = writeConfig(
 			`export default { preview: { functions: { hello: { name: 'Hello', source: ${JSON.stringify(
 				source,
-			)}, env: { resendApiKey: process.env.RESEND_API_KEY ?? '' } } } } };\n`,
+			)}, env: { resendApiKey: process.env.RESEND_API_KEY } } } } };\n`,
 		);
 		const envFile = join(cwd, ".env.deploy");
 		writeFileSync(envFile, "RESEND_API_KEY=re_from_file\n");

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -175,7 +175,8 @@ export const envFlag = {
 	env: {
 		describe:
 			"Path to a .env file to load into the environment before evaluating neon.ts " +
-			"(so function env values resolve from it). Existing env vars are not overridden.",
+			"so Function env values resolve from it. Existing env vars are not overridden. " +
+			"Every key declared in neon.ts must be set in this file or the environment.",
 		type: "string",
 	},
 } as const;

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -176,7 +176,7 @@ export const envFlag = {
 		describe:
 			"Path to a .env file to load into the environment before evaluating neon.ts " +
 			"so Function env values resolve from it. Existing env vars are not overridden. " +
-			"Every key declared in neon.ts must be set in this file or the environment.",
+			"Function env values that read process.env must be set in this file or the environment.",
 		type: "string",
 	},
 } as const;

--- a/packages/cli/src/commands/deploy.test.ts
+++ b/packages/cli/src/commands/deploy.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect } from "vitest";
+import { test } from "../test_utils/fixtures";
+
+describe("deploy", () => {
+	test("help distinguishes neon deploy from neon functions deploy", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["deploy", "--help"], {
+			mockDir: "single_org",
+			snapshot: false,
+			stderr: expect.stringContaining(
+				"Use neon deploy with a neon.ts file for a full deployment",
+			),
+		});
+		await testCliCommand(["deploy", "--help"], {
+			mockDir: "single_org",
+			snapshot: false,
+			stderr: expect.stringContaining(
+				"neon deploy --env <file> loads that .env file",
+			),
+		});
+	});
+});

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -8,6 +8,7 @@ import {
 	envFlag,
 	envPullFlag,
 } from "./config.js";
+import { DEPLOY_COMMANDS_EPILOGUE } from "./deploy_help.js";
 
 export const command = "deploy";
 export const describe =
@@ -34,6 +35,7 @@ export const builder = (argv: yargs.Argv) =>
 			...envPullFlag,
 		})
 		.middleware(fillSingleProject as any)
+		.epilogue(DEPLOY_COMMANDS_EPILOGUE)
 		.strict();
 
 export const handler = (props: ConfigProps) => applyCmd(props);

--- a/packages/cli/src/commands/deploy_help.ts
+++ b/packages/cli/src/commands/deploy_help.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared --help footer for `neon deploy` and `neon functions deploy`. The two
+ * commands overlap in name and both take `--env`, with different meanings.
+ */
+export const DEPLOY_COMMANDS_EPILOGUE = [
+	"",
+	"Use neon deploy with a neon.ts file for a full deployment (declared services and functions).",
+	"Use neon functions deploy to deploy one function manually, including a targeted env update.",
+	"neon deploy --env <file> loads that .env file so neon.ts can read Function env from it.",
+	"neon functions deploy --env is KEY=VALUE (repeatable), not a file path.",
+].join("\n");

--- a/packages/cli/src/commands/deploy_help.ts
+++ b/packages/cli/src/commands/deploy_help.ts
@@ -1,7 +1,3 @@
-/**
- * Shared --help footer for `neon deploy` and `neon functions deploy`. The two
- * commands overlap in name and both take `--env`, with different meanings.
- */
 export const DEPLOY_COMMANDS_EPILOGUE = [
 	"",
 	"Use neon deploy with a neon.ts file for a full deployment (declared services and functions).",

--- a/packages/cli/src/commands/functions.test.ts
+++ b/packages/cli/src/commands/functions.test.ts
@@ -16,6 +16,25 @@ afterAll(() => {
 });
 
 describe("functions", () => {
+	test("deploy --help distinguishes neon deploy from neon functions deploy", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["functions", "deploy", "--help"], {
+			mockDir: "single_org",
+			snapshot: false,
+			stderr: expect.stringContaining(
+				"Use neon functions deploy to deploy one function manually",
+			),
+		});
+		await testCliCommand(["functions", "deploy", "--help"], {
+			mockDir: "single_org",
+			snapshot: false,
+			stderr: expect.stringContaining(
+				"neon functions deploy --env is KEY=VALUE",
+			),
+		});
+	});
+
 	test("deploy --no-wait", async ({ testCliCommand }) => {
 		await testCliCommand(
 			[

--- a/packages/cli/src/commands/functions.ts
+++ b/packages/cli/src/commands/functions.ts
@@ -25,6 +25,7 @@ import { branchIdFromProps, fillSingleProject } from "../utils/enrichers.js";
 import { bundleEntry } from "../utils/esbuild.js";
 import { zipBundle } from "../utils/zip.js";
 import { writer } from "../writer.js";
+import { DEPLOY_COMMANDS_EPILOGUE } from "./deploy_help.js";
 
 const FUNCTION_FIELDS = [
 	"slug",
@@ -160,7 +161,8 @@ export const builder = (argv: yargs.Argv) =>
 							type: "boolean",
 							default: true,
 						},
-					}),
+					})
+					.epilogue(DEPLOY_COMMANDS_EPILOGUE),
 			(args) => deploy(args as any),
 		)
 		.command(

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -432,6 +432,8 @@ describe("resolveConfig", () => {
 		expect(issue).toContain('function "hello"');
 		// …explains the likely cause + a fix…
 		expect(issue).toContain("process.env");
+		expect(issue).toContain("omit the key from neon.ts");
+		expect(issue).not.toContain('?? ""');
 		// …and drops zod's opaque default.
 		expect(issue).not.toContain(
 			"Invalid input: expected string, received undefined",

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -404,6 +404,8 @@ describe("configInputSchema", () => {
 		expect(formatted).toContain('function "hello"');
 		// …explains the likely cause and the fix…
 		expect(formatted).toContain("process.env");
+		expect(formatted).toContain("omit the key from neon.ts");
+		expect(formatted).not.toContain('?? ""');
 		// …and drops zod's opaque default.
 		expect(formatted).not.toContain(
 			"Invalid input: expected string, received undefined",

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -180,7 +180,7 @@ const functionEnvValueSchema = z.string({
 				: key !== undefined
 					? `Environment variable "${key}"`
 					: "An environment variable";
-		return `${subject} is undefined — its value (typically a \`process.env.*\`) is unset. Set it (e.g. add it to your .env) or provide a fallback like \`process.env.X ?? ""\`.`;
+		return `${subject} is undefined — its value (typically a \`process.env.*\`) is unset. Set it (for example \`neon deploy --env <file>\`) or omit the key from neon.ts if you do not want to write it. Do not coerce a missing value to an empty string: that uploads and deletes the live key.`;
 	},
 });
 

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -368,10 +368,8 @@ export interface FunctionDef {
 	/**
 	 * Environment variables injected into the deployed function, keyed by the var name the
 	 * function reads at runtime. The **keys** are static (preserved at the type level so
-	 * `parseEnv(config, "<slug>").function.<key>` is typed); the **values** are arbitrary
-	 * strings evaluated when `neon.ts` is loaded and uploaded at `config apply`. An unset
-	 * `process.env.X` fails validation. Omit the key to leave the live value unchanged;
-	 * an empty string deletes it.
+	 * `parseEnv(config, "<slug>").function.<key>` is typed). An unset `process.env.X`
+	 * fails validation. Omit a key to preserve its deployed value; an empty string deletes it.
 	 * @example { resendApiKey: process.env.RESEND_API_KEY! }
 	 */
 	env?: Record<string, string>;

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -369,11 +369,10 @@ export interface FunctionDef {
 	 * Environment variables injected into the deployed function, keyed by the var name the
 	 * function reads at runtime. The **keys** are static (preserved at the type level so
 	 * `parseEnv(config, "<slug>").function.<key>` is typed); the **values** are arbitrary
-	 * strings evaluated when `neon.ts` is loaded (typically `process.env.X`) and uploaded
-	 * at `config apply`. Every value must be a defined string — a `process.env.X` that is
-	 * `undefined` (unset) errors at validation time rather than silently shipping
-	 * `undefined`.
-	 * @example { resendApiKey: process.env.RESEND_API_KEY ?? "" }
+	 * strings evaluated when `neon.ts` is loaded and uploaded at `config apply`. An unset
+	 * `process.env.X` fails validation. Omit the key to leave the live value unchanged;
+	 * an empty string deletes it.
+	 * @example { resendApiKey: process.env.RESEND_API_KEY! }
 	 */
 	env?: Record<string, string>;
 	/**


### PR DESCRIPTION
## Problem

`neon deploy` and `neon functions deploy` both take `--env`. One flag is a `.env` file loaded before evaluating neon.ts. The other is repeatable `KEY=VALUE` on a single function.

Each `--help` listed its own `--env` and stopped. There was no pointer to the other command.

When a Function env value in neon.ts was unset, validation already failed. The failure text and the `FunctionDef.env` JSDoc example told you to write `process.env.X ?? ""`. Empty string is a defined `string`, so it passes validation, gets uploaded and deletes the live key.

## Diagnosis

`neon deploy` is an alias for `config apply`. `--env` is a file path; existing process env is not overridden.

`neon functions deploy` deploys one function from a local directory. `--env` is parsed as `KEY=VALUE`.

The flag lines already differed. The mix-up is across commands. Passing `.env` to `neon functions deploy --env` fails `KEY=VALUE` parsing. Passing `KEY=VALUE` to `neon deploy --env` is treated as a file path.

`process.env.X` is `string | undefined` and `env` values must be `string`. That is why the JSDoc example used `?? ""`. The `!` assertion keeps the type and leaves an unset value as `undefined`, which the schema still rejects.

## User-facing interface

### CLI

Invocations are unchanged:

```bash
neon deploy --env .env
neon functions deploy hello --env RESEND_API_KEY=re_xxx
```

`neon deploy --help` now describes `--env` as:

```
Path to a .env file to load into the environment before evaluating neon.ts so Function env values resolve from it. Existing env vars are not overridden. Function env values that read process.env must be set in this file or the environment.
```

The last sentence documents existing `defineConfig` validation. It does not add a check. `neon functions deploy --help` still describes `--env` as `Environment variable as KEY=VALUE (repeatable)`.

Both `--help` screens now end with:

```
Use neon deploy with a neon.ts file for a full deployment (declared services and functions).
Use neon functions deploy to deploy one function manually, including a targeted env update.
neon deploy --env <file> loads that .env file so neon.ts can read Function env from it.
neon functions deploy --env is KEY=VALUE (repeatable), not a file path.
```

Existing `neon deploy` and `neon functions deploy` callers keep the same flags, types and runtime behavior.

### `@neon/config`

```ts
env: { resendApiKey: process.env.RESEND_API_KEY! }
```

Omit the key to leave the deployed value. An empty string deletes it.

Unset env, `defineConfig` throws:

```
Invalid Neon config:
  - preview.functions.hello.env.test: Environment variable "test" for function "hello" is undefined — its value (typically a `process.env.*`) is unset. Set it (for example `neon deploy --env <file>`) or omit the key from neon.ts if you do not want to write it. Do not coerce a missing value to an empty string: that uploads and deletes the live key.
```

The previous close was: `Set it (e.g. add it to your .env) or provide a fallback like \`process.env.X ?? ""\`.`

## Also in here

- `envFlag` is shared with `neon config plan` and `neon config apply`, so those `--help` screens get the new `--env` describe. They do not get the four-line paragraph.
- The `config apply --env` fixture reads `process.env.RESEND_API_KEY` with no `?? ""`.
- Patch changeset for `neon`, `neonctl` and `@neon/config`. `neonctl` is the compatibility binary that depends on `neon`.

## Verification

`docs/deploy-help` at `067048b` vs `origin/main` at `c31b22a`.

- `pnpm --filter neon build`
- `node packages/cli/dist/index.js --no-analytics --no-color deploy --help`
- `node packages/cli/dist/index.js --no-analytics --no-color functions deploy --help`
- `pnpm --filter neon exec vitest run src/commands/deploy.test.ts src/commands/functions.test.ts src/commands/config.test.ts` — 3 files, 82 passed
- `pnpm --filter @neon/config exec vitest run src/lib/schema.test.ts src/lib/define-config.test.ts` — 2 files, 109 passed

Behaviors covered:

- `neon deploy --help` includes the full-deploy line and `neon deploy --env <file>`
- `neon functions deploy --help` includes the manual-deploy line and `neon functions deploy --env is KEY=VALUE`
- unset Function env copy includes `omit the key from neon.ts` and does not include `?? ""`

No live Function was deployed in this pass.

## For your attention

- The four-line paragraph is on `neon deploy` and `neon functions deploy` only. `neon config apply` is the same full deploy under another name and does not get it.
- `process.env.RESEND_API_KEY!` still fails validation when the var is unset. The `!` satisfies TypeScript; the schema is what stops the upload.
