### PR TITLE
Wait for in-flight operations between shared-project SDK e2e mutations

### DIFF
--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -10,9 +10,13 @@ import { expectOk, makeClient } from "./helpers.js";
 
 /**
  * The resource CRUD spine, exercised against one shared project. Creating a project per
- * test would triple the runtime for no extra signal — these methods are independent of
- * each other, and the fixtures they need (a default branch, its endpoint, its role) come
- * with any project.
+ * test would triple the runtime for no extra signal — the fixtures they need (a default
+ * branch, its endpoint, its role) come with any project.
+ *
+ * Mutations still serialize at the project. A call that returns before its operations
+ * finish rejects the next one with "project already has running conflicting operations",
+ * so every mutating call here waits (`waitForReadiness: true`, or a method default that
+ * already waits).
  *
  * The project is created through the harness rather than the SDK so that a regression in
  * `projects.create` fails its own test in `workflows.e2e.test.ts` instead of taking the
@@ -50,9 +54,12 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		expect(fetched.id).toBe(created.id);
 
 		const renamed = expectOk(
-			await neon.branches.update(projectId, created.id, {
-				name: "crud-renamed",
-			}),
+			await neon.branches.update(
+				projectId,
+				created.id,
+				{ name: "crud-renamed" },
+				{ waitForReadiness: true },
+			),
 		);
 		expect(renamed.name).toBe("crud-renamed");
 
@@ -121,7 +128,11 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		);
 		expect(matchingAgain.diff ?? "").toBe("");
 
-		expectOk(await neon.branches.delete(projectId, branchId));
+		expectOk(
+			await neon.branches.delete(projectId, branchId, {
+				waitForReadiness: true,
+			}),
+		);
 	});
 
 	it("creates a branch with its compute and a connection string in one call", async () => {
@@ -147,7 +158,11 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			created.endpoint.id,
 		);
 
-		expectOk(await neon.branches.delete(projectId, created.branch.id));
+		expectOk(
+			await neon.branches.delete(projectId, created.branch.id, {
+				waitForReadiness: true,
+			}),
+		);
 	});
 
 	it("attaches a read-write endpoint unless noCompute is true", async () => {
@@ -179,8 +194,16 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		);
 		expect(none).toEqual([]);
 
-		expectOk(await neon.branches.delete(projectId, withCompute.id));
-		expectOk(await neon.branches.delete(projectId, bare.id));
+		expectOk(
+			await neon.branches.delete(projectId, withCompute.id, {
+				waitForReadiness: true,
+			}),
+		);
+		expectOk(
+			await neon.branches.delete(projectId, bare.id, {
+				waitForReadiness: true,
+			}),
+		);
 	});
 
 	it("manages roles, including the two different password shapes", async () => {
@@ -190,9 +213,12 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		expect(before.length).toBeGreaterThan(0);
 
 		const created = expectOk(
-			await neon.postgres.roles.create(projectId, defaultBranchId, {
-				name: "e2e_role",
-			}),
+			await neon.postgres.roles.create(
+				projectId,
+				defaultBranchId,
+				{ name: "e2e_role" },
+				{ waitForReadiness: true },
+			),
 		);
 		expect(created.name).toBe("e2e_role");
 
@@ -213,6 +239,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				projectId,
 				defaultBranchId,
 				"e2e_role",
+				{ waitForReadiness: true },
 			),
 		);
 		expect(reset.name).toBe("e2e_role");
@@ -240,10 +267,12 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		if (!owner) throw new Error("project has no role to own a database");
 
 		const created = expectOk(
-			await neon.postgres.databases.create(projectId, defaultBranchId, {
-				name: "e2e_db",
-				owner_name: owner.name,
-			}),
+			await neon.postgres.databases.create(
+				projectId,
+				defaultBranchId,
+				{ name: "e2e_db", owner_name: owner.name },
+				{ waitForReadiness: true },
+			),
 		);
 		expect(created.name).toBe("e2e_db");
 


### PR DESCRIPTION
## Problem

The live `@neon/sdk` resource suite fails intermittently on `round-trips a database` in `packages/sdk/e2e/resources.e2e.test.ts`. In [this run](https://github.com/neondatabase/neon-pkgs/actions/runs/33836498787) `databases.create` succeeded and the `databases.delete` right after it failed with:

```
project already has running conflicting operations, scheduling of new ones is prohibited
```

Both attempts of that post-merge run failed the same way. The config, config-runtime, env and CLI suites passed in the same run, and the same SDK suite was green on #530 and #531.

## Diagnosis

Neon mutations are asynchronous: the call returns while its `operations` are still running, and the project rejects the next conflicting mutation until they settle. The suite runs its mutations sequentially against one shared project, so any unwaited mutation races the one after it.

The file already handled this for some calls (`waitForReadiness: true`) and not others. `databases.create` in the failing test did not wait, so the delete landed while create's operations were still in flight. The same gap existed on `branches.update`, four `branches.delete` calls, `roles.create` and `resetPassword`. Which mutation loses the race depends on API timing, which is why the suite was green on adjacent PRs and red here twice.

## The change

Test-only. Every mutating call in `resources.e2e.test.ts` now waits, either explicitly:

```ts
await neon.postgres.databases.create(
	projectId,
	defaultBranchId,
	{ name: "e2e_db", owner_name: owner.name },
	{ waitForReadiness: true },
);
```

or through a method default that already waits (`branches.create` and `createAndConnect` default `waitForReadiness` on). The file's header comment now states the rule, so a new test in this file starts from it instead of rediscovering the race.

The published SDK is unchanged. No changeset.

## Verification

`pnpm --filter @neon/sdk test:e2e` against the real Neon API: 3 files, 18 passed.

A race fix can't be proven by one green run, but every mutation in the file now blocks on its own operations before the next one is scheduled, which removes the mechanism the error message describes. The stubbed unit suite answers every request instantly and cannot reproduce this.