### PR TITLE
Accept a per-call `wait` budget on `CallOptions`

### DIFF
--- a/.changeset/sdk-per-call-wait.md
+++ b/.changeset/sdk-per-call-wait.md
@@ -1,5 +1,5 @@
 ---
-"@neon/sdk": minor
+"@neon/sdk": major
 ---
 
 `CallOptions` now accepts `wait: { pollIntervalMs?, timeoutMs? }`, so a single client can use a longer readiness budget on one `projects.create` without changing the rest. Client `wait` no longer accepts `signal`; pass `signal` on the call. `operations.waitFor` still takes top-level `pollIntervalMs`, `timeoutMs`, and `signal`.

--- a/.changeset/sdk-per-call-wait.md
+++ b/.changeset/sdk-per-call-wait.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": minor
+---
+
+`CallOptions` now accepts `wait: { pollIntervalMs?, timeoutMs? }`, so a single client can use a longer readiness budget on one `projects.create` without changing the rest. Client `wait` no longer accepts `signal`; pass `signal` on the call. `operations.waitFor` still takes top-level `pollIntervalMs`, `timeoutMs`, and `signal`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -189,7 +189,7 @@ consuming it twice gets a fresh deadline each time.
 
 ## Readiness & workflows
 
-Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. Per-call `wait` overrides the client's poll interval and timeout for that call. The primitive is `neon.operations.waitFor(operations)`.
+Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. Per-call `wait` overrides the client's poll interval and timeout for that call, field by field: `{ wait: { timeoutMs: 600_000 } }` keeps the client's `pollIntervalMs`. The primitive is `neon.operations.waitFor(operations)`.
 
 ```ts
 await neon.projects.create(

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -48,7 +48,7 @@ const { project, connectionString } = data;
 | `baseUrl` | `string` | `https://console.neon.tech/api/v2` | Override the API base URL. |
 | `fetch` | `typeof fetch` | global `fetch` | Custom fetch implementation (proxies, tests, non-global runtimes). |
 
-Every option except `apiKey` is also accepted **per call** via the last `options` argument (`{ throwOnError?, waitForReadiness?, requestTimeoutMs?, signal? }`), overriding the client default. Paginated methods take it too, after their query.
+Every option except `apiKey` is also accepted **per call** via the last `options` argument (`{ throwOnError?, waitForReadiness?, requestTimeoutMs?, wait?, signal? }`), overriding the client default. Paginated methods take it too, after their query.
 
 ## The result model
 
@@ -189,7 +189,14 @@ consuming it twice gets a fresh deadline each time.
 
 ## Readiness & workflows
 
-Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
+Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. Per-call `wait` overrides the client's poll interval and timeout for that call. The primitive is `neon.operations.waitFor(operations)`.
+
+```ts
+await neon.projects.create(
+  { name: "app" },
+  { wait: { timeoutMs: 600_000 } },
+);
+```
 
 ---
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -65,7 +65,7 @@ export type {
 	UpdateSnapshotInput,
 } from "./neon/resources/snapshots.js";
 export type { NeonResult, Outcome } from "./neon/result.js";
-export type { WaitForOptions } from "./neon/wait.js";
+export type { WaitBudget, WaitForOptions } from "./neon/wait.js";
 export type * from "./raw.js";
 // The raw 1:1 surface as a namespace, and all generated types flat.
 export * as raw from "./raw.js";

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -130,6 +130,41 @@ it("cancellation and deadline options are accepted on the client and per call", 
 		// @ts-expect-error — a deadline is a number of milliseconds
 		requestTimeoutMs: "30s",
 	});
