### PR TITLE
Let `error.kind` narrow `NeonResult` to the matching error class

### DIFF
--- a/.changeset/sdk-error-kind-narrowing.md
+++ b/.changeset/sdk-error-kind-narrowing.md
@@ -2,4 +2,4 @@
 "@neon/sdk": minor
 ---
 
-`error.kind` now narrows. `NeonResult` and `RawResult` type `error` as `NeonErrorUnion`, and every error class carries a literal `kind`, so `if (error?.kind === "not_found") error.status` compiles without `instanceof`. New `NeonClientError` (`kind: "client"`) replaces the bare `NeonError` the SDK used for SDK-side failures. `instanceof NeonError` still matches. `NeonApiError` is now `NeonApiError<K = "api">`; annotate `NeonApiError<NeonApiErrorKind>` if you need a variable that also holds 404/401/429 subclasses.
+`error.kind` now narrows. `NeonResult` and `RawResult` type `error` as `NeonErrorUnion`, and every error class carries a literal `kind`, so `if (error?.kind === "not_found") error.status` compiles without `instanceof`. New `NeonClientError` (`kind: "client"`) replaces the bare `NeonError` the SDK used for SDK-side failures. `instanceof NeonError` still matches; `instanceof NeonApiError` still matches 404/401/429 subclasses.

--- a/.changeset/sdk-error-kind-narrowing.md
+++ b/.changeset/sdk-error-kind-narrowing.md
@@ -2,4 +2,4 @@
 "@neon/sdk": minor
 ---
 
-`error.kind` now narrows. `NeonResult` and `RawResult` type `error` as `NeonErrorUnion`, and every error class carries a literal `kind`, so `if (error?.kind === "not_found") error.status` compiles without `instanceof`. New `NeonClientError` (`kind: "client"`) replaces the bare `NeonError` the SDK used for SDK-side failures. `instanceof NeonError` still matches; `instanceof NeonApiError` still matches 404/401/429 subclasses.
+`error.kind` now narrows. `NeonResult` and `RawResult` type `error` as `NeonErrorUnion`, and every error class carries a literal `kind`, so `if (error?.kind === "not_found") error.status` compiles without `instanceof`. New `NeonClientError` (`kind: "client"`) replaces the bare `NeonError` the SDK used for SDK-side failures. `isNeonError` is the type guard for `catch` after `throwOnError`. `instanceof NeonError` still matches; `instanceof NeonApiError` still matches 404/401/429 subclasses.

--- a/.changeset/sdk-error-kind-narrowing.md
+++ b/.changeset/sdk-error-kind-narrowing.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": minor
+---
+
+`error.kind` now narrows. `NeonResult` and `RawResult` type `error` as `NeonErrorUnion`, and every error class carries a literal `kind`, so `if (error?.kind === "not_found") error.status` compiles without `instanceof`. New `NeonClientError` (`kind: "client"`) replaces the bare `NeonError` the SDK used for SDK-side failures. `instanceof NeonError` still matches. `NeonApiError` is now `NeonApiError<K = "api">`; annotate `NeonApiError<NeonApiErrorKind>` if you need a variable that also holds 404/401/429 subclasses.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -57,7 +57,7 @@ By default every method resolves to a discriminated `{ data, error }` envelope �
 ```ts
 const { data, error } = await neon.projects.get("late-frost-12345");
 if (error) {
-  // error is a typed NeonError union
+  // error is NeonErrorUnion — discriminate on error.kind
   return;
 }
 data; // narrowed to Project
@@ -86,19 +86,28 @@ The `error` channel carries a typed hierarchy (all `Error` subclasses with a `ki
 | `NeonTimeoutError` | `"timeout"` | a deadline was exceeded — `requestTimeoutMs`, or the readiness/wait budget |
 | `NeonAbortError` | `"aborted"` | the caller's `signal` fired |
 | `NeonNetworkError` | `"network"` | `reason` — transport failure (no response) |
-| `NeonError` | `"client"` | SDK-side errors (e.g. ambiguous connection-string selection) |
+| `NeonClientError` | `"client"` | SDK-side errors (e.g. ambiguous connection-string selection, invalid `requestTimeoutMs`) |
+
+The error channel is typed as `NeonErrorUnion`, the union of every row below the base.
 
 ```ts
 const { error } = await neon.branches.get(pid, "nope");
-if (error?.kind === "not_found") { /* … */ }
+if (error?.kind === "not_found") {
+  error.status;    // 404
+  error.requestId; // string | undefined
+}
+if (error?.kind === "network") {
+  error.reason;    // "ECONNRESET"
+}
 ```
 
 Branch on `kind` rather than `name` or `message`. `name` is a stable string literal on every
 class, so it survives bundling, but `message` is not a contract.
 
-`kind` tells you what happened. To reach a subclass's **own** fields — `NeonNetworkError.reason`,
-`NeonApiError.body` — narrow with `instanceof`: the result envelope types `error` as the base
-`NeonError`, so a `kind` check alone does not make those properties visible.
+A `kind` check narrows to the class, so subclass fields are visible without `instanceof`.
+`instanceof` still works — every class extends `NeonError`, and `instanceof NeonApiError`
+matches the 404/401/429 subclasses too — and is the right tool in a `catch (e: unknown)`
+block where there is no union to narrow.
 
 `NeonNetworkError.reason` carries the most specific reason the platform gave — an `errno`
 code such as `ECONNRESET` when one is available, otherwise the innermost non-empty message.
@@ -124,7 +133,7 @@ rather than anything that names the argument.
 
 Pass a `signal` to cancel a call, or `requestTimeoutMs` to bound it. Both arrive on the
 `error` channel as typed errors — a cancelled call never rejects with a raw `DOMException`,
-and a `throwOnError` client throws the same `NeonError` subclass it would have returned:
+and a `throwOnError` client throws the same `NeonErrorUnion` member it would have returned:
 
 ```ts
 const controller = new AbortController();
@@ -150,7 +159,7 @@ cancellation is not.
 
 `requestTimeoutMs` must be a positive number of milliseconds up to `2147483647`, or
 `Infinity`. Anything else — `0`, a negative, `NaN`, or a value past that range — is
-rejected with a `client`-kind error when the client is created or the call is made, rather
+rejected with a `NeonClientError` when the client is created or the call is made, rather
 than silently becoming an instant timeout or no timeout at all.
 
 Cancellation reaches everything the SDK controls: the request and its retries, readiness
@@ -519,7 +528,7 @@ value discovered by one is not guaranteed to appear in the other.
 
 `query` pages for you, replaying the filters unchanged as the endpoint requires. If a
 page reports more records than it returned but no cursor to reach them, the walk fails
-with a `client`-kind `NeonError` rather than handing back a partial result as if it
+with a `NeonClientError` rather than handing back a partial result as if it
 were complete.
 
 ```ts
