### PR TITLE
Default `NeonClient`'s type argument to `false`

### DIFF
--- a/.changeset/sdk-neon-client-default-type.md
+++ b/.changeset/sdk-neon-client-default-type.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": patch
+---
+
+`NeonClient` now defaults its type parameter to `false`, so `NeonClient` can be used without a type argument to describe the client returned by `createNeonClient({ apiKey })`. `NeonClient<true>` continues to describe a `throwOnError: true` client.

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -11,7 +11,7 @@ import type {
 	ProjectPermission,
 	Snapshot,
 } from "../client/types.gen.js";
-import { createNeonClient } from "./client.js";
+import { createNeonClient, type NeonClient } from "./client.js";
 import type { Paginated } from "./paginate.js";
 import type { BranchConnection } from "./resources/branches.js";
 import type { ProjectConnection } from "./resources/projects.js";
@@ -261,4 +261,21 @@ it("functions.customDomains is typed", () => {
 	expectTypeOf(
 		throwing.functions.customDomains.delete("p", "br", "docs.example.com"),
 	).resolves.toEqualTypeOf<void>();
+});
+
+it("NeonClient without a type argument is the non-throwing client", () => {
+	function seed(neon: NeonClient) {
+		return neon.projects.get("p");
+	}
+	expectTypeOf(seed).returns.toEqualTypeOf<Promise<NeonResult<Project>>>();
+	const neon: NeonClient = createNeonClient({ apiKey: "x" });
+	expectTypeOf(neon).toEqualTypeOf<NeonClient<false>>();
+});
+
+it("NeonClient<true> still returns the bare resource", () => {
+	const throwing: NeonClient<true> = createNeonClient({
+		apiKey: "x",
+		throwOnError: true,
+	});
+	expectTypeOf(throwing.projects.get("p")).resolves.toEqualTypeOf<Project>();
 });

--- a/packages/sdk/src/neon/client.ts
+++ b/packages/sdk/src/neon/client.ts
@@ -23,8 +23,11 @@ import { Storage } from "./resources/storage.js";
  * `projects` and `branches` are top-level; the Postgres data plane (compute endpoints,
  * roles, databases, the Data API, connection strings) is grouped under `postgres` so
  * future top-level namespaces (e.g. functions, object storage) stay unambiguous.
+ *
+ * `DThrow` defaults to `false`, matching `createNeonClient`. Use `NeonClient<true>` for a
+ * client created with `throwOnError: true`.
  */
-export interface NeonClient<DThrow extends boolean> {
+export interface NeonClient<DThrow extends boolean = false> {
 	readonly projects: Projects<DThrow>;
 	readonly branches: Branches<DThrow>;
 	readonly postgres: Postgres<DThrow>;


### PR DESCRIPTION
## Problem

`NeonClient` is exported from `@neon/sdk` as `NeonClient<DThrow extends boolean>` with no default. Annotating a parameter or variable with the bare name fails to compile:

```ts
function seed(neon: NeonClient) {} // TS2314 Generic type 'NeonClient<DThrow>' requires 1 type argument(s).
```

Callers have to write `NeonClient<false>` to name the client that `createNeonClient()` returns by default. `createNeonClient` already defaults its `throwOnError` option to `false`, so the interface and the factory disagree on what the bare name means.

## Diagnosis

The generic parameter `DThrow` controls whether methods return `Promise<NeonResult<T>>` or `Promise<T>`. It was declared without a default when the interface was introduced. Nothing in the type depends on the parameter being explicit; adding a default of `false` makes the unparameterized name resolve to the same client `createNeonClient()` produces.

## Interface

Before:

```ts
function seed(neon: NeonClient) {} // TS2314 Generic type 'NeonClient<DThrow>' requires 1 type argument(s).
function seed(neon: NeonClient<false>) {}
```

After:

```ts
function seed(neon: NeonClient) {
  return neon.projects.get("p"); // Promise<NeonResult<Project>>
}
function seedThrowing(neon: NeonClient<true>) {
  return neon.projects.get("p"); // Promise<Project>
}
```

`NeonClient<true>` is unchanged and still types the throwing client. `NeonClient<false>` is unchanged and is now equivalent to `NeonClient`.

## Also in here

- One-sentence JSDoc on the interface stating that the type argument defaults to `false`.
- Two type tests in `client.test-d.ts`: a `seed(neon: NeonClient)` function whose `projects.get` returns `Promise<NeonResult<Project>>`, and a `NeonClient<true>` counterpart that returns `Promise<Project>`.
- Patch changeset for `@neon/sdk`.

No runtime change. No README change; the README does not name `NeonClient`.

## Verification

- `pnpm --filter @neon/sdk test:types` — 18 passed (11 in `client.test-d.ts`, up from 9).
- `pnpm --filter @neon/sdk test:ci` — 141 passed.

## For your attention

- This is a widening of the public type surface, not a narrowing: existing code that writes `NeonClient<false>` or `NeonClient<true>` compiles unchanged. Released as a patch.
- The default is `false` to match `createNeonClient`. If the factory default ever changes, this default should change with it.
