### PR TITLE
Honor dataApi: false on deploy and send neon.ts Data API on claim create

### DIFF
--- a/.changeset/data-api-claimable-lifecycle.md
+++ b/.changeset/data-api-claimable-lifecycle.md
@@ -1,0 +1,7 @@
+---
+"@neon/config": minor
+"@neon/config-runtime": minor
+"neon": minor
+---
+
+`neon.ts` `dataApi: false` disables the Data API on deploy. `neon claim create` sends the Data API create body from neon.ts, including an external JWKS.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -78,9 +78,12 @@ neon claim create --service auth --service data-api
 ```
 
 When the current directory has a `neon.ts`, `claim create` also requests every service
-declared there. Explicit `--service` values are added to that set. Object Storage, Functions,
-and the AI Gateway are sent to the service so demand is recorded, but are reported as
-unavailable until the project is claimed; the CLI does not silently remove them.
+declared there. Explicit `--service` values are added to that set. If that policy enables
+the Data API, the identity request includes the provider, JWKS URL, and settings so the
+first enable is correct (`--service data-api` without a neon.ts Data API block does not
+send those fields). Object Storage, Functions, and the AI Gateway are sent to the service
+so demand is recorded, but are reported as unavailable until the project is claimed; the
+CLI does not silently remove them.
 
 The command writes:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -79,11 +79,30 @@ neon claim create --service auth --service data-api
 
 When the current directory has a `neon.ts`, `claim create` also requests every service
 declared there. Explicit `--service` values are added to that set. If that policy enables
-the Data API, the identity request includes the provider, JWKS URL, and settings so the
-first enable is correct (`--service data-api` without a neon.ts Data API block does not
-send those fields). Object Storage, Functions, and the AI Gateway are sent to the service
-so demand is recorded, but are reported as unavailable until the project is claimed; the
-CLI does not silently remove them.
+the Data API, identity includes a snake_case `data_api` object. A neon.ts with
+`dataApi: { authProvider: "external", jwksUrl: "https://idp.example.com/jwks.json" }`
+sends:
+
+```json
+{
+  "type": "anonymous",
+  "capabilities": ["postgres", "data_api"],
+  "data_api": {
+    "auth_provider": "external",
+    "jwks_url": "https://idp.example.com/jwks.json"
+  }
+}
+```
+
+`neon claim create --service data-api` with no neon.ts Data API block omits `data_api`:
+
+```json
+{ "type": "anonymous", "capabilities": ["postgres", "data_api"] }
+```
+
+Object Storage, Functions, and the AI Gateway are sent to the service so demand is
+recorded, but are reported as unavailable until the project is claimed; the CLI does
+not silently remove them.
 
 The command writes:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -87,6 +87,7 @@ sends:
 {
   "type": "anonymous",
   "capabilities": ["postgres", "data_api"],
+  "source": "neon_cli",
   "data_api": {
     "auth_provider": "external",
     "jwks_url": "https://idp.example.com/jwks.json"
@@ -97,7 +98,11 @@ sends:
 `neon claim create --service data-api` with no neon.ts Data API block omits `data_api`:
 
 ```json