@@ -737,12 +746,12 @@ const { data, error } = await raw.getProjectBranchSchema({
 ```
 
 **The raw layer speaks the exact same result contract as the ergonomic client.** By default a
-raw call resolves to a `{ data, error }` `NeonResult` with the typed `NeonError` on the error
+raw call resolves to a `{ data, error }` `NeonResult` with the typed `NeonErrorUnion` on the error
 channel; pass `throwOnError: true` to get the bare resource and throw instead — and the
 return type narrows accordingly:
 
 ```ts
-// bare resource, throws the typed NeonError on failure
+// bare resource, throws a NeonErrorUnion member on failure
 const { project } = await raw.getProject({
   client: neon.client,
   path: { project_id },

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -106,8 +106,23 @@ class, so it survives bundling, but `message` is not a contract.
 
 A `kind` check narrows to the class, so subclass fields are visible without `instanceof`.
 `instanceof` still works — every class extends `NeonError`, and `instanceof NeonApiError`
-matches the 404/401/429 subclasses too — and is the right tool in a `catch (e: unknown)`
-block where there is no union to narrow.
+matches the 404/401/429 subclasses too.
+
+With `throwOnError`, the thrown value is a `NeonErrorUnion` member at runtime, but
+`catch (e)` types it as `unknown`. `instanceof NeonError` only yields the base class
+(whose `kind` does not narrow). Use `isNeonError`:
+
+```ts
+import { isNeonError } from "@neon/sdk";
+
+try {
+  await neon.projects.get(pid, { throwOnError: true });
+} catch (e: unknown) {
+  if (!isNeonError(e)) throw e;
+  if (e.kind === "not_found") e.status;   // number
+  if (e.kind === "network")   e.reason;   // string
+}
+```
 
 `NeonNetworkError.reason` carries the most specific reason the platform gave — an `errno`
 code such as `ECONNRESET` when one is available, otherwise the innermost non-empty message.

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -25,6 +25,7 @@ export { createNeonClient } from "./neon/client.js";
 export type { NeonConfig } from "./neon/config.js";
 export type { CallOptions } from "./neon/context.js";
 export {
+	isNeonError,
 	NeonAbortError,
 	NeonApiError,
 	type NeonApiErrorKind,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -27,9 +27,12 @@ export type { CallOptions } from "./neon/context.js";
 export {
 	NeonAbortError,
 	NeonApiError,
+	type NeonApiErrorKind,
 	NeonAuthError,
+	NeonClientError,
 	NeonError,
 	type NeonErrorKind,
+	type NeonErrorUnion,
 	NeonNetworkError,
 	NeonNotFoundError,
 	NeonOperationError,

--- a/packages/sdk/src/neon/connection.ts
+++ b/packages/sdk/src/neon/connection.ts
@@ -1,5 +1,5 @@
 import type { ConnectionDetails } from "../client/types.gen.js";
-import { NeonError } from "./errors.js";
+import { NeonClientError } from "./errors.js";
 import { err, type NeonResult, ok } from "./result.js";
 
 /**
@@ -23,8 +23,8 @@ export function pickConnectionString(
 }
 
 /**
- * Attach a derived connection string to a create result, returning a `client`-kind
- * {@link NeonError} when the response carries no connection URI.
+ * Attach a derived connection string to a create result, returning a
+ * {@link NeonClientError} when the response carries no connection URI.
  */
 export function withConnectionString<D, T>(
 	result: NeonResult<D>,
@@ -36,9 +36,8 @@ export function withConnectionString<D, T>(
 	const connectionString = pickConnectionString(uris(result.data), pooled);
 	if (!connectionString) {
 		return err(
-			new NeonError(
+			new NeonClientError(
 				"The response did not include a connection URI (the branch or project may have multiple roles or databases). Use `raw.getConnectionUri` with an explicit role and database.",
-				"client",
 			),
 		);
 	}

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -6,7 +6,7 @@ import {
 	resolveTimeoutMs,
 	runBounded,
 } from "./deadline.js";
-import { type NeonError, toNeonError } from "./errors.js";
+import { type NeonErrorUnion, toNeonError } from "./errors.js";
 import { err, finalize, type NeonResult, ok } from "./result.js";
 import { withRetries } from "./retry.js";
 import {
@@ -57,7 +57,7 @@ type Exec<D> = (
 /** The request phase's outcome, before readiness polling is considered. */
 type Requested<D> =
 	| { ok: true; data: D | undefined; response: Response | undefined }
-	| { ok: false; error: NeonError };
+	| { ok: false; error: NeonErrorUnion };
 
 /**
  * Shared execution core: runs a raw client call under a deadline and with retries, maps

--- a/packages/sdk/src/neon/deadline.ts
+++ b/packages/sdk/src/neon/deadline.ts
@@ -12,7 +12,7 @@
  * to a caller who was promised `{ data, error }`.
  */
 
-import { NeonAbortError, NeonError, NeonTimeoutError } from "./errors.js";
+import { NeonAbortError, NeonClientError, NeonTimeoutError } from "./errors.js";
 
 /**
  * The largest delay `setTimeout` can represent. Beyond it Node warns
@@ -78,15 +78,13 @@ export function resolveTimeoutMs(value: number | undefined): number {
 		return Number.POSITIVE_INFINITY;
 	}
 	if (typeof value !== "number" || Number.isNaN(value) || value <= 0) {
-		throw new NeonError(
+		throw new NeonClientError(
 			`requestTimeoutMs must be a positive number of milliseconds, or Infinity to disable; received ${String(value)}.`,
-			"client",
 		);
 	}
 	if (value > MAX_TIMER_MS) {
-		throw new NeonError(
+		throw new NeonClientError(
 			`requestTimeoutMs must be at most ${MAX_TIMER_MS}ms (about 24.8 days); received ${value}. Pass Infinity for no deadline.`,
-			"client",
 		);
 	}
 	return value;
@@ -100,7 +98,9 @@ export function resolveTimeoutMs(value: number | undefined): number {
  * interceptor, transport and parsing faults through one channel, so an error merely named
  * `AbortError` is not evidence that the caller cancelled.
  */
-export function cancelled(deadline: Deadline): NeonError | undefined {
+export function cancelled(
+	deadline: Deadline,
+): NeonAbortError | NeonTimeoutError | undefined {
 	const source = deadline.source();
 	if (source === "caller") {
 		return new NeonAbortError("The request was aborted by its signal.");

--- a/packages/sdk/src/neon/errors.test-d.ts
+++ b/packages/sdk/src/neon/errors.test-d.ts
@@ -10,7 +10,7 @@ import {
 	NeonError,
 	type NeonErrorUnion,
 	type NeonNetworkError,
-	type NeonNotFoundError,
+	NeonNotFoundError,
 	type NeonOperationError,
 	type NeonRateLimitError,
 	type NeonTimeoutError,
@@ -42,8 +42,11 @@ it("kind narrows NeonResult.error to the matching subclass", async () => {
 	}
 
 	if (error?.kind === "api") {
-		expectTypeOf(error).toEqualTypeOf<NeonApiError>();
+		expectTypeOf(error.kind).toEqualTypeOf<"api">();
 		expectTypeOf(error.status).toEqualTypeOf<number>();
+		expectTypeOf(error).toEqualTypeOf<
+			NeonApiError & { readonly kind: "api" }
+		>();
 	}
 
 	if (error?.kind === "aborted") {
@@ -113,10 +116,21 @@ it("toNeonError returns the union", () => {
 it("NeonApiError construction cannot claim a subclass kind", () => {
 	expectTypeOf(
 		new NeonApiError("x", { status: 500 }).kind,
-	).toEqualTypeOf<"api">();
+	).toEqualTypeOf<NeonApiErrorKind>();
 	new NeonApiError("x", {
 		status: 404,
 		// @ts-expect-error a 404 must be NeonNotFoundError, not NeonApiError with kind not_found
 		kind: "not_found",
 	});
+});
+
+it("HTTP subclasses remain assignable to NeonApiError", () => {
+	const error: NeonApiError = new NeonNotFoundError("x", { status: 404 });
+	expectTypeOf(error.status).toEqualTypeOf<number>();
+	expectTypeOf(error.kind).toEqualTypeOf<NeonApiErrorKind>();
+});
+
+it("NeonApiError is not a generic that can advertise a false kind", () => {
+	// @ts-expect-error NeonApiError takes no type arguments
+	new NeonApiError<"not_found">("x", { status: 500 });
 });

--- a/packages/sdk/src/neon/errors.test-d.ts
+++ b/packages/sdk/src/neon/errors.test-d.ts
@@ -2,6 +2,7 @@ import { expectTypeOf, it } from "vitest";
 import type { Project } from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
 import {
+	isNeonError,
 	type NeonAbortError,
 	NeonApiError,
 	type NeonApiErrorKind,
@@ -133,4 +134,20 @@ it("HTTP subclasses remain assignable to NeonApiError", () => {
 it("NeonApiError is not a generic that can advertise a false kind", () => {
 	// @ts-expect-error NeonApiError takes no type arguments
 	new NeonApiError<"not_found">("x", { status: 500 });
+});
+
+it("new NeonApiError is assignable to NeonErrorUnion", () => {
+	const error: NeonErrorUnion = new NeonApiError("x", { status: 500 });
+	expectTypeOf(error).toEqualTypeOf<NeonErrorUnion>();
+});
+
+it("isNeonError narrows unknown to NeonErrorUnion", () => {
+	const e: unknown = new NeonNotFoundError("x", { status: 404 });
+	if (isNeonError(e)) {
+		expectTypeOf(e).toEqualTypeOf<NeonErrorUnion>();
+		if (e.kind === "not_found") {
+			expectTypeOf(e).toEqualTypeOf<NeonNotFoundError>();
+			expectTypeOf(e.status).toEqualTypeOf<number>();
+		}
+	}
 });

--- a/packages/sdk/src/neon/errors.test-d.ts
+++ b/packages/sdk/src/neon/errors.test-d.ts
@@ -1,0 +1,122 @@
+import { expectTypeOf, it } from "vitest";
+import type { Project } from "../client/types.gen.js";
+import { createNeonClient } from "./client.js";
+import {
+	type NeonAbortError,
+	NeonApiError,
+	type NeonApiErrorKind,
+	type NeonAuthError,
+	type NeonClientError,
+	NeonError,
+	type NeonErrorUnion,
+	type NeonNetworkError,
+	type NeonNotFoundError,
+	type NeonOperationError,
+	type NeonRateLimitError,
+	type NeonTimeoutError,
+	toNeonError,
+} from "./errors.js";
+import type { NeonResult } from "./result.js";
+
+it("kind narrows NeonResult.error to the matching subclass", async () => {
+	const neon = createNeonClient({ apiKey: "x" });
+	const { error }: NeonResult<Project> = await neon.projects.get("p");
+
+	if (error?.kind === "not_found") {
+		expectTypeOf(error).toEqualTypeOf<NeonNotFoundError>();
+		expectTypeOf(error.status).toEqualTypeOf<number>();
+		expectTypeOf(error.requestId).toEqualTypeOf<string | undefined>();
+		// @ts-expect-error reason is a network-error field
+		error.reason;
+	}
+
+	if (error?.kind === "network") {
+		expectTypeOf(error).toEqualTypeOf<NeonNetworkError>();
+		expectTypeOf(error.reason).toEqualTypeOf<string>();
+		// @ts-expect-error status is an API-error field
+		error.status;
+	}
+
+	if (error?.kind === "client") {
+		expectTypeOf(error).toEqualTypeOf<NeonClientError>();
+	}
+
+	if (error?.kind === "api") {
+		expectTypeOf(error).toEqualTypeOf<NeonApiError>();
+		expectTypeOf(error.status).toEqualTypeOf<number>();
+	}
+
+	if (error?.kind === "aborted") {
+		expectTypeOf(error).toEqualTypeOf<NeonAbortError>();
+	}
+
+	if (error?.kind === "timeout") {
+		expectTypeOf(error).toEqualTypeOf<NeonTimeoutError>();
+	}
+
+	if (error?.kind === "operation") {
+		expectTypeOf(error).toEqualTypeOf<NeonOperationError>();
+		expectTypeOf(error.operationId).toEqualTypeOf<string>();
+	}
+
+	if (error?.kind === "auth") {
+		expectTypeOf(error).toEqualTypeOf<NeonAuthError>();
+		expectTypeOf(error.status).toEqualTypeOf<number>();
+	}
+
+	if (error?.kind === "rate_limit") {
+		expectTypeOf(error).toEqualTypeOf<NeonRateLimitError>();
+		expectTypeOf(error.status).toEqualTypeOf<number>();
+	}
+});
+
+it("a switch over kind is exhaustive", async () => {
+	const neon = createNeonClient({ apiKey: "x" });
+	const { error }: NeonResult<Project> = await neon.projects.get("p");
+	if (!error) return;
+
+	switch (error.kind) {
+		case "api":
+		case "not_found":
+		case "auth":
+		case "rate_limit":
+		case "operation":
+		case "timeout":
+		case "aborted":
+		case "network":
+		case "client":
+			break;
+		default: {
+			expectTypeOf(error).toBeNever();
+		}
+	}
+});
+
+it("instanceof NeonApiError exposes status on the union", async () => {
+	const neon = createNeonClient({ apiKey: "x" });
+	const { error }: NeonResult<Project> = await neon.projects.get("p");
+	if (error instanceof NeonApiError) {
+		expectTypeOf(error.status).toEqualTypeOf<number>();
+		expectTypeOf(error.kind).toEqualTypeOf<NeonApiErrorKind>();
+	}
+	if (error instanceof NeonError) {
+		expectTypeOf(error).toEqualTypeOf<NeonErrorUnion>();
+	}
+});
+
+it("toNeonError returns the union", () => {
+	expectTypeOf(
+		toNeonError(undefined, undefined),
+	).toEqualTypeOf<NeonErrorUnion>();
+});
+
+it("NeonApiError construction cannot claim a subclass kind", () => {
+	expectTypeOf(
+		new NeonApiError("x", { status: 500 }).kind,
+	).toEqualTypeOf<"api">();
+	new NeonApiError("x", {
+		status: 404,
+		// @ts-expect-error a 404 must be NeonNotFoundError, not NeonApiError with kind not_found
+		kind: "not_found",
+	});
+});

--- a/packages/sdk/src/neon/errors.test.ts
+++ b/packages/sdk/src/neon/errors.test.ts
@@ -3,6 +3,7 @@ import { getProject } from "../client/raw.gen.js";
 import { createNeonClient } from "./client.js";
 import {
 	describeTransportFailure,
+	isNeonError,
 	NeonAbortError,
 	NeonApiError,
 	NeonAuthError,
@@ -144,6 +145,17 @@ describe("describeTransportFailure", () => {
 		const b = new Error("", { cause: a });
 		a.cause = b;
 		expect(describeTransportFailure(a)).toBe("cause unavailable");
+	});
+});
+
+describe("isNeonError", () => {
+	it("accepts every NeonErrorUnion member and rejects the base class", () => {
+		expect(isNeonError(new NeonApiError("x", apiInit))).toBe(true);
+		expect(isNeonError(new NeonNotFoundError("x", apiInit))).toBe(true);
+		expect(isNeonError(new NeonClientError("x"))).toBe(true);
+		expect(isNeonError(new NeonError("x", "client"))).toBe(false);
+		expect(isNeonError(new Error("x"))).toBe(false);
+		expect(isNeonError(undefined)).toBe(false);
 	});
 });
 

--- a/packages/sdk/src/neon/errors.test.ts
+++ b/packages/sdk/src/neon/errors.test.ts
@@ -3,8 +3,10 @@ import { getProject } from "../client/raw.gen.js";
 import { createNeonClient } from "./client.js";
 import {
 	describeTransportFailure,
+	NeonAbortError,
 	NeonApiError,
 	NeonAuthError,
+	NeonClientError,
 	NeonError,
 	NeonNetworkError,
 	NeonNotFoundError,
@@ -62,7 +64,9 @@ describe("error names survive minification", () => {
 			NeonOperationError,
 		],
 		["NeonTimeoutError", () => new NeonTimeoutError("x"), NeonTimeoutError],
+		["NeonAbortError", () => new NeonAbortError("x"), NeonAbortError],
 		["NeonNetworkError", () => new NeonNetworkError("x"), NeonNetworkError],
+		["NeonClientError", () => new NeonClientError("x"), NeonClientError],
 	];
 
 	for (const [expected, construct, cls] of cases) {
@@ -71,6 +75,37 @@ describe("error names survive minification", () => {
 			expect(nameAfterMinification(construct, cls)).toBe(expected);
 		});
 	}
+});
+
+describe("NeonClientError", () => {
+	it("is a client-kind NeonError with optional cause", () => {
+		const cause = new Error("inner");
+		const error = new NeonClientError("ambiguous selection", { cause });
+		expect(error).toBeInstanceOf(NeonClientError);
+		expect(error).toBeInstanceOf(NeonError);
+		expect(error.kind).toBe("client");
+		expect(error.name).toBe("NeonClientError");
+		expect(error.cause).toBe(cause);
+	});
+});
+
+describe("each class reports its literal kind", () => {
+	it("matches the discriminant the type system advertises", () => {
+		expect(new NeonApiError("x", apiInit).kind).toBe("api");
+		expect(new NeonNotFoundError("x", apiInit).kind).toBe("not_found");
+		expect(new NeonAuthError("x", apiInit).kind).toBe("auth");
+		expect(new NeonRateLimitError("x", apiInit).kind).toBe("rate_limit");
+		expect(
+			new NeonOperationError("x", {
+				operationId: "op-1",
+				status: "failed",
+			}).kind,
+		).toBe("operation");
+		expect(new NeonTimeoutError("x").kind).toBe("timeout");
+		expect(new NeonAbortError("x").kind).toBe("aborted");
+		expect(new NeonNetworkError("x").kind).toBe("network");
+		expect(new NeonClientError("x").kind).toBe("client");
+	});
 });
 
 describe("describeTransportFailure", () => {

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -179,10 +179,9 @@ export class NeonNetworkError extends NeonError {
 }
 
 /**
- * A failure the SDK detected itself, before or after talking to the API — an ambiguous
- * connection-string selection, an invalid `requestTimeoutMs`, a `noCompute` branch with
- * compute settings, a response missing a field the wrapper needs. Nothing was wrong on
- * the wire; the call could not be completed as asked.
+ * A failure the SDK detected itself — an ambiguous connection-string selection, an
+ * invalid `requestTimeoutMs`, a `noCompute` branch with compute settings, a response
+ * missing a field the wrapper needs. `cause` is set when a lower-level error triggered it.
  */
 export class NeonClientError extends NeonError {
 	declare readonly kind: "client";
@@ -209,11 +208,11 @@ export type NeonErrorUnion =
 	| NeonClientError;
 
 /**
- * Whether `error` is one of the classes {@link NeonErrorUnion} names. Used where a value
- * arrives as `unknown` or as the base {@link NeonError} (for example a page fetcher that
- * already classified a failure) and must be handed to `err()`.
+ * Whether `error` is a member of {@link NeonErrorUnion}. Use this in a `catch` after
+ * `throwOnError`: `instanceof NeonError` only yields the base class, whose `kind` does
+ * not narrow.
  */
-export function isNeonErrorUnion(error: unknown): error is NeonErrorUnion {
+export function isNeonError(error: unknown): error is NeonErrorUnion {
 	return (
 		error instanceof NeonApiError ||
 		error instanceof NeonOperationError ||
@@ -303,10 +302,5 @@ export function toNeonError(
 	if (status === 401 || status === 403)
 		return new NeonAuthError(message, init);
 	if (status === 429) return new NeonRateLimitError(message, init);
-	const apiError = new NeonApiError(message, init);
-	// Constructor always sets kind "api"; the check is what makes that a type fact.
-	if (apiError.kind !== "api") {
-		throw new Error(`NeonApiError produced kind ${apiError.kind}`);
-	}
-	return apiError;
+	return new NeonApiError(message, init);
 }

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -56,10 +56,8 @@ export class NeonError extends Error {
 }
 
 /** A non-2xx HTTP response from the Neon API. */
-export class NeonApiError<
-	K extends NeonApiErrorKind = "api",
-> extends NeonError {
-	declare readonly kind: K;
+export class NeonApiError extends NeonError {
+	declare readonly kind: NeonApiErrorKind;
 	/** HTTP status code. */
 	readonly status: number;
 	/** Machine-readable Neon error code (`GeneralError.code`), when present. */
@@ -83,8 +81,8 @@ export class NeonApiError<
 }
 
 /** 404 — the resource does not exist. */
-export class NeonNotFoundError extends NeonApiError<"not_found"> {
-	// Assigned after super() so the runtime kind matches the generic, not "api".
+export class NeonNotFoundError extends NeonApiError {
+	// Assigned after super() so the runtime kind is not the parent's `"api"`.
 	override readonly kind: "not_found" = "not_found";
 	constructor(message: string, init: NeonApiErrorInit) {
 		super(message, init);
@@ -93,7 +91,7 @@ export class NeonNotFoundError extends NeonApiError<"not_found"> {
 }
 
 /** 401/403 — the API key is missing, invalid, or lacks permission. */
-export class NeonAuthError extends NeonApiError<"auth"> {
+export class NeonAuthError extends NeonApiError {
 	override readonly kind: "auth" = "auth";
 	constructor(message: string, init: NeonApiErrorInit) {
 		super(message, init);
@@ -102,7 +100,7 @@ export class NeonAuthError extends NeonApiError<"auth"> {
 }
 
 /** 429 — rate limited (after retries, if enabled, were exhausted). */
-export class NeonRateLimitError extends NeonApiError<"rate_limit"> {
+export class NeonRateLimitError extends NeonApiError {
 	override readonly kind: "rate_limit" = "rate_limit";
 	constructor(message: string, init: NeonApiErrorInit) {
 		super(message, init);
@@ -200,7 +198,7 @@ export class NeonClientError extends NeonError {
  * extends {@link NeonError}, so `instanceof NeonError` still matches all of them.
  */
 export type NeonErrorUnion =
-	| NeonApiError
+	| (NeonApiError & { readonly kind: "api" })
 	| NeonNotFoundError
 	| NeonAuthError
 	| NeonRateLimitError
@@ -305,5 +303,10 @@ export function toNeonError(
 	if (status === 401 || status === 403)
 		return new NeonAuthError(message, init);
 	if (status === 429) return new NeonRateLimitError(message, init);
-	return new NeonApiError(message, init);
+	const apiError = new NeonApiError(message, init);
+	// Constructor always sets kind "api"; the check is what makes that a type fact.
+	if (apiError.kind !== "api") {
+		throw new Error(`NeonApiError produced kind ${apiError.kind}`);
+	}
+	return apiError;
 }

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -1,8 +1,9 @@
 /**
  * Typed error hierarchy surfaced on the `error` channel of every ergonomic call (and
- * thrown when `throwOnError` is set). All are `Error` subclasses with a `kind`
- * discriminant, so the same value works whether you read it from `{ error }` or `catch`
- * it.
+ * thrown when `throwOnError` is set). All are `Error` subclasses. Each concrete class
+ * carries a literal `kind`, so {@link NeonErrorUnion} is a discriminated union: a
+ * `kind` check narrows to that class. Every member extends {@link NeonError}, so
+ * `instanceof NeonError` still matches all of them.
  */
 
 /** Used when a transport failure carries neither an `errno` code nor any message. */
@@ -19,6 +20,17 @@ export type NeonErrorKind =
 	| "network"
 	| "client";
 
+/** The `kind`s an HTTP-response error can carry. */
+export type NeonApiErrorKind = "api" | "not_found" | "auth" | "rate_limit";
+
+interface NeonApiErrorInit {
+	status: number;
+	code?: string;
+	requestId?: string;
+	response?: Response;
+	body?: unknown;
+}
+
 /**
  * Base class for every error the ergonomic layer produces.
  *
@@ -26,6 +38,8 @@ export type NeonErrorKind =
  * constructor. Bundlers rename classes, so deriving the name at runtime leaves consumers
  * of a minified build with errors called `s` and `r` — unreadable in logs and impossible
  * to group on in an error tracker.
+ *
+ * The SDK does not construct this class directly; it emits {@link NeonErrorUnion} members.
  */
 export class NeonError extends Error {
 	readonly kind: NeonErrorKind;
@@ -42,7 +56,10 @@ export class NeonError extends Error {
 }
 
 /** A non-2xx HTTP response from the Neon API. */
-export class NeonApiError extends NeonError {
+export class NeonApiError<
+	K extends NeonApiErrorKind = "api",
+> extends NeonError {
+	declare readonly kind: K;
 	/** HTTP status code. */
 	readonly status: number;
 	/** Machine-readable Neon error code (`GeneralError.code`), when present. */
@@ -54,18 +71,8 @@ export class NeonApiError extends NeonError {
 	/** The parsed error body, as returned by the API. */
 	readonly body: unknown;
 
-	constructor(
-		message: string,
-		init: {
-			kind?: NeonErrorKind;
-			status: number;
-			code?: string;
-			requestId?: string;
-			response?: Response;
-			body?: unknown;
-		},
-	) {
-		super(message, init.kind ?? "api");
+	constructor(message: string, init: NeonApiErrorInit) {
+		super(message, "api");
 		this.name = "NeonApiError";
 		this.status = init.status;
 		this.code = init.code;
@@ -76,40 +83,36 @@ export class NeonApiError extends NeonError {
 }
 
 /** 404 — the resource does not exist. */
-export class NeonNotFoundError extends NeonApiError {
-	constructor(
-		message: string,
-		init: ConstructorParameters<typeof NeonApiError>[1],
-	) {
-		super(message, { ...init, kind: "not_found" });
+export class NeonNotFoundError extends NeonApiError<"not_found"> {
+	// Assigned after super() so the runtime kind matches the generic, not "api".
+	override readonly kind: "not_found" = "not_found";
+	constructor(message: string, init: NeonApiErrorInit) {
+		super(message, init);
 		this.name = "NeonNotFoundError";
 	}
 }
 
 /** 401/403 — the API key is missing, invalid, or lacks permission. */
-export class NeonAuthError extends NeonApiError {
-	constructor(
-		message: string,
-		init: ConstructorParameters<typeof NeonApiError>[1],
-	) {
-		super(message, { ...init, kind: "auth" });
+export class NeonAuthError extends NeonApiError<"auth"> {
+	override readonly kind: "auth" = "auth";
+	constructor(message: string, init: NeonApiErrorInit) {
+		super(message, init);
 		this.name = "NeonAuthError";
 	}
 }
 
 /** 429 — rate limited (after retries, if enabled, were exhausted). */
-export class NeonRateLimitError extends NeonApiError {
-	constructor(
-		message: string,
-		init: ConstructorParameters<typeof NeonApiError>[1],
-	) {
-		super(message, { ...init, kind: "rate_limit" });
+export class NeonRateLimitError extends NeonApiError<"rate_limit"> {
+	override readonly kind: "rate_limit" = "rate_limit";
+	constructor(message: string, init: NeonApiErrorInit) {
+		super(message, init);
 		this.name = "NeonRateLimitError";
 	}
 }
 
 /** An awaited Neon operation ended in a non-success terminal state. */
 export class NeonOperationError extends NeonError {
+	declare readonly kind: "operation";
 	/** The id of the operation that failed. */
 	readonly operationId: string;
 	/** The terminal status reported by the API (`failed` / `error` / `cancelled`). */
@@ -131,6 +134,7 @@ export class NeonOperationError extends NeonError {
  * the `wait` budget while polling operations for readiness.
  */
 export class NeonTimeoutError extends NeonError {
+	declare readonly kind: "timeout";
 	constructor(message: string) {
 		super(message, "timeout");
 		this.name = "NeonTimeoutError";
@@ -149,6 +153,7 @@ export class NeonTimeoutError extends NeonError {
  * name is not evidence about which one occurred.
  */
 export class NeonAbortError extends NeonError {
+	declare readonly kind: "aborted";
 	constructor(message: string, options?: { cause?: unknown }) {
 		super(message, "aborted", options);
 		this.name = "NeonAbortError";
@@ -157,6 +162,7 @@ export class NeonAbortError extends NeonError {
 
 /** A transport-level failure (DNS, connection, abort) — no HTTP response received. */
 export class NeonNetworkError extends NeonError {
+	declare readonly kind: "network";
 	/**
 	 * The most specific reason the platform gave for the failure — an `errno` code such as
 	 * `ECONNRESET` when one is available, otherwise the innermost non-empty message. Read
@@ -172,6 +178,52 @@ export class NeonNetworkError extends NeonError {
 		this.name = "NeonNetworkError";
 		this.reason = options?.reason ?? UNKNOWN_TRANSPORT_REASON;
 	}
+}
+
+/**
+ * A failure the SDK detected itself, before or after talking to the API — an ambiguous
+ * connection-string selection, an invalid `requestTimeoutMs`, a `noCompute` branch with
+ * compute settings, a response missing a field the wrapper needs. Nothing was wrong on
+ * the wire; the call could not be completed as asked.
+ */
+export class NeonClientError extends NeonError {
+	declare readonly kind: "client";
+	constructor(message: string, options?: { cause?: unknown }) {
+		super(message, "client", options);
+		this.name = "NeonClientError";
+	}
+}
+
+/**
+ * Every error the SDK emits, as a discriminated union on `kind`. This is the type of
+ * `NeonResult`/`RawResult`'s `error` and of what `throwOnError` throws. Every member
+ * extends {@link NeonError}, so `instanceof NeonError` still matches all of them.
+ */
+export type NeonErrorUnion =
+	| NeonApiError
+	| NeonNotFoundError
+	| NeonAuthError
+	| NeonRateLimitError
+	| NeonOperationError
+	| NeonTimeoutError
+	| NeonAbortError
+	| NeonNetworkError
+	| NeonClientError;
+
+/**
+ * Whether `error` is one of the classes {@link NeonErrorUnion} names. Used where a value
+ * arrives as `unknown` or as the base {@link NeonError} (for example a page fetcher that
+ * already classified a failure) and must be handed to `err()`.
+ */
+export function isNeonErrorUnion(error: unknown): error is NeonErrorUnion {
+	return (
+		error instanceof NeonApiError ||
+		error instanceof NeonOperationError ||
+		error instanceof NeonTimeoutError ||
+		error instanceof NeonAbortError ||
+		error instanceof NeonNetworkError ||
+		error instanceof NeonClientError
+	);
 }
 
 interface ApiErrorBody {
@@ -225,7 +277,7 @@ export function describeTransportFailure(error: unknown): string {
 export function toNeonError(
 	error: unknown,
 	response: Response | undefined,
-): NeonError {
+): NeonErrorUnion {
 	if (!response) {
 		const reason = describeTransportFailure(error);
 		return new NeonNetworkError(

--- a/packages/sdk/src/neon/paginate.ts
+++ b/packages/sdk/src/neon/paginate.ts
@@ -1,5 +1,5 @@
 import { cancelled, type Deadline, runBounded } from "./deadline.js";
-import { isNeonErrorUnion, toNeonError } from "./errors.js";
+import { isNeonError, toNeonError } from "./errors.js";
 import { err, type NeonResult, ok } from "./result.js";
 
 export interface Page<T> {
@@ -70,7 +70,7 @@ class PaginatedList<T, D> implements Paginated<T> {
 			// A fetcher that already classified the failure keeps its own error.
 			// Re-deriving one from the response would mislabel a fault the SDK
 			// found in a 200 body as an API error with a 2xx status.
-			if (isNeonErrorUnion(raw?.error)) return err(raw.error);
+			if (isNeonError(raw?.error)) return err(raw.error);
 			return err(toNeonError(raw?.error, raw?.response));
 		}
 		return ok(this.#mapPage(raw.data));

--- a/packages/sdk/src/neon/paginate.ts
+++ b/packages/sdk/src/neon/paginate.ts
@@ -1,5 +1,5 @@
 import { cancelled, type Deadline, runBounded } from "./deadline.js";
-import { NeonError, toNeonError } from "./errors.js";
+import { isNeonErrorUnion, toNeonError } from "./errors.js";
 import { err, type NeonResult, ok } from "./result.js";
 
 export interface Page<T> {
@@ -70,7 +70,7 @@ class PaginatedList<T, D> implements Paginated<T> {
 			// A fetcher that already classified the failure keeps its own error.
 			// Re-deriving one from the response would mislabel a fault the SDK
 			// found in a 200 body as an API error with a 2xx status.
-			if (raw?.error instanceof NeonError) return err(raw.error);
+			if (isNeonErrorUnion(raw?.error)) return err(raw.error);
 			return err(toNeonError(raw?.error, raw?.response));
 		}
 		return ok(this.#mapPage(raw.data));

--- a/packages/sdk/src/neon/raw-wrap.ts
+++ b/packages/sdk/src/neon/raw-wrap.ts
@@ -4,7 +4,7 @@
  * The generated `client/sdk.gen.ts` functions return hey-api's `{ data, error, request,
  * response }` envelope and are driven by two orthogonal switches (`throwOnError` and
  * `responseStyle`). {@link wrapRaw} collapses that onto the ergonomic client's contract: a
- * `{ data, error }` result by default (with the typed {@link NeonError} on the error
+ * `{ data, error }` result by default (with {@link NeonErrorUnion} on the error
  * channel), or the bare resource when you pass `throwOnError: true`. `responseStyle` is
  * removed from the public raw surface — `throwOnError` is the only switch and the return
  * type always tracks it.
@@ -14,8 +14,7 @@
  * and headers without dropping to the low-level client.
  */
 
-import type { NeonError } from "./errors.js";
-import { NeonAbortError, toNeonError } from "./errors.js";
+import { NeonAbortError, type NeonErrorUnion, toNeonError } from "./errors.js";
 
 /**
  * Did the caller's own signal end this call?
@@ -71,14 +70,14 @@ export type RawOptions<F extends AnyRawFn> = Omit<
 
 /**
  * The non-throwing result of a wrapped raw call: the ergonomic `{ data, error }` union
- * (typed {@link NeonError}), plus the underlying `response`/`request` for HTTP status and
- * headers.
+ * ({@link NeonErrorUnion} on the error channel), plus the underlying `response`/`request`
+ * for HTTP status and headers.
  */
 export type RawResult<T> =
 	| { data: T; error: undefined; response?: Response; request?: Request }
 	| {
 			data: undefined;
-			error: NeonError;
+			error: NeonErrorUnion;
 			response?: Response;
 			request?: Request;
 	  };

--- a/packages/sdk/src/neon/resources/branches.test.ts
+++ b/packages/sdk/src/neon/resources/branches.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createNeonClient } from "../client.js";
+import { NeonClientError } from "../errors.js";
 
 function neonRouting(
 	respond: (request: { url: string; method: string; body: unknown }) => {
@@ -114,6 +115,7 @@ describe("branches.create", () => {
 		});
 
 		expect(data).toBeUndefined();
+		expect(error).toBeInstanceOf(NeonClientError);
 		expect(error?.kind).toBe("client");
 		expect(error?.message).toBe(
 			"Pass compute settings or noCompute, not both.",

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -19,7 +19,7 @@ import type {
 } from "../../client/types.gen.js";
 import { withConnectionString } from "../connection.js";
 import type { CallOptions, RequestContext } from "../context.js";
-import { NeonError } from "../errors.js";
+import { NeonClientError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
@@ -295,7 +295,7 @@ export class Branches<DThrow extends boolean> {
 
 	/**
 	 * Resolve the project's default branch (by the `default` flag — not by name).
-	 * Returns a `client`-kind {@link NeonError} when no default branch is found.
+	 * Returns a {@link NeonClientError} when no default branch is found.
 	 */
 	getDefault(projectId: string): Promise<Outcome<Branch, DThrow>>;
 	getDefault<Throw extends boolean = DThrow>(
@@ -325,9 +325,8 @@ export class Branches<DThrow extends boolean> {
 		if (!branch) {
 			return finalize(
 				err<Branch>(
-					new NeonError(
+					new NeonClientError(
 						"No default branch found for the project.",
-						"client",
 					),
 				),
 				shouldThrow,
@@ -407,9 +406,8 @@ export class Branches<DThrow extends boolean> {
 		if (!parentId) {
 			return finalize(
 				err<Branch>(
-					new NeonError(
+					new NeonClientError(
 						"Branch has no parent and cannot be reset.",
-						"client",
 					),
 				),
 				shouldThrow,
@@ -528,7 +526,7 @@ export class Branches<DThrow extends boolean> {
 
 function parseCreateInput(input?: CreateInput):
 	| {
-			error: NeonError;
+			error: NeonClientError;
 	  }
 	| {
 			error?: undefined;
@@ -542,7 +540,7 @@ function parseCreateInput(input?: CreateInput):
 	if (input.noCompute === true) {
 		if ("compute" in input && input.compute !== undefined) {
 			return {
-				error: new NeonError(NO_COMPUTE_WITH_COMPUTE, "client"),
+				error: new NeonClientError(NO_COMPUTE_WITH_COMPUTE),
 			};
 		}
 		const { noCompute: _noCompute, compute: _compute, ...branch } = input;

--- a/packages/sdk/src/neon/resources/logs.ts
+++ b/packages/sdk/src/neon/resources/logs.ts
@@ -11,7 +11,7 @@ import type {
 	ProjectBranchLogsQueryResponse,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
-import { NeonError } from "../errors.js";
+import { NeonClientError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
@@ -87,9 +87,8 @@ export class Logs<DThrow extends boolean> {
 				if (page.data?.is_truncated && !page.data.next_cursor) {
 					return {
 						response: page.response,
-						error: new NeonError(
+						error: new NeonClientError(
 							"Neon reported more log records than it returned but gave no cursor to reach them.",
-							"client",
 						),
 					};
 				}

--- a/packages/sdk/src/neon/resources/postgres.ts
+++ b/packages/sdk/src/neon/resources/postgres.ts
@@ -6,7 +6,7 @@ import {
 } from "../../client/sdk.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { cancelled, runBounded } from "../deadline.js";
-import { NeonError, toNeonError } from "../errors.js";
+import { NeonClientError, toNeonError } from "../errors.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 import { DataApi } from "./dataapi.js";
 import { Databases } from "./databases.js";
@@ -51,7 +51,7 @@ export class Postgres<DThrow extends boolean> {
 	/**
 	 * Resolve a Postgres connection string. Auto-selects the default branch and the sole
 	 * role/database when not specified (mirrors `@neon/config`'s `fetchEnv`); returns
-	 * a `client`-kind {@link NeonError} when the selection is ambiguous.
+	 * a {@link NeonClientError} when the selection is ambiguous.
 	 */
 	connectionString(
 		params: ConnectionStringParams,
@@ -81,9 +81,8 @@ export class Postgres<DThrow extends boolean> {
 					? err(cancellation)
 					: (resolved ??
 						err(
-							new NeonError(
+							new NeonClientError(
 								"The connection-string resolver ended without a result.",
-								"client",
 							),
 						));
 			return finalize(result, shouldThrow);
@@ -117,9 +116,8 @@ export class Postgres<DThrow extends boolean> {
 			)?.id;
 			if (!branchId) {
 				return err(
-					new NeonError(
+					new NeonClientError(
 						"Could not determine the default branch; pass branchId.",
-						"client",
 					),
 				);
 			}
@@ -185,16 +183,18 @@ export class Postgres<DThrow extends boolean> {
 	}
 }
 
-function branchRequired(param: string): NeonError {
-	return new NeonError(
+function branchRequired(param: string): NeonClientError {
+	return new NeonClientError(
 		`Pass branchId or ${param} to resolve a connection string.`,
-		"client",
 	);
 }
 
-function ambiguous(kind: string, count: number, param: string): NeonError {
-	return new NeonError(
+function ambiguous(
+	kind: string,
+	count: number,
+	param: string,
+): NeonClientError {
+	return new NeonClientError(
 		`Expected exactly one ${kind} to auto-select for the connection string; found ${count}. Pass ${param}.`,
-		"client",
 	);
 }

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -28,7 +28,7 @@ import type {
 } from "../../client/types.gen.js";
 import { withConnectionString } from "../connection.js";
 import type { CallOptions, RequestContext } from "../context.js";
-import { NeonError } from "../errors.js";
+import { NeonClientError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
 import { err, finalize, type NeonResult, type Outcome } from "../result.js";
 
@@ -550,9 +550,8 @@ export class Projects<DThrow extends boolean> {
 		if (!fromOrgId) {
 			return finalize(
 				err<void>(
-					new NeonError(
+					new NeonClientError(
 						"Pass fromOrgId or set orgId on the client.",
-						"client",
 					),
 				),
 				shouldThrow,

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -16,7 +16,7 @@ import type {
 	Snapshot,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
-import { NeonAbortError, NeonError } from "../errors.js";
+import { NeonAbortError, NeonClientError } from "../errors.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 /**
@@ -335,9 +335,8 @@ export class Snapshots<DThrow extends boolean> {
 								"The restore was aborted while its preview callback ran; the restored branch is left un-finalized.",
 								{ cause: error },
 							)
-						: new NeonError(
+						: new NeonClientError(
 								`The restore's preview callback threw; the restored branch is left un-finalized: ${error instanceof Error ? error.message : String(error)}`,
-								"client",
 								{ cause: error },
 							),
 				),

--- a/packages/sdk/src/neon/result.ts
+++ b/packages/sdk/src/neon/result.ts
@@ -1,13 +1,13 @@
-import type { NeonError } from "./errors.js";
+import type { NeonErrorUnion } from "./errors.js";
 
 /**
  * The uniform result envelope returned by every ergonomic call when `throwOnError` is
  * off (the default). A discriminated union: when `error` is set, `data` is `undefined`,
- * and vice versa.
+ * and vice versa. `error` is {@link NeonErrorUnion} — discriminate on `error.kind`.
  */
 export type NeonResult<T> =
 	| { data: T; error: undefined }
-	| { data: undefined; error: NeonError };
+	| { data: undefined; error: NeonErrorUnion };
 
 /**
  * The return type of a method, conditioned on whether errors are thrown. With
@@ -22,7 +22,7 @@ export function ok<T>(data: T): NeonResult<T> {
 	return { data, error: undefined };
 }
 
-export function err<T>(error: NeonError): NeonResult<T> {
+export function err<T>(error: NeonErrorUnion): NeonResult<T> {
 	return { data: undefined, error };
 }
 

--- a/packages/sdk/src/neon/wait.ts
+++ b/packages/sdk/src/neon/wait.ts
@@ -9,7 +9,6 @@ import {
 } from "./deadline.js";
 import {
 	NeonAbortError,
-	type NeonError,
 	NeonOperationError,
 	NeonTimeoutError,
 	toNeonError,
@@ -39,7 +38,7 @@ function readinessEnded(
 	deadline: Deadline,
 	timeoutMs: number,
 	pending: number,
-): NeonError | undefined {
+): NeonAbortError | NeonTimeoutError | undefined {
 	const source = deadline.source();
 	if (source === "caller") {
 		return new NeonAbortError(

--- a/packages/sdk/src/raw.test-d.ts
+++ b/packages/sdk/src/raw.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, test } from "vitest";
 import type { ProjectResponse, ProjectsResponse } from "./client/types.gen.js";
 import { createNeonClient } from "./neon/client.js";
-import type { NeonError } from "./neon/errors.js";
+import type { NeonErrorUnion } from "./neon/errors.js";
 import type { RawResult } from "./neon/raw-wrap.js";
 import { getProject, listProjects } from "./raw.js";
 
@@ -43,11 +43,14 @@ describe("raw result contract (types)", () => {
 		>();
 	});
 
-	test("the error channel is the typed NeonError; success exposes data + response", async () => {
+	test("the error channel is NeonErrorUnion; success exposes data + response", async () => {
 		const res = await getProject({ client, path: { project_id: "p" } });
 		if (res.error) {
-			expectTypeOf(res.error).toEqualTypeOf<NeonError>();
+			expectTypeOf(res.error).toEqualTypeOf<NeonErrorUnion>();
 			expectTypeOf(res.error.kind).toBeString();
+			if (res.error.kind === "not_found") {
+				expectTypeOf(res.error.status).toBeNumber();
+			}
 		} else {
 			expectTypeOf(res.data).toEqualTypeOf<ProjectResponse>();
 		}

--- a/packages/sdk/src/raw.ts
+++ b/packages/sdk/src/raw.ts
@@ -6,7 +6,7 @@
  *
  * Every operation speaks the **same result contract as the ergonomic client**: it resolves
  * to a `{ data, error }` {@link NeonResult} by default, or the bare resource when you pass
- * `throwOnError: true` (throwing the typed `NeonError`). There is no `responseStyle` switch —
+ * `throwOnError: true` (throwing a `NeonErrorUnion` member). There is no `responseStyle` switch —
  * `throwOnError` is the only one, and the return type always tracks it.
  */
 


### PR DESCRIPTION
## Problem

Every SDK call resolves to `{ data, error }`, and the README says to branch on `error.kind`. But `NeonResult` and `RawResult` typed `error` as the base `NeonError`, whose `kind` is the wide `NeonErrorKind` string union. A `kind` check proved nothing to the compiler:

```ts
const { error } = await neon.branches.get(projectId, "nope");
if (error?.kind === "not_found") {
  error.status; // TS2339: Property 'status' does not exist on type 'NeonError'
}
```

Reaching any subclass field (`status`, `requestId`, `reason`, `operationId`) needed a redundant `instanceof`, and a `switch (error.kind)` could not be made exhaustive. The README documented the workaround rather than the fix.

Two related gaps:

- SDK-side failures (ambiguous connection-string selection, invalid `requestTimeoutMs`, `noCompute` plus `compute`, a truncated page with no cursor) were emitted as a bare `new NeonError(msg, "client")`. There was no class to `instanceof` against, and the base class doubled as the root of the hierarchy and one concrete member of it.
- With `throwOnError`, `catch (e)` gives `unknown`. `instanceof NeonError` recovers only the base class, so `kind` still did not narrow in a `catch`.

## Solution

- Every concrete error class carries a **literal** `kind` (`declare readonly kind: "timeout"`, and so on), so the classes form a discriminated union.
- New exported type **`NeonErrorUnion`**: the union of every concrete error. `NeonResult`, `RawResult`, `toNeonError`, and what `throwOnError` throws are typed as `NeonErrorUnion` instead of `NeonError`.
- New class **`NeonClientError`** (`kind: "client"`, `name: "NeonClientError"`, optional `cause`) replaces every internal `new NeonError(..., "client")`. The SDK no longer constructs the base class.
- New exported type guard **`isNeonError(error: unknown): error is NeonErrorUnion`**. This is the tool for a `catch` after `throwOnError`; once it passes, `e.kind` narrows the same way `error.kind` does on a result.
- **`NeonApiError` stays a plain, non-generic class** with `kind: NeonApiErrorKind` (`"api" | "not_found" | "auth" | "rate_limit"`). `NeonNotFoundError`, `NeonAuthError`, and `NeonRateLimitError` extend it and override `kind` with their own literal, so a 404 remains assignable to `NeonApiError`. The union's `"api"` arm is `NeonApiError & { readonly kind: "api" }`. `new NeonApiError(...)` is assignable to `NeonErrorUnion` directly: TypeScript distributes its `NeonApiErrorKind` discriminant across the four API arms.
- The `kind` option is removed from `NeonApiError`'s constructor, so a 404 cannot be smuggled in as `NeonApiError` with `kind: "not_found"`. A type argument is likewise rejected (`new NeonApiError<"not_found">(...)` is a compile error).
- New exported type **`NeonApiErrorKind`**.
- The paginator uses `isNeonError` (instead of `instanceof NeonError`) to keep a fetcher's pre-classified error.
- README "Errors" section, JSDoc, and changeset updated. `@neon/sdk` gets a **minor** bump.

`instanceof NeonError` still matches every member. `instanceof NeonApiError` still matches the 404/401/429 subclasses.

## User-facing API

```ts
// New exports from "@neon/sdk"
export class NeonClientError extends NeonError {
  readonly kind: "client";
  constructor(message: string, options?: { cause?: unknown });
}

export type NeonApiErrorKind = "api" | "not_found" | "auth" | "rate_limit";

export type NeonErrorUnion =
  | (NeonApiError & { readonly kind: "api" })
  | NeonNotFoundError
  | NeonAuthError
  | NeonRateLimitError
  | NeonOperationError
  | NeonTimeoutError
  | NeonAbortError
  | NeonNetworkError
  | NeonClientError;

export function isNeonError(error: unknown): error is NeonErrorUnion;

// Changed signatures
export class NeonApiError extends NeonError {
  readonly kind: NeonApiErrorKind; // was NeonErrorKind
  constructor(
    message: string,
    init: { status: number; code?: string; requestId?: string; response?: Response; body?: unknown },
    // `kind` is no longer accepted here
  );
}

export type NeonResult<T> =
  | { data: T; error: undefined }
  | { data: undefined; error: NeonErrorUnion }; // was NeonError

export type RawResult<T> =
  | { data: T; error: undefined; response?: Response; request?: Request }
  | { data: undefined; error: NeonErrorUnion; response?: Response; request?: Request }; // was NeonError

// Each concrete class now has a literal kind
NeonNotFoundError["kind"];  // "not_found"
NeonAuthError["kind"];      // "auth"
NeonRateLimitError["kind"]; // "rate_limit"
NeonOperationError["kind"]; // "operation"
NeonTimeoutError["kind"];   // "timeout"
NeonAbortError["kind"];     // "aborted"
NeonNetworkError["kind"];   // "network"
NeonClientError["kind"];    // "client"
```

## Usage examples

### Before

```ts
import { createNeonClient, NeonApiError, NeonError, NeonNetworkError } from "@neon/sdk";

const neon = createNeonClient({ apiKey });
const { data, error } = await neon.branches.get(projectId, branchId);

if (error?.kind === "not_found") {
  // error is still NeonError here; status is not visible
  if (error instanceof NeonApiError) {
    console.warn(`404 ${error.requestId}`);
  }
}

if (error?.kind === "network" && error instanceof NeonNetworkError) {
  retry(error.reason);
}

// Not exhaustive: kind is the full NeonErrorKind, so `default` cannot be `never`.
switch (error?.kind) {
  case "not_found": /* ... */ break;
  case "network":   /* ... */ break;
}

// throwOnError: instanceof NeonError yields the base class, kind does not narrow
try {
  await neon.projects.get(projectId, { throwOnError: true });
} catch (e: unknown) {
  if (e instanceof NeonError && e.kind === "not_found") {
    e.status; // TS2339: Property 'status' does not exist on type 'NeonError'
  }
}
```

### After

```ts
import { createNeonClient, isNeonError, type NeonErrorUnion } from "@neon/sdk";

const neon = createNeonClient({ apiKey });
const { data, error } = await neon.branches.get(projectId, branchId);

if (error?.kind === "not_found") {
  // error: NeonNotFoundError
  console.warn(`404 ${error.requestId}`);
}

if (error?.kind === "network") {
  // error: NeonNetworkError
  retry(error.reason);
}

if (error?.kind === "operation") {
  // error: NeonOperationError
  console.error(error.operationId, error.status);
}

// Exhaustive over the union
function describe(e: NeonErrorUnion): string {
  switch (e.kind) {
    case "api":        return `HTTP ${e.status}`;
    case "not_found":  return `missing (${e.requestId})`;
    case "auth":       return "check the API key";
    case "rate_limit": return "slow down";
    case "operation":  return `operation ${e.operationId} ${e.status}`;
    case "timeout":    return "deadline exceeded";
    case "aborted":    return "cancelled";
    case "network":    return e.reason;
    case "client":     return e.message;
    default: {
      const _: never = e;
      return _;
    }
  }
}

// throwOnError: isNeonError narrows unknown to NeonErrorUnion, then kind narrows further
try {
  await neon.projects.get(projectId, { throwOnError: true });
} catch (e: unknown) {
  if (!isNeonError(e)) throw e;
  if (e.kind === "not_found") console.warn(`404 ${e.requestId}`); // e: NeonNotFoundError
  if (e.kind === "network")   retry(e.reason);                     // e: NeonNetworkError
  if (e.kind === "client")    console.error("SDK-side:", e.message);
}
```

### Raw layer

```ts
import { getProject } from "@neon/sdk/raw";

const res = await getProject({ client: neon.client, path: { project_id } });
if (res.error?.kind === "rate_limit") {
  res.error.status; // number, no instanceof needed
}
```

## Verification

Run from `packages/sdk`:

- `pnpm exec tsc --noEmit`: clean.
- `pnpm run test:types`: 3 files, 25 type tests, no type errors. `src/neon/errors.test-d.ts` (new) asserts that each `kind` narrows `NeonResult.error` to the exact class and rejects fields from other classes, that a `switch` over `kind` is exhaustive, that `instanceof NeonApiError` exposes `status` and narrows `kind` to `NeonApiErrorKind`, that `new NeonApiError(...)` cannot claim a subclass `kind` via option or type argument, that `new NeonApiError(...)` is assignable to `NeonErrorUnion`, that `NeonNotFoundError` is assignable to `NeonApiError`, and that `isNeonError` narrows `unknown` to `NeonErrorUnion` and then by `kind`. `src/raw.test-d.ts` covers the same narrowing on `RawResult`.
- `pnpm exec vitest run --typecheck`: 17 files, 171 tests pass. `src/neon/errors.test.ts` adds runtime checks that every class reports the literal `kind` the type system advertises, that `NeonClientError` has the right `kind`/`name`/`cause`, that `NeonAbortError`/`NeonClientError` names survive minification, and that `isNeonError` accepts every union member and rejects a bare `NeonError`, a plain `Error`, and `undefined`. `branches.test.ts` asserts the `noCompute` + `compute` conflict is a `NeonClientError`.
- `pnpm exec biome check packages/sdk` (from the repo root): clean.

## Known gaps

- **`name` changes for client-kind errors.** SDK-side failures now report `name: "NeonClientError"` instead of `"NeonError"`. `kind === "client"` and `instanceof NeonError` are unaffected; anything grouping on `name` or checking `error.constructor === NeonError` will see the new class. This is part of the reason for the minor bump.
- **A bare `NeonError` is outside the union.** `new NeonError(msg, kind)` is no longer assignable to `NeonResult.error`, and `isNeonError` returns `false` for it. The SDK never emits one; code that built a `NeonResult` by hand with the base class needs `NeonClientError` (or the matching class) instead.
- **`NeonApiError`'s constructor no longer accepts `kind`.** Callers that passed `{ kind: "not_found", status: 404 }` must construct `NeonNotFoundError` instead. Same for `"auth"` and `"rate_limit"`.
- **The `"api"` arm is an intersection, not a class.** `error.kind === "api"` narrows to `NeonApiError & { readonly kind: "api" }`. `instanceof NeonApiError` narrows to `NeonApiError` with `kind: NeonApiErrorKind`, which still covers the 404/401/429 subclasses.
- **`instanceof NeonError` in a `catch` does not narrow `kind`.** It yields the base class. Use `isNeonError` for a `kind` switch after `throwOnError`; the README says so.
