### PR TITLE
chore: release neon@4.13.1 / neonctl@4.13.1

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.13.1
+
+### Patch Changes
+
+- `neon ask` sends `x-neon-source: cli` on POST `/ask`.
+
 ## 4.13.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.13.0",
+	"version": "4.13.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.13.1
+
+### Patch Changes
+
+- `neon ask` sends `x-neon-source: cli` on POST `/ask`.
+- Updated dependencies
+  - neon@4.13.1
+
 ## 4.13.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.13.0",
+  "version": "4.13.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Problem

`neon ask` on `main` now sends `x-neon-source: cli` ([#520](https://github.com/neondatabase/neon-pkgs/pull/520)). npm still serves 4.13.0:

```console
$ npm view neon version
4.13.0

$ npm view neonctl version
4.13.0
```

The header needs release metadata on `main` before the npm publish workflow can ship it.

## Diagnosis

A patch changeset marked both `neon` and `neonctl`. They are a fixed Changesets group and advance together.

This branch consumes that changeset, sets both package versions to 4.13.1, and writes their changelog entries. The header itself remains in the merged feature PR.

## User-facing interface

Invocation is unchanged:

```console
$ neon ask --prompt "How do schema-only branches work?"
```

The POST to `/ask` now includes:

```http
x-neon-source: cli
```

`-o json` and `-o yaml` send the same header with `Accept: application/json`. `--url` and `NEON_ASK_URL` still override the URL and still send the header. Flags, stdout, and exit codes match 4.13.0.

## Also in here

- Consumes `.changeset/ask-source-header.md`.
- Records `neon@4.13.1` as the dependency version for the `neonctl` compatibility package.

## Verification

- `pnpm lint:ci`: checked 720 files with no fixes.
- Confirmed npm still serves `neon@4.13.0` and `neonctl@4.13.0`.

Installing 4.13.1 from npm and running the published command remain unverified because the packages have not been published.

## For your attention

Merging this PR lands package versions and changelogs. The manual publish workflow must then publish `neon` first, then `neonctl`.