### PR TITLE
Make the README cancellation examples compile

### DIFF
--- a/.changeset/sdk-readme-cancellation.md
+++ b/.changeset/sdk-readme-cancellation.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": patch
+---
+
+README Cancellation & deadlines examples now compile: the AbortSignal is passed to `list({}, { signal })`, and the timeout client is named `bounded` so `neon` is not redeclared.

--- a/.changeset/sdk-readme-cancellation.md
+++ b/.changeset/sdk-readme-cancellation.md
@@ -2,4 +2,4 @@
 "@neon/sdk": patch
 ---
 
-README Cancellation & deadlines examples now compile: the AbortSignal is passed to `list({}, { signal })`, and the timeout client is named `bounded` so `neon` is not redeclared.
+README Cancellation & deadlines examples now compile. Abort uses `list({}, { signal })`; a request timeout is `source === "request"`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -128,19 +128,19 @@ and a `throwOnError` client throws the same `NeonError` subclass it would have r
 
 ```ts
 const controller = new AbortController();
-const { error } = await neon.projects.list().all();
+const { error } = await neon.projects.list({}, { signal: controller.signal }).all();
+if (error?.kind === "aborted") { /* the caller stopped it */ }
 
-// cancel in-flight work (a user navigating away, a request handler aborting)
 const result = await neon.projects.get(id, { signal: controller.signal });
 if (result.error?.kind === "aborted") { /* the caller stopped it */ }
+```
 
-// bound a call, on the client or per call
-const neon = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
-const slow = await neon.projects.get(id, { requestTimeoutMs: 5_000 });
+```ts
+const bounded = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
+const slow = await bounded.projects.get(id, { requestTimeoutMs: 5_000 });
 if (slow.error?.kind === "timeout") { /* the deadline was exceeded */ }
 
-// opt a single call back out of a client-wide deadline
-await neon.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
+await bounded.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
   requestTimeoutMs: Number.POSITIVE_INFINITY,
 });
 ```

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -164,7 +164,9 @@ if (result.error?.kind === "aborted") { /* the caller stopped it */ }
 ```ts
 const bounded = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
 const slow = await bounded.projects.get(id, { requestTimeoutMs: 5_000 });
-if (slow.error?.kind === "timeout") { /* the deadline was exceeded */ }
+if (slow.error?.kind === "timeout" && slow.error.source === "request") {
+  /* the request deadline was exceeded */
+}
 
 await bounded.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
   requestTimeoutMs: Number.POSITIVE_INFINITY,

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -262,3 +262,40 @@ it("functions.customDomains is typed", () => {
 		throwing.functions.customDomains.delete("p", "br", "docs.example.com"),
 	).resolves.toEqualTypeOf<void>();
 });
+
+it("README cancellation snippets typecheck", async () => {
+	const apiKey = "x";
+	const id = "p";
+	const projectId = "p";
+	const branchId = "br";
+	const neon = createNeonClient({ apiKey });
+
+	const controller = new AbortController();
+	const { error } = await neon.projects
+		.list({}, { signal: controller.signal })
+		.all();
+	if (error?.kind === "aborted") {
+		expectTypeOf(error.kind).toEqualTypeOf<"aborted">();
+	}
+
+	const result = await neon.projects.get(id, { signal: controller.signal });
+	if (result.error?.kind === "aborted") {
+		expectTypeOf(result.error.kind).toEqualTypeOf<"aborted">();
+	}
+
+	const bounded = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
+	const slow = await bounded.projects.get(id, { requestTimeoutMs: 5_000 });
+	if (slow.error?.kind === "timeout") {
+		expectTypeOf(slow.error.kind).toEqualTypeOf<"timeout">();
+	}
+
+	await bounded.storage.objects.get(
+		projectId,
+		branchId,
+		"bucket",
+		"big.tar",
+		{
+			requestTimeoutMs: Number.POSITIVE_INFINITY,
+		},
+	);
+});

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -322,8 +322,10 @@ it("README cancellation snippets typecheck", async () => {
 
 	const bounded = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
 	const slow = await bounded.projects.get(id, { requestTimeoutMs: 5_000 });
-	if (slow.error?.kind === "timeout") {
-		expectTypeOf(slow.error.kind).toEqualTypeOf<"timeout">();
+	if (slow.error?.kind === "timeout" && slow.error.source === "request") {
+		expectTypeOf(slow.error.source).toEqualTypeOf<"request">();
+		// @ts-expect-error operations is a wait-timeout field
+		slow.error.operations;
 	}
 
 	await bounded.storage.objects.get(
@@ -335,6 +337,21 @@ it("README cancellation snippets typecheck", async () => {
 			requestTimeoutMs: Number.POSITIVE_INFINITY,
 		},
 	);
+
+	const created = await neon.projects.create(
+		{ name: "app" },
+		{ wait: { timeoutMs: 30_000 } },
+	);
+	if (created.error?.kind === "timeout" && created.error.source === "wait") {
+		expectTypeOf(created.error.operations).toEqualTypeOf<
+			readonly Operation[]
+		>();
+		const resumed = await neon.operations.waitFor(
+			created.error.operations,
+			{ timeoutMs: 120_000 },
+		);
+		if (resumed.error) throw resumed.error;
+	}
 });
 
 it("NeonClient without a type argument is the non-throwing client", () => {


### PR DESCRIPTION
## Problem

The "Cancellation & deadlines" section of `packages/sdk/README.md` is the place a reader goes to copy an abort or timeout example. On `main`, the first code block does not compile and the abort example does not abort.

Pasting that block into a file next to the SDK and running `tsc --strict`:

```
error TS2448: Block-scoped variable 'neon' used before its declaration.
error TS2454: Variable 'neon' is used before being assigned.
```

Two things cause it:

- `const neon = createNeonClient({ apiKey, requestTimeoutMs: 30_000 })` sits in the middle of a block that already uses `neon` above it, so every earlier line hits the TDZ error.
- `neon.projects.list().all()` never receives `controller.signal`. The `AbortController` created on the line above is dead code, so the example that claims to show cancellation shows a plain list call.

The request-timeout example also narrows only on `kind === "timeout"`. `NeonTimeoutError` is abstract with `source: "request" | "wait"`, and the wait variant carries `operations` for resuming via `neon.operations.waitFor`. The same section already documents the `source === "wait"` case a few lines further down, so the request example left the reader with a union it had just been told to split.

## Change

The section is now two blocks. The first is cancellation and reuses the `neon` client from earlier in the README. The second is deadlines and binds its own client as `bounded`, so nothing shadows anything.

```ts
const controller = new AbortController();
const { error } = await neon.projects.list({}, { signal: controller.signal }).all();
if (error?.kind === "aborted") { /* the caller stopped it */ }

