### PR TITLE
chore: release pending changesets

### DIFF
--- a/.changeset/checkout-env.md
+++ b/.changeset/checkout-env.md
@@ -1,6 +1,0 @@
----
-"neon": patch
-"neonctl": patch
----
-
-`neon checkout --env <file>` loads that .env file before applying neon.ts when checkout creates a branch, the same as `neon deploy --env`. Checking out an existing branch ignores `--env`.

--- a/.changeset/cli-oauth-refresh-durability.md
+++ b/.changeset/cli-oauth-refresh-durability.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-Keep the OAuth session across a token refresh, a concurrent command, and a 401 from an expired access token. A dead session is reported instead of opening a browser.

--- a/.changeset/data-api-claimable-lifecycle.md
+++ b/.changeset/data-api-claimable-lifecycle.md
@@ -1,7 +1,0 @@
----
-"@neon/config": minor
-"@neon/config-runtime": minor
-"neon": minor
----
-
-`neon.ts` `dataApi: false` disables the Data API on deploy. `neon claim create` sends the Data API create body from neon.ts, including an external JWKS.

--- a/.changeset/deploy-help-env.md
+++ b/.changeset/deploy-help-env.md
@@ -1,7 +1,0 @@
----
-"neon": patch
-"neonctl": patch
-"@neon/config": patch
----
-
-`neon deploy --help` and `neon functions deploy --help` now say which command is the neon.ts full deploy and which is the manual/targeted path, and that `neon deploy --env` is a .env file. An unset Function env value in neon.ts tells you to set it or omit the key, not to coerce with `?? ""`.

--- a/.changeset/env-pull-function-base-url.md
+++ b/.changeset/env-pull-function-base-url.md
@@ -1,7 +1,0 @@
----
-"neon": minor
-"neonctl": minor
-"@neon/env": minor
----
-
-`neon env pull` writes `NEON_FUNCTION_<SLUG>_BASE_URL` from the branch connection host for each `neon.ts` function (deployed or not). `--service functions` still lists live functions. `neon dev` injects `http://localhost:<port>`. `parseEnv` requires a URL; `fetchEnv` types `env.functions.<slug>.baseUrl` as `string`.

--- a/.changeset/env-pull-omit-unset-function-env.md
+++ b/.changeset/env-pull-omit-unset-function-env.md
@@ -1,7 +1,0 @@
----
-"@neon/config": patch
-"neon": patch
-"neonctl": patch
----
-
-`neon env pull` (and the pull bundled into `link` / `checkout`) loads neon.ts even when function env vars are unset, so it can still write `NEON_FUNCTION_*_BASE_URL`. `neon dev`, `neon-env run`, and `defineConfig` still reject those missing values.

--- a/.changeset/hono-websocket-helper.md
+++ b/.changeset/hono-websocket-helper.md
@@ -1,8 +1,0 @@
----
-"@neon/functions": minor
----
-
-Add `@neon/functions/hono` — `upgradeWebSocket` as a Hono route helper.
-
-`hono` is an optional peer (`^4.7.8`). Installing `@neon/functions` without it
-pulls in nothing extra and warns about nothing.

--- a/.changeset/sdk-custom-domains.md
+++ b/.changeset/sdk-custom-domains.md
@@ -1,7 +1,0 @@
----
-"@neon/sdk": minor
-"@neon/tools": minor
-"neon": minor
----
-
-List, register, and delete branch custom domains on the SDK, tools, and CLI. v1 points a domain at a function.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @neon-internals/env-core
 
+## 0.0.7
+
+### Patch Changes
+
+- Updated dependencies [fac2226]
+- Updated dependencies [c2030a5]
+- Updated dependencies [09f01b9]
+  - @neon/config@1.2.0
+
 ## 0.0.6
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.6",
+	"version": "0.0.7",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,27 @@
 # neon
 
