### PR TITLE
Let `neon.ts` record every compute size Neon offers

### DIFF
--- a/.changeset/compute-unit-catalog.md
+++ b/.changeset/compute-unit-catalog.md
@@ -1,0 +1,5 @@
+---
+"@neon/config": minor
+---
+
+`ComputeUnit` now covers every compute size Neon offers (0.25, 0.5, 1–16, and even sizes 18–56 for fixed-size computes), and `computeSettingsSchema` validates the documented autoscaling rules (bounds up to 16 CU, range at most 8 CU).

--- a/packages/config-runtime/e2e/lifecycle.e2e.test.ts
+++ b/packages/config-runtime/e2e/lifecycle.e2e.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe("e2e — branch policy lifecycle", () => {
 	e2eTest(
-		"creates a dev branch and pushes main policy",
+		"protects main and applies 0.25-3 CU on a new dev branch",
 		async ({ track }) => {
 			const scope = await detectApiKeyScope();
 			if (scope.kind !== "org-or-user") return;
@@ -29,7 +29,16 @@ describe("e2e — branch policy lifecycle", () => {
 				branch: (b) =>
 					b.name === main.name
 						? { protected: true }
-						: { parent: main.name, ttl: "1h" },
+						: {
+								parent: main.name,
+								ttl: "1h",
+								postgres: {
+									computeSettings: {
+										autoscalingLimitMinCu: 0.25,
+										autoscalingLimitMaxCu: 3,
+									},
+								},
+							},
 			});
 			const created = await api.createBranch(projectId, {
 				name: "dev",
@@ -42,10 +51,22 @@ describe("e2e — branch policy lifecycle", () => {
 				branchId: main.id,
 				updateExisting: true,
 			});
+			await pushConfig(config, {
+				api,
+				projectId,
+				branchId: created.branch.id,
+				updateExisting: true,
+			});
 			const reread = (await api.listBranches(projectId)).find(
 				(b) => b.id === main.id,
 			);
 			expect(reread?.protected).toBe(true);
+			const endpoint = (await api.listEndpoints(projectId)).find(
+				(e) =>
+					e.branchId === created.branch.id && e.type === "read_write",
+			);
+			expect(endpoint?.autoscalingLimitMinCu).toBe(0.25);
+			expect(endpoint?.autoscalingLimitMaxCu).toBe(3);
 		},
 	);
 });

--- a/packages/config/src/lib/define-config.test.ts
+++ b/packages/config/src/lib/define-config.test.ts
@@ -43,6 +43,29 @@ describe("defineConfig", () => {
 });
 
 describe("resolveConfig", () => {
+	test("records a 4-12 CU always-on compute on the branch", () => {
+		const config = defineConfig({
+			branch: () => ({
+				postgres: {
+					computeSettings: {
+						autoscalingLimitMinCu: 4,
+						autoscalingLimitMaxCu: 12,
+						suspendTimeout: false,
+					},
+				},
+			}),
+		});
+		expect(
+			resolveConfig(config, { name: "main", exists: true }).postgres,
+		).toEqual({
+			computeSettings: {
+				autoscalingLimitMinCu: 4,
+				autoscalingLimitMaxCu: 12,
+				suspendTimeout: false,
+			},
+		});
+	});
+
 	test("normalizes static services and branch tuning", () => {
 		const config = defineConfig({
 			auth: {},

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -140,6 +140,9 @@ describe("computeSettingsSchema", () => {
 		expect(parseIssues({ autoscalingLimitMaxCu: 17 })).toEqual([
 			"autoscalingLimitMaxCu: must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got 17)",
 		]);
+		expect(parseIssues({ autoscalingLimitMaxCu: "4" })).toEqual([
+			'autoscalingLimitMaxCu: must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got "4")',
+		]);
 	});
 });
 

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -6,8 +6,29 @@ import {
 	dataApiConfigSchema,
 	formatZodIssues,
 } from "./schema.js";
+import { COMPUTE_UNITS } from "./types.js";
+
+/**
+ * Size table at
+ * https://neon.com/docs/manage/endpoints#compute-size-and-autoscaling-configuration.
+ * Independent of {@link COMPUTE_UNITS} so a mistyped catalog entry fails this file.
+ */
+const DOCUMENTED_COMPUTE_UNITS = [
+	0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20,
+	22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56,
+] as const;
+
+function parseIssues(input: unknown): string[] {
+	const result = computeSettingsSchema.safeParse(input);
+	if (result.success) throw new Error("expected failure");
+	return formatZodIssues(result.error);
+}
 
 describe("computeSettingsSchema", () => {
+	test("the catalog matches the documented size table", () => {
+		expect(COMPUTE_UNITS).toEqual(DOCUMENTED_COMPUTE_UNITS);
+	});
+
 	test("accepts valid compute settings", () => {
 		expect(
 			computeSettingsSchema.parse({
@@ -20,12 +41,105 @@ describe("computeSettingsSchema", () => {
 		});
 	});
 
-	test("rejects min greater than max", () => {
-		const result = computeSettingsSchema.safeParse({
+	test("accepts every documented size as a fixed compute", () => {
+		for (const cu of DOCUMENTED_COMPUTE_UNITS) {
+			expect(
+				computeSettingsSchema.parse({
+					autoscalingLimitMinCu: cu,
+					autoscalingLimitMaxCu: cu,
+				}),
+			).toEqual({
+				autoscalingLimitMinCu: cu,
+				autoscalingLimitMaxCu: cu,
+			});
+		}
+	});
+
+	test("accepts documented autoscaling ranges and a single bound", () => {
+		expect(
+			computeSettingsSchema.parse({
+				autoscalingLimitMinCu: 4,
+				autoscalingLimitMaxCu: 12,
+			}),
+		).toEqual({
 			autoscalingLimitMinCu: 4,
-			autoscalingLimitMaxCu: 1,
+			autoscalingLimitMaxCu: 12,
 		});
-		expect(result.success).toBe(false);
+		expect(
+			computeSettingsSchema.parse({
+				autoscalingLimitMinCu: 0.5,
+				autoscalingLimitMaxCu: 3,
+			}),
+		).toEqual({
+			autoscalingLimitMinCu: 0.5,
+			autoscalingLimitMaxCu: 3,
+		});
+		expect(
+			computeSettingsSchema.parse({
+				autoscalingLimitMinCu: 8,
+				autoscalingLimitMaxCu: 16,
+			}),
+		).toEqual({
+			autoscalingLimitMinCu: 8,
+			autoscalingLimitMaxCu: 16,
+		});
+		expect(
+			computeSettingsSchema.parse({ autoscalingLimitMinCu: 12 }),
+		).toEqual({ autoscalingLimitMinCu: 12 });
+		expect(
+			computeSettingsSchema.parse({ autoscalingLimitMaxCu: 12 }),
+		).toEqual({ autoscalingLimitMaxCu: 12 });
+	});
+
+	test("rejects min greater than max with only that issue", () => {
+		expect(
+			parseIssues({
+				autoscalingLimitMinCu: 4,
+				autoscalingLimitMaxCu: 1,
+			}),
+		).toEqual([
+			"autoscalingLimitMinCu: autoscalingLimitMinCu (4) must be <= autoscalingLimitMaxCu (1)",
+		]);
+	});
+
+	test("rejects an autoscaling range wider than 8 CU", () => {
+		expect(
+			parseIssues({
+				autoscalingLimitMinCu: 4,
+				autoscalingLimitMaxCu: 16,
+			}),
+		).toEqual([
+			"autoscalingLimitMaxCu: autoscaling range cannot exceed 8 CU: min 4 to max 16 is a range of 12",
+		]);
+	});
+
+	test("rejects autoscaling when a bound is above 16 CU", () => {
+		expect(
+			parseIssues({
+				autoscalingLimitMinCu: 16,
+				autoscalingLimitMaxCu: 18,
+			}),
+		).toEqual([
+			"autoscalingLimitMaxCu: autoscalingLimitMaxCu (18) exceeds the autoscaling maximum of 16 CU — sizes above 16 are fixed-size only (set autoscalingLimitMinCu = autoscalingLimitMaxCu)",
+		]);
+		expect(
+			parseIssues({
+				autoscalingLimitMinCu: 18,
+				autoscalingLimitMaxCu: 20,
+			}),
+		).toEqual([
+			"autoscalingLimitMinCu: autoscalingLimitMinCu (18) exceeds the autoscaling maximum of 16 CU — sizes above 16 are fixed-size only (set autoscalingLimitMinCu = autoscalingLimitMaxCu)",
+			"autoscalingLimitMaxCu: autoscalingLimitMaxCu (20) exceeds the autoscaling maximum of 16 CU — sizes above 16 are fixed-size only (set autoscalingLimitMinCu = autoscalingLimitMaxCu)",
+		]);
+	});
+
+	test("rejects a size that is not in the catalog", () => {
+		expect(
+			parseIssues({ autoscalingLimitMaxCu: 7.5 }).join("\n"),
+		).toContain("must be a compute size Neon offers");
+		expect(parseIssues({ autoscalingLimitMaxCu: 17 }).join("\n")).toContain(
+			"must be a compute size Neon offers",
+		);
 	});
 });
 
@@ -564,6 +678,21 @@ describe("formatZodIssues", () => {
 		if (result.success) throw new Error("expected failure");
 		expect(formatZodIssues(result.error).join("\n")).toContain(
 			"postgres.computeSettings.autoscalingLimitMinCu",
+		);
+	});
+
+	test("renders autoscaling-range paths through branch tuning", () => {
+		const result = branchTuningSchema.safeParse({
+			postgres: {
+				computeSettings: {
+					autoscalingLimitMinCu: 4,
+					autoscalingLimitMaxCu: 16,
+				},
+			},
+		});
+		if (result.success) throw new Error("expected failure");
+		expect(formatZodIssues(result.error).join("\n")).toContain(
+			"postgres.computeSettings.autoscalingLimitMaxCu",
 		);
 	});
 });

--- a/packages/config/src/lib/schema.test.ts
+++ b/packages/config/src/lib/schema.test.ts
@@ -134,12 +134,12 @@ describe("computeSettingsSchema", () => {
 	});
 
 	test("rejects a size that is not in the catalog", () => {
-		expect(
-			parseIssues({ autoscalingLimitMaxCu: 7.5 }).join("\n"),
-		).toContain("must be a compute size Neon offers");
-		expect(parseIssues({ autoscalingLimitMaxCu: 17 }).join("\n")).toContain(
-			"must be a compute size Neon offers",
-		);
+		expect(parseIssues({ autoscalingLimitMaxCu: 7.5 })).toEqual([
+			"autoscalingLimitMaxCu: must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got 7.5)",
+		]);
+		expect(parseIssues({ autoscalingLimitMaxCu: 17 })).toEqual([
+			"autoscalingLimitMaxCu: must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got 17)",
+		]);
 	});
 });
 

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -11,7 +11,7 @@ const AUTOSCALING_MAX_RANGE_CU = 8;
 
 const computeUnitSchema = z.literal(COMPUTE_UNITS, {
 	error: (issue) =>
-		`must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got ${String(issue.input)})`,
+		`must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got ${JSON.stringify(issue.input)})`,
 });
 
 /**

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -10,8 +10,8 @@ const AUTOSCALING_MAX_CU = 16;
 const AUTOSCALING_MAX_RANGE_CU = 8;
 
 const computeUnitSchema = z.literal(COMPUTE_UNITS, {
-	error: () =>
-		"must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56",
+	error: (issue) =>
+		`must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got ${String(issue.input)})`,
 });
 
 /**

--- a/packages/config/src/lib/schema.ts
+++ b/packages/config/src/lib/schema.ts
@@ -2,42 +2,36 @@ import { z } from "zod";
 import { parseBranchTtl, parseSuspendTimeout } from "./duration.js";
 import { externalPackageRoot } from "./external-packages.js";
 import { isWildcardPattern, validatePattern } from "./patterns.js";
-import type { FunctionBundlerInput } from "./types.js";
+import { COMPUTE_UNITS, type FunctionBundlerInput } from "./types.js";
+
+/** Autoscaling max from the compute size table; larger sizes are fixed-size only. */
+const AUTOSCALING_MAX_CU = 16;
+/** Documented ceiling on `max - min` when both bounds are set and differ. */
+const AUTOSCALING_MAX_RANGE_CU = 8;
+
+const computeUnitSchema = z.literal(COMPUTE_UNITS, {
+	error: () =>
+		"must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56",
+});
 
 /**
  * Zod schema for {@link import("./types.js").ComputeSettings}.
  *
- * - CU values must be one of: 0.25, 0.5, 1, 2, 4, 8
- * - `suspendTimeout` can be:
+ * CU values come from {@link COMPUTE_UNITS} (the Console size table). Plan limits are
+ * the API's job. Cross-field autoscaling rules apply only when both bounds are set:
+ * `min <= max`; if they differ, each bound is ≤ 16 and `max - min` ≤ 8. A single bound
+ * cannot be checked against those rules because the other end is the project's default.
+ *
+ * `suspendTimeout` can be:
  *   - `false` (never suspend)
  *   - duration string like "5m", "1h" (must be 60s-604800s when parsed)
  *   - number in seconds (60-604800, or -1/0 for special values)
  *   - `undefined` (use platform default)
- *
- * Cross-field invariants (min <= max) are enforced via `superRefine`.
  */
 export const computeSettingsSchema = z
 	.strictObject({
-		autoscalingLimitMinCu: z
-			.union([
-				z.literal(0.25),
-				z.literal(0.5),
-				z.literal(1),
-				z.literal(2),
-				z.literal(4),
-				z.literal(8),
-			])
-			.optional(),
-		autoscalingLimitMaxCu: z
-			.union([
-				z.literal(0.25),
-				z.literal(0.5),
-				z.literal(1),
-				z.literal(2),
-				z.literal(4),
-				z.literal(8),
-			])
-			.optional(),
+		autoscalingLimitMinCu: computeUnitSchema.optional(),
+		autoscalingLimitMaxCu: computeUnitSchema.optional(),
 		suspendTimeout: z
 			.union([z.literal(false), z.string(), z.number()])
 			.optional()
@@ -55,11 +49,37 @@ export const computeSettingsSchema = z
 	.superRefine((settings, ctx) => {
 		const { autoscalingLimitMinCu: min, autoscalingLimitMaxCu: max } =
 			settings;
-		if (min !== undefined && max !== undefined && min > max) {
+		if (min === undefined || max === undefined) return;
+		if (min > max) {
 			ctx.addIssue({
 				code: "custom",
 				path: ["autoscalingLimitMinCu"],
 				message: `autoscalingLimitMinCu (${min}) must be <= autoscalingLimitMaxCu (${max})`,
+			});
+			return;
+		}
+		if (min === max) return;
+		const overMaxMessage = (field: string, value: number) =>
+			`${field} (${value}) exceeds the autoscaling maximum of ${AUTOSCALING_MAX_CU} CU — sizes above ${AUTOSCALING_MAX_CU} are fixed-size only (set autoscalingLimitMinCu = autoscalingLimitMaxCu)`;
+		if (min > AUTOSCALING_MAX_CU) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["autoscalingLimitMinCu"],
+				message: overMaxMessage("autoscalingLimitMinCu", min),
+			});
+		}
+		if (max > AUTOSCALING_MAX_CU) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["autoscalingLimitMaxCu"],
+				message: overMaxMessage("autoscalingLimitMaxCu", max),
+			});
+		}
+		if (max - min > AUTOSCALING_MAX_RANGE_CU) {
+			ctx.addIssue({
+				code: "custom",
+				path: ["autoscalingLimitMaxCu"],
+				message: `autoscaling range cannot exceed ${AUTOSCALING_MAX_RANGE_CU} CU: min ${min} to max ${max} is a range of ${max - min}`,
 			});
 		}
 	});

--- a/packages/config/src/lib/types.ts
+++ b/packages/config/src/lib/types.ts
@@ -1,8 +1,14 @@
 /**
- * Valid Neon Compute Unit values.
- * Most plans support 0.25, 0.5, 1, 2, 4, 8. Higher values may be available on Business plans.
+ * Every compute size in the Console size table
+ * (https://neon.com/docs/manage/endpoints#compute-size-and-autoscaling-configuration).
+ * Plan availability is enforced by the API, not this list.
  */
-export type ComputeUnit = 0.25 | 0.5 | 1 | 2 | 4 | 8;
+export const COMPUTE_UNITS = [
+	0.25, 0.5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 18, 20,
+	22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56,
+] as const;
+
+export type ComputeUnit = (typeof COMPUTE_UNITS)[number];
 
 /** Time units accepted in a {@link DurationString}: seconds, minutes, hours, days, weeks. */
 export type DurationUnit = "s" | "m" | "h" | "d" | "w";
@@ -68,14 +74,25 @@ type DurationField<Suggestions extends DurationString> =
 export interface ComputeSettings {
 	/**
 	 * Minimum number of Compute Units. Set to 0.25 for true scale-to-zero.
+	 *
+	 * Sizes above 16 CU are fixed-size only: if this is set with a different
+	 * {@link ComputeSettings.autoscalingLimitMaxCu}, both bounds must be ≤ 16 and
+	 * `max - min` cannot exceed 8 CU. A single bound is checked against the catalog
+	 * only — the other bound comes from the project's default endpoint settings, so
+	 * the API is the arbiter of the resolved pair.
+	 *
 	 * @example 0.25  // scale-to-zero
 	 * @example 1     // always-on with 1 CU minimum
+	 * @example 4
 	 */
 	autoscalingLimitMinCu?: ComputeUnit;
 	/**
-	 * Maximum number of Compute Units for autoscaling.
+	 * Maximum number of Compute Units for autoscaling, or the fixed size when equal
+	 * to {@link ComputeSettings.autoscalingLimitMinCu}.
+	 *
 	 * @example 2
-	 * @example 8
+	 * @example 12
+	 * @example 56  // fixed-size; pair with the same min
 	 */
 	autoscalingLimitMaxCu?: ComputeUnit;
 	/**

--- a/packages/config/src/v1.test-d.ts
+++ b/packages/config/src/v1.test-d.ts
@@ -202,6 +202,66 @@ describe("defineConfig return-type stability", () => {
 		>().toEqualTypeOf<"hello" | "world">();
 	});
 
+	test("ComputeUnit is the documented size table, not a subset", () => {
+		type DocumentedComputeUnit =
+			| 0.25
+			| 0.5
+			| 1
+			| 2
+			| 3
+			| 4
+			| 5
+			| 6
+			| 7
+			| 8
+			| 9
+			| 10
+			| 11
+			| 12
+			| 13
+			| 14
+			| 15
+			| 16
+			| 18
+			| 20
+			| 22
+			| 24
+			| 26
+			| 28
+			| 30
+			| 32
+			| 34
+			| 36
+			| 38
+			| 40
+			| 42
+			| 44
+			| 46
+			| 48
+			| 50
+			| 52
+			| 54
+			| 56;
+		expectTypeOf<ComputeUnit>().toEqualTypeOf<DocumentedComputeUnit>();
+		expectTypeOf<7.5>().not.toExtend<ComputeUnit>();
+		expectTypeOf<17>().not.toExtend<ComputeUnit>();
+	});
+
+	test("a 4-12 always-on compute type-checks on defineConfig", () => {
+		const config = defineConfig({
+			branch: () => ({
+				postgres: {
+					computeSettings: {
+						autoscalingLimitMinCu: 4,
+						autoscalingLimitMaxCu: 12,
+						suspendTimeout: false,
+					},
+				},
+			}),
+		});
+		expectTypeOf(config).toExtend<Config>();
+	});
+
 	test("bundler accepts esbuild, none, or a function, not zip-directory", () => {
 		expectTypeOf<"esbuild">().toExtend<FunctionBundlerInput>();
 		expectTypeOf<"none">().toExtend<FunctionBundlerInput>();


### PR DESCRIPTION
## Problem

`ComputeUnit` was `0.25 | 0.5 | 1 | 2 | 4 | 8`. Neon's compute size table offers 0.25, 0.5, every integer from 1 to 16 and even sizes from 18 to 56 (https://neon.com/docs/manage/endpoints#compute-size-and-autoscaling-configuration).

So a `neon.ts` could not record settings the API already accepts. `autoscalingLimitMaxCu: 3` failed type-check and schema validation. So did `autoscalingLimitMinCu: 4, autoscalingLimitMaxCu: 12`. A policy meant to describe an existing endpoint had to lie about it or leave the compute settings out.

## What the schema now enforces

The type and the runtime schema both follow the documented size table and the documented autoscaling rules:

| Input | Result |
| --- | --- |
| any catalog size as a fixed compute (`min === max`), up to 56 | accepted |
| autoscaling range (`min < max`) with both bounds <= 16 and `max - min` <= 8 | accepted |
| a single bound on its own | catalog check only (see below) |
| `min > max` | rejected, one issue |
| autoscaling bound above 16 | rejected, points at fixed-size |
| a value not in the catalog (7.5, 17, `"4"`) | rejected, message lists the valid shapes |

Sizes above 16 are fixed-size only, so the bound-above-16 and range rules apply only when both bounds are set and differ. A single bound skips them: the other end comes from the project's default endpoint settings, which the config cannot see, so the API judges the resolved pair. Plan limits also stay the API's job. The schema answers "is this a size Neon offers", not "is this a size your plan allows".

## Interface

`ComputeUnit` is exported from `@neon/config` / `@neon/config/v1` and now covers the full table:

```ts
// neon.ts
import { defineConfig } from "@neon/config/v1";

export default defineConfig({
	branch: (b) =>
		b.name === "main"
			? {
					postgres: {
						computeSettings: {
							autoscalingLimitMinCu: 4, // rejected before this PR
							autoscalingLimitMaxCu: 12,
							suspendTimeout: false,
						},
					},
				}
			: { parent: "main", ttl: "1h" },
});
```

Validation failures name the field, the rule and the value:

```
autoscalingLimitMaxCu: must be a compute size Neon offers: 0.25, 0.5, an integer 1-16, or an even integer 18-56 (got 7.5)
autoscalingLimitMaxCu: autoscaling range cannot exceed 8 CU: min 4 to max 16 is a range of 12
autoscalingLimitMinCu: autoscalingLimitMinCu (18) exceeds the autoscaling maximum of 16 CU — sizes above 16 are fixed-size only (set autoscalingLimitMinCu = autoscalingLimitMaxCu)
```

Nothing changes for existing configs. The old six values are a subset of the new catalog, `min <= max` was already enforced and `suspendTimeout` handling is untouched. The old set was too narrow to trip the new cross-field rules (its widest possible range is 0.25 to 8), so no previously-valid config becomes invalid.

## Also in here

- The `@neon/config-runtime` lifecycle e2e now gives the dev branch a 0.25-3 CU policy, pushes it and asserts the endpoint's limits via `listEndpoints`. 3 was one of the sizes the old type rejected, so the live suite exercises exactly the gap this PR closes.
- A changeset (minor bump for `@neon/config`).

## Verification

- `pnpm --filter @neon/config test:ci`: 15 files, 300 tests pass.
- `pnpm --filter @neon/config test:types`: 26 tests, no type errors. Includes an exact type-level equality check between `ComputeUnit` and the documented table, plus negative checks for 7.5 and 17.
- The catalog is written down twice on purpose: once in `types.ts` and once re-typed from the docs page in `schema.test.ts`. A parity test compares them, so a typo in either copy fails instead of shipping.
- Schema tests cover: every documented size as a fixed compute, three documented autoscaling ranges, single bounds, `min > max` (and that it reports only that issue), a range wider than 8, bounds above 16 (one and both), non-catalog numbers and a string, and issue paths through `branchTuningSchema`.

Not run here: the live e2e suite (`test:e2e:live`). The lifecycle test's 0.25-3 CU push needs one live run against the real Management API before merge.

## For your attention

- **The catalog is a snapshot of the docs page.** If Neon adds a size, the type rejects it until this list is updated. The parity test pins the current table but nothing detects upstream drift automatically.
- **A single bound is deliberately under-validated.** `{ autoscalingLimitMinCu: 18 }` passes the schema even though it can only resolve to a valid endpoint if the default max also lands on 18. Rejecting it would require knowing the project's defaults, which the config layer does not.
