### PR TITLE
Honour client `waitForReadiness: false` on create and createAndConnect

### DIFF
--- a/.changeset/wait-for-readiness-client-false.md
+++ b/.changeset/wait-for-readiness-client-false.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": patch
+---
+
+`createNeonClient({ waitForReadiness: false })` now turns off readiness polling on `projects.create`, `projects.createAndConnect`, `branches.create`, and `branches.createAndConnect`. Those methods still default polling on when the client option is unset. Per-call `{ waitForReadiness }` still wins.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -40,7 +40,7 @@ const { project, connectionString } = data;
 | --- | --- | --- | --- |
 | `apiKey` | `string \| (() => string \| Promise<string>)` | — (required) | Neon API key, or a function returning it (sync/async). Sent as a Bearer token. |
 | `throwOnError` | `boolean` | `false` | When `true`, methods return the resource directly and **throw** on error. When `false`, they return `{ data, error }`. **Narrows return types** at the type level. |
-| `waitForReadiness` | `boolean` | `false` | When `true`, mutations block until their provisioning `operations` finish, so the returned resource is ready to use. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on when this option is unset; pass `false` here to turn those off too. |
+| `waitForReadiness` | `boolean` | — (unset) | Omit to use per-method defaults: `projects.create`, `projects.createAndConnect`, `branches.create`, and `branches.createAndConnect` poll until `operations` finish; other mutations do not. Set `false` to disable polling on those four. Set `true` to poll on every mutation that returns operations. |
 | `wait` | `{ pollIntervalMs?: number; timeoutMs?: number }` | `1000` / `300000` | Tuning for the readiness poller. |
 | `retries` | `number` | `2` | Automatic retries on always-safe statuses (`423`, `429`, `503`) with backoff. |
 | `requestTimeoutMs` | `number` | — (unbounded) | Deadline for a request **and** its retries. Aborts the request and resolves with a `NeonTimeoutError`. Pass `Infinity` per call to opt out of a client-wide value. Separate from `wait.timeoutMs`. |
@@ -189,15 +189,21 @@ consuming it twice gets a fresh deadline each time.
 
 ## Readiness & workflows
 
-Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on when the client option is unset; `createNeonClient({ waitForReadiness: false })` turns them off. Per-call `{ waitForReadiness }` still wins. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
+Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle.
+
+Omit the client option to use per-method defaults: `projects.create`, `projects.createAndConnect`, `branches.create`, and `branches.createAndConnect` poll; other mutations (for example `projects.update`) do not. `createNeonClient({ waitForReadiness: false })` disables polling on those four. `createNeonClient({ waitForReadiness: true })` enables it on every mutation that returns operations. Per-call `{ waitForReadiness }` still wins. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
 
 ```ts
 const neon = createNeonClient({ apiKey });
 await neon.projects.create({ name: "app" }); // polls (method default)
+await neon.projects.update(id, { name: "renamed" }); // does not poll
 
-const fireAndForget = createNeonClient({ apiKey, waitForReadiness: false });
-await fireAndForget.projects.create({ name: "app" }); // returns while operations still run
-await fireAndForget.projects.create({ name: "app" }, { waitForReadiness: true }); // polls anyway
+const skipWait = createNeonClient({ apiKey, waitForReadiness: false });
+await skipWait.projects.create({ name: "app" }); // returns before operations finish
+await skipWait.projects.create({ name: "app" }, { waitForReadiness: true }); // polls anyway
+
+const alwaysWait = createNeonClient({ apiKey, waitForReadiness: true });
+await alwaysWait.projects.update(id, { name: "renamed" }); // polls
 ```
 
 ---

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -40,7 +40,7 @@ const { project, connectionString } = data;
 | --- | --- | --- | --- |
 | `apiKey` | `string \| (() => string \| Promise<string>)` | — (required) | Neon API key, or a function returning it (sync/async). Sent as a Bearer token. |
 | `throwOnError` | `boolean` | `false` | When `true`, methods return the resource directly and **throw** on error. When `false`, they return `{ data, error }`. **Narrows return types** at the type level. |