+## 4.14.0
+
+### Minor Changes
+
+- 1ac60bd: `neon checkout --env <file>` loads that .env file before applying neon.ts when checkout creates a branch, the same as `neon deploy --env`. Checking out an existing branch ignores `--env`.
+- fac2226: `neon.ts` `dataApi: false` disables the Data API on deploy. `neon claim create` sends the Data API create body from neon.ts, including an external JWKS.
+- 915f429: `neon env pull` writes `NEON_FUNCTION_<SLUG>_BASE_URL` from the branch connection host for each `neon.ts` function (deployed or not). `--service functions` still lists live functions. `neon dev` injects `http://localhost:<port>`. `parseEnv` requires a URL; `fetchEnv` types `env.functions.<slug>.baseUrl` as `string`.
+- ba16d4d: List, register, and delete branch custom domains on the SDK, tools, and CLI. v1 points a domain at a function.
+
+### Patch Changes
+
+- 0a39157: Keep the OAuth session across a token refresh, a concurrent command, and a 401 from an expired access token. A dead session is reported instead of opening a browser.
+- c2030a5: `neon deploy --help` and `neon functions deploy --help` now say which command is the neon.ts full deploy and which is the manual/targeted path, and that `neon deploy --env` is a .env file. An unset Function env value in neon.ts tells you to set it or omit the key, not to coerce with `?? ""`.
+- 09f01b9: `neon env pull` (and the pull bundled into `link` / `checkout`) loads neon.ts even when function env vars are unset, so it can still write `NEON_FUNCTION_*_BASE_URL`. `neon dev`, `neon-env run`, and `defineConfig` still reject those missing values.
+- Updated dependencies [fac2226]
+- Updated dependencies [c2030a5]
+- Updated dependencies [09f01b9]
+- Updated dependencies [ba16d4d]
+  - @neon/config@1.2.0
+  - @neon/config-runtime@1.2.0
+  - @neon/sdk@3.1.0
+
 ## 4.13.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.13.1",
+	"version": "4.14.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @neondatabase/config-runtime
 
+## 1.2.0
+
+### Minor Changes
+
+- fac2226: `neon.ts` `dataApi: false` disables the Data API on deploy. `neon claim create` sends the Data API create body from neon.ts, including an external JWKS.
+
+### Patch Changes
+
+- Updated dependencies [fac2226]
+- Updated dependencies [c2030a5]
+- Updated dependencies [09f01b9]
+  - @neon/config@1.2.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @neondatabase/config
 
+## 1.2.0
+
+### Minor Changes
+
+- fac2226: `neon.ts` `dataApi: false` disables the Data API on deploy. `neon claim create` sends the Data API create body from neon.ts, including an external JWKS.
+
+### Patch Changes
+
+- c2030a5: `neon deploy --help` and `neon functions deploy --help` now say which command is the neon.ts full deploy and which is the manual/targeted path, and that `neon deploy --env` is a .env file. An unset Function env value in neon.ts tells you to set it or omit the key, not to coerce with `?? ""`.
+- 09f01b9: `neon env pull` (and the pull bundled into `link` / `checkout`) loads neon.ts even when function env vars are unset, so it can still write `NEON_FUNCTION_*_BASE_URL`. `neon dev`, `neon-env run`, and `defineConfig` still reject those missing values.
+- Updated dependencies [ba16d4d]
+  - @neon/sdk@3.1.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @neondatabase/env
 
+## 1.2.0
+
+### Minor Changes
+
+- 915f429: `neon env pull` writes `NEON_FUNCTION_<SLUG>_BASE_URL` from the branch connection host for each `neon.ts` function (deployed or not). `--service functions` still lists live functions. `neon dev` injects `http://localhost:<port>`. `parseEnv` requires a URL; `fetchEnv` types `env.functions.<slug>.baseUrl` as `string`.
+
+### Patch Changes
+
+- Updated dependencies [fac2226]
+- Updated dependencies [c2030a5]
+- Updated dependencies [09f01b9]
+  - @neon/config@1.2.0
+
 ## 1.1.6
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.1.6",
+	"version": "1.2.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @neondatabase/functions
 
+## 0.9.0
+
+### Minor Changes
+
+- f31a3f3: Add `@neon/functions/hono` — `upgradeWebSocket` as a Hono route helper.
+
+  `hono` is an optional peer (`^4.7.8`). Installing `@neon/functions` without it
+  pulls in nothing extra and warns about nothing.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/functions",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, `upgradeWebSocket` for serving WebSockets from a fetch handler or a Hono route, and `attachDatabasePool` for node-postgres idle-client errors.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,26 @@
 # neonctl
 
+## 4.14.0
+
+### Minor Changes
+
+- 1ac60bd: `neon checkout --env <file>` loads that .env file before applying neon.ts when checkout creates a branch, the same as `neon deploy --env`. Checking out an existing branch ignores `--env`.
+- 915f429: `neon env pull` writes `NEON_FUNCTION_<SLUG>_BASE_URL` from the branch connection host for each `neon.ts` function (deployed or not). `--service functions` still lists live functions. `neon dev` injects `http://localhost:<port>`. `parseEnv` requires a URL; `fetchEnv` types `env.functions.<slug>.baseUrl` as `string`.
+
+### Patch Changes
+
+- 0a39157: Keep the OAuth session across a token refresh, a concurrent command, and a 401 from an expired access token. A dead session is reported instead of opening a browser.
+- c2030a5: `neon deploy --help` and `neon functions deploy --help` now say which command is the neon.ts full deploy and which is the manual/targeted path, and that `neon deploy --env` is a .env file. An unset Function env value in neon.ts tells you to set it or omit the key, not to coerce with `?? ""`.
+- 09f01b9: `neon env pull` (and the pull bundled into `link` / `checkout`) loads neon.ts even when function env vars are unset, so it can still write `NEON_FUNCTION_*_BASE_URL`. `neon dev`, `neon-env run`, and `defineConfig` still reject those missing values.
+- Updated dependencies [1ac60bd]
+- Updated dependencies [0a39157]
+- Updated dependencies [fac2226]
+- Updated dependencies [c2030a5]
+- Updated dependencies [915f429]
+- Updated dependencies [09f01b9]
+- Updated dependencies [ba16d4d]
+  - neon@4.14.0
+
 ## 4.13.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.13.1",