+
+	createNeonClient({
+		apiKey: "x",
+		wait: { timeoutMs: 5_000 },
+	});
+	createNeonClient({
+		apiKey: "x",
+		wait: {
+			pollIntervalMs: 500,
+			timeoutMs: 5_000,
+			// @ts-expect-error — abort is per-call, not client wait
+			signal: controller.signal,
+		},
+	});
+	expectTypeOf(
+		neon.projects.create({ name: "x" }, { wait: { timeoutMs: 600_000 } }),
+	).resolves.toEqualTypeOf<NeonResult<Project>>();
+	neon.projects.create(
+		{ name: "x" },
+		{
+			wait: {
+				timeoutMs: 600_000,
+				// @ts-expect-error — abort is CallOptions.signal, not wait.signal
+				signal: controller.signal,
+			},
+		},
+	);
+	neon.operations.waitFor([], {
+		timeoutMs: 120_000,
+		signal: controller.signal,
+	});
+	neon.operations.waitFor([], {
+		// @ts-expect-error — waitFor takes top-level timeoutMs, not nested wait
+		wait: { timeoutMs: 120_000 },
+	});
 });
 
 it("postgres namespace + tier-2/3 resources are reachable and typed", () => {

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -1,7 +1,7 @@
 import { createClient, createConfig } from "../client/client/index.js";
 import type { ResolvedConfig } from "./context.js";
 import { resolveTimeoutMs } from "./deadline.js";
-import type { WaitForOptions } from "./wait.js";
+import type { WaitBudget } from "./wait.js";
 
 const DEFAULT_BASE_URL = "https://console.neon.tech/api/v2";
 
@@ -23,8 +23,8 @@ export interface NeonConfig<Throw extends boolean = false> {
 	 * Default `false`. Overridable per call.
 	 */
 	waitForReadiness?: boolean;
-	/** Tuning for the readiness poller (interval / timeout). */
-	wait?: WaitForOptions;
+	/** Tuning for the readiness poller (interval / timeout). Not a per-call abort. */
+	wait?: WaitBudget;
 	/** Number of automatic retries on always-safe statuses (423/429/503). Default 2. */
 	retries?: number;
 	/**

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -9,11 +9,7 @@ import {
 import { type NeonError, toNeonError } from "./errors.js";
 import { err, finalize, type NeonResult, ok } from "./result.js";
 import { withRetries } from "./retry.js";
-import {
-	hasOperations,
-	type WaitForOptions,
-	waitForOperations,
-} from "./wait.js";
+import { hasOperations, type WaitBudget, waitForOperations } from "./wait.js";
 
 /** Fully-resolved runtime configuration shared by every resource namespace. */
 export interface ResolvedConfig {
@@ -23,7 +19,7 @@ export interface ResolvedConfig {
 	/** `Infinity` when calls are unbounded, which is the default. */
 	requestTimeoutMs: number;
 	waitForReadiness: boolean;
-	waitOptions: WaitForOptions;
+	waitOptions: WaitBudget;
 	orgId?: string;
 }
 
@@ -38,6 +34,12 @@ export interface CallOptions<Throw extends boolean = boolean> {
 	 * value; readiness polling keeps its own `wait` budget either way.
 	 */
 	requestTimeoutMs?: number;
+	/**
+	 * Override the client's `wait` budget for this call's readiness polling.
+	 * Does not turn polling on; pair it with `waitForReadiness` when the method
+	 * would not wait otherwise.
+	 */
+	wait?: WaitBudget;
 	/** Cancel the call. Surfaces as a `NeonAbortError` (`kind: "aborted"`). */
 	signal?: AbortSignal;
 }
@@ -188,8 +190,12 @@ export class RequestContext {
 		const wait = opts?.waitForReadiness ?? this.#config.waitForReadiness;
 		if (!wait || !hasOperations(data)) return undefined;
 		return waitForOperations(this.#config.client, data.operations, {
-			...this.#config.waitOptions,
-			signal: opts?.signal ?? this.#config.waitOptions.signal,
+			pollIntervalMs:
+				opts?.wait?.pollIntervalMs ??
+				this.#config.waitOptions.pollIntervalMs,
+			timeoutMs:
+				opts?.wait?.timeoutMs ?? this.#config.waitOptions.timeoutMs,
+			signal: opts?.signal,
 		});
 	}
 }

--- a/packages/sdk/src/neon/resources/operations.ts
+++ b/packages/sdk/src/neon/resources/operations.ts
@@ -16,7 +16,7 @@ import { type WaitForOptions, waitForOperations } from "../wait.js";
  * offer a knob that silently did nothing.
  */
 export type WaitForForOptions<Throw extends boolean> = WaitForOptions &
-	Omit<CallOptions<Throw>, "requestTimeoutMs" | "waitForReadiness">;
+	Omit<CallOptions<Throw>, "requestTimeoutMs" | "waitForReadiness" | "wait">;
 
 /** Operation resource — read operations and wait for them to finish. */
 export class Operations<DThrow extends boolean> {
@@ -93,7 +93,7 @@ export class Operations<DThrow extends boolean> {
 			pollIntervalMs:
 				opts?.pollIntervalMs ?? defaults.waitOptions.pollIntervalMs,
 			timeoutMs: opts?.timeoutMs ?? defaults.waitOptions.timeoutMs,
-			signal: opts?.signal ?? defaults.waitOptions.signal,
+			signal: opts?.signal,
 		});
 		if (!shouldThrow) return result;
 		if (result.error) throw result.error;

--- a/packages/sdk/src/neon/wait-budget.test.ts
+++ b/packages/sdk/src/neon/wait-budget.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "./client.js";
+
+function runningCreate() {
+	return {
+		project: { id: "p-1", name: "app" },
+		operations: [
+			{
+				id: "op-1",
+				project_id: "p-1",
+				action: "create_timeline",
+				status: "running",
+				failures_count: 0,
+				created_at: "2026-01-01T00:00:00Z",
+				updated_at: "2026-01-01T00:00:00Z",
+				total_duration_ms: 0,
+			},
+		],
+	};
+}
+
+function neonNeverFinishing(config: {
+	wait?: { pollIntervalMs?: number; timeoutMs?: number };
+}) {
+	return createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		waitForReadiness: true,
+		wait: { pollIntervalMs: 5, ...config.wait },
+		fetch: async (input) => {
+			const url = input instanceof Request ? input.url : String(input);
+			if (url.includes("/operations/")) {
+				return new Response(
+					JSON.stringify({
+						operation: runningCreate().operations[0],
+					}),
+					{
+						status: 200,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			}
+			return new Response(JSON.stringify(runningCreate()), {
+				status: 201,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+}
+
+describe("per-call wait budget", () => {
+	it("uses CallOptions.wait.timeoutMs instead of the client wait timeout", async () => {
+		const neon = neonNeverFinishing({ wait: { timeoutMs: 5_000 } });
+		const startedAt = Date.now();
+		const { error } = await neon.projects.create(
+			{ name: "app" },
+			{ wait: { timeoutMs: 80 } },
+		);
+		expect(error?.kind).toBe("timeout");
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+	});
+
+	it("keeps the client timeout when per-call timeoutMs is omitted", async () => {
+		const neon = neonNeverFinishing({ wait: { timeoutMs: 80 } });
+		const startedAt = Date.now();
+		const { error } = await neon.projects.create(
+			{ name: "app" },
+			{ wait: { pollIntervalMs: 5, timeoutMs: undefined } },
+		);
+		expect(error?.kind).toBe("timeout");
+		expect(Date.now() - startedAt).toBeLessThan(2_000);
+	});
+
+	it("aborts readiness polling from CallOptions.signal, not client wait.signal", async () => {
+		const controller = new AbortController();
+		const neon = neonNeverFinishing({ wait: { timeoutMs: 60_000 } });
+		setTimeout(() => controller.abort(), 20);
+		const { error } = await neon.projects.create(
+			{ name: "app" },
+			{ signal: controller.signal },
+		);
+		expect(error?.kind).toBe("aborted");
+	});
+});

--- a/packages/sdk/src/neon/wait.ts
+++ b/packages/sdk/src/neon/wait.ts
@@ -23,11 +23,14 @@ const FAILURE: ReadonlySet<OperationStatus> = new Set([
 	"cancelled",
 ]);
 
-export interface WaitForOptions {
+export interface WaitBudget {
 	/** How often to poll each pending operation. Default 1000ms. */
 	pollIntervalMs?: number;
 	/** Overall deadline before giving up. Default 300000ms (5 min). */
 	timeoutMs?: number;
+}
+
+export interface WaitForOptions extends WaitBudget {
 	signal?: AbortSignal;
 }
 


### PR DESCRIPTION
## Problem

Readiness polling could only be tuned on the client. A 10-minute `projects.create` next to a 5-minute default meant a second client. `operations.waitFor` already took per-call `timeoutMs`. Client `wait` also accepted `signal`, a one-shot abort stored as long-lived config.

## Diagnosis

`CallOptions` had `requestTimeoutMs` and `waitForReadiness`, but not `wait`. `#maybeWait` spread `config.waitOptions` and took `signal` from `opts?.signal ?? config.waitOptions.signal`.

## Interface

Before:

```ts
await neon.projects.create({ name: "app" }, { waitForReadiness: true });
// uses client wait.timeoutMs only
```

After:

```ts
await neon.projects.create({ name: "app" }, { wait: { timeoutMs: 600_000 } });
```

`WaitBudget` is `{ pollIntervalMs?, timeoutMs? }`. That is `NeonConfig.wait` and `CallOptions.wait`. `WaitForOptions` is `WaitBudget` plus `signal`, used by `operations.waitFor`:

```ts
await neon.operations.waitFor(operations, { timeoutMs: 120_000, signal });
```

Per-call `wait` fields override the client with `??`. Explicit `undefined` keeps the client value. `{ wait: { timeoutMs: 600_000 } }` keeps the client's `pollIntervalMs`. `CallOptions.signal` aborts the readiness poll, not only the create request. Nested `wait` on `operations.waitFor` is a type error. Client `wait.signal` is a type error.

## Also in here

- README per-call options list includes `wait?`. Readiness section shows the `projects.create` example. `operations.waitFor` row still documents `{ pollIntervalMs?, timeoutMs?, signal? }`.
- Type tests in `client.test-d.ts`. Runtime in `wait-budget.test.ts`.
- Major changeset: `CallOptions.wait` is additive. Dropping `wait.signal` on `createNeonClient` is a TypeScript break; pass `signal` on the call.

## Verification

- `pnpm --filter @neon/sdk test:types` — 16 passed
- `pnpm --filter @neon/sdk test:ci` — 144 passed, including:
  - per-call `wait.timeoutMs: 80` times out well under a client `timeoutMs: 5000`
  - omitted per-call `timeoutMs` keeps the client budget
  - `CallOptions.signal` aborts the wait

## For your attention

- Anyone who passed `wait: { signal }` on `createNeonClient` will get a type error. Pass `signal` on the call.
- `operations.waitFor` still uses top-level `pollIntervalMs` / `timeoutMs` / `signal`, not nested `wait`.
