### PR TITLE
Add neon checkout --env so create-apply loads Function env

### DIFF
--- a/.changeset/checkout-env.md
+++ b/.changeset/checkout-env.md
@@ -1,0 +1,6 @@
+---
+"neon": patch
+"neonctl": patch
+---
+
+`neon checkout --env <file>` loads that .env file before applying neon.ts when checkout creates a branch, the same as `neon deploy --env`. Checking out an existing branch ignores `--env`.

--- a/packages/cli/src/commands/checkout.test.ts
+++ b/packages/cli/src/commands/checkout.test.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { describe, expect } from "vitest";
 
 import { test as originalTest } from "../test_utils/fixtures";
+import { formatCheckoutPolicyFailure } from "./checkout";
 import { ENV_PULL_SKIPPED_HINT } from "./env";
 
 // All tests in this file share a single temporary directory whose path is
@@ -283,5 +284,55 @@ describe("checkout", () => {
 			},
 		);
 		removeFile(ctx);
+	});
+});
+
+describe("checkout --env", () => {
+	test("help describes --env as a .env file path", async ({
+		testCliCommand,
+	}) => {
+		const { stdout, stderr } = await testCliCommand(
+			["checkout", "--help"],
+			{
+				snapshot: false,
+			},
+		);
+		expect(`${stdout}\n${stderr}`).toContain("Path to a .env file");
+	});
+
+	test("checking out an existing branch does not load --env", async ({
+		testCliCommand,
+		tmpContext,
+	}) => {
+		const ctx = tmpContext("existing_skips_env");
+		await testCliCommand(
+			[
+				"checkout",
+				"main",
+				"--project-id",
+				"test",
+				"--no-env-pull",
+				"--env",
+				"/no/such/neon-checkout.env",
+				"--context-file",
+				ctx,
+			],
+			{ snapshot: false },
+		);
+	});
+});
+
+describe("formatCheckoutPolicyFailure", () => {
+	test("includes --env on the deploy and checkout retries when checkout had one", () => {
+		const message = formatCheckoutPolicyFailure({
+			branchName: "feat",
+			branchId: "br-x",
+			failure: "unset RESEND_API_KEY",
+			env: ".env.local",
+		});
+		expect(message).toContain(
+			"neon deploy --update-existing --env .env.local",
+		);
+		expect(message).toContain("neon checkout feat --env .env.local");
 	});
 });

--- a/packages/cli/src/commands/checkout.ts
+++ b/packages/cli/src/commands/checkout.ts
@@ -18,6 +18,7 @@ import { looksLikeBranchId } from "../utils/formats.js";
 import {
 	applyPolicyOnCreate,
 	createBranchFromPolicyOnCheckout,
+	envFlag,
 } from "./config.js";
 import { autoPullEnvAfterPin } from "./env.js";
 import { handler as linkHandler } from "./link.js";
@@ -27,6 +28,7 @@ type CheckoutProps = CommonProps & {
 	orgId?: string;
 	id?: string;
 	envPull: boolean;
+	env?: string;
 	/** Global `--color` flag (default true); `--no-color` sets it false to force plain output. */
 	color?: boolean;
 };
@@ -36,6 +38,21 @@ type CheckoutProps = CommonProps & {
 export const command = "checkout [id|name]";
 export const describe =
 	"Pin a branch in the local context (.neon) so subsequent commands target it";
+
+export const formatCheckoutPolicyFailure = (opts: {
+	branchName: string;
+	branchId: string;
+	failure: string;
+	env?: string;
+}): string => {
+	const cli = getCliName();
+	const envArg = opts.env ? ` --env ${opts.env}` : "";
+	return [
+		`Branch ${opts.branchName} (${opts.branchId}) was created and checked out, but applying neon.ts to it failed: ${opts.failure}`,
+		`The branch is usable but does not match the policy, and \`${cli} checkout\` never reconciles a branch that already exists.`,
+		`Fix the cause above, then run \`${cli} deploy --update-existing${envArg}\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`${cli} branches delete ${opts.branchName}\` then \`${cli} checkout ${opts.branchName}${envArg}\`.`,
+	].join("\n");
+};
 
 export const builder = (argv: yargs.Argv) =>
 	argv
@@ -58,6 +75,13 @@ export const builder = (argv: yargs.Argv) =>
 				type: "boolean",
 				default: true,
 			},
