### PR TITLE
Honour `throwOnError` on `Paginated.page()` and `Paginated.all()`

### DIFF
--- a/.changeset/paginated-throw-on-error.md
+++ b/.changeset/paginated-throw-on-error.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": minor
+---
+
+`Paginated.page()` and `Paginated.all()` now honour `throwOnError` (client-wide and per call), matching every other method. With `throwOnError: true` they resolve to the bare page / item array and reject on failure instead of always returning `{ data, error }`. `Paginated<T>` gained a second type parameter `Throw` (default `false`), and `Consumption` is now generic over the client's `throwOnError` like the other resources. Default (`throwOnError: false`) clients are unaffected; the async iterator still throws on a page error.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -205,7 +205,16 @@ for await (const project of neon.projects.list()) { … }      // stream; throws
 const { data } = await neon.projects
   .list({ search: "prod" }, { signal, requestTimeoutMs: 10_000 })
   .all();
+
+// throwOnError applies here too — client-wide or per call
+const throwing = createNeonClient({ apiKey, throwOnError: true });
+const projects = await throwing.projects.list().all(); // ProjectListItem[]; throws on failure
+const { data: again } = await throwing.projects
+  .list(undefined, { throwOnError: false })
+  .all();
 ```
+
+`page()` and `all()` follow `throwOnError` like every other method. The `for await` stream always throws on a page error.
 
 A deadline covers **one consumption** — a whole `all()`, or a whole iteration — rather than
 each page, since that is the unit a caller waits on. A `Paginated` is lazy and reusable, so
@@ -219,7 +228,7 @@ Neon mutations are asynchronous (they return `operations`). `waitForReadiness` b
 
 ## API reference
 
-Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take an optional trailing `options` arg and resolve to the resource (or `{ data, error }`).
+Legend: **[P]** returns `Paginated<T>` — `page()`/`all()` resolve to the resource (or `{ data, error }`) per `throwOnError` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take an optional trailing `options` arg and resolve to the resource (or `{ data, error }`).
 
 ### `neon.projects`
 

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -1,18 +1,20 @@
 import { expectTypeOf, it } from "vitest";
 import type {
 	Branch,
+	ConsumptionHistoryPerProject,
 	CustomDomain,
 	Endpoint,
 	NeonAuthIntegration,
 	NeonAuthOauthProvider,
 	Operation,
 	Project,
+	ProjectBranchLogRecord,
 	ProjectListItem,
 	ProjectPermission,
 	Snapshot,
 } from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
-import type { Paginated } from "./paginate.js";
+import type { Page, Paginated } from "./paginate.js";
 import type { BranchConnection } from "./resources/branches.js";
 import type { ProjectConnection } from "./resources/projects.js";
 import type { NeonResult } from "./result.js";
@@ -261,4 +263,57 @@ it("functions.customDomains is typed", () => {
 	expectTypeOf(
 		throwing.functions.customDomains.delete("p", "br", "docs.example.com"),
 	).resolves.toEqualTypeOf<void>();
+});
+
+it("paginated lists honour throwOnError on page() and all()", async () => {
+	const neon = createNeonClient({ apiKey: "x" });
+	expectTypeOf(neon.projects.list().all()).resolves.toEqualTypeOf<
+		NeonResult<ProjectListItem[]>
+	>();
+	expectTypeOf(neon.projects.list().page()).resolves.toEqualTypeOf<
+		NeonResult<Page<ProjectListItem>>
+	>();
+	expectTypeOf(
+		neon.projects.list(undefined, { throwOnError: true }),
+	).toEqualTypeOf<Paginated<ProjectListItem, true>>();
+	expectTypeOf(
+		neon.projects.list(undefined, { throwOnError: true }).all(),
+	).resolves.toEqualTypeOf<ProjectListItem[]>();
+
+	const consumptionQuery = {
+		from: "2024-03-01T00:00:00Z",
+		to: "2024-03-02T00:00:00Z",
+		granularity: "daily" as const,
+	};
+	expectTypeOf(neon.consumption.perProject(consumptionQuery)).toEqualTypeOf<
+		Paginated<ConsumptionHistoryPerProject>
+	>();
+
+	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
+	expectTypeOf(throwing.branches.list("p")).toEqualTypeOf<
+		Paginated<Branch, true>
+	>();
+	expectTypeOf(throwing.branches.list("p").all()).resolves.toEqualTypeOf<
+		Branch[]
+	>();
+	expectTypeOf(throwing.branches.list("p").page()).resolves.toEqualTypeOf<
+		Page<Branch>
+	>();
+	expectTypeOf(
+		throwing.branches.list("p", undefined, { throwOnError: false }).all(),
+	).resolves.toEqualTypeOf<NeonResult<Branch[]>>();
+	expectTypeOf(throwing.operations.list("p")).toEqualTypeOf<
+		Paginated<Operation, true>
+	>();
+	expectTypeOf(throwing.logs.query("p", "br")).toEqualTypeOf<
+		Paginated<ProjectBranchLogRecord, true>
+	>();
+	expectTypeOf(
+		throwing.consumption.perProject(consumptionQuery),
+	).toEqualTypeOf<Paginated<ConsumptionHistoryPerProject, true>>();
+
+	for await (const branch of throwing.branches.list("p")) {
+		expectTypeOf(branch).toEqualTypeOf<Branch>();
+		break;
+	}
 });

--- a/packages/sdk/src/neon/client.ts
+++ b/packages/sdk/src/neon/client.ts
@@ -36,7 +36,7 @@ export interface NeonClient<DThrow extends boolean> {
 	readonly snapshots: Snapshots<DThrow>;
 	readonly operations: Operations<DThrow>;
 	readonly auth: Auth<DThrow>;
-	readonly consumption: Consumption;
+	readonly consumption: Consumption<DThrow>;
 	readonly apiKeys: ApiKeys<DThrow>;
 	readonly regions: Regions<DThrow>;
 	readonly user: User<DThrow>;
@@ -74,7 +74,7 @@ export function createNeonClient<Throw extends boolean = false>(
 		snapshots: new Snapshots<Throw>(ctx),
 		operations: new Operations<Throw>(ctx),
 		auth: new Auth<Throw>(ctx),
-		consumption: new Consumption(ctx),
+		consumption: new Consumption<Throw>(ctx),
 		apiKeys: new ApiKeys<Throw>(ctx),
 		regions: new Regions<Throw>(ctx),
 		user: new User<Throw>(ctx),

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -95,14 +95,21 @@ export class RequestContext {
 		return createDeadline(timeoutMs, opts?.signal);
 	}
 
+	/** The `throwOnError` policy for one call: the per-call override if given, else the client's. */
+	shouldThrow(opts: CallOptions | undefined): boolean {
+		return opts?.throwOnError ?? this.#config.throwOnError;
+	}
+
 	/** Run a raw call and map its body; applies the resolved `throwOnError` policy. */
 	async run<D, T>(
 		opts: CallOptions | undefined,
 		exec: Exec<D>,
 		map: (data: D) => T,
 	): Promise<T | NeonResult<T>> {
-		const shouldThrow = opts?.throwOnError ?? this.#config.throwOnError;
-		return finalize(await this.execute(opts, exec, map), shouldThrow);
+		return finalize(
+			await this.execute(opts, exec, map),
+			this.shouldThrow(opts),
+		);
 	}
 
 	/** Like {@link run} but for endpoints that may return an empty (204) body. */
@@ -110,7 +117,7 @@ export class RequestContext {
 		opts: CallOptions | undefined,
 		exec: Exec<D>,
 	): Promise<void | NeonResult<void>> {
-		const shouldThrow = opts?.throwOnError ?? this.#config.throwOnError;
+		const shouldThrow = this.shouldThrow(opts);
 		const requested = await this.#request(opts, exec);
 		if (!requested.ok)
 			return finalize(err<void>(requested.error), shouldThrow);

--- a/packages/sdk/src/neon/paginate.test.ts
+++ b/packages/sdk/src/neon/paginate.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "./client.js";
+import { createDeadline } from "./deadline.js";
+import { NeonApiError, NeonError } from "./errors.js";
+import { paginate } from "./paginate.js";
+
+function unboundedDeadline() {
+	return createDeadline(Number.POSITIVE_INFINITY);
+}
+
+describe("paginate throwOnError", () => {
+	it("returns the envelope when shouldThrow is false", async () => {
+		const error = new NeonError("classified", "client");
+		const list = paginate<string, { items: string[]; cursor?: string }>(
+			async () => ({ error }),
+			() => ({ items: [] }),
+			unboundedDeadline,
+			false,
+		);
+
+		const page = await list.page();
+		expect("error" in page).toBe(true);
+		if (!("error" in page)) throw new Error("expected envelope");
+		expect(page.data).toBeUndefined();
+		expect(page.error).toBe(error);
+
+		const all = await list.all();
+		expect("error" in all).toBe(true);
+		if (!("error" in all)) throw new Error("expected envelope");
+		expect(all.data).toBeUndefined();
+		expect(all.error).toBe(error);
+
+		await expect(async () => {
+			for await (const _item of list) {
+				void _item;
+			}
+		}).rejects.toBe(error);
+	});
+
+	it("resolves the bare page and concatenated array when shouldThrow is true", async () => {
+		const pages = new Map([
+			[undefined, { items: ["a", "b"], cursor: "c1" }],
+			["c1", { items: ["c"], cursor: undefined }],
+		]);
+		const list = paginate<string, { items: string[]; cursor?: string }>(
+			async (cursor) => ({ data: pages.get(cursor) ?? { items: [] } }),
+			(data) => data,
+			unboundedDeadline,
+			true,
+		);
+
+		const page = await list.page();
+		expect(page).toEqual({ items: ["a", "b"], cursor: "c1" });
+		expect(await list.all()).toEqual(["a", "b", "c"]);
+	});
+
+	it("rejects with the fetcher's NeonError when shouldThrow is true", async () => {
+		const error = new NeonError("classified", "client");
+		let calls = 0;
+		const list = paginate<string, { items: string[]; cursor?: string }>(
+			async (cursor) => {
+				calls += 1;
+				if (cursor === "c1") return { error };
+				return { data: { items: ["a"], cursor: "c1" } };
+			},
+			(data) => data,
+			unboundedDeadline,
+			true,
+		);
+
+		await expect(list.page("c1")).rejects.toBe(error);
+		calls = 0;
+		await expect(list.all()).rejects.toBe(error);
+		expect(calls).toBe(2);
+	});
+});
+
+describe("client paginated throwOnError", () => {
+	it("returns a bare array from a throwing client and the envelope when opted out", async () => {
+		const project = { id: "p-1", name: "one" };
+		const throwing = createNeonClient({
+			apiKey: "test",
+			retries: 0,
+			throwOnError: true,
+			fetch: async () =>
+				new Response(
+					JSON.stringify({
+						projects: [project],
+						pagination: {},
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				),
+		});
+
+		const projects = await throwing.projects.list().all();
+		expect(projects).toEqual([project]);
+		const page = await throwing.projects.list().page();
+		expect(page.items).toEqual([project]);
+
+		const envelope = await throwing.projects
+			.list(undefined, { throwOnError: false })
+			.all();
+		expect(envelope.error).toBeUndefined();
+		expect(envelope.data).toEqual([project]);
+	});
+
+	it("throws a classified API error from a default client with per-call throwOnError", async () => {
+		const neon = createNeonClient({
+			apiKey: "test",
+			retries: 0,
+			fetch: async () =>
+				new Response(JSON.stringify({ message: "boom" }), {
+					status: 500,
+					headers: { "content-type": "application/json" },
+				}),
+		});
+
+		await expect(
+			neon.projects.list(undefined, { throwOnError: true }).all(),
+		).rejects.toBeInstanceOf(NeonApiError);
+	});
+});

--- a/packages/sdk/src/neon/paginate.test.ts
+++ b/packages/sdk/src/neon/paginate.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { createNeonClient } from "./client.js";
 import { createDeadline } from "./deadline.js";
-import { NeonApiError, NeonError } from "./errors.js";
+import { NeonApiError, NeonClientError } from "./errors.js";
 import { paginate } from "./paginate.js";
 
 function unboundedDeadline() {
@@ -10,7 +10,7 @@ function unboundedDeadline() {
 
 describe("paginate throwOnError", () => {
 	it("returns the envelope when shouldThrow is false", async () => {
-		const error = new NeonError("classified", "client");
+		const error = new NeonClientError("classified");
 		const list = paginate<string, { items: string[]; cursor?: string }>(
 			async () => ({ error }),
 			() => ({ items: [] }),
@@ -55,7 +55,7 @@ describe("paginate throwOnError", () => {
 	});
 
 	it("rejects with the fetcher's NeonError when shouldThrow is true", async () => {
-		const error = new NeonError("classified", "client");
+		const error = new NeonClientError("classified");
 		let calls = 0;
 		const list = paginate<string, { items: string[]; cursor?: string }>(
 			async (cursor) => {

--- a/packages/sdk/src/neon/paginate.ts
+++ b/packages/sdk/src/neon/paginate.ts
@@ -1,6 +1,6 @@
 import { cancelled, type Deadline, runBounded } from "./deadline.js";
 import { isNeonError, toNeonError } from "./errors.js";
-import { err, type NeonResult, ok } from "./result.js";
+import { err, finalize, type NeonResult, type Outcome, ok } from "./result.js";
 
 export interface Page<T> {
 	items: T[];
@@ -15,26 +15,29 @@ interface RawResult<D> {
 }
 
 /**
- * A lazy, cursor-paginated list. `all()` / `page()` return the `{ data, error }` envelope;
- * the async iterator streams items lazily and throws on a page-fetch error.
+ * A lazy, cursor-paginated list. `page()` / `all()` follow the resolved `throwOnError`
+ * policy exactly like every other method: bare value (throwing on failure) when it is on,
+ * `{ data, error }` envelope when it is off. The async iterator always throws on a
+ * page-fetch error — a stream has no envelope form.
  *
- * Note: pagination helpers always use the result envelope (the iterator is the throwing
- * form) regardless of the client's `throwOnError` setting.
+ * `waitForReadiness` is not applied: list responses carry no `operations`.
  */
-export interface Paginated<T> extends AsyncIterable<T> {
+export interface Paginated<T, Throw extends boolean = false>
+	extends AsyncIterable<T> {
 	/** Fetch a single page (optionally from a cursor). */
-	page(cursor?: string): Promise<NeonResult<Page<T>>>;
+	page(cursor?: string): Promise<Outcome<Page<T>, Throw>>;
 	/** Fetch and concatenate every page. */
-	all(): Promise<NeonResult<T[]>>;
+	all(): Promise<Outcome<T[], Throw>>;
 }
 
-class PaginatedList<T, D> implements Paginated<T> {
+class PaginatedList<T, D> implements Paginated<T, boolean> {
 	readonly #fetchPage: (
 		cursor: string | undefined,
 		signal?: AbortSignal,
 	) => Promise<RawResult<D>>;
 	readonly #mapPage: (data: D) => Page<T>;
 	readonly #newDeadline: () => Deadline;
+	readonly #shouldThrow: boolean;
 
 	constructor(
 		fetchPage: (
@@ -43,10 +46,12 @@ class PaginatedList<T, D> implements Paginated<T> {
 		) => Promise<RawResult<D>>,
 		mapPage: (data: D) => Page<T>,
 		newDeadline: () => Deadline,
+		shouldThrow: boolean,
 	) {
 		this.#fetchPage = fetchPage;
 		this.#mapPage = mapPage;
 		this.#newDeadline = newDeadline;
+		this.#shouldThrow = shouldThrow;
 	}
 
 	async #page(
@@ -76,10 +81,13 @@ class PaginatedList<T, D> implements Paginated<T> {
 		return ok(this.#mapPage(raw.data));
 	}
 
-	async page(cursor?: string): Promise<NeonResult<Page<T>>> {
+	async page(cursor?: string): Promise<Page<T> | NeonResult<Page<T>>> {
 		const deadline = this.#newDeadline();
 		try {
-			return await this.#page(cursor, deadline);
+			return finalize<Page<T>>(
+				await this.#page(cursor, deadline),
+				this.#shouldThrow,
+			);
 		} finally {
 			deadline.dispose();
 		}
@@ -90,20 +98,21 @@ class PaginatedList<T, D> implements Paginated<T> {
 	 * from the caller's side, and a per-page budget would leave an unbounded number of
 	 * pages unbounded in total.
 	 */
-	async all(): Promise<NeonResult<T[]>> {
+	async all(): Promise<T[] | NeonResult<T[]>> {
 		const deadline = this.#newDeadline();
 		try {
 			const items: T[] = [];
 			let cursor: string | undefined;
 			while (true) {
 				const result = await this.#page(cursor, deadline);
-				if (result.error) return err(result.error);
+				if (result.error)
+					return finalize<T[]>(err(result.error), this.#shouldThrow);
 				items.push(...result.data.items);
 				if (!result.data.cursor || result.data.items.length === 0)
 					break;
 				cursor = result.data.cursor;
 			}
-			return ok(items);
+			return finalize<T[]>(ok(items), this.#shouldThrow);
 		} finally {
 			deadline.dispose();
 		}
@@ -134,6 +143,9 @@ class PaginatedList<T, D> implements Paginated<T> {
  * `newDeadline` is called once per consumption — each `page()`, each `all()`, each
  * iteration — because a `Paginated` is lazy and may be consumed more than once, so a
  * deadline created when the list was built would already be spent.
+ *
+ * `shouldThrow` is the policy resolved when the list is built (per-call override, else
+ * the client default), the same rule the execution core uses for every other method.
  */
 export function paginate<T, D>(
 	fetchPage: (
@@ -142,6 +154,7 @@ export function paginate<T, D>(
 	) => Promise<RawResult<D>>,
 	mapPage: (data: D) => Page<T>,
 	newDeadline: () => Deadline,
-): Paginated<T> {
-	return new PaginatedList(fetchPage, mapPage, newDeadline);
+	shouldThrow: boolean,
+): Paginated<T, boolean> {
+	return new PaginatedList(fetchPage, mapPage, newDeadline, shouldThrow);
 }

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -91,11 +91,17 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches (cursor-paginated) */
+	list(projectId: string, query?: ListQuery): Paginated<Branch, DThrow>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		query: ListQuery | undefined,
+		opts: CallOptions<Throw>,
+	): Paginated<Branch, Throw>;
 	list(
 		projectId: string,
 		query?: ListQuery,
 		opts?: CallOptions,
-	): Paginated<Branch> {
+	): Paginated<Branch, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				listProjectBranches({
@@ -110,6 +116,7 @@ export class Branches<DThrow extends boolean> {
 				cursor: data?.pagination?.next,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/consumption.ts
+++ b/packages/sdk/src/neon/resources/consumption.ts
@@ -28,7 +28,7 @@ type PerBranchV2Query = Omit<
 >;
 
 /** Consumption history (cursor-paginated). */
-export class Consumption {
+export class Consumption<DThrow extends boolean> {
 	readonly #ctx: RequestContext;
 
 	constructor(ctx: RequestContext) {
@@ -38,8 +38,15 @@ export class Consumption {
 	/** @apiCall GET /consumption_history/projects */
 	perProject(
 		query: PerProjectQuery,
+	): Paginated<ConsumptionHistoryPerProject, DThrow>;
+	perProject<Throw extends boolean = DThrow>(
+		query: PerProjectQuery,
+		opts: CallOptions<Throw>,
+	): Paginated<ConsumptionHistoryPerProject, Throw>;
+	perProject(
+		query: PerProjectQuery,
 		opts?: CallOptions,
-	): Paginated<ConsumptionHistoryPerProject> {
+	): Paginated<ConsumptionHistoryPerProject, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				getConsumptionHistoryPerProject({
@@ -53,14 +60,22 @@ export class Consumption {
 				cursor: data?.pagination?.cursor,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 
 	/** @apiCall GET /consumption_history/v2/projects */
 	perProjectV2(
 		query: PerProjectV2Query,
+	): Paginated<ConsumptionHistoryPerProjectV2, DThrow>;
+	perProjectV2<Throw extends boolean = DThrow>(
+		query: PerProjectV2Query,
+		opts: CallOptions<Throw>,
+	): Paginated<ConsumptionHistoryPerProjectV2, Throw>;
+	perProjectV2(
+		query: PerProjectV2Query,
 		opts?: CallOptions,
-	): Paginated<ConsumptionHistoryPerProjectV2> {
+	): Paginated<ConsumptionHistoryPerProjectV2, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				getConsumptionHistoryPerProjectV2({
@@ -74,14 +89,22 @@ export class Consumption {
 				cursor: data?.pagination?.cursor,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 
 	/** @apiCall GET /consumption_history/v2/branches */
 	perBranchV2(
 		query: PerBranchV2Query,
+	): Paginated<ConsumptionHistoryPerBranchV2, DThrow>;
+	perBranchV2<Throw extends boolean = DThrow>(
+		query: PerBranchV2Query,
+		opts: CallOptions<Throw>,
+	): Paginated<ConsumptionHistoryPerBranchV2, Throw>;
+	perBranchV2(
+		query: PerBranchV2Query,
 		opts?: CallOptions,
-	): Paginated<ConsumptionHistoryPerBranchV2> {
+	): Paginated<ConsumptionHistoryPerBranchV2, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				getConsumptionHistoryPerBranchV2({
@@ -95,6 +118,7 @@ export class Consumption {
 				cursor: data?.pagination?.cursor,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 }

--- a/packages/sdk/src/neon/resources/custom-domains.ts
+++ b/packages/sdk/src/neon/resources/custom-domains.ts
@@ -31,8 +31,19 @@ export class CustomDomains<DThrow extends boolean> {
 		projectId: string,
 		branchId: string,
 		query?: ListQuery,
+	): Paginated<CustomDomain, DThrow>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		query: ListQuery | undefined,
+		opts: CallOptions<Throw>,
+	): Paginated<CustomDomain, Throw>;
+	list(
+		projectId: string,
+		branchId: string,
+		query?: ListQuery,
 		opts?: CallOptions,
-	): Paginated<CustomDomain> {
+	): Paginated<CustomDomain, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				listProjectBranchCustomDomains({
@@ -47,6 +58,7 @@ export class CustomDomains<DThrow extends boolean> {
 				cursor: data?.pagination?.next,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/functions.ts
+++ b/packages/sdk/src/neon/resources/functions.ts
@@ -30,7 +30,7 @@ export class Functions<DThrow extends boolean> {
 
 	constructor(ctx: RequestContext) {
 		this.#ctx = ctx;
-		this.customDomains = new CustomDomains(ctx);
+		this.customDomains = new CustomDomains<DThrow>(ctx);
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/functions (cursor-paginated) */
@@ -38,8 +38,19 @@ export class Functions<DThrow extends boolean> {
 		projectId: string,
 		branchId: string,
 		query?: ListQuery,
+	): Paginated<NeonFunction, DThrow>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		query: ListQuery | undefined,
+		opts: CallOptions<Throw>,
+	): Paginated<NeonFunction, Throw>;
+	list(
+		projectId: string,
+		branchId: string,
+		query?: ListQuery,
 		opts?: CallOptions,
-	): Paginated<NeonFunction> {
+	): Paginated<NeonFunction, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				listProjectBranchFunctions({
@@ -54,6 +65,7 @@ export class Functions<DThrow extends boolean> {
 				cursor: data?.pagination?.next,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/logs.ts
+++ b/packages/sdk/src/neon/resources/logs.ts
@@ -66,8 +66,19 @@ export class Logs<DThrow extends boolean> {
 		projectId: string,
 		branchId: string,
 		input?: LogQueryInput,
+	): Paginated<ProjectBranchLogRecord, DThrow>;
+	query<Throw extends boolean = DThrow>(
+		projectId: string,
+		branchId: string,
+		input: LogQueryInput | undefined,
+		opts: CallOptions<Throw>,
+	): Paginated<ProjectBranchLogRecord, Throw>;
+	query(
+		projectId: string,
+		branchId: string,
+		input?: LogQueryInput,
 		opts?: CallOptions,
-	): Paginated<ProjectBranchLogRecord> {
+	): Paginated<ProjectBranchLogRecord, boolean> {
 		// Snapshot the filters. The endpoint returns wrong results unless every page
 		// repeats them unchanged, and a `Paginated` is lazy — reading `input` per page
 		// would let a caller mutating it afterwards change the query mid-walk.
@@ -101,6 +112,7 @@ export class Logs<DThrow extends boolean> {
 				cursor: data?.is_truncated ? data.next_cursor : undefined,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/operations.ts
+++ b/packages/sdk/src/neon/resources/operations.ts
@@ -27,7 +27,12 @@ export class Operations<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/operations (cursor-paginated) */
-	list(projectId: string, opts?: CallOptions): Paginated<Operation> {
+	list(projectId: string): Paginated<Operation, DThrow>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		opts: CallOptions<Throw>,
+	): Paginated<Operation, Throw>;
+	list(projectId: string, opts?: CallOptions): Paginated<Operation, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				listProjectOperations({
@@ -42,6 +47,7 @@ export class Operations<DThrow extends boolean> {
 				cursor: data?.pagination?.cursor,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -198,8 +198,17 @@ export class Members<DThrow extends boolean> {
 	list(
 		projectId: string,
 		query?: MemberListQuery,
+	): Paginated<ProjectMember, DThrow>;
+	list<Throw extends boolean = DThrow>(
+		projectId: string,
+		query: MemberListQuery | undefined,
+		opts: CallOptions<Throw>,
+	): Paginated<ProjectMember, Throw>;
+	list(
+		projectId: string,
+		query?: MemberListQuery,
 		opts?: CallOptions,
-	): Paginated<ProjectMember> {
+	): Paginated<ProjectMember, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				listProjectMembers({
@@ -214,6 +223,7 @@ export class Members<DThrow extends boolean> {
 				cursor: data?.pagination?.next,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 
@@ -321,7 +331,15 @@ export class Projects<DThrow extends boolean> {
 	 *
 	 * @apiCall GET /projects
 	 */
-	list(query?: ListQuery, opts?: CallOptions): Paginated<ProjectListItem> {
+	list(query?: ListQuery): Paginated<ProjectListItem, DThrow>;
+	list<Throw extends boolean = DThrow>(
+		query: ListQuery | undefined,
+		opts: CallOptions<Throw>,
+	): Paginated<ProjectListItem, Throw>;
+	list(
+		query?: ListQuery,
+		opts?: CallOptions,
+	): Paginated<ProjectListItem, boolean> {
 		return paginate(
 			(cursor, signal) =>
 				listProjects({
@@ -339,6 +357,7 @@ export class Projects<DThrow extends boolean> {
 				cursor: data?.pagination?.cursor,
 			}),
 			() => this.#ctx.deadlineFor(opts),
+			this.#ctx.shouldThrow(opts),
 		);
 	}
 

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -203,38 +203,25 @@ export const collectObjectList = async (
 };
 
 export const collectPages = async <T>(
-	list: Paginated<T>,
+	list: Paginated<T, true>,
 	maxItems?: number,
 ): Promise<T[]> => {
 	if (maxItems === undefined) {
-		const result = await list.all();
-		if (result.error) {
-			throw result.error;
-		}
-		if (result.data === undefined) {
-			throw new NeonError("List returned no data.", "client");
-		}
-		return result.data;
+		return list.all();
 	}
 
 	const items: T[] = [];
 	let cursor: string | undefined;
 	for (;;) {
-		const result = await list.page(cursor);
-		if (result.error) {
-			throw result.error;
-		}
-		if (result.data === undefined) {
-			throw new NeonError("List returned no data.", "client");
-		}
-		items.push(...result.data.items);
+		const page = await list.page(cursor);
+		items.push(...page.items);
 		if (items.length >= maxItems) {
 			return items.slice(0, maxItems);
 		}
-		if (!result.data.cursor || result.data.items.length === 0) {
+		if (!page.cursor || page.items.length === 0) {
 			break;
 		}
-		cursor = result.data.cursor;
+		cursor = page.cursor;
 	}
 	return items;
 };


### PR DESCRIPTION
## Problem

`throwOnError` is the SDK's switch between the `{ data, error }` envelope and bare values that reject on failure. Every method honours it, client-wide and per call, except pagination: `Paginated.page()` and `Paginated.all()` always returned the envelope, even on a client created with `throwOnError: true`. The `Paginated` doc comment stated that as the design.

The cost shows up in `@neon/tools`, which builds a `throwOnError: true` client and then had to hand-unwrap every pagination result anyway: `collectPages` carried its own `if (result.error) throw` and `if (result.data === undefined) throw` checks that `finalize` already performs for every other call.

## The interface

`page()` and `all()` now follow the resolved `throwOnError` policy, the same per-call-override-else-client-default rule as every other method:

```ts
const neon = createNeonClient({ apiKey });
const { data, error } = await neon.projects.list().all();   // unchanged: NeonResult<ProjectListItem[]>

