### PR TITLE
Refuse a non-integer `retries` at `createNeonClient`

### DIFF
--- a/.changeset/sdk-retries-validation.md
+++ b/.changeset/sdk-retries-validation.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": patch
+---
+
+`retries` is validated at `createNeonClient`. `NaN`, `Infinity`, fractions, and negatives throw a `"client"`-kind error instead of retrying forever (`NaN`/`Infinity`) or being accepted silently. `0` and the default `2` are unchanged.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -42,7 +42,7 @@ const { project, connectionString } = data;
 | `throwOnError` | `boolean` | `false` | When `true`, methods return the resource directly and **throw** on error. When `false`, they return `{ data, error }`. **Narrows return types** at the type level. |
 | `waitForReadiness` | `boolean` | `false` | When `true`, mutations block until their provisioning `operations` finish, so the returned resource is ready to use. |
 | `wait` | `{ pollIntervalMs?: number; timeoutMs?: number }` | `1000` / `300000` | Tuning for the readiness poller. |
-| `retries` | `number` | `2` | Automatic retries on always-safe statuses (`423`, `429`, `503`) with backoff. |
+| `retries` | `number` | `2` | Automatic retries on always-safe statuses (`423`, `429`, `503`) with backoff. Must be a non-negative integer (`0` disables retries). `NaN`, `Infinity`, a fraction, or a negative throws a `client`-kind error at construction. |
 | `requestTimeoutMs` | `number` | — (unbounded) | Deadline for a request **and** its retries. Aborts the request and resolves with a `NeonTimeoutError`. Pass `Infinity` per call to opt out of a client-wide value. Separate from `wait.timeoutMs`. |
 | `orgId` | `string` | — | Default organization, applied to project create/list and as the transfer source org. Overridable per call. |
 | `baseUrl` | `string` | `https://console.neon.tech/api/v2` | Override the API base URL. |

--- a/packages/sdk/src/neon/config.test.ts
+++ b/packages/sdk/src/neon/config.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "./client.js";
+import { NeonError } from "./errors.js";
+
+describe("createNeonClient retries", () => {
+	it("refuses NaN at construction, before fetch", () => {
+		let fetches = 0;
+		try {
+			createNeonClient({
+				apiKey: "k",
+				retries: Number.NaN,
+				fetch: async () => {
+					fetches += 1;
+					return new Response("{}", { status: 200 });
+				},
+			});
+			throw new Error("expected createNeonClient to throw");
+		} catch (error) {
+			expect(error).toBeInstanceOf(NeonError);
+			expect(error).toMatchObject({
+				kind: "client",
+				message:
+					"retries must be a non-negative integer; received NaN.",
+			});
+		}
+		expect(fetches).toBe(0);
+	});
+
+	it("accepts 0 and the default", () => {
+		expect(() =>
+			createNeonClient({ apiKey: "k", retries: 0 }),
+		).not.toThrow();
+		expect(() => createNeonClient({ apiKey: "k" })).not.toThrow();
+	});
+});

--- a/packages/sdk/src/neon/config.ts
+++ b/packages/sdk/src/neon/config.ts
@@ -1,6 +1,7 @@
 import { createClient, createConfig } from "../client/client/index.js";
 import type { ResolvedConfig } from "./context.js";
 import { resolveTimeoutMs } from "./deadline.js";
+import { resolveRetries } from "./retry.js";
 import type { WaitForOptions } from "./wait.js";
 
 const DEFAULT_BASE_URL = "https://console.neon.tech/api/v2";
