### PR TITLE
Stop env pull and link from failing on unset function env

### DIFF
--- a/.changeset/env-pull-omit-unset-function-env.md
+++ b/.changeset/env-pull-omit-unset-function-env.md
@@ -1,0 +1,7 @@
+---
+"@neon/config": patch
+"neon": patch
+"neonctl": patch
+---
+
+`neon env pull` (and the pull bundled into `link` / `checkout`) loads neon.ts even when function env vars are unset, so it can still write `NEON_FUNCTION_*_BASE_URL`. `neon dev`, `neon-env run`, and `defineConfig` still reject those missing values.

--- a/packages/cli/src/commands/env.apihost.test.ts
+++ b/packages/cli/src/commands/env.apihost.test.ts
@@ -62,7 +62,10 @@ describe("env pull wires apiHost into the resolver context", () => {
 			};
 			await pull(props);
 			expect(resolveNeonEnvVars).toHaveBeenCalledWith(
-				expect.objectContaining({ apiHost: HOST }),
+				expect.objectContaining({
+					apiHost: HOST,
+					omitUnsetFunctionEnv: true,
+				}),
 			);
 		} finally {
 			rmSync(cwd, { recursive: true, force: true });

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -871,6 +871,27 @@ describe("env pull function invocation URLs", () => {
 		).toBe(helloUrl);
 	});
 