+			...envFlag,
+			env: {
+				...envFlag.env,
+				describe:
+					envFlag.env.describe +
+					" Used when this checkout creates a branch from neon.ts; ignored for an existing branch.",
+			},
 		})
 		.example([
 			[
@@ -67,6 +91,10 @@ export const builder = (argv: yargs.Argv) =>
 			[
 				"$0 checkout main",
 				'Pin the branch named "main" in the closest .neon file',
+			],
+			[
+				"$0 checkout feat --env .env.local",
+				"Create feat from neon.ts, loading Function env from .env.local first",
 			],
 			[
 				"$0 checkout br-cool-snow-12345678 --project-id project-id-123",
@@ -132,6 +160,7 @@ export const handler = async (props: CheckoutProps) => {
 					...(props.color !== undefined
 						? { color: props.color }
 						: {}),
+					...(props.env ? { env: props.env } : {}),
 				})
 			: policyFailure;
 
@@ -150,11 +179,12 @@ export const handler = async (props: CheckoutProps) => {
 	// policy, and `checkout` will not reconcile it on a second run.
 	if (failure) {
 		throw new Error(
-			[
-				`Branch ${branchName} (${branchId}) was created and checked out, but applying neon.ts to it failed: ${failure}`,
-				`The branch is usable but does not match the policy, and \`${getCliName()} checkout\` never reconciles a branch that already exists.`,
-				`Fix the cause above, then run \`${getCliName()} deploy --update-existing\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`${getCliName()} branches delete ${branchName}\` then \`${getCliName()} checkout ${branchName}\`.`,
-			].join("\n"),
+			formatCheckoutPolicyFailure({
+				branchName,
+				branchId,
+				failure,
+				...(props.env ? { env: props.env } : {}),
+			}),
 		);
 	}
 };
@@ -301,6 +331,7 @@ const createCheckoutBranch = async (
 		...(props.apiKey ? { apiKey: props.apiKey } : {}),
 		...(props.apiHost ? { apiHost: props.apiHost } : {}),
 		...(props.color !== undefined ? { color: props.color } : {}),
+		...(props.env ? { env: props.env } : {}),
 	});
 	if (fromPolicy) {
 		return {

--- a/packages/cli/src/commands/config.test.ts
+++ b/packages/cli/src/commands/config.test.ts
@@ -1083,6 +1083,57 @@ describe("applyPolicyOnCreate", () => {
 
 		expect(api.enableNeonAuthCalls).toHaveLength(0);
 	});
+
+	it("fails before applying when --env names a missing file", async () => {
+		const api = new FakeNeonApi();
+		writeFileSync(join(cwd, "neon.ts"), "export default { auth: {} };\n");
+
+		await expect(
+			applyPolicyOnCreate({
+				projectId: PROJECT_ID,
+				branchId: BRANCH_ID,
+				runtimeApi: api,
+				cwd,
+				env: join(cwd, "missing.env"),
+			}),
+		).rejects.toThrow(/Env file not found/);
+		expect(api.enableNeonAuthCalls).toEqual([]);
+	});
+
+	it("loads --env into process.env before evaluating function env", async () => {
+		const api = new FakeNeonApi();
+		const source = join(cwd, "hello.ts");
+		writeFileSync(
+			source,
+			"export default { fetch() { return new Response('ok'); } };\n",
+		);
+		writeFileSync(
+			join(cwd, "neon.ts"),
+			`export default { preview: { functions: { hello: { name: 'Hello', source: ${JSON.stringify(
+				source,
+			)}, env: { resendApiKey: process.env.RESEND_API_KEY } } } } };\n`,
+		);
+		const envFile = join(cwd, ".env.deploy");
+		writeFileSync(envFile, "RESEND_API_KEY=re_from_file\n");
+		delete process.env.RESEND_API_KEY;
+
+		try {
+			await applyPolicyOnCreate({
+				projectId: PROJECT_ID,
+				branchId: BRANCH_ID,
+				runtimeApi: api,
+				cwd,
+				env: envFile,
+			});
+		} finally {
+			delete process.env.RESEND_API_KEY;
+		}
+
+		expect(api.deployBranchFunctionCalls).toHaveLength(1);
+		expect(api.deployBranchFunctionCalls[0].input.environment).toEqual({
+			resendApiKey: "re_from_file",
+		});
+	});
 });
 
 const NEW_BRANCH_ID = "br-fresh-dawn-98765";
@@ -1310,5 +1361,57 @@ describe("createBranchFromPolicyOnCheckout", () => {
 		});
 
 		expect(created).toBeNull();
+	});
+
+	it("fails before creating a branch when --env names a missing file", async () => {
+		const api = new CreateBranchNeonApi();
+		writeFileSync(join(cwd, "neon.ts"), NEW_BRANCH_POLICY);
+
+		await expect(
+			createBranchFromPolicyOnCheckout({
+				projectId: PROJECT_ID,
+				branchName: NEW_BRANCH_NAME,
+				runtimeApi: api,
+				cwd,
+				env: join(cwd, "missing.env"),
+			}),
+		).rejects.toThrow(/Env file not found/);
+		expect(api.createBranchCalls).toEqual([]);
+	});
+
+	it("loads --env into process.env before evaluating function env", async () => {
+		const api = new CreateBranchNeonApi();
+		const source = join(cwd, "hello.ts");
+		writeFileSync(
+			source,
+			"export default { fetch() { return new Response('ok'); } };\n",
+		);
+		writeFileSync(
+			join(cwd, "neon.ts"),
+			`export default { preview: { functions: { hello: { name: 'Hello', source: ${JSON.stringify(
+				source,
+			)}, env: { resendApiKey: process.env.RESEND_API_KEY } } } } };\n`,
+		);
+		const envFile = join(cwd, ".env.deploy");
+		writeFileSync(envFile, "RESEND_API_KEY=re_from_file\n");
+		delete process.env.RESEND_API_KEY;
+
+		try {
+			const created = await createBranchFromPolicyOnCheckout({
+				projectId: PROJECT_ID,
+				branchName: NEW_BRANCH_NAME,
+				runtimeApi: api,
+				cwd,
+				env: envFile,
+			});
+			expect(created).toEqual({ branchId: NEW_BRANCH_ID });
+		} finally {
+			delete process.env.RESEND_API_KEY;
+		}
+
+		expect(api.deployBranchFunctionCalls).toHaveLength(1);
+		expect(api.deployBranchFunctionCalls[0].input.environment).toEqual({
+			resendApiKey: "re_from_file",
+		});
 	});
 });

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -167,10 +167,6 @@ export type ConfigProps = BranchScopeProps & {
 	color?: boolean;
 };
 