-| `waitForReadiness` | `boolean` | `false` | When `true`, mutations block until their provisioning `operations` finish, so the returned resource is ready to use. |
+| `waitForReadiness` | `boolean` | `false` | When `true`, mutations block until their provisioning `operations` finish, so the returned resource is ready to use. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on when this option is unset; pass `false` here to turn those off too. |
 | `wait` | `{ pollIntervalMs?: number; timeoutMs?: number }` | `1000` / `300000` | Tuning for the readiness poller. |
 | `retries` | `number` | `2` | Automatic retries on always-safe statuses (`423`, `429`, `503`) with backoff. |
 | `requestTimeoutMs` | `number` | — (unbounded) | Deadline for a request **and** its retries. Aborts the request and resolves with a `NeonTimeoutError`. Pass `Infinity` per call to opt out of a client-wide value. Separate from `wait.timeoutMs`. |
@@ -189,7 +189,16 @@ consuming it twice gets a fresh deadline each time.
 
 ## Readiness & workflows
 
-Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
+Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on when the client option is unset; `createNeonClient({ waitForReadiness: false })` turns them off. Per-call `{ waitForReadiness }` still wins. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
+
+```ts
+const neon = createNeonClient({ apiKey });
+await neon.projects.create({ name: "app" }); // polls (method default)
+
+const fireAndForget = createNeonClient({ apiKey, waitForReadiness: false });
+await fireAndForget.projects.create({ name: "app" }); // returns while operations still run
+await fireAndForget.projects.create({ name: "app" }, { waitForReadiness: true }); // polls anyway
+```
 
 ---
 

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -20,7 +20,9 @@ export interface NeonConfig<Throw extends boolean = false> {
 	/**
 	 * When `true`, mutations that kick off provisioning operations poll until those
 	 * operations finish before resolving, so the returned resource is ready to use.
-	 * Default `false`. Overridable per call.
+	 * Default `false` for mutations in general. `projects.create`, `branches.create`,
+	 * and the `createAndConnect` workflows default it on when this option is unset;
+	 * pass `false` here to turn those off too. Overridable per call.
 	 */
 	waitForReadiness?: boolean;
 	/** Tuning for the readiness poller (interval / timeout). */
@@ -68,7 +70,7 @@ export function resolveConfig(config: NeonConfig<boolean>): ResolvedConfig {
 		throwOnError: config.throwOnError ?? false,
 		retries: config.retries ?? 2,
 		requestTimeoutMs: resolveTimeoutMs(config.requestTimeoutMs),
-		waitForReadiness: config.waitForReadiness ?? false,
+		waitForReadiness: config.waitForReadiness,
 		waitOptions: config.wait ?? {},
 		orgId: config.orgId,
 	};

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -18,11 +18,11 @@ export interface NeonConfig<Throw extends boolean = false> {
 	 */
 	throwOnError?: Throw;
 	/**
-	 * When `true`, mutations that kick off provisioning operations poll until those
-	 * operations finish before resolving, so the returned resource is ready to use.
-	 * Default `false` for mutations in general. `projects.create`, `branches.create`,
-	 * and the `createAndConnect` workflows default it on when this option is unset;
-	 * pass `false` here to turn those off too. Overridable per call.
+	 * Omit to use per-method defaults: `projects.create`, `projects.createAndConnect`,
+	 * `branches.create`, and `branches.createAndConnect` poll until provisioning
+	 * operations finish; other mutations do not. Set `false` to disable polling on
+	 * those four. Set `true` to poll on every mutation that returns operations.
+	 * Overridable per call.
 	 */
 	waitForReadiness?: boolean;
 	/** Tuning for the readiness poller (interval / timeout). */

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -22,7 +22,11 @@ export interface ResolvedConfig {
 	retries: number;
 	/** `Infinity` when calls are unbounded, which is the default. */
 	requestTimeoutMs: number;
-	waitForReadiness: boolean;
+	/**
+	 * Unset and `false` stay distinct. Create-family methods default polling on when
+	 * this is unset; collapsing them in `resolveConfig` made a client `false` a no-op.
+	 */
+	waitForReadiness: boolean | undefined;
 	waitOptions: WaitForOptions;
 	orgId?: string;
 }
@@ -93,6 +97,18 @@ export class RequestContext {
 				? this.#config.requestTimeoutMs
 				: resolveTimeoutMs(opts.requestTimeoutMs);
 		return createDeadline(timeoutMs, opts?.signal);
+	}
+
+	/** Per-call, then client, then the method's own default. */
+	resolveWait(
+		opts: CallOptions | undefined,
+		methodDefault: boolean,
+	): boolean {
+		return (
+			opts?.waitForReadiness ??
+			this.#config.waitForReadiness ??
+			methodDefault
+		);
 	}
 
 	/** Run a raw call and map its body; applies the resolved `throwOnError` policy. */

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -169,7 +169,7 @@ export class Branches<DThrow extends boolean> {
 		return this.#ctx.run(
 			{
 				...opts,
-				waitForReadiness: opts?.waitForReadiness ?? true,
+				waitForReadiness: this.#ctx.resolveWait(opts, true),
 			},
 			(client, signal) =>
 				createProjectBranch({
@@ -263,7 +263,7 @@ export class Branches<DThrow extends boolean> {
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
-			{ ...opts, waitForReadiness: opts?.waitForReadiness ?? true },
+			{ ...opts, waitForReadiness: this.#ctx.resolveWait(opts, true) },
 			(client, signal) =>
 				createProjectBranch({
 					client,

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -383,7 +383,7 @@ export class Projects<DThrow extends boolean> {
 		return this.#ctx.run(
 			{
 				...opts,
-				waitForReadiness: opts?.waitForReadiness ?? true,
+				waitForReadiness: this.#ctx.resolveWait(opts, true),
 			},
 			(client, signal) =>
 				createProject({
@@ -424,7 +424,7 @@ export class Projects<DThrow extends boolean> {
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
-			{ ...opts, waitForReadiness: opts?.waitForReadiness ?? true },
+			{ ...opts, waitForReadiness: this.#ctx.resolveWait(opts, true) },
 			(client, signal) =>
 				createProject({
 					client,

--- a/packages/sdk/src/neon/wait-for-readiness.test.ts
+++ b/packages/sdk/src/neon/wait-for-readiness.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient, type NeonClient } from "./client.js";
+import type { NeonConfig } from "./config.js";
+import type { CallOptions } from "./context.js";
+import type { NeonResult } from "./result.js";
+
+function operation(status: "running" | "finished", action: string) {
+	return {
+		id: "op-1",
+		project_id: "p-1",
+		action,
+		status,
+		failures_count: 0,
+		created_at: "2026-01-01T00:00:00Z",
+		updated_at: "2026-01-01T00:00:00Z",
+		total_duration_ms: 0,
+	};
+}
+
+const connectionUris = [
+	{
+		connection_uri: "postgresql://user:pass@ep-host/neondb",
+		connection_parameters: {
+			host: "ep-host",
+			pooler_host: "ep-pooler-host",
+		},
+	},
+];
+
+function neonRouting(
+	respond: (request: { url: string; method: string }) => {
+		status: number;
+		body: unknown;
+	},
+	config: Omit<Partial<NeonConfig>, "throwOnError" | "apiKey" | "fetch"> = {},
+): {
+	neon: NeonClient<false>;
+	calls: Array<{ url: string; method: string }>;
+} {
+	const calls: Array<{ url: string; method: string }> = [];
+	const neon = createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		wait: { pollIntervalMs: 1, timeoutMs: 5_000 },
+		...config,
+		fetch: async (input, init) => {
+			const request = input instanceof Request ? input : undefined;
+			const url = request ? request.url : String(input);
+			const method = (
+				request?.method ??
+				init?.method ??
+				"GET"
+			).toUpperCase();
+			const call = { url, method };
+			calls.push(call);
+			const { status, body } = respond(call);
+			return new Response(JSON.stringify(body), {
+				status,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+	return { neon, calls };
+}
+
+function polled(calls: Array<{ url: string; method: string }>) {
+	return calls.some(
+		(call) => call.method === "GET" && call.url.includes("/operations/"),
+	);
+}
+
+function createRespond(
+	kind: "project" | "projectConnect" | "branch" | "branchConnect",
+) {
+	const action =
+		kind === "project" || kind === "projectConnect"
+			? "create_timeline"
+			: "create_branch";
+	return ({ url, method }: { url: string; method: string }) => {
+		if (method === "GET" && url.includes("/operations/")) {
+			return {
+				status: 200,
+				body: { operation: operation("finished", action) },
+			};
+		}
+		const operations = [operation("running", action)];
+		if (kind === "project") {
+			return {
+				status: 201,
+				body: { project: { id: "p-1", name: "app" }, operations },
+			};
+		}
+		if (kind === "projectConnect") {
+			return {
+				status: 201,
+				body: {
+					project: { id: "p-1", name: "app" },
+					operations,
+					connection_uris: connectionUris,
+				},
+			};
+		}
+		if (kind === "branch") {
+			return {
+				status: 201,
+				body: {
+					branch: { id: "br-1", name: "feature" },
+					endpoints: [{ id: "ep-1", type: "read_write" }],
+					operations,
+				},
+			};
+		}
+		return {
+			status: 201,
+			body: {
+				branch: { id: "br-1", name: "feature" },
+				endpoints: [{ id: "ep-1", type: "read_write" }],
+				operations,
+				connection_uris: connectionUris,
+			},
+		};
+	};
+}
+
+const methods = [
+	{
+		name: "projects.create",
+		kind: "project" as const,
+		call: (
+			neon: NeonClient<false>,
+			opts?: CallOptions<false>,
+		): Promise<NeonResult<unknown>> =>
+			opts
+				? neon.projects.create({ name: "app" }, opts)
+				: neon.projects.create({ name: "app" }),
+	},
+	{
+		name: "projects.createAndConnect",
+		kind: "projectConnect" as const,
+		call: (
+			neon: NeonClient<false>,
+			opts?: CallOptions<false>,
+		): Promise<NeonResult<unknown>> =>
+			opts
+				? neon.projects.createAndConnect({ name: "app" }, opts)
+				: neon.projects.createAndConnect({ name: "app" }),
+	},
+	{
+		name: "branches.create",
+		kind: "branch" as const,
+		call: (
+			neon: NeonClient<false>,
+			opts?: CallOptions<false>,
+		): Promise<NeonResult<unknown>> =>
+			opts
+				? neon.branches.create("p-1", { name: "feature" }, opts)
+				: neon.branches.create("p-1", { name: "feature" }),
+	},
+	{
+		name: "branches.createAndConnect",
+		kind: "branchConnect" as const,
+		call: (
+			neon: NeonClient<false>,
+			opts?: CallOptions<false>,
+		): Promise<NeonResult<unknown>> =>
+			opts
+				? neon.branches.createAndConnect(
+						"p-1",
+						{ name: "feature" },
+						opts,
+					)
+				: neon.branches.createAndConnect("p-1", { name: "feature" }),
+	},
+];
+
+describe("create-family waitForReadiness precedence", () => {
+	for (const method of methods) {
+		describe(method.name, () => {
+			it("does not poll when the client sets waitForReadiness: false", async () => {
+				const { neon, calls } = neonRouting(
+					createRespond(method.kind),
+					{
+						waitForReadiness: false,
+					},
+				);
+				const { error } = await method.call(neon);
+				expect(error).toBeUndefined();
+				expect(polled(calls)).toBe(false);
+			});
+
+			it("polls when the client option is unset (method default)", async () => {
+				const { neon, calls } = neonRouting(createRespond(method.kind));
+				const { error } = await method.call(neon);
+				expect(error).toBeUndefined();
+				expect(polled(calls)).toBe(true);
+			});
+
+			it("polls when the client is false and the call passes true", async () => {
+				const { neon, calls } = neonRouting(
+					createRespond(method.kind),
+					{
+						waitForReadiness: false,
+					},
+				);
+				const { error } = await method.call(neon, {
+					waitForReadiness: true,
+				});
+				expect(error).toBeUndefined();
+				expect(polled(calls)).toBe(true);
+			});
+
+			it("does not poll when the client is true and the call passes false", async () => {
+				const { neon, calls } = neonRouting(
+					createRespond(method.kind),
+					{
+						waitForReadiness: true,
+					},
+				);
+				const { error } = await method.call(neon, {
+					waitForReadiness: false,
+				});
+				expect(error).toBeUndefined();
+				expect(polled(calls)).toBe(false);
+			});
+
+			it("does not poll when the client is unset and the call passes false", async () => {
+				const { neon, calls } = neonRouting(createRespond(method.kind));
+				const { error } = await method.call(neon, {
+					waitForReadiness: false,
+				});
+				expect(error).toBeUndefined();
+				expect(polled(calls)).toBe(false);
+			});
+		});
+	}
+
+	it("does not poll projects.update when the client option is unset", async () => {
+		const { neon, calls } = neonRouting(({ url, method }) => {
+			if (method === "GET" && url.includes("/operations/")) {
+				return {
+					status: 200,
+					body: { operation: operation("finished", "apply_config") },
+				};
+			}
+			return {
+				status: 200,
+				body: {
+					project: { id: "p-1", name: "renamed" },
+					operations: [operation("running", "apply_config")],
+				},
+			};
+		});
+		const { error } = await neon.projects.update("p-1", {
+			name: "renamed",
+		});
+		expect(error).toBeUndefined();
+		expect(polled(calls)).toBe(false);
+	});
+
+	it("polls projects.update when the client sets waitForReadiness: true", async () => {
+		const { neon, calls } = neonRouting(
+			({ url, method }) => {
+				if (method === "GET" && url.includes("/operations/")) {
+					return {
+						status: 200,
+						body: {
+							operation: operation("finished", "apply_config"),
+						},
+					};
+				}
+				return {
+					status: 200,
+					body: {
+						project: { id: "p-1", name: "renamed" },
+						operations: [operation("running", "apply_config")],
+					},
+				};
+			},
+			{ waitForReadiness: true },
+		);
+		const { error } = await neon.projects.update("p-1", {
+			name: "renamed",
+		});
+		expect(error).toBeUndefined();
+		expect(polled(calls)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Problem

`createNeonClient({ waitForReadiness: false })` did not turn off readiness polling on `projects.create`, `projects.createAndConnect`, `branches.create`, or `branches.createAndConnect`. Those four methods kept polling `GET /projects/{id}/operations/{op}` until the operation finished, regardless of the client option. The only way to skip the wait was to pass `{ waitForReadiness: false }` on every call.

The README already treated the client option as the default for every mutation, overridable per call, and already said create-family methods default polling on:

> Every option except `apiKey` is also accepted **per call** via the last `options` argument (`{ throwOnError?, waitForReadiness?, requestTimeoutMs?, signal? }`), overriding the client default.

> `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on.

The documented client option did not work, so this is a patch.

## Diagnosis

Two collapses of `false` into "unset":

- The four create-family methods computed `waitForReadiness: opts?.waitForReadiness ?? true`. The client-level value never reached `#maybeWait`; only the per-call value and the method default were consulted.
- `resolveConfig` stored `config.waitForReadiness ?? false`, so `ResolvedConfig.waitForReadiness` could not distinguish "user set false" from "user set nothing". Even if the methods had read it, they could not have applied the method default correctly.

Resolution is now per-call, then client, then method default. `ResolvedConfig.waitForReadiness` is `boolean | undefined`. The four create-family methods call `resolveWait(opts, true)`. Snapshot methods are unchanged and still force a wait.

## Interface

Before:

```ts
const neon = createNeonClient({ apiKey, waitForReadiness: false });
await neon.projects.create({ name: "app" });
// still polled GET /projects/{id}/operations/{op} until finished
```

After:

```ts
const neon = createNeonClient({ apiKey });
await neon.projects.create({ name: "app" }); // polls (method default)
await neon.projects.update(id, { name: "renamed" }); // does not poll

const skipWait = createNeonClient({ apiKey, waitForReadiness: false });
await skipWait.projects.create({ name: "app" }); // returns before operations finish
await skipWait.projects.create({ name: "app" }, { waitForReadiness: true }); // polls anyway

const alwaysWait = createNeonClient({ apiKey, waitForReadiness: true });
await alwaysWait.projects.update(id, { name: "renamed" }); // polls
```

Resolution order for `projects.create`, `projects.createAndConnect`, `branches.create`, `branches.createAndConnect`:

1. Per-call `opts.waitForReadiness`
2. Client `waitForReadiness`
3. Method default `true`

The README options table default for `waitForReadiness` is `—` (unset), not `false`. Omit uses per-method defaults. `false` disables polling on those four methods. `true` polls on every mutation that returns operations.

## Also in here

- `wait-for-readiness.test.ts` (new, 22 tests) covering all four create-family methods: client `false` does not poll; unset polls; per-call `true`/`false` overrides the client value in both directions; `projects.update` as a control (unset does not poll, client `true` does).
- Patch changeset for `@neon/sdk`.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 15 files, 163 tests passed (22 new in `wait-for-readiness.test.ts`)
- `pnpm --filter @neon/sdk test:types` — 16 passed
- No live e2e run for this change. The existing e2e suite already exercises `waitForReadiness: true` and is unaffected by the resolution change.

## For your attention

- `ResolvedConfig.waitForReadiness` changed from `boolean` to `boolean | undefined`. Any internal code reading it directly and expecting a `boolean` needs to go through `resolveWait` or handle `undefined`.
- Behaviour change for users who set `waitForReadiness: false` on the client and relied on create-family methods still waiting: those calls now return before operations finish. That is the documented meaning of the client option.