+	it("writes a neon.ts function URL when function env vars are unset", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_PULL_TEST";
+		delete process.env[key];
+		writeFileSync(
+			join(cwd, "neon.ts"),
+			"export default { preview: { functions: { hello: " +
+				`{ name: 'Hello', source: './hello.ts', env: { SECRET: process.env.${key} } } } } };\n`,
+		);
+
+		try {
+			await pull(baseProps(new FakeNeonApi(), cwd));
+			const env = readEnvFile(join(cwd, ".env.local"));
+			expect(env.NEON_FUNCTION_HELLO_BASE_URL).toBe(helloUrl);
+			expect(env.DATABASE_URL).toBeDefined();
+			expect(env.SECRET).toBeUndefined();
+			expect(process.env[key]).toBeUndefined();
+		} finally {
+			delete process.env[key];
+		}
+	});
+
 	it("writes a neon.ts function URL when the listed invocation URL is empty", async () => {
 		writeFileSync(
 			join(cwd, "neon.ts"),
@@ -1355,6 +1376,32 @@ describe("autoPullEnvAfterPin (bundled into link / checkout)", () => {
 		expect(result.status).toBe("written");
 		const content = readFileSync(join(cwd, ".env.local"), "utf8");
 		expect(content).toMatch(/^DATABASE_URL=/m);
+	});
+
+	it("pulls when neon.ts function env vars are unset", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_AUTOPULL_TEST";
+		delete process.env[key];
+		writeFileSync(
+			join(cwd, "neon.ts"),
+			"export default { preview: { functions: { hello: " +
+				`{ name: 'Hello', source: './hello.ts', env: { SECRET: process.env.${key} } } } } };\n`,
+		);
+
+		try {
+			const result = await autoPullEnvAfterPin({
+				...baseProps(new FakeNeonApi(), cwd),
+				envPull: true,
+			});
+
+			expect(result.status).toBe("written");
+			const env = readEnvFile(join(cwd, ".env.local"));
+			expect(env.DATABASE_URL).toBeDefined();
+			expect(env.NEON_FUNCTION_HELLO_BASE_URL).toBe(
+				`https://${BRANCH_ID}-hello.compute.fake.neon.tech`,
+			);
+		} finally {
+			delete process.env[key];
+		}
 	});
 
 	it("skips the pull (writing nothing) when --no-env-pull is passed", async () => {

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -266,6 +266,7 @@ export const pull = async (
 		...(props.services ? { services: props.services } : {}),
 		...(props.envKeys ? { envKeys: props.envKeys } : {}),
 		...(opts.implyAiGateway ? { implyAiGateway: true } : {}),
+		omitUnsetFunctionEnv: true,
 		...(props.apiKey ? { apiKey: props.apiKey } : {}),
 		...(props.apiHost ? { apiHost: props.apiHost } : {}),
 		...(props.runtimeApi ? { api: props.runtimeApi } : {}),

--- a/packages/cli/src/dev/env.test.ts
+++ b/packages/cli/src/dev/env.test.ts
@@ -676,6 +676,56 @@ describe("resolveDevEnv", () => {
 		expect(api.listBranchFunctionsCalled).toBe(false);
 	});
 
+	it("throws when neon.ts function env is unset", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_RESOLVE_TEST";
+		delete process.env[key];
+		writeFileSync(
+			join(cwd, "neon.ts"),
+			"export default { preview: { functions: { hello: " +
+				`{ name: 'Hello', source: './hello.ts', env: { SECRET: process.env.${key} } } } } };\n`,
+		);
+
+		try {
+			await expect(
+				resolveNeonEnvVars({
+					cwd,
+					projectId: PROJECT_ID,
+					branchId: BRANCH_ID,
+					api: new FakeNeonApi(),
+				}),
+			).rejects.toThrow(/is undefined/);
+		} finally {
+			delete process.env[key];
+		}
+	});
+
+	it("omitUnsetFunctionEnv still resolves DATABASE_URL and function URLs", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_RESOLVE_OMIT_TEST";
+		delete process.env[key];
+		writeFileSync(
+			join(cwd, "neon.ts"),
+			"export default { preview: { functions: { hello: " +
+				`{ name: 'Hello', source: './hello.ts', env: { SECRET: process.env.${key} } } } } };\n`,
+		);
+		const helloUrl = `https://${BRANCH_ID}-hello.compute.fake.neon.tech`;
+
+		try {
+			const result = await resolveNeonEnvVars({
+				cwd,
+				projectId: PROJECT_ID,
+				branchId: BRANCH_ID,
+				api: new FakeNeonApi(),
+				omitUnsetFunctionEnv: true,
+			});
+
+			expect(result.vars.DATABASE_URL).toBeDefined();
+			expect(result.vars.NEON_FUNCTION_HELLO_BASE_URL).toBe(helloUrl);
+			expect(result.vars.SECRET).toBeUndefined();
+		} finally {
+			delete process.env[key];
+		}
+	});
+
 	it('neon.ts importing an uninstalled package -> a clear "did you run npm install" error', async () => {
 		// A neon.ts that imports a package which isn't installed (no node_modules in
 		// the temp dir) fails to load with a cryptic "Cannot find module". We expect

--- a/packages/cli/src/dev/env.ts
+++ b/packages/cli/src/dev/env.ts
@@ -73,6 +73,8 @@ export type DevEnvContext = {
 	 * Ignored when {@link DevEnvContext.services} is set, since that selection already says.
 	 */
 	implyAiGateway?: boolean;
+	/** Env pull needs function slugs even when their runtime secrets are unset. */
+	omitUnsetFunctionEnv?: boolean;
 };
 
 /** The API-targeting options every runtime call forwards from the context. */
@@ -153,7 +155,7 @@ export const resolveNeonEnvVars = async (
 		);
 	}
 
-	const config = await loadNeonConfig(ctx.cwd);
+	const config = await loadNeonConfig(ctx);
 
 	if (config) {
 		if (!ctx.projectId || !ctx.branchId) {
@@ -709,9 +711,14 @@ const looksLikeMissingDependency = (err: unknown): boolean => {
 	return MISSING_DEPENDENCY_HINTS.some((hint) => text.includes(hint));
 };
 
-const loadNeonConfig = async (cwd: string): Promise<Config | null> => {
+const loadNeonConfig = async (ctx: DevEnvContext): Promise<Config | null> => {
 	try {
-		const { config } = await loadConfigFromFile({ cwd });
+		const { config } = await loadConfigFromFile({
+			cwd: ctx.cwd,
+			...(ctx.omitUnsetFunctionEnv
+				? { unsetFunctionEnv: "omit" as const }
+				: {}),
+		});
 		return config;
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
@@ -723,7 +730,7 @@ const loadNeonConfig = async (cwd: string): Promise<Config | null> => {
 		if (looksLikeMissingDependency(err)) {
 			throw new Error(
 				"Could not load neon.ts: a package it imports is not installed. " +
-					`Run \`${formatInstallCommand(resolvePackageManager(cwd))}\`, then try again.\n` +
+					`Run \`${formatInstallCommand(resolvePackageManager(ctx.cwd))}\`, then try again.\n` +
 					`Original error: ${message}`,
 			);
 		}

--- a/packages/cli/src/dev/functions.test.ts
+++ b/packages/cli/src/dev/functions.test.ts
@@ -201,4 +201,28 @@ describe("resolveFunctionsFromConfig", () => {
 		const resolved = await resolveFunctionsFromConfig(cwd);
 		expect(resolved?.functions[0]).not.toHaveProperty("bundler");
 	});
+
+	it("throws when a declared function env value is unset", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_DEV_TEST";
+		delete process.env[key];
+		writeWorkspace(
+			cwd,
+			`export default {
+        preview: {
+          functions: {
+            hello: {
+              name: 'Hello',
+              source: './hello.ts',
+              env: { SECRET: process.env.${key} },
+            },
+          },
+        },
+      };\n`,
+			["hello.ts"],
+		);
+		await expect(resolveFunctionsFromConfig(cwd)).rejects.toThrow(
+			/is undefined/,
+		);
+		delete process.env[key];
+	});
 });

--- a/packages/config/src/lib/loader.test.ts
+++ b/packages/config/src/lib/loader.test.ts
@@ -274,4 +274,72 @@ export default defineConfig({
 			repo.cleanup();
 		}
 	}, 30_000);
+
+	test("unsetFunctionEnv omit drops a function env key that contains a colon", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_COLON";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}";
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "Hello",
+        source: "./hello.ts",
+        env: { "SECRET:VERSION": process.env.${key} },
+      },
+    },
+  },
+});`,
+		});
+		try {
+			const { config } = await loadConfigFromFile({
+				cwd: repo.root,
+				unsetFunctionEnv: "omit",
+			});
+			expect(config.preview?.functions?.hello?.env).toEqual({});
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
+
+	test("a concurrent strict load still fails while omit is reloading", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_RACE";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}";
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "Hello",
+        source: "./hello.ts",
+        env: { SECRET: process.env.${key} },
+      },
+    },
+  },
+});`,
+		});
+		try {
+			const omit = loadConfigFromFile({
+				cwd: repo.root,
+				unsetFunctionEnv: "omit",
+			});
+			const strict = loadConfigFromFile({ cwd: repo.root });
+			const [omitResult, strictResult] = await Promise.allSettled([
+				omit,
+				strict,
+			]);
+			expect(omitResult.status).toBe("fulfilled");
+			expect(strictResult.status).toBe("rejected");
+			if (strictResult.status === "rejected") {
+				expect(String(strictResult.reason)).toMatch(/is undefined/);
+			}
+			expect(process.env[key]).toBeUndefined();
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
 });