-/**
- * Shared `--env` flag for `config plan|apply` and `deploy`. Loads a `.env` into
- * `process.env` before the policy is evaluated.
- */
 export const envFlag = {
 	env: {
 		describe:
@@ -609,18 +605,20 @@ const liveConfigView = async (opts: {
 	return { live, view: toNeonConfigView(resolved, live.preview) };
 };
 
+const loadEnvFileIfGiven = (env?: string): void => {
+	// Function env reads process.env when neon.ts is evaluated.
+	if (!env) return;
+	const applied = loadEnvFileIntoProcess(env);
+	log.debug(
+		"Loaded %d var(s) from %s into the environment: %s",
+		applied.length,
+		env,
+		applied.join(", "),
+	);
+};
+
 const loadConfig = async (props: ConfigProps): Promise<Config> => {
-	// Load the optional --env file FIRST so a `neon.ts` whose function `env` values read
-	// `process.env.X` sees them. Must happen before the policy module is imported/evaluated.
-	if (props.env) {
-		const applied = loadEnvFileIntoProcess(props.env);
-		log.debug(
-			"Loaded %d var(s) from %s into the environment: %s",
-			applied.length,
-			props.env,
-			applied.join(", "),
-		);
-	}
+	loadEnvFileIfGiven(props.env);
 	const { config } = await loadConfigFromFile({
 		...(props.config ? { path: props.config } : {}),
 	});
@@ -925,7 +923,9 @@ export const applyPolicyOnCreate = async (props: {
 	cwd?: string;
 	/** Global `--color` flag; `false` forces the plain-text diff. */
 	color?: boolean;
+	env?: string;
 }): Promise<void> => {
+	loadEnvFileIfGiven(props.env);
 	let config: Config;
 	try {
 		({ config } = await loadConfigFromFile({
@@ -1010,7 +1010,9 @@ export const createBranchFromPolicyOnCheckout = async (props: {
 	cwd?: string;
 	/** Global `--color` flag; `false` forces the plain-text diff. */
 	color?: boolean;
+	env?: string;
 }): Promise<{ branchId: string; policyFailure?: string } | null> => {
+	loadEnvFileIfGiven(props.env);
 	let config: Config;
 	try {
 		({ config } = await loadConfigFromFile({


### PR DESCRIPTION
## Problem

`neon.ts` Function env is often read from `process.env` at evaluation time:

```ts
export default {
  preview: {
    functions: {
      hello: {
        name: "Hello",
        source: "./hello.ts",
        env: { resendApiKey: process.env.RESEND_API_KEY },
      },
    },
  },
};
```

`neon deploy --env .env.local` loads that file into `process.env` before evaluating `neon.ts`, so those values resolve. Checkout that creates a branch also evaluates `neon.ts` (it creates the branch from the policy and deploys Functions). That path had no `--env`. Unless `RESEND_API_KEY` was already exported in the shell, `process.env.RESEND_API_KEY` is `undefined` and `defineConfig` throws.

A second `neon checkout` doesn't fix it. Checkout never reconciles a branch that already exists; the retry is `neon deploy --env`.

## Diagnosis

`neon deploy --env` loads the file inside `loadConfig`, then imports `neon.ts`.

Checkout create doesn't call `loadConfig`. A missing `neon.ts` has to be a skip (bare branch or no policy apply), so those paths call `loadConfigFromFile` themselves and treat "Could not find a Neon config file" as empty. The env load never ran there.

`--env` has to be loaded at the start of `createBranchFromPolicyOnCheckout` and `applyPolicyOnCreate`, before those imports. Those are the two create-apply paths: policy-driven create and the bare-create fallback.

Checking out a branch that already exists doesn't evaluate `neon.ts`. `--env` is parsed and ignored on that path, including a file that is not on disk.

## The user-facing interface

`neon checkout` takes `--env`, the same loader as `neon deploy --env`.

From `node packages/cli/dist/cli.js checkout --help` on this branch:

```
--env
  Path to a .env file to load into the environment before evaluating neon.ts
  (so function env values resolve from it). Existing env vars are not overridden.
  Used when this checkout creates a branch from neon.ts; ignored for an existing
  branch. [string]
```

New example from that help:

```
neon checkout feat --env .env.local
  Create feat from neon.ts, loading Function env from .env.local first
```

`--env` is passed into both create paths, including the interactive picker ("create a new branch") and the "branch does not exist, create it?" confirm.

`--env-pull` is unchanged. After checkout it writes the branch's Neon vars (`DATABASE_URL`, …) into a local `.env`. `--env` reads a local file before evaluating `neon.ts`. Both flags can be passed on one command.

Without `--env`, checkout is unchanged. `neon deploy --env`, `neon config plan --env` and `neon config apply --env` are unchanged. Deploy's `--env` help text is unchanged.

Existing `process.env` entries win over the file, same as deploy.

A missing `--env` file on a create fails with `Env file not found: <path>` before the branch is created. On the bare-create fallback it fails before the policy is applied.

When create applies the policy and then fails, the remediation repeats the `--env` checkout used:

```
neon deploy --update-existing --env .env.local
```

If the policy only configures new branches (keyed on `!branch.exists`):

```
neon branches delete feat
neon checkout feat --env .env.local
```

## Also in here

- `loadEnvFileIfGiven` is the shared helper used by `loadConfig`, `applyPolicyOnCreate` and `createBranchFromPolicyOnCheckout`.
- Patch changeset for `neon` and `neonctl`.

## Verification

Base `c7be498` (`origin/main`). Help captured with `node packages/cli/dist/cli.js checkout --help` in this worktree.

CLI (forked `neon checkout` against the mock API):

- `checkout --help` includes `Path to a .env file`
- `neon checkout main --env /no/such/neon-checkout.env` exits 0 (existing branch doesn't open the file)
- policy-failure text includes `--env .env.local` on both `deploy --update-existing` and `checkout feat`

`applyPolicyOnCreate` and `createBranchFromPolicyOnCheckout` (in-memory Neon API):

- `--env` pointing at a missing file throws `Env file not found` and makes no API call (no branch create, no auth enable)
- `--env` with `RESEND_API_KEY=re_from_file` deploys the Function with `environment: { resendApiKey: "re_from_file" }`

Not verified against a live Neon project: no create-and-deploy with a real `--env` file.

## For your attention

- On an existing branch, `--env` isn't read, so a missing or typo'd path doesn't fail. On a create, the same path fails before the branch exists.
- Checkout still doesn't reconcile an existing branch. `--env` doesn't change that. After a failed create-apply, the next command is `deploy --update-existing --env <file>`, or delete and checkout again.
- `--env` isn't loaded on any path that only pins `.neon`.