const throwing = createNeonClient({ apiKey, throwOnError: true });
const projects = await throwing.projects.list().all();      // ProjectListItem[]; rejects on failure
const page = await throwing.projects.list().page();         // Page<ProjectListItem>

// per-call override, in either direction
await neon.projects.list(undefined, { throwOnError: true }).all();           // ProjectListItem[]
await throwing.branches.list("p", undefined, { throwOnError: false }).all(); // NeonResult<Branch[]>
```

The async iterator is unchanged: `for await` always throws on a page error, since a stream has no envelope form.

Nothing changes for default clients. `Paginated<T>` gained a second type parameter `Throw` with a default of `false`, so existing type annotations compile unchanged and existing envelope destructuring keeps working.

## How it works

`RequestContext.shouldThrow(opts)` extracts the policy resolution the execution core already used inline. Every paginated method resolves it when the list is built and passes it to `paginate()`, and `PaginatedList.page()` / `.all()` run their result through the same `finalize` as every other call, so a rejection carries the same classified `NeonError` the envelope would have carried.

Each of the ten paginated methods (`projects.list`, `branches.list`, `operations.list`, `projects.members.list`, `functions.list`, `functions.customDomains.list`, `logs.query` and the three `consumption` histories) gained two overloads: without options it returns `Paginated<T, DThrow>` from the client's type; with options, `Throw` is inferred from `opts.throwOnError`.

`collectPages` in `@neon/tools` now takes `Paginated<T, true>` and consumes the bare page and array directly. The manual unwrapping is gone.

## Also in here

- `Consumption` is now generic over the client's `throwOnError` (`Consumption<DThrow>`), like every other resource. It was the one resource without the parameter, which pagination now needs.
- README: the pagination section shows the throwing forms and the API-reference legend notes that `[P]` methods follow `throwOnError`.
- Changeset: minor for `@neon/sdk`.

## Verification

`pnpm vitest run --typecheck` in `packages/sdk`: 177 tests and 26 type tests pass, no type errors. `pnpm tsc --noEmit` and `pnpm vitest run` in `packages/tools`: 140 tests pass.

New unit tests (`paginate.test.ts`) cover the behaviour matrix:

- `shouldThrow: false` returns the envelope from `page()` and `all()`, and the iterator throws the same error instance
- `shouldThrow: true` resolves the bare page and the concatenated array across a two-page walk
- `shouldThrow: true` rejects `page()` and `all()` with the fetcher's `NeonError`, and `all()` stops fetching at the failing page
- a `throwOnError: true` client end to end (fake `fetch`): bare array from `all()`, bare page from `page()`, envelope again with a per-call `throwOnError: false`
- a default client with per-call `throwOnError: true` rejects with a classified `NeonApiError` on a 500

New type tests (`client.test-d.ts`) pin the inference: default client returns `NeonResult`, `throwOnError: true` client returns bare types across `branches`, `operations`, `logs` and `consumption`, per-call overrides flip the type in both directions and the iterator element type stays bare.

Not verified against the live API; all runtime tests use an injected `fetch`.

## For your attention

- **Behaviour change for existing `throwOnError: true` clients.** Their `page()` and `all()` previously resolved to the envelope; they now resolve to bare values and reject on failure. TypeScript callers get a compile error where they destructured `{ data }`; plain JavaScript callers would get `undefined` silently. `@neon/tools` was the known caller in this repo and is migrated here. The changeset ships this as a minor.
- The policy is resolved when the list is built, so a `Paginated` carries one policy across repeated consumptions. Changing the client default afterwards does not affect an already-built list, which matches how per-call options behave everywhere else.