--- a/packages/config/src/lib/loader.test.ts
+++ b/packages/config/src/lib/loader.test.ts
@@ -96,4 +96,182 @@ describe("loadConfigFromFile", () => {
 			repo.cleanup();
 		}
 	}, 30_000);
+
+	test("unsetFunctionEnv omit drops undefined function env and keeps the rest", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_OMIT";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}";
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "Hello",
+        source: "./hello.ts",
+        env: { KEEP: "present", SECRET: process.env.${key} },
+      },
+    },
+  },
+});`,
+		});
+		try {
+			const { config } = await loadConfigFromFile({
+				cwd: repo.root,
+				unsetFunctionEnv: "omit",
+			});
+			expect(config.preview?.functions?.hello?.env).toEqual({
+				KEEP: "present",
+			});
+			expect(process.env[key]).toBeUndefined();
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
+
+	test("unsetFunctionEnv omit works for a raw default export (loader defineConfig)", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_RAW";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.ts": `export default {
+  preview: {
+    functions: {
+      hello: {
+        name: "Hello",
+        source: "./hello.ts",
+        env: { SECRET: process.env.${key} },
+      },
+    },
+  },
+};`,
+		});
+		try {
+			const { config } = await loadConfigFromFile({
+				cwd: repo.root,
+				unsetFunctionEnv: "omit",
+			});
+			expect(config.preview?.functions?.hello?.env).toEqual({});
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
+
+	test("unsetFunctionEnv omit works for neon.js", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_JS";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.js": `export default {
+  preview: {
+    functions: {
+      hello: {
+        name: "Hello",
+        source: "./hello.ts",
+        env: { SECRET: process.env.${key} },
+      },
+    },
+  },
+};
+`,
+		});
+		try {
+			const { config } = await loadConfigFromFile({
+				cwd: repo.root,
+				unsetFunctionEnv: "omit",
+			});
+			expect(config.preview?.functions?.hello?.env).toEqual({});
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
+
+	test("unsetFunctionEnv defaults to error", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_STRICT";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}";
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "Hello",
+        source: "./hello.ts",
+        env: { SECRET: process.env.${key} },
+      },
+    },
+  },
+});`,
+		});
+		try {
+			await expect(
+				loadConfigFromFile({ cwd: repo.root }),
+			).rejects.toThrow(/is undefined/);
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
+
+	test("unsetFunctionEnv omit still rejects a bad function slug", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_SLUG";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}";
+export default defineConfig({
+  preview: {
+    functions: {
+      "hello-world": {
+        name: "hello",
+        source: "src/index.ts",
+        env: { SECRET: process.env.${key} },
+      },
+    },
+  },
+});`,
+		});
+		try {
+			await expect(
+				loadConfigFromFile({
+					cwd: repo.root,
+					unsetFunctionEnv: "omit",
+				}),
+			).rejects.toThrow(/function slug must be/);
+			expect(process.env[key]).toBeUndefined();
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
+
+	test("strict load after omit still fails on the same unset env", async () => {
+		const key = "NEON_PKGS_UNSET_FN_ENV_LOADER_SEQ";
+		delete process.env[key];
+		const repo = makeTempRepo({
+			"neon.ts": `import { defineConfig } from "${PLATFORM_SRC}";
+export default defineConfig({
+  preview: {
+    functions: {
+      hello: {
+        name: "Hello",
+        source: "./hello.ts",
+        env: { SECRET: process.env.${key} },
+      },
+    },
+  },
+});`,
+		});
+		try {
+			await loadConfigFromFile({
+				cwd: repo.root,
+				unsetFunctionEnv: "omit",
+			});
+			await expect(
+				loadConfigFromFile({ cwd: repo.root }),
+			).rejects.toThrow(/is undefined/);
+		} finally {
+			delete process.env[key];
+			repo.cleanup();
+		}
+	}, 30_000);
 });

--- a/packages/config/src/lib/loader.ts
+++ b/packages/config/src/lib/loader.ts
@@ -59,6 +59,17 @@ export async function loadConfigFromFile(
 	config: Config;
 	resolvedPath: string;
 }> {
+	// The omit reload replaces process.env. Concurrent strict loads in this
+	// process would then see "" for missing keys.
+	return await withSerializedConfigLoad(() =>
+		loadConfigFromFileUnlocked(options),
+	);
+}
+
+async function loadConfigFromFileUnlocked(options: LoadConfigOptions): Promise<{
+	config: Config;
+	resolvedPath: string;
+}> {
 	if (options.unsetFunctionEnv !== "omit") {
 		return await loadConfigOnce(options);
 	}
@@ -264,7 +275,7 @@ function safeIsFile(path: string): boolean {
 }
 
 const UNSET_FUNCTION_ENV_ISSUE =
-	/^preview\.functions\.[^.]+\.env\.([^:]+): Environment variable ".+" for function ".+" is undefined/;
+	/^preview\.functions\.[^.]+\.env\.(.+): Environment variable "\1" for function ".+" is undefined/;
 
 function unsetFunctionEnvKeys(err: unknown): string[] | null {
 	if (!isPlatformError(err) || err.code !== ErrorCode.InvalidConfig) {
@@ -317,6 +328,17 @@ async function withPlaceholderFunctionEnv<T>(
 	} finally {
 		process.env = original;
 	}
+}
+
+let configLoadChain: Promise<unknown> = Promise.resolve();
+
+async function withSerializedConfigLoad<T>(run: () => Promise<T>): Promise<T> {
+	const next = configLoadChain.then(run, run);
+	configLoadChain = next.then(
+		() => undefined,
+		() => undefined,
+	);
+	return next;
 }
 
 function withoutFunctionEnvKeys(

--- a/packages/config/src/lib/loader.ts
+++ b/packages/config/src/lib/loader.ts
@@ -3,8 +3,8 @@ import { homedir } from "node:os";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { defineConfig } from "./define-config.js";
-import { ConfigLoadError, isPlatformError } from "./errors.js";
-import type { Config } from "./types.js";
+import { ConfigLoadError, ErrorCode, isPlatformError } from "./errors.js";
+import type { Config, FunctionDef } from "./types.js";
 
 /**
  * Default file names tried (in order) when {@link loadConfigFromFile} is called without an
@@ -29,6 +29,13 @@ export interface LoadConfigOptions {
 	 * stray runs from outside any repo never leak into the user's `~` files.
 	 */
 	stopAt?: string;
+	/**
+	 * `"error"` (default) prevents deploy and dev from proceeding without
+	 * function secrets.
+	 * `"omit"` is for metadata-only reads because apply or deploy would lose the
+	 * omitted keys.
+	 */
+	unsetFunctionEnv?: "error" | "omit";
 }
 
 /**
@@ -52,6 +59,31 @@ export async function loadConfigFromFile(
 	config: Config;
 	resolvedPath: string;
 }> {
+	if (options.unsetFunctionEnv !== "omit") {
+		return await loadConfigOnce(options);
+	}
+
+	try {
+		return await loadConfigOnce(options);
+	} catch (err) {
+		const keys = unsetFunctionEnvKeys(err);
+		if (keys === null) throw err;
+		// The user's neon.ts may resolve another @neon/config copy, so the reload
+		// input must satisfy its validation.
+		return await withPlaceholderFunctionEnv(async () => {
+			const loaded = await loadConfigOnce(options);
+			return {
+				...loaded,
+				config: withoutFunctionEnvKeys(loaded.config, new Set(keys)),
+			};
+		});
+	}
+}
+
+async function loadConfigOnce(options: LoadConfigOptions): Promise<{
+	config: Config;
+	resolvedPath: string;
+}> {
 	const resolvedPath = options.path
 		? resolveExplicitPath(options.path, options.cwd)
 		: findDefaultConfig(options.cwd, options.stopAt);
@@ -68,7 +100,10 @@ export async function loadConfigFromFile(
 
 	let mod: unknown;
 	try {
-		mod = await importModule(resolvedPath);
+		mod = await importModule(
+			resolvedPath,
+			options.unsetFunctionEnv === "omit",
+		);
 	} catch (cause) {
 		// `defineConfig()` runs at module-eval time, so a config the user got *wrong*
 		// (a bad function slug, an unknown key, an invalid duration, …) throws a
@@ -149,9 +184,13 @@ function findDefaultConfig(
 	}
 }
 
-async function importModule(absPath: string): Promise<unknown> {
+async function importModule(
+	absPath: string,
+	forceJiti = false,
+): Promise<unknown> {
 	const lower = absPath.toLowerCase();
 	const needsJiti =
+		forceJiti ||
 		lower.endsWith(".ts") ||
 		lower.endsWith(".mts") ||
 		lower.endsWith(".cts");
@@ -222,4 +261,83 @@ function safeIsFile(path: string): boolean {
 	} catch {
 		return false;
 	}
+}
+
+const UNSET_FUNCTION_ENV_ISSUE =
+	/^preview\.functions\.[^.]+\.env\.([^:]+): Environment variable ".+" for function ".+" is undefined/;
+
+function unsetFunctionEnvKeys(err: unknown): string[] | null {
+	if (!isPlatformError(err) || err.code !== ErrorCode.InvalidConfig) {
+		return null;
+	}
+	const issues = platformErrorIssues(err);
+	if (issues === null || issues.length === 0) return null;
+	const keys: string[] = [];
+	for (const issue of issues) {
+		const match = UNSET_FUNCTION_ENV_ISSUE.exec(issue);
+		const key = match?.[1];
+		if (key === undefined) return null;
+		keys.push(key);
+	}
+	return keys;
+}
+
+function platformErrorIssues(err: unknown): readonly string[] | null {
+	if (typeof err !== "object" || err === null || !("issues" in err)) {
+		return null;
+	}
+	const { issues } = err;
+	if (
+		!Array.isArray(issues) ||
+		issues.some((issue) => typeof issue !== "string")
+	) {
+		return null;
+	}
+	return issues;
+}
+
+async function withPlaceholderFunctionEnv<T>(
+	run: () => Promise<T>,
+): Promise<T> {
+	// Validation reports config keys, not source process.env names, so the reload
+	// must cover every unset lookup.
+	const original = process.env;
+	const proxy = new Proxy(original, {
+		get(target, prop, receiver) {
+			if (typeof prop === "symbol") {
+				return Reflect.get(target, prop, receiver);
+			}
+			const value = Reflect.get(target, prop, receiver);
+			return value === undefined ? "" : value;
+		},
+	});
+	process.env = proxy;
+	try {
+		return await run();
+	} finally {
+		process.env = original;
+	}
+}
+
+function withoutFunctionEnvKeys(
+	config: Config,
+	keys: ReadonlySet<string>,
+): Config {
+	const functions = config.preview?.functions;
+	if (!functions) return config;
+	const nextFunctions: Record<string, FunctionDef> = {};
+	for (const [slug, fn] of Object.entries(functions)) {
+		if (!fn.env) {
+			nextFunctions[slug] = fn;
+			continue;
+		}
+		const env = Object.fromEntries(
+			Object.entries(fn.env).filter(([key]) => !keys.has(key)),
+		);
+		nextFunctions[slug] = { ...fn, env };
+	}
+	return Object.freeze({
+		...config,
+		preview: { ...config.preview, functions: nextFunctions },
+	});
 }

--- a/packages/config/src/lib/loader.ts
+++ b/packages/config/src/lib/loader.ts
@@ -59,8 +59,8 @@ export async function loadConfigFromFile(
 	config: Config;
 	resolvedPath: string;
 }> {
-	// The omit reload replaces process.env. Concurrent strict loads in this
-	// process would then see "" for missing keys.
+	// The omit reload replaces process.env, which is process-global, including
+	// across duplicate @neon/config copies. Queue loads on globalThis.
 	return await withSerializedConfigLoad(() =>
 		loadConfigFromFileUnlocked(options),
 	);
@@ -330,11 +330,23 @@ async function withPlaceholderFunctionEnv<T>(
 	}
 }
 
-let configLoadChain: Promise<unknown> = Promise.resolve();
+const CONFIG_LOAD_LOCK = Symbol.for("@neon/config loadConfigFromFile lock");
+
+type ConfigLoadLock = { chain: Promise<unknown> };
+
+function configLoadLock(): ConfigLoadLock {
+	const g = globalThis as typeof globalThis & {
+		[CONFIG_LOAD_LOCK]?: ConfigLoadLock;
+	};
+	const lock = g[CONFIG_LOAD_LOCK] ?? { chain: Promise.resolve() };
+	g[CONFIG_LOAD_LOCK] = lock;
+	return lock;
+}
 
 async function withSerializedConfigLoad<T>(run: () => Promise<T>): Promise<T> {
-	const next = configLoadChain.then(run, run);
-	configLoadChain = next.then(
+	const lock = configLoadLock();
+	const next = lock.chain.then(run, run);
+	lock.chain = next.then(
 		() => undefined,
 		() => undefined,
 	);


### PR DESCRIPTION
## Problem

`neon link` and `neon env pull` fail while evaluating `neon.ts` when a function declares env like `DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN` and that variable is unset.

Bot templates do this. `neon bootstrap` copies the template; `link` then auto-pulls env. The pin succeeds. The bundled pull prints:

```
WARNING: Branch pinned, but pulling its Neon env vars failed: Invalid Neon config:
  - preview.functions.discord.env.DISCORD_PUBLIC_KEY: Environment variable "DISCORD_PUBLIC_KEY" for function "discord" is undefined
```

`DATABASE_URL` and `NEON_FUNCTION_*_BASE_URL` never get written. `--service postgres` works around it by skipping `neon.ts`.

## Diagnosis

`env pull` loads `neon.ts` so it can derive `NEON_FUNCTION_<SLUG>_BASE_URL` from the branch connection host, including for functions that are not deployed yet.

`defineConfig` rejects `undefined` function env. That is correct for deploy, `neon dev`, and `parseEnv`: a missing secret must not ship.

The load runs the user's `defineConfig` from their `@neon/config` copy. The CLI cannot loosen that schema. Falling back to `pullConfig` would drop the declared slugs and skip the invocation URLs.

The loader therefore retries only when every validation issue is an unset function env value: treat unset `process.env` reads as `""` for that reload, then strip those keys from the returned config so an empty string is never declared env. Config loads in the process are serialized for that reload, because the proxy is process-global.

## Interface

Commands that now succeed with those keys unset:

```
neon env pull
neon link
neon checkout
```

They still write Neon vars only (`DATABASE_URL`, `NEON_FUNCTION_*_BASE_URL`, …). Function secrets are not pulled.

Commands and APIs that still fail:

```
neon dev
neon-env run -- <cmd>
```

```ts
defineConfig({
  preview: {
    functions: {
      discord: {
        name: "discord",
        source: "./src/index.ts",
        env: { DISCORD_BOT_TOKEN: process.env.DISCORD_BOT_TOKEN },
      },
    },
  },
});
```

`loadConfigFromFile` default is unchanged (`unsetFunctionEnv: "error"`). Env pull passes `"omit"`:

```ts
await loadConfigFromFile({ cwd, unsetFunctionEnv: "omit" }); // env pull only
await loadConfigFromFile({ cwd }); // default: still throws
```

| `unsetFunctionEnv` | Behavior |
|---|---|
| `"error"` (default) | `defineConfig` rejection |
| `"omit"` | Drop unset function env keys; keep slugs and the rest of the policy |

Do not apply or deploy a config loaded with `"omit"`. Omitted keys are not written.

## Also in here

Patch changeset for `@neon/config`, `neon`, and `neonctl`.

## Verification

```
pnpm exec vitest run src/lib/loader.test.ts
# packages/config: 12 passed

pnpm exec vitest run src/commands/env.test.ts src/dev/env.test.ts src/dev/functions.test.ts src/commands/env.apihost.test.ts
# packages/cli: 93 passed
```

Added coverage:

- omit keeps a set sibling env key and drops the unset one
- omit works for `defineConfig` in `neon.ts`, a raw default export, and `neon.js`
- default load still throws
- omit still throws on a bad function slug
- a strict load after omit still throws
- omit drops a function env key that contains a colon
- a concurrent strict load still fails while omit is reloading
- `env pull` and `autoPullEnvAfterPin` write `DATABASE_URL` and `NEON_FUNCTION_HELLO_BASE_URL` when function env is unset
- `resolveNeonEnvVars` without the flag still throws; with `omitUnsetFunctionEnv` it resolves
- `resolveFunctionsFromConfig` (`neon dev`) still throws

Not run: live `neon bootstrap` + `link` against a Discord template. CLI tests use `FakeNeonApi`.

## For your attention

- `"omit"` is a loader flag, not a `defineConfig` change. Mixed validation errors (bad slug plus unset env) still fail with no retry.
- The reload proxies `process.env` so `env: { TOKEN: process.env.DISCORD_BOT_TOKEN }` works when the config key and the env var name differ. Loads are queued on a process-global lock so a concurrent strict load cannot see those empty strings.
- Templates are unchanged. `process.env.X ?? ""` still uploads and deletes the live key on deploy.
