### PR TITLE
Print a parent command's help when it's run without a subcommand

### DIFF
--- a/.changeset/parent-command-help.md
+++ b/.changeset/parent-command-help.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+A top-level command that only has subcommands (`neon claim`, `neon env`, `neon logs`, …) prints that command's help when you run it with no subcommand, instead of an error that says to run `--help`.

--- a/packages/cli/AGENTS.md
+++ b/packages/cli/AGENTS.md
@@ -10,6 +10,14 @@ Coding-agent targeting is `--agent <name>` (repeatable) on `skills`, `plugins`, 
 
 Human output (`-o table`, the default) is for a terminal. `-o json` and `-o yaml` are for scripts. Never parse the human format in a script, a test that is checking a machine contract, or an agent workflow that needs a field.
 
+## Parent commands
+
+A command that only groups subcommands prints its own help and exits 0 when run
+without a subcommand. Do not add a top-level `demandCommand` to these command
+modules; the help middleware in `src/index.ts` handles the bare invocation.
+Commands that perform an action of their own belong in `NO_SUBCOMMANDS_VERBS`
+and keep that action.
+
 ## `-o table`
 
 Implemented in `src/writer.ts` and `src/human_table.ts`. Every list and get goes through `writer`. Do not draw a table in a command.

--- a/packages/cli/CONTRIBUTING.md
+++ b/packages/cli/CONTRIBUTING.md
@@ -16,6 +16,21 @@ alignment is gone. Do not add `cli-table` or any other box drawer.
 All list and get commands go through `writer` in `src/writer.ts`. Change the
 layout there, not in a command.
 
+## Parent commands
+
+When a command only groups subcommands, running it without a subcommand prints
+that command's help and exits 0:
+
+```console
+$ neon projects
+neon projects <sub-command> [options]
+
+Commands:
+...
+```
+
+Commands that perform an action of their own keep that behavior.
+
 ## Layout
 
 | Input | Format |

