### PR TITLE
chore: release pending changesets

### DIFF
--- a/.changeset/compute-unit-catalog.md
+++ b/.changeset/compute-unit-catalog.md
@@ -1,5 +1,0 @@
----
-"@neon/config": minor
----
-
-`ComputeUnit` now covers every compute size Neon offers (0.25, 0.5, 1–16, and even sizes 18–56 for fixed-size computes), and `computeSettingsSchema` validates the documented autoscaling rules (bounds up to 16 CU, range at most 8 CU).

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neon-internals/env-core
 
+## 0.0.8
+
+### Patch Changes
+
+- Updated dependencies [676b559]
+  - @neon/config@1.3.0
+
 ## 0.0.7
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.7",
+	"version": "0.0.8",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neon
 
+## 4.14.1
+
+### Patch Changes
+
+- Updated dependencies [676b559]
+  - @neon/config@1.3.0
+  - @neon/config-runtime@1.2.1
+
 ## 4.14.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.14.0",
+	"version": "4.14.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config-runtime
 
+## 1.2.1
+
+### Patch Changes
+
+- Updated dependencies [676b559]
+  - @neon/config@1.3.0
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config
 
+## 1.3.0
+
+### Minor Changes
+
+- 676b559: `ComputeUnit` now covers every compute size Neon offers (0.25, 0.5, 1–16, and even sizes 18–56 for fixed-size computes), and `computeSettingsSchema` validates the documented autoscaling rules (bounds up to 16 CU, range at most 8 CU).
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/env
 
+## 1.2.1
+
+### Patch Changes
+
+- Updated dependencies [676b559]
+  - @neon/config@1.3.0
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 4.14.1
+
+### Patch Changes
+
+- neon@4.14.1
+
 ## 4.14.0
 
 ### Minor Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.14.0",
+  "version": "4.14.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## What this releases

One pending changeset, from #530: `ComputeUnit` now covers every compute size Neon offers (0.25, 0.5, 1–16 and even sizes 18–56 for fixed-size computes), and `computeSettingsSchema` validates the documented autoscaling rules (bounds up to 16 CU, range at most 8 CU).

`@neon/config` gets the minor bump. The rest are dependency cascades: each package pins `@neon/config`, so consuming the changeset bumps them as patches, and `neonctl` is version-fixed with `neon`.

| Package | npm now | This PR |
|---|---|---|
| `@neon/config` | 1.2.0 | 1.3.0 (minor, the changeset) |
| `@neon/config-runtime` | 1.2.0 | 1.2.1 (dependent bump) |
| `@neon/env` | 1.2.0 | 1.2.1 (dependent bump) |
| `neon` | 4.14.0 | 4.14.1 (dependent bump) |
| `neonctl` | 4.14.0 | 4.14.1 (fixed group with `neon`) |
| `@neon-internals/env-core` | 0.0.7 | 0.0.8 (private, bundled into consumers, never published) |

## What's in the diff

`changeset version` output only: `package.json` versions, CHANGELOG entries and the consumed `.changeset/compute-unit-catalog.md`. No source changes; the code shipping in 1.3.0 is already on `main` from #530.

## Verification

- Diff against `main` touches only `package.json` and `CHANGELOG.md` files plus the deleted changeset (13 files).
- `.changeset/` holds no pending changesets after this PR.
- Each CHANGELOG entry references commit 676b559, the merge of #530.