-{ "type": "anonymous", "capabilities": ["postgres", "data_api"] }
+{
+  "type": "anonymous",
+  "capabilities": ["postgres", "data_api"],
+  "source": "neon_cli"
+}
 ```
 
 Object Storage, Functions, and the AI Gateway are sent to the service so demand is

--- a/packages/cli/src/claimable/api.ts
+++ b/packages/cli/src/claimable/api.ts
@@ -365,6 +365,13 @@ export class ClaimableClient {
 	async register(input: {
 		capabilities: readonly ClaimableCapability[];
 		source: string;
+		dataApi?: {
+			auth_provider: "neon_auth" | "external";
+			jwks_url?: string;
+			provider_name?: string;
+			jwt_audience?: string;
+			settings?: Record<string, unknown>;
+		};
 	}): Promise<Registration> {
 		return parseRegistrationResponse(
 			await this.request("/v1/agent/identity", {
@@ -373,6 +380,9 @@ export class ClaimableClient {
 					type: "anonymous",
 					capabilities: input.capabilities,
 					source: input.source,
+					...(input.dataApi !== undefined
+						? { data_api: input.dataApi }
+						: {}),
 				},
 			}),
 		);

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -21,7 +21,11 @@ import {
 	type StoredClaimableCredentials,
 	writeClaimableCredentials,
 } from "../claimable/state.js";
-import { declaredNeonServices } from "../config_services.js";
+import {
+	type ClaimableDataApiCreateBody,
+	claimableDataApiCreateBody,
+	declaredNeonServices,
+} from "../config_services.js";
 import {
 	applyContext,
 	contextBranch,
@@ -58,6 +62,7 @@ type CreateProps = ClaimProps & {
 	config?: string;
 	file?: string;
 	envPull: boolean;
+	dataApi?: ClaimableDataApiCreateBody;
 };
 
 type AcceptProps = ClaimProps & {
@@ -140,13 +145,11 @@ export const findNeonConfig = (cwd = process.cwd()): string | undefined => {
 	}
 };
 
-const servicesFromConfig = async (
-	explicitPath: string | undefined,
-): Promise<NeonService[]> => {
+const loadCreatePolicy = async (explicitPath: string | undefined) => {
 	const path = explicitPath ?? findNeonConfig();
-	if (!path) return [];
+	if (!path) return undefined;
 	const { config } = await loadConfigFromFile({ path });
-	return declaredNeonServices(config);
+	return config;
 };
 
 const removeFileIfPresent = (path: string): void => {
@@ -252,14 +255,21 @@ export const builder = (argv: yargs.Argv) =>
 								),
 						})
 					: [];
-				const configuredServices = await servicesFromConfig(
+				const policy = await loadCreatePolicy(
 					typeof args.config === "string" ? args.config : undefined,
 				);
+				const configuredServices = policy
+					? declaredNeonServices(policy)
+					: [];
+				const dataApi = policy
+					? claimableDataApiCreateBody(policy)
+					: undefined;
 				await create({
 					...(args as unknown as CreateProps),
 					services: [
 						...new Set([...services, ...configuredServices]),
 					],
+					...(dataApi ? { dataApi } : {}),
 				});
 			},
 		)
@@ -420,6 +430,7 @@ const create = async (props: CreateProps): Promise<void> => {
 	const registration = await client.register({
 		capabilities: claimableCapabilities(props.services ?? []),
 		source: "neon_cli",
+		...(props.dataApi ? { dataApi: props.dataApi } : {}),
 	});
 	const stored: StoredClaimableCredentials = {
 		version: 1,

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -198,6 +198,8 @@ class FakeNeonApi implements NeonApi {
 		throw new Error("not implemented");
 	}
 
+	async deleteProjectBranchDataApi(): Promise<void> {}
+
 	async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
 		return [];
 	}

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -154,6 +154,7 @@ class FakeNeonApi implements NeonApi {
 	async updateProjectBranchDataApi(): Promise<NeonDataApiSnapshot> {
 		throw new Error("not implemented");
 	}
+	async deleteProjectBranchDataApi(): Promise<void> {}
 	async listBranchBuckets(): Promise<NeonBucketSnapshot[]> {
 		return [];
 	}

--- a/packages/cli/src/config_services.test.ts
+++ b/packages/cli/src/config_services.test.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "@neon/config-runtime";
 import { describe, expect, it } from "vitest";
-import { declaredNeonServices } from "./config_services.js";
+import {
+	claimableDataApiCreateBody,
+	declaredNeonServices,
+} from "./config_services.js";
 
 describe("declaredNeonServices", () => {
 	it("maps every static neon.ts service without adding Postgres", () => {
@@ -41,5 +44,60 @@ describe("declaredNeonServices", () => {
 		});
 
 		expect(declaredNeonServices(config)).toEqual([]);
+	});
+});
+
+describe("claimableDataApiCreateBody", () => {
+	it("omits the body when Data API is off or absent", () => {
+		expect(claimableDataApiCreateBody(defineConfig({}))).toBeUndefined();
+		expect(
+			claimableDataApiCreateBody(defineConfig({ dataApi: false })),
+		).toBeUndefined();
+	});
+
+	it("maps neon Auth and settings to snake_case", () => {
+		expect(
+			claimableDataApiCreateBody(
+				defineConfig({ auth: true, dataApi: true }),
+			),
+		).toEqual({ auth_provider: "neon_auth" });
+		expect(
+			claimableDataApiCreateBody(
+				defineConfig({
+					auth: true,
+					dataApi: {
+						settings: { dbMaxRows: 50, dbAnonRole: "anonymous" },
+					},
+				}),
+			),
+		).toEqual({
+			auth_provider: "neon_auth",
+			settings: { db_max_rows: 50, db_anon_role: "anonymous" },
+		});
+	});
+
+	it("requires jwksUrl for an external provider", () => {
+		expect(
+			claimableDataApiCreateBody(
+				defineConfig({
+					dataApi: {
+						authProvider: "external",
+						jwksUrl: "https://idp.example.com/jwks.json",
+						providerName: "Clerk",
+					},
+				}),
+			),
+		).toEqual({
+			auth_provider: "external",
+			jwks_url: "https://idp.example.com/jwks.json",
+			provider_name: "Clerk",
+		});
+		expect(() =>
+			claimableDataApiCreateBody(
+				defineConfig({
+					dataApi: { authProvider: "external" },
+				}),
+			),
+		).toThrow(/jwksUrl/);
 	});
 });

--- a/packages/cli/src/config_services.ts
+++ b/packages/cli/src/config_services.ts
@@ -1,3 +1,4 @@
+import type { DataApiSettings } from "@neon/config";
 import type { Config } from "@neon/config-runtime";
 import type { NeonService } from "./neon_services.js";
 
@@ -24,4 +25,87 @@ export const declaredNeonServices = (config: Config): NeonService[] => {
 		services.push("ai-gateway");
 	}
 	return services;
+};
+
+export type ClaimableDataApiCreateBody = {
+	auth_provider: "neon_auth" | "external";
+	jwks_url?: string;
+	provider_name?: string;
+	jwt_audience?: string;
+	settings?: Record<string, unknown>;
+};
+
+const dataApiSettingsToSnake = (
+	settings: DataApiSettings,
+): Record<string, unknown> => {
+	const out: Record<string, unknown> = {};
+	if (settings.dbAggregatesEnabled !== undefined) {
+		out.db_aggregates_enabled = settings.dbAggregatesEnabled;
+	}
+	if (settings.dbAnonRole !== undefined) {
+		out.db_anon_role = settings.dbAnonRole;
+	}
+	if (settings.dbExtraSearchPath !== undefined) {
+		out.db_extra_search_path = settings.dbExtraSearchPath;
+	}
+	if (settings.dbMaxRows !== undefined) {
+		out.db_max_rows = settings.dbMaxRows;
+	}
+	if (settings.dbSchemas !== undefined) {
+		out.db_schemas = settings.dbSchemas;
+	}
+	if (settings.jwtRoleClaimKey !== undefined) {
+		out.jwt_role_claim_key = settings.jwtRoleClaimKey;
+	}
+	if (settings.jwtCacheMaxLifetime !== undefined) {
+		out.jwt_cache_max_lifetime = settings.jwtCacheMaxLifetime;
+	}
+	if (settings.openapiMode !== undefined) {
+		out.openapi_mode = settings.openapiMode;
+	}
+	if (settings.serverCorsAllowedOrigins !== undefined) {
+		out.server_cors_allowed_origins = settings.serverCorsAllowedOrigins;
+	}
+	if (settings.serverTimingEnabled !== undefined) {
+		out.server_timing_enabled = settings.serverTimingEnabled;
+	}
+	return out;
+};
+
+/** Omitting this body preserves the server heuristic used by `--service data-api`. */
+export const claimableDataApiCreateBody = (
+	config: Config,
+): ClaimableDataApiCreateBody | undefined => {
+	if (!isToggleEnabled(config.dataApi)) return undefined;
+	const input = config.dataApi;
+	if (typeof input !== "object") {
+		return { auth_provider: "neon_auth" };
+	}
+	const settings = input.settings
+		? dataApiSettingsToSnake(input.settings)
+		: undefined;
+	const withSettings = (
+		body: ClaimableDataApiCreateBody,
+	): ClaimableDataApiCreateBody =>
+		settings && Object.keys(settings).length > 0
+			? { ...body, settings }
+			: body;
+	if (input.authProvider === "external") {
+		if (input.jwksUrl === undefined || input.jwksUrl.length === 0) {
+			throw new Error(
+				'neon.ts dataApi.authProvider "external" requires dataApi.jwksUrl.',
+			);
+		}
+		return withSettings({
+			auth_provider: "external",
+			jwks_url: input.jwksUrl,
+			...(input.providerName !== undefined
+				? { provider_name: input.providerName }
+				: {}),
+			...(input.jwtAudience !== undefined
+				? { jwt_audience: input.jwtAudience }
+				: {}),
+		});
+	}
+	return withSettings({ auth_provider: "neon_auth" });
 };

--- a/packages/cli/src/dev/env.test.ts
+++ b/packages/cli/src/dev/env.test.ts
@@ -189,6 +189,8 @@ class FakeNeonApi implements NeonApi {
 		throw new Error("not implemented");
 	}
 
+	async deleteProjectBranchDataApi(): Promise<void> {}
+
 	async listBranchBuckets(
 		projectId: string,
 		branchId: string,

--- a/packages/cli/src/utils/config_diff.test.ts
+++ b/packages/cli/src/utils/config_diff.test.ts
@@ -202,4 +202,14 @@ describe("renderAppliedChanges", () => {
 		expect(text).not.toContain("invocationUrl");
 		expect(text).not.toContain("https://");
 	});
+
+	it("renders a Data API disable as a - line", () => {
+		const changes: AppliedChange[] = [
+			{ kind: "service", action: "delete", identifier: "dataApi" },
+		];
+		const text = renderAppliedChanges(changes, "Applied changes", {
+			color: false,
+		});
+		expect(text.split("\n")[1]).toBe("  - Data API");
+	});
 });

--- a/packages/cli/src/utils/config_diff.ts
+++ b/packages/cli/src/utils/config_diff.ts
@@ -167,18 +167,6 @@ const appliedBranchFields = (change: AppliedChange): FieldChange[] => {
 	}
 };
 
-/**
- * Render the applied (or planned) changes as a `git diff`-style list:
- *
- * - **Service changes** (auth / Data API / buckets / functions) are additions
- *   with no meaningful "before", so they list as green `+ <label>` lines
- *   (`~ <label>` for the lone Data API settings *update*).
- * - **Branch setting changes** group per branch and render as sorted
- *   `field → value` lines under a `~ <branch>` header.
- *
- * Returns "" when there is nothing to show. Pure — callers own the heading
- * spacing and any surrounding summary.
- */
 export const renderAppliedChanges = (
 	changes: AppliedChange[],
 	title: string,
@@ -193,10 +181,20 @@ export const renderAppliedChanges = (
 		.sort((a, b) => a.identifier.localeCompare(b.identifier));
 	for (const service of services) {
 		const label = serviceLabel(service.identifier);
-		lines.push(
+		const line =
 			service.action === "create"
-				? `  ${paint.added(`+ ${label}`)}`
-				: `  ${paint.arrow(`~ ${label}`)}`,
+				? `+ ${label}`
+				: service.action === "delete"
+					? `- ${label}`
+					: `~ ${label}`;
+		lines.push(
+			`  ${
+				service.action === "create"
+					? paint.added(line)
+					: service.action === "delete"
+						? paint.removed(line)
+						: paint.arrow(line)
+			}`,
 		);
 	}
 

--- a/packages/config-runtime/README.md
+++ b/packages/config-runtime/README.md
@@ -29,3 +29,5 @@ import { inspect, plan, apply } from "@neon/config-runtime/v1";
 ```
 
 See [`@neon/config`](../config) for authoring the `neon.ts` policy these operate on.