--- a/packages/cli/src/commands/__snapshots__/logs.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/logs.test.ts.snap
@@ -1,7 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`logs > a sub-command is required 1`] = `""`;
-
 exports[`logs > a truncated field-values run keeps json output clean and stderr empty 1`] = `
 "{
   "values": [

--- a/packages/cli/src/commands/api_keys.ts
+++ b/packages/cli/src/commands/api_keys.ts
@@ -156,8 +156,7 @@ export const builder = (argv: yargs.Argv) =>
 					.strict()
 					.check(noPassthrough("api-keys")),
 			async (args) => await revoke(args as unknown as RevokeProps),
-		)
-		.demandCommand(1, "Run `neon api-keys --help` to see the subcommands.");
+		);
 
 export const handler = (args: yargs.Argv) => args;
 

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -251,8 +251,7 @@ export const builder = (argv: yargs.Argv) =>
 					})
 					.demandCommand(1, "")
 					.strictCommands(),
-		)
-		.demandCommand(1, "");
+		);
 
 export const handler = (args: yargs.Argv) => {
 	return args;

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -331,8 +331,7 @@ export const builder = (argv: yargs.Argv) =>
 					.strict()
 					.check(noPassthrough("claim delete")),
 			async (args) => await deleteProject(args as unknown as DeleteProps),
-		)
-		.demandCommand(1, "Run `neon claim --help` to see the subcommands.");
+		);
 
 export const handler = (_args: yargs.Arguments) => {
 	/* Yargs requires a handler for command groups. */

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -187,8 +187,7 @@ export const builder = (argv: yargs.Argv) =>
 					},
 				);
 			},
-		)
-		.demandCommand(1);
+		);
 
 export const handler = (args: yargs.Argv) => args;
 

--- a/packages/cli/src/commands/help.test.ts
+++ b/packages/cli/src/commands/help.test.ts
@@ -11,8 +11,6 @@ describe("help", () => {
 	});
 });
 
-// Command groups with no action of their own: a bare invocation must print that
-// group's help (the same output as `--help`), not "run --help" / demandCommand.
 const PARENT_COMMANDS = [
 	"profile",
 	"api-keys",

--- a/packages/cli/src/commands/help.test.ts
+++ b/packages/cli/src/commands/help.test.ts
@@ -41,10 +41,14 @@ const PARENT_COMMANDS = [
 describe("parent commands print help with no subcommand", () => {
 	for (const verb of PARENT_COMMANDS) {
 		test(verb, async ({ testCliCommand }) => {
-			const { stderr } = await testCliCommand([verb], {
+			const { stderr: bare } = await testCliCommand([verb], {
 				snapshot: false,
 			});
-			const text = strip(stderr);
+			const { stderr: flagged } = await testCliCommand([verb, "--help"], {
+				snapshot: false,
+			});
+			const text = strip(bare);
+			expect(text).toBe(strip(flagged));
 			expect(text).toContain("Commands:");
 			expect(text).not.toMatch(/ERROR:/);
 		});

--- a/packages/cli/src/commands/help.test.ts
+++ b/packages/cli/src/commands/help.test.ts
@@ -1,3 +1,4 @@
+import strip from "strip-ansi";
 import { describe, expect } from "vitest";
 
 import { test } from "../test_utils/fixtures";
@@ -8,4 +9,44 @@ describe("help", () => {
 			stderr: expect.stringContaining(`neon <command> [options]`),
 		});
 	});
+});
+
+// Command groups with no action of their own: a bare invocation must print that
+// group's help (the same output as `--help`), not "run --help" / demandCommand.
+const PARENT_COMMANDS = [
+	"profile",
+	"api-keys",
+	"orgs",
+	"projects",
+	"ip-allow",
+	"vpc",
+	"neon-auth",
+	"branches",
+	"databases",
+	"roles",
+	"operations",
+	"logs",
+	"snapshots",
+	"inspect",
+	"claim",
+	"data-api",
+	"functions",
+	"config",
+	"env",
+	"buckets",
+	"project",
+	"claimable",
+] as const;
+
+describe("parent commands print help with no subcommand", () => {
+	for (const verb of PARENT_COMMANDS) {
+		test(verb, async ({ testCliCommand }) => {
+			const { stderr } = await testCliCommand([verb], {
+				snapshot: false,
+			});
+			const text = strip(stderr);
+			expect(text).toContain("Commands:");
+			expect(text).not.toMatch(/ERROR:/);
+		});
+	}
 });

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -131,14 +131,6 @@ describe("logs", () => {
 		});
 	});
 
-	test("a sub-command is required", async ({ testCliCommand }) => {
-		await testCliCommand(["logs"], {
-			mockDir: "single_org",
-			code: 1,
-			stderr: "ERROR: Run `neon logs --help` to see the subcommands.",
-		});
-	});
-
 	test("an unknown sub-command is rejected", async ({ testCliCommand }) => {
 		await testCliCommand(["logs", "definitely-not-a-subcommand"], {
 			mockDir: "single_org",

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -304,7 +304,6 @@ export const builder = (argv: yargs.Argv) =>
 					.check(noPassthrough("logs field-values")),
 			(args) => fieldValues(args as any),
 		)
-		.demandCommand(1, "Run `neon logs --help` to see the subcommands.")
 		.epilogue(LOGS_EPILOG);
 
 export const handler = (args: yargs.Argv) => {

--- a/packages/cli/src/commands/profile.ts
+++ b/packages/cli/src/commands/profile.ts
@@ -239,8 +239,7 @@ export const builder = (argv: yargs.Argv) =>
 						yes: boolean;
 					},
 				),
-		)
-		.demandCommand(1, "Run `neon profile --help` to see the subcommands.");
+		);
 
 export const handler = (_args: yargs.Arguments) => {
 	/* subcommands only */

--- a/packages/cli/src/commands/snapshots.ts
+++ b/packages/cli/src/commands/snapshots.ts
@@ -292,8 +292,7 @@ export const builder = (argv: yargs.Argv) =>
 					)
 					.demandCommand(1, "Specify `get` or `set`."),
 			() => {},
-		)
-		.demandCommand(1, "Specify a snapshots sub-command.");
+		);
 
 export const handler = (args: yargs.Argv) => {
 	return args;


### PR DESCRIPTION
## Problem

Six parent commands (`neon claim`, `neon env`, `neon logs`, `neon profile`, `neon api-keys`, `neon snapshots`) exit 1 on a bare invocation and tell you to go run another command:

```console
$ neon logs
ERROR: Run `neon logs --help` to see the subcommands.
```

The other parent groups (`neon projects`, `neon branches`, `neon functions`, ...) already print their own help on a bare invocation. So the CLI answered the same input two different ways depending on which group you hit.

## Diagnosis

The help fallback already exists. A middleware in `src/index.ts` catches a bare one-word invocation, skips the verbs listed in `NO_SUBCOMMANDS_VERBS` (commands with an action of their own, like `neon api` and `neon link`) and prints the group's help.

The six broken groups each carried their own `.demandCommand(1, ...)` in the command module. Yargs validation runs before the middleware's output lands, so `demandCommand` won and printed the error instead. The fix is deleting those six calls, not adding anything.

## What changes for the user

A bare parent command now prints exactly what `--help` prints and exits 0:

```console
$ neon claim
neon claim <sub-command> [options]