+  "version": "4.14.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/sdk
 
+## 3.1.0
+
+### Minor Changes
+
+- ba16d4d: List, register, and delete branch custom domains on the SDK, tools, and CLI. v1 points a domain at a function.
+
 ## 3.0.0
 
 ### Major Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @neon/tools
 
+## 1.2.0
+
+### Minor Changes
+
+- ba16d4d: List, register, and delete branch custom domains on the SDK, tools, and CLI. v1 points a domain at a function.
+
+### Patch Changes
+
+- Updated dependencies [ba16d4d]
+  - @neon/sdk@3.1.0
+
 ## 1.1.1
 
 ### Patch Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.1.1",
+	"version": "1.2.0",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Problem

Eight unconsumed changeset files are sitting on `main`. The packages they describe cannot be published until those files are turned into versions and changelog entries.

This PR is that step. It rewrites each affected `package.json` version, prepends a section to each `CHANGELOG.md` and deletes the consumed `.changeset/*.md` files. The tarballs that publish from these versions contain the code already on `main`.

## Diagnosis

Changesets publishes from `package.json` and `CHANGELOG.md`. Unconsumed `.changeset/*.md` files are the queue; they are not the npm release. `changeset version` is the conversion.

`neon` and `neonctl` share a version. That lock is the `fixed` group in `.changeset/config.json`.

## The user-facing interface

| Package | npm now | This PR |
| --- | --- | --- |
| `neon` | 4.13.1 | 4.14.0 |
| `neonctl` | 4.13.1 | 4.14.0 |
| `@neon/sdk` | 3.0.0 | 3.1.0 |
| `@neon/config` | 1.1.0 | 1.2.0 |
| `@neon/config-runtime` | 1.1.0 | 1.2.0 |
| `@neon/env` | 1.1.6 | 1.2.0 |
| `@neon/functions` | 0.8.0 | 0.9.0 |
| `@neon/tools` | 1.1.1 | 1.2.0 |
| `@neon-internals/env-core` | 0.0.6 | 0.0.7 |

`neonctl` is the compatibility bin for the same CLI (`"neon": "workspace:*"`). Commands below work as `neon …` or `neonctl …`.

### CLI (`neon` / `neonctl` 4.14.0)

Checkout loads a `.env` file before applying `neon.ts` when it **creates** a branch. Checking out a branch that already exists ignores `--env`.

```bash
neon checkout feat --env .env.local
```

`neon env pull` writes `NEON_FUNCTION_<SLUG>_BASE_URL` from the branch connection host for each function declared in `neon.ts`, whether that function is deployed or not. `--service functions` still lists live functions. `neon dev` injects `http://localhost:<port>` instead.

The pull bundled into `link` / `checkout` (and a standalone `neon env pull`) still loads `neon.ts` when function env vars are unset, so it can write those `NEON_FUNCTION_*_BASE_URL` keys. `neon dev`, `neon-env run` and `defineConfig` still reject the missing values.

Custom domains (beta). v1 points a domain at a function. `register` takes `--slug`; the API stores that as `entity_type: "function"` and `entity_id` as the slug. The response `cname_target` is the hostname to CNAME.

```bash
neon functions domains list
neon functions domains register docs.example.com --slug api
neon functions domains delete docs.example.com
```

OAuth: the session is kept across a token refresh, a concurrent command and a 401 from an expired access token. A dead session is reported. The CLI does not open a browser for that case.

`neon deploy --help` and `neon functions deploy --help` end with:

```
Use neon deploy with a neon.ts file for a full deployment (declared services and functions).
Use neon functions deploy to deploy one function manually, including a targeted env update.
neon deploy --env <file> loads that .env file so neon.ts can read Function env from it.
neon functions deploy --env is KEY=VALUE (repeatable), not a file path.
```

An unset Function env value in `neon.ts` tells you to set it or omit the key.

### `neon.ts` (`@neon/config` 1.2.0, `@neon/config-runtime` 1.2.0)

`dataApi: false` disables the Data API on deploy. Apply deletes an existing integration. Omit the field to leave one alone.

