### PR TITLE
Carry the outstanding operations on a wait timeout so `waitFor` can resume

### DIFF
--- a/.changeset/sdk-timeout-source.md
+++ b/.changeset/sdk-timeout-source.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": minor
+---
+
+`NeonTimeoutError` now has `source` (`"request"` when the API call exceeded `requestTimeoutMs`, `"wait"` when readiness polling exceeded `timeoutMs`) and `timeoutMs` (the budget that was exceeded). `kind` remains `"timeout"`. Direct construction requires `{ source, timeoutMs }`.

--- a/.changeset/sdk-timeout-source.md
+++ b/.changeset/sdk-timeout-source.md
@@ -2,4 +2,4 @@
 "@neon/sdk": minor
 ---
 
-`NeonTimeoutError` now has `source` (`"request"` when the API call exceeded `requestTimeoutMs`, `"wait"` when readiness polling exceeded `timeoutMs`) and `timeoutMs` (the budget that was exceeded). `kind` remains `"timeout"`. Direct construction requires `{ source, timeoutMs }`.
+`NeonTimeoutError` is now the abstract base of `NeonRequestTimeoutError` (`source: "request"`) and `NeonWaitTimeoutError` (`source: "wait"`, plus `operations` for `neon.operations.waitFor`). `kind` remains `"timeout"`. Direct construction uses the subclasses.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -83,7 +83,7 @@ The `error` channel carries a typed hierarchy (all `Error` subclasses with a `ki
 | `NeonAuthError` | `"auth"` | (401/403) |
 | `NeonRateLimitError` | `"rate_limit"` | (429, after retries) |
 | `NeonOperationError` | `"operation"` | `operationId`, `status` — an awaited operation failed |
-| `NeonTimeoutError` | `"timeout"` | a deadline was exceeded — `requestTimeoutMs`, or the readiness/wait budget |
+| `NeonTimeoutError` | `"timeout"` | `source` (`"request"` \| `"wait"`), `timeoutMs` — `"request"` is `requestTimeoutMs`; `"wait"` is the readiness budget after the resource was created |
 | `NeonAbortError` | `"aborted"` | the caller's `signal` fired |
 | `NeonNetworkError` | `"network"` | `reason` — transport failure (no response) |
 | `NeonError` | `"client"` | SDK-side errors (e.g. ambiguous connection-string selection) |
@@ -146,7 +146,15 @@ await neon.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
 ```
 
 `"aborted"` and `"timeout"` are deliberately distinct: a timeout is worth retrying, a
-cancellation is not.
+cancellation is not. `"timeout"` still covers both budgets; `source` says which one fired:
+
+```ts
+import { NeonTimeoutError } from "@neon/sdk";
+
+if (error instanceof NeonTimeoutError && error.source === "wait") {
+  // the resource was created; readiness polling ran out — keep polling
+}
+```
 
 `requestTimeoutMs` must be a positive number of milliseconds up to `2147483647`, or
 `Infinity`. Anything else — `0`, a negative, `NaN`, or a value past that range — is

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -83,7 +83,9 @@ The `error` channel carries a typed hierarchy (all `Error` subclasses with a `ki
 | `NeonAuthError` | `"auth"` | (401/403) |
 | `NeonRateLimitError` | `"rate_limit"` | (429, after retries) |
 | `NeonOperationError` | `"operation"` | `operationId`, `status` — an awaited operation failed |
-| `NeonTimeoutError` | `"timeout"` | `source` (`"request"` \| `"wait"`), `timeoutMs` — `"request"` is `requestTimeoutMs`; `"wait"` is the readiness budget after the resource was created |
+| `NeonTimeoutError` | `"timeout"` | abstract base of the two rows below; `instanceof` still matches both |
+| `NeonRequestTimeoutError` | `"timeout"` | `source: "request"`, `timeoutMs` — `requestTimeoutMs` ran out |
+| `NeonWaitTimeoutError` | `"timeout"` | `source: "wait"`, `timeoutMs`, `operations` — readiness budget ran out; pass `operations` to `neon.operations.waitFor` |
 | `NeonAbortError` | `"aborted"` | the caller's `signal` fired |
 | `NeonNetworkError` | `"network"` | `reason` — transport failure (no response) |
 | `NeonClientError` | `"client"` | SDK-side errors (e.g. ambiguous connection-string selection, invalid `requestTimeoutMs`) |
@@ -173,10 +175,15 @@ await neon.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
 cancellation is not. `"timeout"` still covers both budgets; `source` says which one fired:
 
 ```ts
-import { NeonTimeoutError } from "@neon/sdk";
+const { data, error } = await neon.projects.create({ name: "app" });
 
-if (error instanceof NeonTimeoutError && error.source === "wait") {
-  // the resource was created; readiness polling ran out — keep polling
+if (error?.kind === "timeout" && error.source === "wait") {
+  // The project exists and is still provisioning. Poll again with a fresh budget
+  // instead of calling create a second time.
+  const resumed = await neon.operations.waitFor(error.operations, {
+    timeoutMs: 120_000,
+  });
+  if (resumed.error) throw resumed.error;
 }
 ```
 
@@ -657,7 +664,7 @@ await neon.snapshots.restore(projectId, snapshotId, {
 | --- | --- | --- |
 | `list(projectId)` | **[P]** `Operation` | |
 | `get(projectId, operationId)` | `Operation` | |
-| `waitFor(operations, options?)` | **→void** | `options`: `{ pollIntervalMs?, timeoutMs?, signal? }` — the readiness primitive |
+| `waitFor(operations, options?)` | **→void** | `options`: `{ pollIntervalMs?, timeoutMs?, signal? }` — the readiness primitive. A wait timeout's `error.operations` is the still-outstanding subset; pass it here to resume. |
 
 ```ts
 // Wait on operations from a raw call (or when waitForReadiness is off)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -175,7 +175,10 @@ await neon.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
 cancellation is not. `"timeout"` still covers both budgets; `source` says which one fired:
 
 ```ts
-const { data, error } = await neon.projects.create({ name: "app" });
+const { data, error } = await neon.projects.create(
+  { name: "app" },
+  { wait: { timeoutMs: 30_000 } },
+);
 
 if (error?.kind === "timeout" && error.source === "wait") {
   // The project exists and is still provisioning. Poll again with a fresh budget

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -1,11 +1,17 @@
 import {
+	configuredBaseUrl,
+	configuredOrgId,
 	createProject,
 	deleteProject,
+	requireApiKey,
 	uniqueProjectName,
 } from "@neon/e2e-harness";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import type { NeonClient } from "../src/index.js";
-import { NeonNotFoundError } from "../src/index.js";
+import {
+	createNeonClient,
+	type NeonClient,
+	NeonNotFoundError,
+} from "../src/index.js";
 import { expectOk, makeClient } from "./helpers.js";
 
 /**
@@ -337,5 +343,54 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			await neon.operations.get(projectId, single.id),
 		);
 		expect(fetched.id).toBe(single.id);
+	});
+
+	it("a wait timeout carries outstanding operations so waitFor can resume", async () => {
+		const impatient = createNeonClient({
+			apiKey: requireApiKey(),
+			orgId: configuredOrgId(),
+			baseUrl: configuredBaseUrl(),
+			waitForReadiness: true,
+			wait: { timeoutMs: 1, pollIntervalMs: 1 },
+		});
+
+		const { data, error } = await impatient.branches.create(projectId, {
+			name: "wait-timeout-resume",
+			parent_id: defaultBranchId,
+			noCompute: true,
+		});
+
+		let branchId: string | undefined = data?.id;
+		try {
+			if (error === undefined) {
+				throw new Error(
+					`expected a wait timeout: the API finished the create in under 1ms (branch ${data?.id})`,
+				);
+			}
+			expect(error.kind).toBe("timeout");
+			if (error.kind !== "timeout" || error.source !== "wait") {
+				throw new Error(`unexpected error: ${error.kind}`);
+			}
+			expect(error.operations.length).toBeGreaterThan(0);
+			for (const op of error.operations) {
+				expect(op.project_id).toBe(projectId);
+			}
+			branchId =
+				error.operations.find((op) => op.branch_id)?.branch_id ??
+				branchId;
+			expectOk(await neon.operations.waitFor(error.operations));
+			if (branchId) {
+				const branch = expectOk(
+					await neon.branches.get(projectId, branchId),
+				);
+				expect(branch.id).toBe(branchId);
+			}
+		} finally {
+			if (branchId) {
+				await neon.branches.delete(projectId, branchId, {
+					waitForReadiness: true,
+				});
+			}
+		}
 	});
 });

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -1,17 +1,10 @@
 import {
-	configuredBaseUrl,
-	configuredOrgId,
 	createProject,
 	deleteProject,
-	requireApiKey,
 	uniqueProjectName,
 } from "@neon/e2e-harness";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import {
-	createNeonClient,
-	type NeonClient,
-	NeonNotFoundError,
-} from "../src/index.js";
+import { type NeonClient, NeonNotFoundError } from "../src/index.js";
 import { expectOk, makeClient } from "./helpers.js";
 
 /**
@@ -346,19 +339,18 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 	});
 
 	it("a wait timeout carries outstanding operations so waitFor can resume", async () => {
-		const impatient = createNeonClient({
-			apiKey: requireApiKey(),
-			orgId: configuredOrgId(),
-			baseUrl: configuredBaseUrl(),
-			waitForReadiness: true,
-			wait: { timeoutMs: 1, pollIntervalMs: 1 },
-		});
-
-		const { data, error } = await impatient.branches.create(projectId, {
-			name: "wait-timeout-resume",
-			parent_id: defaultBranchId,
-			noCompute: true,
-		});
+		const { data, error } = await neon.branches.create(
+			projectId,
+			{
+				name: "wait-timeout-resume",
+				parent_id: defaultBranchId,
+				noCompute: true,
+			},
+			{
+				waitForReadiness: true,
+				wait: { timeoutMs: 1, pollIntervalMs: 1 },
+			},
+		);
 
 		let branchId: string | undefined = data?.id;
 		try {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -38,7 +38,9 @@ export {
 	NeonNotFoundError,
 	NeonOperationError,
 	NeonRateLimitError,
+	NeonRequestTimeoutError,
 	NeonTimeoutError,
+	NeonWaitTimeoutError,
 } from "./neon/errors.js";
 export type { Page, Paginated } from "./neon/paginate.js";
 export type {

--- a/packages/sdk/src/neon/cancellation.server.test.ts
+++ b/packages/sdk/src/neon/cancellation.server.test.ts
@@ -259,6 +259,7 @@ describe("readiness polling", () => {
 		const { error } = await neon.projects.create({ name: "test" });
 		expect(behaviour.operationPolls).toBeGreaterThan(0);
 		expect(error?.kind).toBe("timeout");
+		expect(error).toMatchObject({ source: "wait", timeoutMs: 80 });
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
 		resetBehaviour();
 	});
@@ -275,6 +276,7 @@ describe("readiness polling", () => {
 
 		const { error } = await neon.projects.create({ name: "test" });
 		expect(error?.kind).toBe("timeout");
+		expect(error).toMatchObject({ source: "wait", timeoutMs: 80 });
 	});
 
 	it("resolves once the operations finish", async () => {

--- a/packages/sdk/src/neon/cancellation.server.test.ts
+++ b/packages/sdk/src/neon/cancellation.server.test.ts
@@ -12,6 +12,10 @@ import { createNeonClient } from "./client.js";
  * covers were invisible to the stubbed suite.
  */
 
+interface CreateOp {
+	id: string;
+}
+
 interface Behaviour {
 	/** Never respond, leaving the socket open until the client gives up. */
 	hang: boolean;
@@ -22,7 +26,15 @@ interface Behaviour {
 	operationPolls: number;
 	/** Resolves the first time an operation poll is received. */
 	onOperationPoll?: () => void;
+	/** Operations returned on create. Defaults to one running `op-1`. */
+	createOperations: CreateOp[];
+	/** Operation ids whose poll never responds. */
+	hangOperationIds: string[];
+	/** Operation ids that report `finished` when polled, even if others stay running. */
+	finishOperationIds: string[];
 }
+
+const DEFAULT_CREATE_OPS: CreateOp[] = [{ id: "op-1" }];
 
 let server: Server;
 let baseUrl: string;
@@ -31,6 +43,9 @@ const behaviour: Behaviour = {
 	operationRunning: true,
 	hangOperations: false,
 	operationPolls: 0,
+	createOperations: DEFAULT_CREATE_OPS,
+	hangOperationIds: [],
+	finishOperationIds: [],
 };
 
 /** Reset between tests so one test's server behaviour cannot leak into the next. */
@@ -40,6 +55,9 @@ function resetBehaviour(overrides: Partial<Behaviour> = {}) {
 	behaviour.hangOperations = false;
 	behaviour.operationPolls = 0;
 	behaviour.onOperationPoll = undefined;
+	behaviour.createOperations = DEFAULT_CREATE_OPS;
+	behaviour.hangOperationIds = [];
+	behaviour.finishOperationIds = [];
 	Object.assign(behaviour, overrides);
 }
 
@@ -56,19 +74,28 @@ beforeAll(async () => {
 		if (url.pathname.includes("/operations/")) {
 			behaviour.operationPolls += 1;
 			behaviour.onOperationPoll?.();
+			const operationId = url.pathname.slice(
+				url.pathname.lastIndexOf("/") + 1,
+			);
 			// Leaves the poll in flight, so an abort or a deadline lands during the
 			// request rather than in the gap between polls.
-			if (behaviour.hangOperations) return;
+			if (
+				behaviour.hangOperations ||
+				behaviour.hangOperationIds.includes(operationId)
+			) {
+				return;
+			}
+			const finished =
+				behaviour.finishOperationIds.includes(operationId) ||
+				!behaviour.operationRunning;
 			res.writeHead(200, { "content-type": "application/json" });
 			res.end(
 				json({
 					operation: {
-						id: "op-1",
+						id: operationId,
 						project_id: "p-1",
 						action: "create_timeline",
-						status: behaviour.operationRunning
-							? "running"
-							: "finished",
+						status: finished ? "finished" : "running",
 					},
 				}),
 			);
@@ -80,14 +107,12 @@ beforeAll(async () => {
 			res.end(
 				json({
 					project: { id: "p-1", name: "test" },
-					operations: [
-						{
-							id: "op-1",
-							project_id: "p-1",
-							action: "create_timeline",
-							status: "running",
-						},
-					],
+					operations: behaviour.createOperations.map((op) => ({
+						id: op.id,
+						project_id: "p-1",
+						action: "create_timeline",
+						status: "running",
+					})),
 					connection_uris: [
 						{
 							connection_uri: "postgresql://u:p@host/db",
@@ -260,6 +285,10 @@ describe("readiness polling", () => {
 		expect(behaviour.operationPolls).toBeGreaterThan(0);
 		expect(error?.kind).toBe("timeout");
 		expect(error).toMatchObject({ source: "wait", timeoutMs: 80 });
+		if (error?.kind !== "timeout" || error.source !== "wait") {
+			throw new Error("expected wait timeout");
+		}
+		expect(error.operations.map((op) => op.id)).toEqual(["op-1"]);
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
 		resetBehaviour();
 	});
@@ -277,6 +306,81 @@ describe("readiness polling", () => {
 		const { error } = await neon.projects.create({ name: "test" });
 		expect(error?.kind).toBe("timeout");
 		expect(error).toMatchObject({ source: "wait", timeoutMs: 80 });
+		if (error?.kind !== "timeout" || error.source !== "wait") {
+			throw new Error("expected wait timeout");
+		}
+		expect(error.operations.map((op) => op.id)).toEqual(["op-1"]);
+	});
+
+	it("on a mid-round timeout, operations is the still-outstanding subset", async () => {
+		resetBehaviour({
+			createOperations: [{ id: "op-a" }, { id: "op-b" }],
+			finishOperationIds: ["op-a"],
+			hangOperationIds: ["op-b"],
+		});
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			waitForReadiness: true,
+			wait: { pollIntervalMs: 5, timeoutMs: 80 },
+		});
+
+		const { error } = await neon.projects.create({ name: "test" });
+		expect(error?.kind).toBe("timeout");
+		if (error?.kind !== "timeout" || error.source !== "wait") {
+			throw new Error("expected wait timeout");
+		}
+		expect(error.operations.map((op) => op.id)).toEqual(["op-b"]);
+		resetBehaviour();
+	});
+
+	it("resumes polling from a wait timeout via operations.waitFor", async () => {
+		resetBehaviour({ hangOperations: true });
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+			waitForReadiness: true,
+			wait: { pollIntervalMs: 5, timeoutMs: 80 },
+		});
+
+		const { error } = await neon.projects.create({ name: "test" });
+		if (error?.kind !== "timeout" || error.source !== "wait") {
+			throw new Error("expected wait timeout");
+		}
+		resetBehaviour({ operationRunning: false, hangOperations: false });
+		const resumed = await neon.operations.waitFor(error.operations);
+		expect(resumed.error).toBeUndefined();
+	});
+
+	it("waitFor itself returns the still-pending operations on timeout", async () => {
+		resetBehaviour({ hangOperations: true });
+		const neon = createNeonClient({
+			apiKey: "k",
+			baseUrl,
+			retries: 0,
+		});
+		const { error } = await neon.operations.waitFor(
+			[
+				{
+					id: "op-1",
+					project_id: "p-1",
+					action: "create_timeline",
+					status: "running",
+					failures_count: 0,
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+					total_duration_ms: 0,
+				},
+			],
+			{ pollIntervalMs: 5, timeoutMs: 80 },
+		);
+		if (error?.kind !== "timeout" || error.source !== "wait") {
+			throw new Error("expected wait timeout");
+		}
+		expect(error.operations.map((op) => op.id)).toEqual(["op-1"]);
+		resetBehaviour();
 	});
 
 	it("resolves once the operations finish", async () => {

--- a/packages/sdk/src/neon/cancellation.test.ts
+++ b/packages/sdk/src/neon/cancellation.test.ts
@@ -137,6 +137,7 @@ describe("requestTimeoutMs bounds a call", () => {
 
 		expect(Date.now() - startedAt).toBeLessThan(1_000);
 		expect(error?.kind).toBe("timeout");
+		expect(error).toMatchObject({ source: "request", timeoutMs: 20 });
 	});
 
 	it("bounds a slow auth phase, which the request signal cannot reach", async () => {

--- a/packages/sdk/src/neon/cancellation.test.ts
+++ b/packages/sdk/src/neon/cancellation.test.ts
@@ -138,6 +138,7 @@ describe("requestTimeoutMs bounds a call", () => {
 		expect(Date.now() - startedAt).toBeLessThan(1_000);
 		expect(error?.kind).toBe("timeout");
 		expect(error).toMatchObject({ source: "request", timeoutMs: 20 });
+		expect(error && "operations" in error).toBe(false);
 	});
 
 	it("bounds a slow auth phase, which the request signal cannot reach", async () => {

--- a/packages/sdk/src/neon/deadline.test.ts
+++ b/packages/sdk/src/neon/deadline.test.ts
@@ -30,6 +30,7 @@ describe("createDeadline", () => {
 	it("is unbounded and allocates no signal when nothing can cancel it", () => {
 		const deadline = createDeadline(Number.POSITIVE_INFINITY);
 		expect(deadline.signal).toBeUndefined();
+		expect(deadline.timeoutMs).toBeUndefined();
 		expect(deadline.remainingMs()).toBe(Number.POSITIVE_INFINITY);
 		expect(deadline.source()).toBeUndefined();
 	});
@@ -41,6 +42,7 @@ describe("createDeadline", () => {
 			controller.signal,
 		);
 		expect(deadline.signal).toBeDefined();
+		expect(deadline.timeoutMs).toBeUndefined();
 		expect(deadline.remainingMs()).toBe(Number.POSITIVE_INFINITY);
 		deadline.dispose();
 	});
@@ -49,6 +51,7 @@ describe("createDeadline", () => {
 		const deadline = createDeadline(5);
 		await deadline.fired();
 		expect(deadline.source()).toBe("timeout");
+		expect(deadline.timeoutMs).toBe(5);
 		expect(deadline.signal?.aborted).toBe(true);
 		deadline.dispose();
 	});
@@ -117,7 +120,9 @@ describe("cancelled", () => {
 	it("maps a timeout to a timeout error", async () => {
 		const deadline = createDeadline(1);
 		await deadline.fired();
-		expect(cancelled(deadline)?.kind).toBe("timeout");
+		const error = cancelled(deadline);
+		expect(error?.kind).toBe("timeout");
+		expect(error).toMatchObject({ source: "request", timeoutMs: 1 });
 		deadline.dispose();
 	});
 

--- a/packages/sdk/src/neon/deadline.test.ts
+++ b/packages/sdk/src/neon/deadline.test.ts
@@ -1,6 +1,7 @@
 import { getEventListeners } from "node:events";
 import { describe, expect, it } from "vitest";
 import { cancelled, createDeadline, delay, runBounded } from "./deadline.js";
+import { NeonRequestTimeoutError } from "./errors.js";
 
 describe("delay", () => {
 	it("reports elapsed when it runs to completion", async () => {
@@ -121,8 +122,10 @@ describe("cancelled", () => {
 		const deadline = createDeadline(1);
 		await deadline.fired();
 		const error = cancelled(deadline);
+		expect(error).toBeInstanceOf(NeonRequestTimeoutError);
 		expect(error?.kind).toBe("timeout");
 		expect(error).toMatchObject({ source: "request", timeoutMs: 1 });
+		expect(error && "operations" in error).toBe(false);
 		deadline.dispose();
 	});
 

--- a/packages/sdk/src/neon/deadline.ts
+++ b/packages/sdk/src/neon/deadline.ts
@@ -33,6 +33,8 @@ export interface Deadline {
 	 * the caller passed no signal, so nothing extra is allocated for the common case.
 	 */
 	readonly signal: AbortSignal | undefined;
+	/** Finite `requestTimeoutMs` when this deadline has a request budget. */
+	readonly timeoutMs: number | undefined;
 	/** Budget left in milliseconds; `Infinity` when no request timeout applies. */
 	remainingMs(): number;
 	/**
@@ -56,6 +58,7 @@ export interface Deadline {
 
 const UNBOUNDED: Deadline = {
 	signal: undefined,
+	timeoutMs: undefined,
 	remainingMs: () => Number.POSITIVE_INFINITY,
 	source: () => undefined,
 	fired: () => new Promise<void>(() => {}),
@@ -106,8 +109,16 @@ export function cancelled(deadline: Deadline): NeonError | undefined {
 		return new NeonAbortError("The request was aborted by its signal.");
 	}
 	if (source === "timeout") {
+		const timeoutMs = deadline.timeoutMs;
+		if (timeoutMs === undefined) {
+			throw new NeonError(
+				"Internal: a request timeout fired without a requestTimeoutMs budget.",
+				"client",
+			);
+		}
 		return new NeonTimeoutError(
 			"Timed out waiting for the Neon API to respond (requestTimeoutMs).",
+			{ source: "request", timeoutMs },
 		);
 	}
 	return undefined;
@@ -215,6 +226,7 @@ export function createDeadline(
 
 	return {
 		signal: controller.signal,
+		timeoutMs: bounded ? timeoutMs : undefined,
 		remainingMs,
 		source: () => {
 			if (!source && remainingMs() === 0) trip("timeout");

--- a/packages/sdk/src/neon/deadline.ts
+++ b/packages/sdk/src/neon/deadline.ts
@@ -111,9 +111,8 @@ export function cancelled(
 	if (source === "timeout") {
 		const timeoutMs = deadline.timeoutMs;
 		if (timeoutMs === undefined) {
-			throw new NeonError(
+			throw new NeonClientError(
 				"Internal: a request timeout fired without a requestTimeoutMs budget.",
-				"client",
 			);
 		}
 		return new NeonTimeoutError(

--- a/packages/sdk/src/neon/deadline.ts
+++ b/packages/sdk/src/neon/deadline.ts
@@ -12,7 +12,11 @@
  * to a caller who was promised `{ data, error }`.
  */
 
-import { NeonAbortError, NeonClientError, NeonTimeoutError } from "./errors.js";
+import {
+	NeonAbortError,
+	NeonClientError,
+	NeonRequestTimeoutError,
+} from "./errors.js";
 
 /**
  * The largest delay `setTimeout` can represent. Beyond it Node warns
@@ -103,7 +107,7 @@ export function resolveTimeoutMs(value: number | undefined): number {
  */
 export function cancelled(
 	deadline: Deadline,
-): NeonAbortError | NeonTimeoutError | undefined {
+): NeonAbortError | NeonRequestTimeoutError | undefined {
 	const source = deadline.source();
 	if (source === "caller") {
 		return new NeonAbortError("The request was aborted by its signal.");
@@ -115,9 +119,9 @@ export function cancelled(
 				"Internal: a request timeout fired without a requestTimeoutMs budget.",
 			);
 		}
-		return new NeonTimeoutError(
+		return new NeonRequestTimeoutError(
 			"Timed out waiting for the Neon API to respond (requestTimeoutMs).",
-			{ source: "request", timeoutMs },
+			{ timeoutMs },
 		);
 	}
 	return undefined;

--- a/packages/sdk/src/neon/errors.test-d.ts
+++ b/packages/sdk/src/neon/errors.test-d.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf, it } from "vitest";
+import { NeonTimeoutError } from "./errors.js";
+
+it("NeonTimeoutError requires source and timeoutMs", () => {
+	const error = new NeonTimeoutError("x", {
+		source: "wait",
+		timeoutMs: 80,
+	});
+	expectTypeOf(error.source).toEqualTypeOf<"request" | "wait">();
+	expectTypeOf(error.timeoutMs).toEqualTypeOf<number>();
+	// @ts-expect-error source is readonly
+	error.source = "request";
+	// @ts-expect-error timeoutMs is readonly
+	error.timeoutMs = 1;
+	// @ts-expect-error init is required
+	new NeonTimeoutError("x");
+});

--- a/packages/sdk/src/neon/errors.test-d.ts
+++ b/packages/sdk/src/neon/errors.test-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf, it } from "vitest";
-import type { Project } from "../client/types.gen.js";
+import type { Operation, Project } from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
 import {
 	isNeonError,
@@ -14,24 +14,37 @@ import {
 	NeonNotFoundError,
 	type NeonOperationError,
 	type NeonRateLimitError,
+	NeonRequestTimeoutError,
 	NeonTimeoutError,
+	NeonWaitTimeoutError,
 	toNeonError,
 } from "./errors.js";
 import type { NeonResult } from "./result.js";
 
-it("NeonTimeoutError requires source and timeoutMs", () => {
-	const error = new NeonTimeoutError("x", {
-		source: "wait",
-		timeoutMs: 80,
-	});
-	expectTypeOf(error.source).toEqualTypeOf<"request" | "wait">();
-	expectTypeOf(error.timeoutMs).toEqualTypeOf<number>();
+it("NeonTimeoutError is abstract; subclasses take the matching init", () => {
+	// @ts-expect-error NeonTimeoutError is abstract
+	new NeonTimeoutError("x", { timeoutMs: 1 });
+
+	const request = new NeonRequestTimeoutError("x", { timeoutMs: 20 });
+	expectTypeOf(request.source).toEqualTypeOf<"request">();
+	expectTypeOf(request.timeoutMs).toEqualTypeOf<number>();
 	// @ts-expect-error source is readonly
-	error.source = "request";
+	request.source = "wait";
 	// @ts-expect-error timeoutMs is readonly
-	error.timeoutMs = 1;
-	// @ts-expect-error init is required
-	new NeonTimeoutError("x");
+	request.timeoutMs = 1;
+	// @ts-expect-error operations is a wait-timeout field
+	request.operations;
+
+	const wait = new NeonWaitTimeoutError("x", {
+		timeoutMs: 80,
+		operations: [],
+	});
+	expectTypeOf(wait.source).toEqualTypeOf<"wait">();
+	expectTypeOf(wait.operations).toEqualTypeOf<readonly Operation[]>();
+	// @ts-expect-error operations is readonly
+	wait.operations = [];
+	// @ts-expect-error operations is required
+	new NeonWaitTimeoutError("x", { timeoutMs: 1 });
 });
 
 it("kind narrows NeonResult.error to the matching subclass", async () => {
@@ -70,9 +83,22 @@ it("kind narrows NeonResult.error to the matching subclass", async () => {
 	}
 
 	if (error?.kind === "timeout") {
-		expectTypeOf(error).toEqualTypeOf<NeonTimeoutError>();
+		expectTypeOf(error).toEqualTypeOf<
+			NeonRequestTimeoutError | NeonWaitTimeoutError
+		>();
 		expectTypeOf(error.source).toEqualTypeOf<"request" | "wait">();
 		expectTypeOf(error.timeoutMs).toEqualTypeOf<number>();
+		if (error.source === "wait") {
+			expectTypeOf(error).toEqualTypeOf<NeonWaitTimeoutError>();
+			expectTypeOf(error.operations).toEqualTypeOf<
+				readonly Operation[]
+			>();
+		}
+		if (error.source === "request") {
+			expectTypeOf(error).toEqualTypeOf<NeonRequestTimeoutError>();
+			// @ts-expect-error operations is a wait-timeout field
+			error.operations;
+		}
 	}
 
 	if (error?.kind === "operation") {
@@ -153,9 +179,13 @@ it("NeonApiError is not a generic that can advertise a false kind", () => {
 	new NeonApiError<"not_found">("x", { status: 500 });
 });
 
-it("new NeonApiError is assignable to NeonErrorUnion", () => {
-	const error: NeonErrorUnion = new NeonApiError("x", { status: 500 });
-	expectTypeOf(error).toEqualTypeOf<NeonErrorUnion>();
+it("timeout subclasses are assignable to NeonErrorUnion", () => {
+	expectTypeOf(
+		new NeonRequestTimeoutError("x", { timeoutMs: 1 }),
+	).toMatchTypeOf<NeonErrorUnion>();
+	expectTypeOf(
+		new NeonWaitTimeoutError("x", { timeoutMs: 1, operations: [] }),
+	).toMatchTypeOf<NeonErrorUnion>();
 });
 
 it("isNeonError narrows unknown to NeonErrorUnion", () => {

--- a/packages/sdk/src/neon/errors.test.ts
+++ b/packages/sdk/src/neon/errors.test.ts
@@ -61,7 +61,15 @@ describe("error names survive minification", () => {
 				}),
 			NeonOperationError,
 		],
-		["NeonTimeoutError", () => new NeonTimeoutError("x"), NeonTimeoutError],
+		[
+			"NeonTimeoutError",
+			() =>
+				new NeonTimeoutError("x", {
+					source: "request",
+					timeoutMs: 1,
+				}),
+			NeonTimeoutError,
+		],
 		["NeonNetworkError", () => new NeonNetworkError("x"), NeonNetworkError],
 	];
 
@@ -71,6 +79,26 @@ describe("error names survive minification", () => {
 			expect(nameAfterMinification(construct, cls)).toBe(expected);
 		});
 	}
+});
+
+describe("NeonTimeoutError", () => {
+	it("records which deadline fired and the budget that was exceeded", () => {
+		const request = new NeonTimeoutError("x", {
+			source: "request",
+			timeoutMs: 20,
+		});
+		expect(request.kind).toBe("timeout");
+		expect(request.source).toBe("request");
+		expect(request.timeoutMs).toBe(20);
+		expect(request).toBeInstanceOf(NeonError);
+
+		const wait = new NeonTimeoutError("x", {
+			source: "wait",
+			timeoutMs: 80,
+		});
+		expect(wait.source).toBe("wait");
+		expect(wait.timeoutMs).toBe(80);
+	});
 });
 
 describe("describeTransportFailure", () => {

--- a/packages/sdk/src/neon/errors.test.ts
+++ b/packages/sdk/src/neon/errors.test.ts
@@ -13,7 +13,9 @@ import {
 	NeonNotFoundError,
 	NeonOperationError,
 	NeonRateLimitError,
+	NeonRequestTimeoutError,
 	NeonTimeoutError,
+	NeonWaitTimeoutError,
 	toNeonError,
 } from "./errors.js";
 
@@ -65,13 +67,21 @@ describe("error names survive minification", () => {
 			NeonOperationError,
 		],
 		[
-			"NeonTimeoutError",
+			"NeonRequestTimeoutError",
 			() =>
-				new NeonTimeoutError("x", {
-					source: "request",
+				new NeonRequestTimeoutError("x", {
 					timeoutMs: 1,
 				}),
-			NeonTimeoutError,
+			NeonRequestTimeoutError,
+		],
+		[
+			"NeonWaitTimeoutError",
+			() =>
+				new NeonWaitTimeoutError("x", {
+					timeoutMs: 1,
+					operations: [],
+				}),
+			NeonWaitTimeoutError,
 		],
 		["NeonAbortError", () => new NeonAbortError("x"), NeonAbortError],
 		["NeonNetworkError", () => new NeonNetworkError("x"), NeonNetworkError],
@@ -88,21 +98,36 @@ describe("error names survive minification", () => {
 
 describe("NeonTimeoutError", () => {
 	it("records which deadline fired and the budget that was exceeded", () => {
-		const request = new NeonTimeoutError("x", {
-			source: "request",
+		const request = new NeonRequestTimeoutError("x", {
 			timeoutMs: 20,
 		});
 		expect(request.kind).toBe("timeout");
 		expect(request.source).toBe("request");
 		expect(request.timeoutMs).toBe(20);
+		expect(request).toBeInstanceOf(NeonTimeoutError);
 		expect(request).toBeInstanceOf(NeonError);
+		expect("operations" in request).toBe(false);
 
-		const wait = new NeonTimeoutError("x", {
-			source: "wait",
+		const operations = [
+			{
+				id: "op-1",
+				project_id: "p-1",
+				action: "create_timeline" as const,
+				status: "running" as const,
+				failures_count: 0,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+				total_duration_ms: 0,
+			},
+		];
+		const wait = new NeonWaitTimeoutError("x", {
 			timeoutMs: 80,
+			operations,
 		});
 		expect(wait.source).toBe("wait");
 		expect(wait.timeoutMs).toBe(80);
+		expect(wait).toBeInstanceOf(NeonTimeoutError);
+		expect(wait.operations).toBe(operations);
 	});
 });
 
@@ -131,9 +156,14 @@ describe("each class reports its literal kind", () => {
 			}).kind,
 		).toBe("operation");
 		expect(
-			new NeonTimeoutError("x", {
-				source: "request",
+			new NeonRequestTimeoutError("x", {
 				timeoutMs: 1,
+			}).kind,
+		).toBe("timeout");
+		expect(
+			new NeonWaitTimeoutError("x", {
+				timeoutMs: 1,
+				operations: [],
 			}).kind,
 		).toBe("timeout");
 		expect(new NeonAbortError("x").kind).toBe("aborted");
@@ -186,6 +216,17 @@ describe("isNeonError", () => {
 		expect(isNeonError(new NeonApiError("x", apiInit))).toBe(true);
 		expect(isNeonError(new NeonNotFoundError("x", apiInit))).toBe(true);
 		expect(isNeonError(new NeonClientError("x"))).toBe(true);
+		expect(
+			isNeonError(new NeonRequestTimeoutError("x", { timeoutMs: 1 })),
+		).toBe(true);
+		expect(
+			isNeonError(
+				new NeonWaitTimeoutError("x", {
+					timeoutMs: 1,
+					operations: [],
+				}),
+			),
+		).toBe(true);
 		expect(isNeonError(new NeonError("x", "client"))).toBe(false);
 		expect(isNeonError(new Error("x"))).toBe(false);
 		expect(isNeonError(undefined)).toBe(false);

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -131,9 +131,17 @@ export class NeonOperationError extends NeonError {
  * the `wait` budget while polling operations for readiness.
  */
 export class NeonTimeoutError extends NeonError {
-	constructor(message: string) {
+	readonly source: "request" | "wait";
+	readonly timeoutMs: number;
+
+	constructor(
+		message: string,
+		init: { source: "request" | "wait"; timeoutMs: number },
+	) {
 		super(message, "timeout");
 		this.name = "NeonTimeoutError";
+		this.source = init.source;
+		this.timeoutMs = init.timeoutMs;
 	}
 }
 

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -6,6 +6,8 @@
  * `instanceof NeonError` still matches all of them.
  */
 
+import type { Operation } from "../client/types.gen.js";
+
 /** Used when a transport failure carries neither an `errno` code nor any message. */
 const UNKNOWN_TRANSPORT_REASON = "cause unavailable";
 
@@ -129,21 +131,45 @@ export class NeonOperationError extends NeonError {
 
 /**
  * A deadline was exceeded — either `requestTimeoutMs` for a request and its retries, or
- * the `wait` budget while polling operations for readiness.
+ * the `wait` budget while polling operations for readiness. Not constructible: use
+ * {@link NeonRequestTimeoutError} or {@link NeonWaitTimeoutError}.
  */
-export class NeonTimeoutError extends NeonError {
+export abstract class NeonTimeoutError extends NeonError {
 	declare readonly kind: "timeout";
-	readonly source: "request" | "wait";
+	abstract readonly source: "request" | "wait";
+	/** The budget that was exceeded, in ms. */
 	readonly timeoutMs: number;
+
+	constructor(message: string, init: { timeoutMs: number }) {
+		super(message, "timeout");
+		this.name = "NeonTimeoutError";
+		this.timeoutMs = init.timeoutMs;
+	}
+}
+
+/** `requestTimeoutMs` ran out. The call may never have reached the API. */
+export class NeonRequestTimeoutError extends NeonTimeoutError {
+	override readonly source: "request" = "request";
+
+	constructor(message: string, init: { timeoutMs: number }) {
+		super(message, init);
+		this.name = "NeonRequestTimeoutError";
+	}
+}
+
+/** `wait.timeoutMs` ran out. The mutation was accepted; these operations were still running. */
+export class NeonWaitTimeoutError extends NeonTimeoutError {
+	override readonly source: "wait" = "wait";
+	/** Pass to `neon.operations.waitFor` to resume. Each carries `project_id`. */
+	readonly operations: readonly Operation[];
 
 	constructor(
 		message: string,
-		init: { source: "request" | "wait"; timeoutMs: number },
+		init: { timeoutMs: number; operations: readonly Operation[] },
 	) {
-		super(message, "timeout");
-		this.name = "NeonTimeoutError";
-		this.source = init.source;
-		this.timeoutMs = init.timeoutMs;
+		super(message, init);
+		this.name = "NeonWaitTimeoutError";
+		this.operations = init.operations;
 	}
 }
 
@@ -210,7 +236,8 @@ export type NeonErrorUnion =
 	| NeonAuthError
 	| NeonRateLimitError
 	| NeonOperationError
-	| NeonTimeoutError
+	| NeonRequestTimeoutError
+	| NeonWaitTimeoutError
 	| NeonAbortError
 	| NeonNetworkError
 	| NeonClientError;

--- a/packages/sdk/src/neon/wait-budget.test.ts
+++ b/packages/sdk/src/neon/wait-budget.test.ts
@@ -57,6 +57,11 @@ describe("per-call wait budget", () => {
 			{ wait: { timeoutMs: 80 } },
 		);
 		expect(error?.kind).toBe("timeout");
+		if (error?.kind !== "timeout" || error.source !== "wait") {
+			throw new Error("expected wait timeout");
+		}
+		expect(error.timeoutMs).toBe(80);
+		expect(error.operations.map((op) => op.id)).toEqual(["op-1"]);
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
 	});
 

--- a/packages/sdk/src/neon/wait.ts
+++ b/packages/sdk/src/neon/wait.ts
@@ -49,6 +49,7 @@ function readinessEnded(
 	if (source === "timeout") {
 		return new NeonTimeoutError(
 			`Timed out after ${timeoutMs}ms waiting for ${pending} operation(s) to finish.`,
+			{ source: "wait", timeoutMs },
 		);
 	}
 	return undefined;

--- a/packages/sdk/src/neon/wait.ts
+++ b/packages/sdk/src/neon/wait.ts
@@ -10,7 +10,7 @@ import {
 import {
 	NeonAbortError,
 	NeonOperationError,
-	NeonTimeoutError,
+	NeonWaitTimeoutError,
 	toNeonError,
 } from "./errors.js";
 import { err, type NeonResult, ok } from "./result.js";
@@ -37,8 +37,8 @@ export interface WaitForOptions {
 function readinessEnded(
 	deadline: Deadline,
 	timeoutMs: number,
-	pending: number,
-): NeonAbortError | NeonTimeoutError | undefined {
+	outstanding: readonly Operation[],
+): NeonAbortError | NeonWaitTimeoutError | undefined {
 	const source = deadline.source();
 	if (source === "caller") {
 		return new NeonAbortError(
@@ -46,9 +46,9 @@ function readinessEnded(
 		);
 	}
 	if (source === "timeout") {
-		return new NeonTimeoutError(
-			`Timed out after ${timeoutMs}ms waiting for ${pending} operation(s) to finish.`,
-			{ source: "wait", timeoutMs },
+		return new NeonWaitTimeoutError(
+			`Timed out after ${timeoutMs}ms waiting for ${outstanding.length} operation(s) to finish.`,
+			{ timeoutMs, operations: outstanding },
 		);
 	}
 	return undefined;
@@ -57,7 +57,7 @@ function readinessEnded(
 /**
  * Poll the given operations until each reaches a terminal `finished`/`skipped` state.
  * Returns an error result carrying {@link NeonOperationError} if any operation ends in
- * `failed`/`error`/`cancelled`, {@link NeonTimeoutError} if the deadline is exceeded, or
+ * `failed`/`error`/`cancelled`, {@link NeonWaitTimeoutError} if the deadline is exceeded, or
  * {@link NeonAbortError} if the caller's signal fired.
  *
  * `timeoutMs` is a real deadline rather than a check between polls. Each poll runs under
@@ -86,14 +86,14 @@ export async function waitForOperations(
 		pending = pending.filter((op) => !FAILURE.has(op.status));
 
 		while (pending.length > 0) {
-			const ended = readinessEnded(deadline, timeoutMs, pending.length);
+			const ended = readinessEnded(deadline, timeoutMs, pending);
 			if (ended) return err(ended);
 
 			if (
 				(await delay(pollIntervalMs, deadline.signal)) === "cancelled"
 			) {
 				return err(
-					readinessEnded(deadline, timeoutMs, pending.length) ??
+					readinessEnded(deadline, timeoutMs, pending) ??
 						new NeonAbortError(
 							"Waiting for operations was aborted by its signal.",
 						),
@@ -101,10 +101,8 @@ export async function waitForOperations(
 			}
 
 			const stillPending: Operation[] = [];
-			// Counted from what is left rather than from the round's starting size, so a
-			// timeout part-way through a round reports the operations actually outstanding.
-			let remaining = pending.length;
-			for (const op of pending) {
+			for (let i = 0; i < pending.length; i++) {
+				const op = pending[i];
 				const polled = await runBounded(deadline, () =>
 					getProjectOperation({
 						client,
@@ -117,10 +115,15 @@ export async function waitForOperations(
 					}),
 				);
 
-				// Cancellation is read from the deadline before the response is
-				// classified: an aborted poll comes back as a transport failure with no
-				// response, which `toNeonError` would otherwise report as a network error.
-				const stopped = readinessEnded(deadline, timeoutMs, remaining);
+				// Classify from the deadline first: an aborted poll is a transport
+				// failure with no response, which toNeonError would report as a network
+				// error. The in-flight op is still outstanding.
+				const outstanding = [...stillPending, ...pending.slice(i)];
+				const stopped = readinessEnded(
+					deadline,
+					timeoutMs,
+					outstanding,
+				);
 				if (stopped) return err(stopped);
 				if (polled === undefined) {
 					return err(toNeonError(undefined, undefined));
@@ -133,8 +136,7 @@ export async function waitForOperations(
 				if (FAILURE.has(current.status)) {
 					return err(operationFailed(current));
 				}
-				if (SUCCESS.has(current.status)) remaining -= 1;
-				else stillPending.push(current);
+				if (!SUCCESS.has(current.status)) stillPending.push(current);
 			}
 			pending = stillPending;
 		}


### PR DESCRIPTION
## Problem

`neon.projects.create` and `neon.branches.create` poll the returned operations until they finish. When the `wait` budget runs out, the caller gets `{ error: NeonTimeoutError }` and no `data`. The resource exists and is still provisioning, but the error carries only a message:

```
Timed out after 30000ms waiting for 1 operation(s) to finish.
```

Nothing in it identifies the project, the branch or the operations. The only way to keep going is to list operations by hand or call `create` again, which makes a second resource.

The same `NeonTimeoutError` also covers `requestTimeoutMs`. That case is a different situation: the request may never have reached the API and there is nothing to resume. Both fire as `kind: "timeout"` with no field to tell them apart.

## Diagnosis

`waitForOperations` in `wait.ts` already holds the list of pending operations when the deadline trips. It passed only `pending.length` into the error message. The fix is to pass the list.

The one subtlety is a timeout in the middle of a polling round. The loop polls each pending operation in turn, so at the moment the deadline fires some operations in the round have already reported `finished` and one is in flight. `operations` is built from the ones not yet confirmed done in this round plus the in-flight one and the ones not yet polled, so a caller never re-waits on a finished operation and never drops a running one.

The request timeout side needed `Deadline` to remember its budget. `createDeadline` knew `timeoutMs` at construction but did not expose it, so `cancelled()` could not report it.

## Interface

`NeonTimeoutError` becomes an abstract base with two subclasses. `kind` stays `"timeout"`, so `error.kind === "timeout"` still matches both. `source` says which budget fired:

| Class | `kind` | `source` | Fields |
| --- | --- | --- | --- |
| `NeonRequestTimeoutError` | `"timeout"` | `"request"` | `timeoutMs` (the `requestTimeoutMs` that ran out) |
| `NeonWaitTimeoutError` | `"timeout"` | `"wait"` | `timeoutMs` (the `wait.timeoutMs` that ran out), `operations: readonly Operation[]` |

Resuming after a wait timeout, using the per-call `wait` budget already on `main`:

```ts
import { createNeonClient } from "@neon/sdk";

const neon = createNeonClient({ apiKey });

const { data, error } = await neon.projects.create(
  { name: "app" },
  { wait: { timeoutMs: 30_000 } },
);

if (error?.kind === "timeout" && error.source === "wait") {
  // The project exists and is still provisioning. Poll again with a fresh
  // budget instead of calling create a second time.
  const resumed = await neon.operations.waitFor(error.operations, {
    timeoutMs: 120_000,
  });
  if (resumed.error) throw resumed.error;
}
```

Each `Operation` in `error.operations` carries `project_id`, and branch operations carry `branch_id`, so the created resource is recoverable from the error alone.

`source` narrows the type. Inside `error.source === "wait"`, `error` is `NeonWaitTimeoutError` and `error.operations` is `readonly Operation[]`. Inside `error.source === "request"`, `error` is `NeonRequestTimeoutError` and `error.operations` is a type error.

`neon.operations.waitFor` returns the same `NeonWaitTimeoutError` when its own budget runs out, so a resume can itself be resumed.

Both subclasses are exported from `@neon/sdk`. `NeonErrorUnion` lists the two subclasses in place of the base.

What does not change for existing callers:

- `error.kind === "timeout"` matches both subclasses.
- `instanceof NeonTimeoutError` matches both subclasses.
- `throwOnError` throws the same objects.
- The messages are unchanged.

What changes: `new NeonTimeoutError(message)` no longer compiles. The class is abstract and the subclasses take `{ timeoutMs }` and `{ timeoutMs, operations }`. Code that constructs the error directly, which is test code in practice, has to pick a subclass.

## Also in here

- `Deadline` gains `readonly timeoutMs: number | undefined`, set when the deadline was created with a finite `requestTimeoutMs`. `cancelled()` reads it to fill `NeonRequestTimeoutError.timeoutMs`. If the deadline reports `"timeout"` without a budget, `cancelled()` throws `NeonClientError` rather than inventing a value; that state has no valid producer.
- The stub HTTP server in `cancellation.server.test.ts` can now return several operations from create, hang the poll for specific operation ids and finish others. That is what makes the mid-round case testable.
- README: the error table gets the two new rows, the timeout section gets the resume example above and the `operations.waitFor` row says what to pass it after a timeout.
- Changeset: `@neon/sdk` minor.

## Verification

Unit and stub-server tests added or extended, all under `pnpm --filter @neon/sdk test`:

- a wait timeout from `projects.create` has `source: "wait"`, `timeoutMs` equal to the configured budget and `operations` equal to the running operations (client-level `wait` and per-call `wait`)
- a wait timeout that lands while a poll is in flight reports the same fields
- a mid-round timeout with two operations, one finished and one hanging, reports only the hanging one
- `operations.waitFor(error.operations)` after a wait timeout succeeds once the operations finish
- `operations.waitFor` called directly returns `NeonWaitTimeoutError` with the still-pending operations when its own budget runs out
- a `requestTimeoutMs` timeout has `source: "request"`, `timeoutMs` equal to the budget and no `operations` property
- `Deadline.timeoutMs` is set for a finite budget and `undefined` for unbounded or signal-only deadlines
- both subclasses report `kind: "timeout"`, pass `isNeonError`, are `instanceof NeonTimeoutError` and keep their `name` after minification
- type tests: `new NeonTimeoutError(...)` is a compile error; `error.kind === "timeout"` narrows to the union of the two subclasses; `error.source` narrows to one; `error.operations` is a type error on the request side; `source`, `timeoutMs` and `operations` are readonly; `operations` is required on `NeonWaitTimeoutError`

Live e2e added in `packages/sdk/e2e/resources.e2e.test.ts`: create a branch with `wait: { timeoutMs: 1 }`, assert `source: "wait"` with non-empty `operations` all carrying the project id, resume with `operations.waitFor`, fetch the branch by the `branch_id` from the operations and delete it. Not run locally; it needs the e2e credentials and runs in CI.

## For your attention

- **Breaking for direct constructors.** `new NeonTimeoutError(message)` was public and compiles on `main`. It fails to compile on this branch. The SDK itself never constructs it outside `deadline.ts` and `wait.ts`; user code that does is most likely a test fake. Shipped as a minor per the changeset; bump to major if that guarantee is stricter than intended.
- **The 1ms e2e timeout depends on the API not finishing a branch create in under 1ms.** If it does, the test fails with a message saying so rather than passing vacuously. That has not been observed, but it is a timing assumption on a live system.
- **`operations` is a snapshot at the time of the timeout.** Operations that finished between the last poll response and the deadline can still appear. `waitFor` handles that: it returns immediately for operations already `finished`.