Commands:
neon claim create
└────────────────>    Create a temporary Neon project without an account
neon claim status [project-id]
└────────────────>    Show a claimable project's lifecycle and claim status
...
$ echo $?
0
```

Commands that perform an action of their own (`neon api`, `neon auth`, `neon connection-string`, `neon psql`, `neon checkout`, `neon link`, `neon open`, `neon init`, `neon mcp`, `neon plugins`, `neon skills` and the rest of `NO_SUBCOMMANDS_VERBS`) keep that action. Nothing changes for any invocation that names a subcommand.

## Also in here

- `packages/cli/AGENTS.md` and `packages/cli/CONTRIBUTING.md` record the convention, so a new parent command doesn't reintroduce a `demandCommand`: a group prints its own help on a bare invocation, the middleware in `src/index.ts` handles it and action commands belong in `NO_SUBCOMMANDS_VERBS`.
- The `logs > a sub-command is required` test asserted the old error and is removed, along with its stale snapshot entry.
- `neon snapshots schedule` keeps its inner `.demandCommand(1, "Specify \`get\` or \`set\`.")`. The middleware only fires on one-word invocations, so removing that one would leave a bare `neon snapshots schedule` doing nothing at all.
- `buckets` already printed help. Its inert top-level `demandCommand(1, "")` is removed so the implementation matches the documented convention; the nested `buckets object` requirement stays.
- Changeset: `neon` patch.

## Verification

New test in `src/commands/help.test.ts` covers all 22 parent commands, including the ones that were already correct. For each verb it asserts the bare invocation's stderr equals the `--help` stderr after ANSI stripping, contains a `Commands:` listing and contains no `ERROR:`. The equality check matters: a `Commands:`-contains check alone would pass if the root help leaked through instead of the group's help.

- `pnpm vitest run src/commands/help.test.ts` in `packages/cli`: 23 pass
- `pnpm vitest run src/commands/logs.test.ts`: 49 pass
- `pnpm vitest run src/commands/help.test.ts src/commands/bucket.test.ts`: 62 pass
- Built CLI: `node dist/index.js claim` prints the claim help shown above, exit 0

## For your attention

- **Bare invocation of these commands now exits 0 where it exited 1.** A script that relied on `neon env` failing as a probe would change behavior. That usage seems unlikely; the same script gets the same help text on stderr either way.
- Nested groups two levels deep are outside the middleware's reach. `neon snapshots schedule` still errors with `Specify \`get\` or \`set\`.` rather than printing help. Extending the convention below the top level is a separate change.