```ts
import { defineConfig } from "@neon/config";

export default defineConfig({
  dataApi: false,
});
```

`neon claim create` sends the Data API create body from `neon.ts`, including an external JWKS:

```ts
export default defineConfig({
  dataApi: {
    authProvider: "external",
    jwksUrl: "https://idp.example.com/.well-known/jwks.json",
  },
});
```

### `@neon/env` 1.2.0

`fetchEnv` types `env.functions.<slug>.baseUrl` as `string`. `parseEnv` requires that value to be a URL.

```ts
import { fetchEnv, parseEnv } from "@neon/env";

const env = await fetchEnv(config, { projectId, branch: "main" });
env.functions.hello.baseUrl; // string

const parsed = parseEnv(config);
parsed.functions.hello.baseUrl; // string
```

`.env` key: `NEON_FUNCTION_<SLUG>_BASE_URL` (`<SLUG>` uppercased).

### `@neon/sdk` 3.1.0

```ts
import { createNeonClient } from "@neon/sdk";

const neon = createNeonClient({ apiKey });

const { data: registered } = await neon.functions.customDomains.register(
  projectId,
  branchId,
  { domain: "docs.example.com", entity_type: "function", entity_id: "api" },
);
// CNAME docs.example.com -> registered.cname_target

await neon.functions.customDomains.list(projectId, branchId).all();
await neon.functions.customDomains.delete(projectId, branchId, "docs.example.com");
```

HTTP:

```
GET    /projects/{project_id}/branches/{branch_id}/custom-domains
POST   /projects/{project_id}/branches/{branch_id}/custom-domains
DELETE /projects/{project_id}/branches/{branch_id}/custom-domains/{domain}
```

`POST` body: `{ domain, entity_type, entity_id }`. Response: `{ domain, entity_type, entity_id, cname_target }`. v1 accepts `entity_type: "function"` only (`400` otherwise). The function must already exist on the branch (`404` if not). Re-registering the same domain for the same entity is idempotent. A domain already registered to another resource is `409`.

The generated 1:1 names are `listProjectBranchCustomDomains`, `registerProjectBranchCustomDomain` and `deleteProjectBranchCustomDomain`.

### `@neon/tools` 1.2.0

Selectors are SDK paths. Published MCP / Mastra ids are `list_functions_custom_domains`, `register_functions_custom_domains` and `delete_functions_custom_domains`.

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
  apiKey,
  tools: [
    "functions.customDomains.list",
    "functions.customDomains.register",
    "functions.customDomains.delete",
  ],
});

await tools["functions.customDomains.register"].execute({
  project_id: "project-id",
  branch_id: "br-id",
  domain: "docs.example.com",
  entity_type: "function",
  entity_id: "api",
});
```

### `@neon/functions` 0.9.0

New subpath `@neon/functions/hono`: `upgradeWebSocket` as a Hono route helper. `hono` is an optional peer (`^4.7.8`). The root `@neon/functions` entry and the fetch-handler `upgradeWebSocket` stay as they are.

```bash
npm install @neon/functions hono
```

```ts
import { Hono } from "hono";
import { upgradeWebSocket } from "@neon/functions/hono";

const app = new Hono();

app.get(
  "/ws",
  upgradeWebSocket(() => ({
    onOpen(_event, ws) {
      ws.send("welcome");
    },
    onMessage(event, ws) {
      ws.send(`echo: ${event.data}`);
    },
  })),
);

export default app;
```

A request without `Upgrade: websocket` is passed to the next handler. Types `NeonWSEvents`, `NeonWSContext` and `UpgradeWebSocketOptions` are exported from the same subpath.

## Also in here

`@neon-internals/env-core` is `private: true`. It is bundled into `neon` and `@neon/env`. This PR bumps it to 0.0.7 because it depends on `@neon/config@1.2.0`.

No other packages in the repo are versioned here.

## Verification

Inspected `git diff origin/main...HEAD` (commit `fb28abd`). 26 files: eight `.changeset/*.md` deletions, nine `package.json` version fields, nine `CHANGELOG.md` prepends. `.changeset/` retains `README.md` and `config.json`. The versions in those `package.json` files match the table above.

This diff adds no tests and no source. The APIs above were not re-run as part of this PR.

Publish to npm is the next step after merge. It is not done by this PR.

## For your attention

- Custom domains are beta. v1 can only target a function (`entity_type: "function"`, `entity_id` is the slug).
- `parseEnv` now requires each `NEON_FUNCTION_*_BASE_URL` to be a URL. A non-URL placeholder that used to pass will throw.
- Keep `hono` in `dependencies` (not `devDependencies`) if the function imports `@neon/functions/hono`. `neon deploy` bundles from `node_modules`.