+`apply` / `pushConfig` treat explicit `dataApi: false` as a Data API delete (override).
+Omitting `dataApi` leaves an existing integration alone.

--- a/packages/config-runtime/src/lib/fake-neon-api.ts
+++ b/packages/config-runtime/src/lib/fake-neon-api.ts
@@ -527,6 +527,20 @@ export class FakeNeonApi implements NeonApi {
 		return clone(updated);
 	}
 
+	async deleteProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+	): Promise<void> {
+		this.history.push({
+			method: "deleteProjectBranchDataApi",
+			args: [projectId, branchId, databaseName],
+		});
+		this.requireProject(projectId);
+		this.requireBranch(projectId, branchId);
+		this.neonDataApi.delete(`${projectId}:${branchId}:${databaseName}`);
+	}
+
 	/** Test helper: attach a Neon Auth integration to a branch. */
 	seedNeonAuth(
 		projectId: string,

--- a/packages/config-runtime/src/lib/push-config.test.ts
+++ b/packages/config-runtime/src/lib/push-config.test.ts
@@ -173,6 +173,121 @@ describe("pushConfig", () => {
 		);
 	});
 
+	test("explicit dataApi false deletes an existing integration with --update-existing", async () => {
+		const seedEnabled = () => {
+			const { api, projectId } = seededFake();
+			api.seedNeonDataApi("proj-push", "br-main", "neondb", {
+				url: "https://br-main.fake.neon.tech/data-api/neondb",
+				status: "ready",
+			});
+			return { api, projectId };
+		};
+		const config = defineConfig({ dataApi: false });
+
+		await expect(
+			pushConfig(config, {
+				...seedEnabled(),
+				branchId: "br-main",
+			}),
+		).rejects.toBeInstanceOf(PushConflictError);
+
+		const withFlag = seedEnabled();
+		const result = await pushConfig(config, {
+			api: withFlag.api,
+			projectId: withFlag.projectId,
+			branchId: "br-main",
+			updateExisting: true,
+		});
+		expect(
+			withFlag.api.history.some(
+				(h) => h.method === "deleteProjectBranchDataApi",
+			),
+		).toBe(true);
+		expect(result.applied).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "service",
+					action: "delete",
+					identifier: "dataApi",
+				}),
+			]),
+		);
+
+		const declined = seedEnabled();
+		await expect(
+			pushConfig(config, {
+				api: declined.api,
+				projectId: declined.projectId,
+				branchId: "br-main",
+				confirm: () => false,
+			}),
+		).rejects.toMatchObject({ code: ErrorCode.PushAborted });
+		expect(
+			declined.api.history.some(
+				(h) => h.method === "deleteProjectBranchDataApi",
+			),
+		).toBe(false);
+
+		const accepted = seedEnabled();
+		await pushConfig(config, {
+			api: accepted.api,
+			projectId: accepted.projectId,
+			branchId: "br-main",
+			confirm: () => true,
+		});
+		expect(
+			accepted.api.history.some(
+				(h) => h.method === "deleteProjectBranchDataApi",
+			),
+		).toBe(true);
+
+		const dry = seedEnabled();
+		const planned = await pushConfig(config, {
+			api: dry.api,
+			projectId: dry.projectId,
+			branchId: "br-main",
+			updateExisting: true,
+			dryRun: true,
+		});
+		expect(
+			dry.api.history.some(
+				(h) => h.method === "deleteProjectBranchDataApi",
+			),
+		).toBe(false);
+		expect(planned.applied).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					kind: "service",
+					action: "delete",
+					identifier: "dataApi",
+				}),
+			]),
+		);
+	});
+
+	test("omitted dataApi leaves an existing integration alone", async () => {
+		const { api, projectId } = seededFake();
+		api.seedNeonDataApi("proj-push", "br-main", "neondb", {
+			url: "https://br-main.fake.neon.tech/data-api/neondb",
+			status: "ready",
+		});
+		const result = await pushConfig(defineConfig({}), {
+			api,
+			projectId,
+			branchId: "br-main",
+			updateExisting: true,
+		});
+		expect(api.history.some((h) => h.method === "getNeonDataApi")).toBe(
+			false,
+		);
+		expect(
+			api.history.some((h) => h.method === "deleteProjectBranchDataApi"),
+		).toBe(false);
+		expect(result.applied.some((c) => c.identifier === "dataApi")).toBe(
+			false,
+		);
+	});
+
 	test("auth/dataApi changes carry no redundant details (target branch / derived db)", async () => {
 		const config = defineConfig({ auth: {}, dataApi: {} });
 

--- a/packages/config-runtime/src/lib/push-config.ts
+++ b/packages/config-runtime/src/lib/push-config.ts
@@ -178,7 +178,8 @@ export async function pushConfig(
 		projectId: remoteProject.id,
 		branch,
 		wantsAuth: resolved.authEnabled,
-		wantsDataApi: resolved.dataApiEnabled,
+		wantsDataApi:
+			resolved.dataApiEnabled || resolved.dataApiPolicy === "disabled",
 	});
 	const remote: RemoteState = {
 		projectId: remoteProject.id,
@@ -288,16 +289,13 @@ export async function pushConfig(
 	return result;
 }
 
-/**
- * `update-*` plan steps mutate existing remote state. `enable-*` steps are additive (no
- * existing resource to override) and never trigger the override-confirm prompt.
- */
 function isOverrideStep(step: PlanStep): boolean {
 	return (
 		step.kind === "update-branch-ttl" ||
 		step.kind === "update-branch-protected" ||
 		step.kind === "update-endpoint" ||
-		step.kind === "update-data-api"
+		step.kind === "update-data-api" ||
+		step.kind === "disable-data-api"
 	);
 }
 
@@ -348,6 +346,8 @@ function synthesizeAppliedChange(step: PlanStep): AppliedChange {
 				identifier: "dataApi",
 				details: { field: "settings", settings: step.settings },
 			};
+		case "disable-data-api":
+			return { kind: "service", action: "delete", identifier: "dataApi" };
 		case "create-bucket":
 			return {
 				kind: "service",
@@ -589,6 +589,18 @@ async function applyStep(
 				action: "update",
 				identifier: "dataApi",
 				details: { field: "settings", settings: step.settings },
+			};
+		}
+		case "disable-data-api": {
+			await ctx.api.deleteProjectBranchDataApi(
+				ctx.remoteProjectId,
+				step.branchId,
+				step.databaseName,
+			);
+			return {
+				kind: "service",
+				action: "delete",
+				identifier: "dataApi",
 			};
 		}
 		case "create-bucket": {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -21,7 +21,7 @@ import { defineConfig } from "@neon/config/v1";
 export default defineConfig({
   // Static: what *exists* on every branch. GA service toggles drive the typed env.
   auth: true,
-  dataApi: false,
+  dataApi: true,
   // Beta (Preview) features, keyed by slug / name.
   preview: {
     functions: {

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -219,7 +219,7 @@ import {
 ## Safety Rules
 
 - `apply` / `pushConfig` never creates projects or branches.
-- `auth: {}` and `dataApi: {}` enable those integrations with Neon defaults. `auth.enabled: false`, `dataApi.enabled: false`, or absence leaves existing integrations alone. Disabling is destructive and remains explicit/manual.
+- `auth: {}` and `dataApi: {}` enable those integrations with Neon defaults. Absence of `dataApi` leaves an existing Data API alone. `dataApi: false` / `dataApi.enabled: false` disables it (an override: `updateExisting` or `confirm`). `auth.enabled: false` still leaves Auth alone.
 - Mutable branch drift (`protected`, `ttl`, `postgres.computeSettings`) is reported as a conflict unless `updateExisting` is passed (or a `confirm` callback is supplied to `pushConfig`).
 - Applying to a branch with the `protected` flag set on Neon requires `allowProtectedBranch` (or a `confirm` callback).
 

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -79,6 +79,17 @@ describe("resolveConfig", () => {
 		});
 		expect(resolved.authEnabled).toBe(false);
 		expect(resolved.dataApiEnabled).toBe(false);
+		expect(resolved.dataApiPolicy).toBe("disabled");
+	});
+
+	test("omits Data API when the policy does not mention it", () => {
+		const config = defineConfig({});
+		const resolved = resolveConfig(config, {
+			name: "dev-a",
+			exists: false,
+		});
+		expect(resolved.dataApiEnabled).toBe(false);
+		expect(resolved.dataApiPolicy).toBe("omitted");
 	});
 
 	test("treats `auth: true` as enabled", () => {

--- a/packages/config/src/lib/define-config.ts
+++ b/packages/config/src/lib/define-config.ts
@@ -200,6 +200,12 @@ export function resolveConfig(
 	const resolved: ResolvedBranchConfig = {
 		authEnabled: isServiceEnabled(config.auth),
 		dataApiEnabled: isDataApiEnabled(config.dataApi),
+		dataApiPolicy:
+			config.dataApi === undefined
+				? "omitted"
+				: isDataApiEnabled(config.dataApi)
+					? "enabled"
+					: "disabled",
 	};
 	const dataApi = resolveDataApi(config.dataApi);
 	if (dataApi) resolved.dataApi = dataApi;

--- a/packages/config/src/lib/diff.test.ts
+++ b/packages/config/src/lib/diff.test.ts
@@ -150,6 +150,57 @@ describe("diffConfig", () => {
 		expect(unreported.conflicts).toEqual([]);
 	});
 
+	test("explicit dataApi false plans disable when the remote integration is on", () => {
+		const enabledRemote: RemoteState = {
+			...remote,
+			services: {
+				databaseName: "neondb",
+				authEnabled: false,
+				dataApiEnabled: true,
+			},
+		};
+		const desired = {
+			authEnabled: false,
+			dataApiEnabled: false,
+			dataApiPolicy: "disabled" as const,
+		};
+		const conflictDiff = diffConfig(desired, enabledRemote, {
+			updateExisting: false,
+		});
+		expect(conflictDiff.plan).toEqual([]);
+		expect(conflictDiff.conflicts[0]).toMatchObject({
+			field: "dataApi",
+			current: true,
+			desired: false,
+		});
+
+		const updateDiff = diffConfig(desired, enabledRemote, {
+			updateExisting: true,
+		});
+		expect(updateDiff.conflicts).toEqual([]);
+		expect(updateDiff.plan[0]).toMatchObject({
+			kind: "disable-data-api",
+			databaseName: "neondb",
+		});
+	});
+
+	test("omitted dataApi does not disable an existing integration", () => {
+		const diff = diffConfig(
+			{ authEnabled: false, dataApiEnabled: false },
+			{
+				...remote,
+				services: {
+					databaseName: "neondb",
+					authEnabled: false,
+					dataApiEnabled: true,
+				},
+			},
+			{ updateExisting: true },
+		);
+		expect(diff.plan).toEqual([]);
+		expect(diff.conflicts).toEqual([]);
+	});
+
 	test("reports compute drift unless updateExisting is set", () => {
 		const diff = diffConfig(
 			{

--- a/packages/config/src/lib/diff.ts
+++ b/packages/config/src/lib/diff.ts
@@ -58,17 +58,19 @@ export type PlanStep =
 			input?: EnableDataApiInput;
 	  }
 	| {
-			/**
-			 * Reconcile the runtime settings of an already-enabled Data API integration.
-			 * Only `settings` are mutable post-create, so this is the lone Data API
-			 * *update* step — and it is an override (requires `updateExisting`).
-			 */
 			kind: "update-data-api";
 			projectId: string;
 			branchId: string;
 			branchName: string;
 			databaseName: string;
 			settings: DataApiSettings;
+	  }
+	| {
+			kind: "disable-data-api";
+			projectId: string;
+			branchId: string;
+			branchName: string;
+			databaseName: string;
 	  }
 	| {
 			kind: "create-bucket";
@@ -154,10 +156,7 @@ export function diffConfig(
 }
 
 /**
- * Plan Preview features (functions, buckets). Like {@link diffServices}, this is
- * **additive**: it creates desired buckets and (re-)deploys functions, but never deletes
- * them. Teardown is destructive, so it stays explicit/manual — matching the existing
- * auth / dataApi behaviour.
+ * Data API teardown requires explicit `dataApi: false` so omission remains non-destructive.
  *
  * The AI Gateway is intentionally NOT planned here: it is always available on a branch
  * (credential-gated, not per-branch provisioned), so `preview.aiGateway` produces no plan
@@ -239,8 +238,29 @@ function diffServices(args: {
 		if (state.databaseName) step.databaseName = state.databaseName;
 		plan.push(step);
 	}
-	if (config.dataApiEnabled) {
+	const dataApiPolicy =
+		config.dataApiPolicy ?? (config.dataApiEnabled ? "enabled" : "omitted");
+	if (dataApiPolicy === "enabled") {
 		diffDataApi({ config, remote, options, plan, conflicts });
+	} else if (dataApiPolicy === "disabled" && state.dataApiEnabled) {
+		if (options.updateExisting) {
+			plan.push({
+				kind: "disable-data-api",
+				projectId: remote.projectId,
+				branchId: remote.branch.id,
+				branchName: remote.branch.name,
+				databaseName: state.databaseName,
+			});
+		} else {
+			conflicts.push({
+				kind: "branch",
+				identifier: remote.branch.name,
+				field: "dataApi",
+				current: true,
+				desired: false,
+				reason: "Existing Data API would be deleted. Pass `updateExisting: true` (SDK) or `--update-existing` (CLI) to apply.",
+			});
+		}
 	}
 }
 

--- a/packages/config/src/lib/fake-neon-api.ts
+++ b/packages/config/src/lib/fake-neon-api.ts
@@ -526,6 +526,20 @@ export class FakeNeonApi implements NeonApi {
 		return clone(updated);
 	}
 
+	async deleteProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+	): Promise<void> {
+		this.history.push({
+			method: "deleteProjectBranchDataApi",
+			args: [projectId, branchId, databaseName],
+		});
+		this.requireProject(projectId);
+		this.requireBranch(projectId, branchId);
+		this.neonDataApi.delete(`${projectId}:${branchId}:${databaseName}`);
+	}
+
 	/** Test helper: attach a Neon Auth integration to a branch. */
 	seedNeonAuth(
 		projectId: string,

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -22,6 +22,7 @@ import {
 	createProject as rawCreateProject,
 	createProjectBranch as rawCreateProjectBranch,
 	createProjectBranchDataApi as rawCreateProjectBranchDataApi,
+	deleteProjectBranchDataApi as rawDeleteProjectBranchDataApi,
 	getConnectionUri as rawGetConnectionUri,
 	getNeonAuth as rawGetNeonAuth,
 	getProject as rawGetProject,
@@ -974,6 +975,35 @@ class RealNeonApi implements NeonApi {
 			},
 			{ projectId, mutating: true },
 		);
+	}
+
+	async deleteProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+	): Promise<void> {
+		try {
+			await this.call(
+				`deleteProjectBranchDataApi(${projectId}/${branchId}/${databaseName})`,
+				async () => {
+					unwrap(
+						await rawDeleteProjectBranchDataApi({
+							client: this.client,
+							path: {
+								project_id: projectId,
+								branch_id: branchId,
+								database_name: databaseName,
+							},
+						}),
+					);
+				},
+				{ projectId, mutating: true },
+			);
+		} catch (err) {
+			if (err instanceof PlatformError && err.code === ErrorCode.NotFound)
+				return;
+			throw err;
+		}
 	}
 
 	// ─── Preview: buckets ──────────────────────────────────────────────────────

--- a/packages/config/src/lib/neon-api.ts
+++ b/packages/config/src/lib/neon-api.ts
@@ -399,6 +399,12 @@ export interface NeonApi {
 		settings: DataApiSettings,
 	): Promise<NeonDataApiSnapshot>;
 
+	deleteProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+	): Promise<void>;
+
 	// ─── Preview: buckets ──────────────────────────────────────────────────────
 
 	/** List branchable object-storage buckets visible on a branch. */

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -224,7 +224,7 @@ export interface DataApiSettings {
 
 /** Fields shared by every {@link DataApiConfig} variant. */
 interface DataApiConfigBase {
-	/** Defaults to `true` when the `dataApi` namespace is present. Set `false` to opt out. */
+	/** Defaults to `true` when the `dataApi` namespace is present. `false` disables and apply deletes. */
 	enabled?: boolean;
 	/** Reusable runtime settings. Drift here is reconciled as an update. */
 	settings?: DataApiSettings;
@@ -271,7 +271,8 @@ export type DataApiConfig = DataApiNeonAuthConfig | DataApiExternalAuthConfig;
 /**
  * How the Data API is toggled in a policy: a bare boolean (like the other service toggles)
  * or the richer {@link DataApiConfig} object. `true` / `{}` / `{ enabled: true }` enable it
- * with Neon defaults; `false` / `{ enabled: false }` opt out.
+ * with Neon defaults. `false` / `{ enabled: false }` disable it; apply deletes an existing
+ * Data API. Omit the field to leave an existing integration alone.
  */
 export type DataApiInput = boolean | DataApiConfig;
 

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -684,6 +684,8 @@ export interface ResolvedBranchConfig {
 	postgres?: PostgresConfig;
 	authEnabled: boolean;
 	dataApiEnabled: boolean;
+	/** Optional for compatibility with hand-built configs. */
+	dataApiPolicy?: "omitted" | "enabled" | "disabled";
 	/**
 	 * Resolved Data API integration. Present iff {@link dataApiEnabled} is `true`. Carries the
 	 * create-time auth wiring and the updatable {@link DataApiSettings}.
@@ -701,7 +703,7 @@ export interface AppliedChange {
 	 * Neon Auth, Data API).
 	 */
 	kind: "branch" | "service";
-	action: "create" | "update" | "noop";
+	action: "create" | "update" | "delete" | "noop";
 	identifier: string;
 	details?: Record<string, unknown>;
 }

--- a/packages/env/src/lib/fake-neon-api.ts
+++ b/packages/env/src/lib/fake-neon-api.ts
@@ -527,6 +527,20 @@ export class FakeNeonApi implements NeonApi {
 		return clone(updated);
 	}
 
+	async deleteProjectBranchDataApi(
+		projectId: string,
+		branchId: string,
+		databaseName: string,
+	): Promise<void> {
+		this.history.push({
+			method: "deleteProjectBranchDataApi",
+			args: [projectId, branchId, databaseName],
+		});
+		this.requireProject(projectId);
+		this.requireBranch(projectId, branchId);
+		this.neonDataApi.delete(`${projectId}:${branchId}:${databaseName}`);
+	}
+
 	/** Test helper: attach a Neon Auth integration to a branch. */
 	seedNeonAuth(
 		projectId: string,


### PR DESCRIPTION
## Problem

`neon.ts` can enable Data API with an external JWKS, and it can set `dataApi: false`. Neither reached the system that actually provisions.

`neon claim create` requested the `data_api` capability and left create to Claimable Neon's default (`neon_auth`). An external JWKS in neon.ts was ignored on the first enable.

`pushConfig` treated `dataApi: false` the same as omitting `dataApi`: leave whatever is already on the branch. A claimable project that got Data API from `--service data-api` could not turn it off with a later apply. The same rule is what must keep working for the omit case: a neon.ts with no Data API block must not delete a Data API that claim create just provisioned.

## Diagnosis

Absence and explicit false were one boolean, `dataApiEnabled`. Disable needs a third state.

`dataApiPolicy` is `omitted` | `enabled` | `disabled`. Omitted is the default for hand-built test objects that only set `dataApiEnabled`. `disable-data-api` is an override, same as other destructive drift: `updateExisting` or confirm. Neon DELETE on Data API is idempotent (`200` when it is already gone). The adapter also treats `404` as success.

`--service data-api` without a neon.ts Data API block still omits identity `data_api`, so Claimable keeps its server heuristic.

## Interface

```ts
export default defineConfig({
  dataApi: {
    authProvider: "external",
    jwksUrl: "https://idp.example.com/.well-known/jwks.json",
    providerName: "google",
    jwtAudience: "my-app",
    settings: { dbMaxRows: 100 },
  },
});
```

```ts
export default defineConfig({
  dataApi: false, // or { enabled: false }
});
```

`neon claim create` with that external policy sends:

```json
{
  "type": "anonymous",
  "capabilities": ["postgres", "data_api"],
  "source": "neon_cli",
  "data_api": {
    "auth_provider": "external",
    "jwks_url": "https://idp.example.com/.well-known/jwks.json",
    "provider_name": "google",
    "jwt_audience": "my-app",
    "settings": { "db_max_rows": 100 }
  }
}
```

`neon claim create --service data-api` with no neon.ts Data API block omits `data_api`:

```json
{
  "type": "anonymous",
  "capabilities": ["postgres", "data_api"],
  "source": "neon_cli"
}
```

```bash
neon deploy --update-existing
# dataApi: false plans disable-data-api; output shows a red "- Data API"
```

`claimableDataApiCreateBody` throws if `authProvider` is `"external"` and `jwksUrl` is missing. Claimable still validates the URL; this only maps neon.ts into the identity body.

Omitting `dataApi` is unchanged: no enable, no disable. Auth `enabled: false` is still non-destructive.

Existing `dataApi: true` / `{}` enable paths are unchanged.

## Also in here

- `NeonApi.deleteProjectBranchDataApi` on the real adapter and the fakes.
- Changeset (minor `@neon/config`, `@neon/config-runtime`, `neon`).
- Safety-rule wording in `@neon/config` and `@neon/config-runtime` READMEs.
- Getting-started `defineConfig` example uses `dataApi: true`. `false` is documented as a delete.

## Verification

- `pnpm --filter @neon/config exec vitest run` — 284 passed (full package run on the implementation commit)
- `pnpm --filter @neon/config-runtime test:ci` — 163 passed
- focused: `define-config` + `diff` 62, `push-config` 23, CLI `config_services` / `config_diff` / `claim` / `claimable/api` 26, `pnpm --filter neon typecheck`

Not verified: `neon claim create` against live Claimable with identity `data_api`. That origin does not accept the field until Claimable Neon is deployed with that API. No CLI-to-Claimable integration harness in this repo.

## For your attention

- Merge after Claimable Neon accepts identity `data_api` and allowlisted DELETE, or `claim create` with an external JWKS will 400.
- Recreate (disable then enable) is how provider or JWKS changes. There is no automatic switch while Data API stays enabled.
- Auth disable is unchanged.
- Website docs and `neondatabase/agent-skills` still describe external JWKS as post-claim.