@@ -25,7 +26,11 @@ export interface NeonConfig<Throw extends boolean = false> {
 	waitForReadiness?: boolean;
 	/** Tuning for the readiness poller (interval / timeout). */
 	wait?: WaitForOptions;
-	/** Number of automatic retries on always-safe statuses (423/429/503). Default 2. */
+	/**
+	 * Number of automatic retries on always-safe statuses (423/429/503). Default 2.
+	 * `0` disables retries. Non-integer, negative, `NaN`, or `Infinity` throws a
+	 * `"client"`-kind error at construction.
+	 */
 	retries?: number;
 	/**
 	 * Deadline in milliseconds for a single request **and** its retries, after which the
@@ -66,7 +71,7 @@ export function resolveConfig(config: NeonConfig<boolean>): ResolvedConfig {
 	return {
 		client,
 		throwOnError: config.throwOnError ?? false,
-		retries: config.retries ?? 2,
+		retries: resolveRetries(config.retries),
 		requestTimeoutMs: resolveTimeoutMs(config.requestTimeoutMs),
 		waitForReadiness: config.waitForReadiness ?? false,
 		waitOptions: config.wait ?? {},

--- a/packages/sdk/src/neon/retry.test.ts
+++ b/packages/sdk/src/neon/retry.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { NeonError } from "./errors.js";
 import {
 	backoffMs,
 	MAX_RETRY_WAIT_MS,
 	nextRetryDelayMs,
 	parseRetryAfterMs,
+	resolveRetries,
 } from "./retry.js";
 
 const NOW = Date.parse("2026-08-03T00:00:00Z");
@@ -87,5 +89,36 @@ describe("nextRetryDelayMs", () => {
 
 	it("declines when even generated backoff would outlast the budget", () => {
 		expect(nextRetryDelayMs(4, undefined, 10, () => 1)).toBeUndefined();
+	});
+});
+
+describe("resolveRetries", () => {
+	it("defaults unset to 2 and keeps 0 and other non-negative integers", () => {
+		expect(resolveRetries(undefined)).toBe(2);
+		expect(resolveRetries(0)).toBe(0);
+		expect(resolveRetries(3)).toBe(3);
+	});
+
+	it("rejects NaN, Infinity, fractions, negatives, and null", () => {
+		const cases: unknown[] = [
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			Number.NEGATIVE_INFINITY,
+			1.5,
+			-1,
+			null,
+		];
+		for (const value of cases) {
+			try {
+				Reflect.apply(resolveRetries, undefined, [value]);
+				throw new Error(`expected reject ${String(value)}`);
+			} catch (error) {
+				expect(error).toBeInstanceOf(NeonError);
+				expect(error).toMatchObject({
+					kind: "client",
+					message: `retries must be a non-negative integer; received ${String(value)}.`,
+				});
+			}
+		}
 	});
 });

--- a/packages/sdk/src/neon/retry.ts
+++ b/packages/sdk/src/neon/retry.ts
@@ -9,6 +9,7 @@
  */
 
 import { type Deadline, delay } from "./deadline.js";
+import { NeonError } from "./errors.js";
 
 export interface RawOutcome {
 	error?: unknown;
@@ -22,6 +23,27 @@ const RETRYABLE_STATUS = new Set([423, 429, 503]);
 
 /** Ceiling on generated backoff, and on how long a `Retry-After` is worth honouring. */
 export const MAX_RETRY_WAIT_MS = 10_000;
+
+const DEFAULT_RETRIES = 2;
+
+/**
+ * Client-wide `retries`. `NaN` and `Infinity` make `attempt >= retries` always false,
+ * so a 429 would poll forever; reject them here the way `requestTimeoutMs` is rejected.
+ */
+export function resolveRetries(retries: number | undefined): number {
+	if (retries === undefined) return DEFAULT_RETRIES;
+	if (
+		typeof retries !== "number" ||
+		!Number.isInteger(retries) ||
+		retries < 0
+	) {
+		throw new NeonError(
+			`retries must be a non-negative integer; received ${String(retries)}.`,
+			"client",
+		);
+	}
+	return retries;
+}
 
 /**
  * `Retry-After` in milliseconds, or `undefined` when absent or unparseable.


### PR DESCRIPTION
## Problem

`createNeonClient({ retries })` accepts any number. If `retries` is `NaN`, `Infinity`, a fraction, or negative, the client constructs fine and then never stops retrying on a retryable response (429, 5xx). The most common way to hit this is `Number(process.env.RETRIES)` with the variable unset, which yields `NaN` and turns a single rate-limited request into an infinite loop.

## Diagnosis

`withRetries` decides whether to give up with `attempt >= retries`. For `retries: NaN` that comparison is always `false`, so the loop never exits. `Infinity` has the same effect; a fraction like `1.5` retries one more time than the caller probably intended, and a negative value is equally meaningless but was silently accepted.

The default in `createNeonClient` was `config.retries ?? 2`, which only guards against `undefined`/`null`. Nothing validated the value itself, and by the time `withRetries` saw it, the only place to fail was inside a request that was already running.

The fix validates once, at construction, so a bad `retries` value is a configuration error rather than a runtime hang.

## Interface

Before:

```ts
retries: config.retries ?? 2,
// withRetries: attempt >= retries  — 0 >= NaN is always false
createNeonClient({ apiKey, retries: Number(process.env.RETRIES) }); // unset → NaN → 429 loops forever
```

After:

```ts
createNeonClient({ apiKey, retries: Number.NaN });
// throws NeonError kind "client": retries must be a non-negative integer; received NaN.

createNeonClient({ apiKey, retries: 0 }); // still constructs; no retries
createNeonClient({ apiKey }); // still 2
```

The thrown error is a `NeonError` with `kind: "client"`, matching how other invalid-config cases are reported. The message includes the offending value:

```
retries must be a non-negative integer; received NaN.
```

No public types change. `retries` is still `number | undefined` on the config; the constraint is enforced at runtime.

## Also in here

- `resolveRetries` added to `retry.ts` as an internal helper (not exported from the package). It applies the default of `2` and runs the `Number.isInteger(n) && n >= 0` check.
- `withRetries` loop is unchanged; it now receives an already-validated integer.
- Patch changeset for `@neon/sdk`.
- README `retries` row now documents the accepted range and that invalid values throw at construction.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 145 passed
- `pnpm --filter @neon/sdk test:types` — 16 passed

New tests:

- `retry.test.ts`: `resolveRetries` covers `undefined` → `2`, `0`, positive integers, and rejects `NaN`, `Infinity`, `-Infinity`, `1.5`, `-1`, and `null` with the exact message.
- `config.test.ts`: `createNeonClient` throws the client `NeonError` synchronously during construction, before any `fetch` is invoked.

## For your attention

- Callers passing a fraction or negative now throw. Previously `retries: 1.5` or `retries: -1` constructed and behaved oddly. Shipped as a patch because the old behavior was never intentional; flag if this should be a minor.
- `Infinity` is rejected, not treated as retry-forever.
- The check is `Number.isInteger`, so `retries: 2.0` passes (it's the integer `2` in JS).