const result = await neon.projects.get(id, { signal: controller.signal });
if (result.error?.kind === "aborted") { /* the caller stopped it */ }
```

```ts
const bounded = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
const slow = await bounded.projects.get(id, { requestTimeoutMs: 5_000 });
if (slow.error?.kind === "timeout" && slow.error.source === "request") {
  /* the request deadline was exceeded */
}

await bounded.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
  requestTimeoutMs: Number.POSITIVE_INFINITY,
});
```

`list({}, { signal })` is the existing overload `list(query, opts)`; `{}` is the empty `ListQuery`. Narrowing on `source === "request"` gives `NeonRequestTimeoutError`, and `source === "wait"` gives `NeonWaitTimeoutError` with `operations`, which is what the resume example below it already uses.

Runtime is unchanged. No SDK source outside the type test moves.

## Also in here

- `packages/sdk/src/neon/client.test-d.ts` gets a `README cancellation snippets typecheck` case that carries the whole section: both abort calls, the `bounded` client, the `Infinity` opt-out and the `source === "wait"` resume via `operations.waitFor`. It asserts `slow.error.source` is `"request"` and that `slow.error.operations` is a type error on that branch, so the request/wait split cannot silently collapse. The wait snippet was already on `main`; pinning it here means the README section typechecks as a unit rather than line by line.
- `.changeset/sdk-readme-cancellation.md`, patch for `@neon/sdk`. The README ships in the package, so the fix reaches npm readers with the next release.

## Verification

- `pnpm --filter @neon/sdk test:types`: 30 passed, including the new case.
- `pnpm --filter @neon/sdk test:ci`: 188 passed.
- The `main` version of the first block, compiled as a standalone file against `src/index.ts` with `tsc --noEmit --strict`, produces the two errors quoted above. The same file with this branch's two blocks compiles clean.

Not verified against a live API. Nothing in the diff runs at runtime.
