### PR TITLE
Refuse a missing or empty `apiKey` at `createNeonClient`

### DIFF
--- a/.changeset/sdk-apikey-required.md
+++ b/.changeset/sdk-apikey-required.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": minor
+---
+
+`createNeonClient` now throws a `"client"`-kind error when `apiKey` is missing or `""`, instead of sending an unauthenticated request and surfacing a 401 on the first call. A function that later returns empty is still accepted at construction.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -38,7 +38,7 @@ const { project, connectionString } = data;
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `apiKey` | `string \| (() => string \| Promise<string>)` | — (required) | Neon API key, or a function returning it (sync/async). Sent as a Bearer token. |
+| `apiKey` | `string \| (() => string \| Promise<string>)` | — (required) | Neon API key, or a function returning it (sync/async). Sent as a Bearer token. Missing or `""` throws a `"client"`-kind error when the client is created, not a 401 on the first call. |
 | `throwOnError` | `boolean` | `false` | When `true`, methods return the resource directly and **throw** on error. When `false`, they return `{ data, error }`. **Narrows return types** at the type level. |
 | `waitForReadiness` | `boolean` | `false` | When `true`, mutations block until their provisioning `operations` finish, so the returned resource is ready to use. |
 | `wait` | `{ pollIntervalMs?: number; timeoutMs?: number }` | `1000` / `300000` | Tuning for the readiness poller. |

--- a/packages/sdk/src/neon/config.test.ts
+++ b/packages/sdk/src/neon/config.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "./client.js";
+import { NeonError } from "./errors.js";
+
+describe("createNeonClient apiKey", () => {
+	it("refuses an empty string at construction, before fetch", () => {
+		let fetches = 0;
+		try {
+			createNeonClient({
+				apiKey: "",
+				fetch: async () => {
+					fetches += 1;
+					return new Response("{}", { status: 200 });
+				},
+			});
+			throw new Error("expected createNeonClient to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(NeonError);
+			expect(error).toMatchObject({
+				kind: "client",
+				message:
+					"createNeonClient: `apiKey` is required — pass a string or a function returning one.",
+			});
+		}
+		expect(fetches).toBe(0);
+	});
+
+	it("refuses a missing apiKey at construction", () => {
+		expect(() => Reflect.apply(createNeonClient, undefined, [{}])).toThrow(
+			NeonError,
+		);
+	});
+
+	it("accepts a non-empty string or a function, including one that returns empty", () => {
+		expect(() => createNeonClient({ apiKey: "neon_x" })).not.toThrow();
+		expect(() =>
+			createNeonClient({ apiKey: () => "neon_x" }),
+		).not.toThrow();
+		expect(() =>
+			createNeonClient({ apiKey: async () => "neon_x" }),
+		).not.toThrow();
+		expect(() => createNeonClient({ apiKey: () => "" })).not.toThrow();
+	});
+});

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -1,6 +1,7 @@
 import { createClient, createConfig } from "../client/client/index.js";
 import type { ResolvedConfig } from "./context.js";
 import { resolveTimeoutMs } from "./deadline.js";
+import { NeonError } from "./errors.js";
 import type { WaitForOptions } from "./wait.js";
 
 const DEFAULT_BASE_URL = "https://console.neon.tech/api/v2";
@@ -9,7 +10,9 @@ const DEFAULT_BASE_URL = "https://console.neon.tech/api/v2";
 export interface NeonConfig<Throw extends boolean = false> {
 	/**
 	 * Your Neon API key, or a function returning it (sync or async — handy for refreshing
-	 * short-lived tokens). Used as a Bearer credential on every request.
+	 * short-lived tokens). Used as a Bearer credential on every request. A missing or
+	 * empty string throws a `"client"`-kind error at construction; a function that later
+	 * returns empty is not checked here.
 	 */
 	apiKey: string | (() => string | Promise<string>);
 	/**
@@ -53,6 +56,15 @@ export interface NeonConfig<Throw extends boolean = false> {
 
 export function resolveConfig(config: NeonConfig<boolean>): ResolvedConfig {
 	const apiKey = config.apiKey;
+	if (
+		typeof apiKey !== "function" &&
+		(typeof apiKey !== "string" || apiKey === "")
+	) {
+		throw new NeonError(
+			"createNeonClient: `apiKey` is required — pass a string or a function returning one.",
+			"client",
+		);
+	}
 	const auth = typeof apiKey === "function" ? apiKey : () => apiKey;
 
 	const client = createClient(


### PR DESCRIPTION
## Problem

`createNeonClient({ apiKey: process.env.NEON_API_KEY! })` with the variable unset built a client that sent no `Authorization` and failed as a `NeonAuthError` 401 on the first call. A missing local key looked like a revoked or wrong key.

## Diagnosis

`resolveConfig` wrapped any non-function `apiKey` as `() => apiKey`. `undefined` and `""` became a Bearer of `"undefined"` or empty. `requestTimeoutMs` already fails at construction; `apiKey` did not.

## Interface

Before:

```ts
const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! }); // unset env
await neon.projects.list().all(); // NeonAuthError 401
```

After:

```ts
createNeonClient({ apiKey: process.env.NEON_API_KEY! });
// throws NeonError kind "client":
// createNeonClient: `apiKey` is required — pass a string or a function returning one.

createNeonClient({ apiKey: () => "" }); // still constructs; empty result still 401s later
```

## Also in here

- README `apiKey` row: missing or `""` throws at construction.
- `config.test.ts`: empty string (no fetch), missing key via `Reflect.apply`, functions including `() => ""`.
- Minor changeset.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 144 passed
- `pnpm --filter @neon/sdk test:types` — 16 passed

## For your attention

- Constructing a client with a missing or empty string `apiKey` now throws immediately. Catch `kind: "client"` at construction, not `NeonAuthError` on the first call.
- A function that returns empty is still accepted at construction. That is out of scope here.
