### PR TITLE
Gate destructive neon deletes behind --yes or a TTY confirmation

### DIFF
--- a/.changeset/cli-delete-yes.md
+++ b/.changeset/cli-delete-yes.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+Destructive deletes (`projects`, `branches`, `databases`, `roles`, `snapshots`, `bucket`) require `--yes` or a TTY confirmation, and table output prints a Deleted line instead of the same record as `get`.

--- a/.changeset/cli-delete-yes.md
+++ b/.changeset/cli-delete-yes.md
@@ -1,5 +1,5 @@
 ---
-"neon": patch
+"neon": minor
 ---
 
-Destructive deletes (`projects`, `branches`, `databases`, `roles`, `snapshots`, `bucket`) require `--yes` or a TTY confirmation, and table output prints a Deleted line instead of the same record as `get`.
+Destructive deletes (`projects`, `branches`, `databases`, `roles`, `snapshots`, `bucket`) require `--yes` or a TTY confirmation. Scripts and CI that omit `--yes` now exit 1. Table output prints a Deleted line instead of the same record as `get`.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -923,7 +923,7 @@ neon snapshots finalize br-restored-1234                # commit the swap
 neon snapshots restore snap-1234 --target-branch main --finalize
 
 # Delete
-neon snapshots delete snap-1234
+neon snapshots delete snap-1234 --yes
 
 # Automatic snapshot (backup) schedule of a branch
 neon snapshots schedule get --branch main

--- a/packages/cli/src/commands/__snapshots__/bucket.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/bucket.test.ts.snap
@@ -12,8 +12,6 @@ exports[`bucket > create with default access level 1`] = `""`;
 
 exports[`bucket > create with public_read access level 1`] = `""`;
 
-exports[`bucket > delete 1`] = `""`;
-
 exports[`bucket > delete reports a helpful error when the bucket is missing 1`] = `""`;
 
 exports[`bucket > list (yaml) 1`] = `
@@ -277,5 +275,3 @@ exports[`bucket > object put without a bucket is rejected client-side 1`] = `""`
 exports[`bucket > object put without a key is rejected client-side 1`] = `""`;
 
 exports[`bucket > object rm alias 1`] = `""`;
-
-exports[`bucket > rm alias deletes a bucket 1`] = `""`;

--- a/packages/cli/src/commands/branches.test.ts
+++ b/packages/cli/src/commands/branches.test.ts
@@ -347,6 +347,25 @@ describe("branches", () => {
 
 	/* delete */
 
+	test("delete by id requires confirmation without --yes", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"branches",
+				"delete",
+				"br-sunny-branch-123456",
+				"--project-id",
+				"test",
+			],
+			{
+				code: 1,
+				snapshot: false,
+				stderr: "ERROR: Deleting a branch requires confirmation. Re-run interactively or pass --yes.",
+			},
+		);
+	});
+
 	test("delete by id", async ({ testCliCommand }) => {
 		await testCliCommand([
 			"branches",
@@ -354,7 +373,27 @@ describe("branches", () => {
 			"br-sunny-branch-123456",
 			"--project-id",
 			"test",
+			"--yes",
 		]);
+	});
+
+	test("delete --yes prints Deleted in table mode", async ({
+		testCliCommand,
+	}) => {
+		const { stdout } = await testCliCommand(
+			[
+				"branches",
+				"delete",
+				"br-sunny-branch-123456",
+				"--project-id",
+				"test",
+				"--yes",
+			],
+			{ output: "table", snapshot: false, stderr: "" },
+		);
+		expect(stdout).toBe(
+			"Deleted branch br-sunny-branch-123456 (sunny-branch).\n",
+		);
 	});
 
 	/* rename */

--- a/packages/cli/src/commands/branches.test.ts
+++ b/packages/cli/src/commands/branches.test.ts
@@ -361,6 +361,7 @@ describe("branches", () => {
 			{
 				code: 1,
 				snapshot: false,
+				output: "table",
 				stderr: "ERROR: Deleting a branch requires confirmation. Re-run interactively or pass --yes.",
 			},
 		);

--- a/packages/cli/src/commands/branches.ts
+++ b/packages/cli/src/commands/branches.ts
@@ -558,7 +558,7 @@ const deleteBranch = async (
 		yes: props.yes,
 		noun: "branch",
 		message: `Delete branch ${props.id}?`,
-		forceYes: isMachineOutput(props.output),
+		output: props.output,
 	});
 	const branchId = await branchIdFromProps(props);
 	const { data } = await retryOnLock(() =>

--- a/packages/cli/src/commands/branches.ts
+++ b/packages/cli/src/commands/branches.ts
@@ -9,6 +9,12 @@ import type { IdOrNameProps, ProjectScopeProps } from "../types.js";
 import { EndpointType } from "../utils/api_enums.js";
 import { getComputeUnits } from "../utils/compute_units.js";
 import {
+	confirmDestructive,
+	isMachineOutput,
+	namedResource,
+	yesOption,
+} from "../utils/confirm_destructive.js";
+import {
 	branchIdFromProps,
 	branchIdResolve,
 	fillSingleProject,
@@ -254,7 +260,10 @@ export const builder = (argv: yargs.Argv) =>
 		.command(
 			"delete <id|name>",
 			"Delete a branch",
-			(yargs) => yargs,
+			(yargs) =>
+				yargs.options({
+					yes: yesOption,
+				}),
 			(args) => deleteBranch(args as any),
 		)
 		.command(
@@ -542,17 +551,32 @@ const setDefault = async (props: ProjectScopeProps & IdOrNameProps) => {
 	});
 };
 
-const deleteBranch = async (props: ProjectScopeProps & IdOrNameProps) => {
+const deleteBranch = async (
+	props: ProjectScopeProps & IdOrNameProps & { yes: boolean },
+) => {
+	await confirmDestructive({
+		yes: props.yes,
+		noun: "branch",
+		message: `Delete branch ${props.id}?`,
+		forceYes: isMachineOutput(props.output),
+	});
 	const branchId = await branchIdFromProps(props);
 	const { data } = await retryOnLock(() =>
 		props.apiClient.deleteProjectBranch(props.projectId, branchId),
 	);
 	// A 204 (branch already gone) carries no body; only a 200 returns it.
-	if (data) {
+	if (!data) {
+		return;
+	}
+	if (isMachineOutput(props.output)) {
 		writer(props).end(data.branch, {
 			fields: BRANCH_FIELDS,
 		});
+		return;
 	}
+	writer(props).text(
+		`Deleted branch ${namedResource(data.branch.id, data.branch.name)}.\n`,
+	);
 };
 
 const get = async (props: ProjectScopeProps & IdOrNameProps) => {

--- a/packages/cli/src/commands/bucket.test.ts
+++ b/packages/cli/src/commands/bucket.test.ts
@@ -85,28 +85,58 @@ describe("bucket", () => {
 		});
 	});
 
-	test("delete", async ({ testCliCommand }) => {
+	test("delete requires confirmation without --yes", async ({
+		testCliCommand,
+	}) => {
 		await testCliCommand(["bucket", "delete", "my-bucket", ...SCOPE], {
 			mockDir: "single_org",
-			stderr: 'INFO: Bucket "my-bucket" deleted from branch br-main-branch-123456',
+			code: 1,
+			snapshot: false,
+			stderr: "ERROR: Deleting a bucket requires confirmation. Re-run interactively or pass --yes.",
 		});
 	});
 
+	test("delete", async ({ testCliCommand }) => {
+		const { stdout } = await testCliCommand(
+			["bucket", "delete", "my-bucket", "--yes", ...SCOPE],
+			{
+				mockDir: "single_org",
+				output: "table",
+				snapshot: false,
+				stderr: "",
+			},
+		);
+		expect(stdout).toBe(
+			'Deleted bucket "my-bucket" from branch br-main-branch-123456.\n',
+		);
+	});
+
 	test("rm alias deletes a bucket", async ({ testCliCommand }) => {
-		await testCliCommand(["bucket", "rm", "my-bucket", ...SCOPE], {
-			mockDir: "single_org",
-			stderr: 'INFO: Bucket "my-bucket" deleted from branch br-main-branch-123456',
-		});
+		const { stdout } = await testCliCommand(
+			["bucket", "rm", "my-bucket", "--yes", ...SCOPE],
+			{
+				mockDir: "single_org",
+				output: "table",
+				snapshot: false,
+				stderr: "",
+			},
+		);
+		expect(stdout).toBe(
+			'Deleted bucket "my-bucket" from branch br-main-branch-123456.\n',
+		);
 	});
 
 	test("delete reports a helpful error when the bucket is missing", async ({
 		testCliCommand,
 	}) => {
-		await testCliCommand(["bucket", "delete", "no-such-bucket", ...SCOPE], {
-			mockDir: "single_org",
-			code: 1,
-			stderr: 'ERROR: Bucket "no-such-bucket" not found on branch br-main-branch-123456.',
-		});
+		await testCliCommand(
+			["bucket", "delete", "no-such-bucket", "--yes", ...SCOPE],
+			{
+				mockDir: "single_org",
+				code: 1,
+				stderr: 'ERROR: Bucket "no-such-bucket" not found on branch br-main-branch-123456.',
+			},
+		);
 	});
 
 	test("object list", async ({ testCliCommand }) => {

--- a/packages/cli/src/commands/bucket.test.ts
+++ b/packages/cli/src/commands/bucket.test.ts
@@ -92,6 +92,7 @@ describe("bucket", () => {
 			mockDir: "single_org",
 			code: 1,
 			snapshot: false,
+			output: "table",
 			stderr: "ERROR: Deleting a bucket requires confirmation. Re-run interactively or pass --yes.",
 		});
 	});

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -18,6 +18,11 @@ import {
 	presignUpload,
 } from "../storage_api.js";
 import type { BranchScopeProps } from "../types.js";
+import {
+	confirmDestructive,
+	isMachineOutput,
+	yesOption,
+} from "../utils/confirm_destructive.js";
 import { branchIdFromProps, fillSingleProject } from "../utils/enrichers.js";
 import { writer } from "../writer.js";
 
@@ -117,7 +122,10 @@ export const builder = (argv: yargs.Argv) =>
 						type: "string",
 						demandOption: true,
 					})
-					.options(scopeOptions),
+					.options({
+						...scopeOptions,
+						yes: yesOption,
+					}),
 			handler: (args) => deleteBucket(args as any),
 		})
 		.command(
@@ -295,8 +303,14 @@ const listBuckets = async (props: BranchScopeProps): Promise<void> => {
 };
 
 const deleteBucket = async (
-	props: BranchScopeProps & { name: string },
+	props: BranchScopeProps & { name: string; yes: boolean },
 ): Promise<void> => {
+	await confirmDestructive({
+		yes: props.yes,
+		noun: "bucket",
+		message: `Delete bucket "${props.name}"?`,
+		forceYes: isMachineOutput(props.output),
+	});
 	const branchId = await branchIdFromProps(props);
 	try {
 		await retryOnLock(() =>
@@ -314,7 +328,12 @@ const deleteBucket = async (
 		}
 		throw err;
 	}
-	log.info(`Bucket "${props.name}" deleted from branch ${branchId}`);
+	if (isMachineOutput(props.output)) {
+		return;
+	}
+	writer(props).text(
+		`Deleted bucket "${props.name}" from branch ${branchId}.\n`,
+	);
 };
 
 // Resolve the delimiter to send to the backend, mirroring `aws s3 ls`:

--- a/packages/cli/src/commands/bucket.ts
+++ b/packages/cli/src/commands/bucket.ts
@@ -309,7 +309,7 @@ const deleteBucket = async (
 		yes: props.yes,
 		noun: "bucket",
 		message: `Delete bucket "${props.name}"?`,
-		forceYes: isMachineOutput(props.output),
+		output: props.output,
 	});
 	const branchId = await branchIdFromProps(props);
 	try {

--- a/packages/cli/src/commands/checkout.ts
+++ b/packages/cli/src/commands/checkout.ts
@@ -50,7 +50,7 @@ export const formatCheckoutPolicyFailure = (opts: {
 	return [
 		`Branch ${opts.branchName} (${opts.branchId}) was created and checked out, but applying neon.ts to it failed: ${opts.failure}`,
 		`The branch is usable but does not match the policy, and \`${cli} checkout\` never reconciles a branch that already exists.`,
-		`Fix the cause above, then run \`${cli} deploy --update-existing${envArg}\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`${cli} branches delete ${opts.branchName}\` then \`${cli} checkout ${opts.branchName}${envArg}\`.`,
+		`Fix the cause above, then run \`${cli} deploy --update-existing${envArg}\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`${cli} branches delete ${opts.branchName} --yes\` then \`${cli} checkout ${opts.branchName}${envArg}\`.`,
 	].join("\n");
 };
 

--- a/packages/cli/src/commands/databases.test.ts
+++ b/packages/cli/src/commands/databases.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "vitest";
+import { describe, expect } from "vitest";
 
 import { test } from "../test_utils/fixtures";
 
@@ -29,6 +29,27 @@ describe("databases", () => {
 		]);
 	});
 
+	test("delete requires confirmation without --yes", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"databases",
+				"delete",
+				"test_db",
+				"--project-id",
+				"test",
+				"--branch",
+				"test_branch",
+			],
+			{
+				code: 1,
+				snapshot: false,
+				stderr: "ERROR: Deleting a database requires confirmation. Re-run interactively or pass --yes.",
+			},
+		);
+	});
+
 	test("delete", async ({ testCliCommand }) => {
 		await testCliCommand([
 			"databases",
@@ -38,6 +59,26 @@ describe("databases", () => {
 			"test",
 			"--branch",
 			"test_branch",
+			"--yes",
 		]);
+	});
+
+	test("delete --yes prints Deleted in table mode", async ({
+		testCliCommand,
+	}) => {
+		const { stdout } = await testCliCommand(
+			[
+				"databases",
+				"delete",
+				"test_db",
+				"--project-id",
+				"test",
+				"--branch",
+				"test_branch",
+				"--yes",
+			],
+			{ output: "table", snapshot: false, stderr: "" },
+		);
+		expect(stdout).toBe("Deleted database test_db.\n");
 	});
 });

--- a/packages/cli/src/commands/databases.test.ts
+++ b/packages/cli/src/commands/databases.test.ts
@@ -45,6 +45,7 @@ describe("databases", () => {
 			{
 				code: 1,
 				snapshot: false,
+				output: "table",
 				stderr: "ERROR: Deleting a database requires confirmation. Re-run interactively or pass --yes.",
 			},
 		);

--- a/packages/cli/src/commands/databases.ts
+++ b/packages/cli/src/commands/databases.ts
@@ -127,7 +127,7 @@ export const deleteDb = async (
 		yes: props.yes,
 		noun: "database",
 		message: `Delete database ${props.database}?`,
-		forceYes: isMachineOutput(props.output),
+		output: props.output,
 	});
 	const branchId = await branchIdFromProps(props);
 	const { data } = await retryOnLock(() =>

--- a/packages/cli/src/commands/databases.ts
+++ b/packages/cli/src/commands/databases.ts
@@ -3,6 +3,11 @@ import type yargs from "yargs";
 import { retryOnLock } from "../api.js";
 
 import type { BranchScopeProps } from "../types.js";
+import {
+	confirmDestructive,
+	isMachineOutput,
+	yesOption,
+} from "../utils/confirm_destructive.js";
 import { branchIdFromProps, fillSingleProject } from "../utils/enrichers.js";
 import { writer } from "../writer.js";
 
@@ -51,7 +56,10 @@ export const builder = (argv: yargs.Argv) =>
 		.command(
 			"delete <database>",
 			"Delete a database",
-			(yargs) => yargs,
+			(yargs) =>
+				yargs.options({
+					yes: yesOption,
+				}),
 			(args) => deleteDb(args as any),
 		);
 
@@ -113,8 +121,14 @@ export const create = async (
 };
 
 export const deleteDb = async (
-	props: BranchScopeProps & { database: string },
+	props: BranchScopeProps & { database: string; yes: boolean },
 ) => {
+	await confirmDestructive({
+		yes: props.yes,
+		noun: "database",
+		message: `Delete database ${props.database}?`,
+		forceYes: isMachineOutput(props.output),
+	});
 	const branchId = await branchIdFromProps(props);
 	const { data } = await retryOnLock(() =>
 		props.apiClient.deleteProjectBranchDatabase(
@@ -125,9 +139,14 @@ export const deleteDb = async (
 	);
 
 	// A 204 (database already gone) carries no body; only a 200 returns it.
-	if (data) {
+	if (!data) {
+		return;
+	}
+	if (isMachineOutput(props.output)) {
 		writer(props).end(data.database, {
 			fields: DATABASE_FIELDS,
 		});
+		return;
 	}
+	writer(props).text(`Deleted database ${data.database.name}.\n`);
 };

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -182,6 +182,7 @@ describe("projects", () => {
 		await testCliCommand(["projects", "delete", "test"], {
 			code: 1,
 			snapshot: false,
+			output: "table",
 			stderr: "ERROR: Deleting a project requires confirmation. Re-run interactively or pass --yes.",
 		});
 	});
@@ -198,8 +199,19 @@ describe("projects", () => {
 			{ output: "table", snapshot: false, stderr: "" },
 		);
 		expect(stdout).toBe(
-			"Deleted project test (test).\nRecoverable during the deletion grace period:  neon projects recover test\n",
+			"Deleted project test (test).\nRecoverable during the deletion grace period: neon projects recover test\n",
 		);
+	});
+
+	test("delete --output json without --yes names the flag", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["projects", "delete", "test"], {
+			code: 1,
+			snapshot: false,
+			output: "json",
+			stderr: "ERROR: Confirmation prompts are disabled with --output json; pass --yes.",
+		});
 	});
 
 	test("delete --yes keeps the record in json", async ({

--- a/packages/cli/src/commands/projects.test.ts
+++ b/packages/cli/src/commands/projects.test.ts
@@ -176,8 +176,49 @@ describe("projects", () => {
 		]);
 	});
 
+	test("delete requires confirmation without --yes", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(["projects", "delete", "test"], {
+			code: 1,
+			snapshot: false,
+			stderr: "ERROR: Deleting a project requires confirmation. Re-run interactively or pass --yes.",
+		});
+	});
+
 	test("delete", async ({ testCliCommand }) => {
-		await testCliCommand(["projects", "delete", "test"]);
+		await testCliCommand(["projects", "delete", "test", "--yes"]);
+	});
+
+	test("delete --yes prints Deleted in table mode", async ({
+		testCliCommand,
+	}) => {
+		const { stdout } = await testCliCommand(
+			["projects", "delete", "test", "--yes"],
+			{ output: "table", snapshot: false, stderr: "" },
+		);
+		expect(stdout).toBe(
+			"Deleted project test (test).\nRecoverable during the deletion grace period:  neon projects recover test\n",
+		);
+	});
+
+	test("delete --yes keeps the record in json", async ({
+		testCliCommand,
+	}) => {
+		const { stdout } = await testCliCommand(
+			["projects", "delete", "test", "--yes"],
+			{ output: "json", snapshot: false, stderr: "" },
+		);
+		expect(JSON.parse(stdout)).toMatchObject({
+			id: "test",
+			name: "test",
+		});
+	});
+
+	test("delete -y is an alias of --yes", async ({ testCliCommand }) => {
+		await testCliCommand(["projects", "delete", "test", "-y"], {
+			snapshot: false,
+		});
 	});
 
 	test("recover deleted project", async ({ testCliCommand }) => {

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -17,6 +17,12 @@ import {
 import type { CommonProps, IdOrNameProps } from "../types.js";
 import { getCliName } from "../utils/cli_name.js";
 import { getComputeUnits } from "../utils/compute_units.js";
+import {
+	confirmDestructive,
+	isMachineOutput,
+	namedResource,
+	yesOption,
+} from "../utils/confirm_destructive.js";
 import { psql } from "../utils/psql.js";
 import { writer } from "../writer.js";
 
@@ -222,7 +228,10 @@ export const builder = (argv: yargs.Argv) => {
 		.command(
 			"delete <id>",
 			"Delete a project",
-			(yargs) => yargs,
+			(yargs) =>
+				yargs.options({
+					yes: yesOption,
+				}),
 			async (args) => {
 				await deleteProject(args as any);
 			},
@@ -414,11 +423,26 @@ const create = async (
 	}
 };
 
-const deleteProject = async (props: CommonProps & IdOrNameProps) => {
-	const { data } = await props.apiClient.deleteProject(props.id);
-	writer(props).end(data.project, {
-		fields: PROJECT_FIELDS,
+const deleteProject = async (
+	props: CommonProps & IdOrNameProps & { yes: boolean },
+) => {
+	await confirmDestructive({
+		yes: props.yes,
+		noun: "project",
+		message: `Delete project ${props.id}?`,
+		forceYes: isMachineOutput(props.output),
 	});
+	const { data } = await props.apiClient.deleteProject(props.id);
+	const project = data.project;
+	if (isMachineOutput(props.output)) {
+		writer(props).end(project, {
+			fields: PROJECT_FIELDS,
+		});
+		return;
+	}
+	writer(props).text(
+		`Deleted project ${namedResource(project.id, project.name)}.\nRecoverable during the deletion grace period:  ${getCliName()} projects recover ${project.id}\n`,
+	);
 };
 
 const update = async (

--- a/packages/cli/src/commands/projects.ts
+++ b/packages/cli/src/commands/projects.ts
@@ -430,7 +430,7 @@ const deleteProject = async (
 		yes: props.yes,
 		noun: "project",
 		message: `Delete project ${props.id}?`,
-		forceYes: isMachineOutput(props.output),
+		output: props.output,
 	});
 	const { data } = await props.apiClient.deleteProject(props.id);
 	const project = data.project;
@@ -441,7 +441,7 @@ const deleteProject = async (
 		return;
 	}
 	writer(props).text(
-		`Deleted project ${namedResource(project.id, project.name)}.\nRecoverable during the deletion grace period:  ${getCliName()} projects recover ${project.id}\n`,
+		`Deleted project ${namedResource(project.id, project.name)}.\nRecoverable during the deletion grace period: ${getCliName()} projects recover ${project.id}\n`,
 	);
 };
 

--- a/packages/cli/src/commands/roles.test.ts
+++ b/packages/cli/src/commands/roles.test.ts
@@ -1,4 +1,4 @@
-import { describe } from "vitest";
+import { describe, expect } from "vitest";
 
 import { test } from "../test_utils/fixtures";
 
@@ -27,6 +27,27 @@ describe("roles", () => {
 		]);
 	});
 
+	test("delete requires confirmation without --yes", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"roles",
+				"delete",
+				"test_role",
+				"--project-id",
+				"test",
+				"--branch",
+				"test_branch",
+			],
+			{
+				code: 1,
+				snapshot: false,
+				stderr: "ERROR: Deleting a role requires confirmation. Re-run interactively or pass --yes.",
+			},
+		);
+	});
+
 	test("delete", async ({ testCliCommand }) => {
 		await testCliCommand([
 			"roles",
@@ -36,6 +57,26 @@ describe("roles", () => {
 			"test",
 			"--branch",
 			"test_branch",
+			"--yes",
 		]);
+	});
+
+	test("delete --yes prints Deleted in table mode", async ({
+		testCliCommand,
+	}) => {
+		const { stdout } = await testCliCommand(
+			[
+				"roles",
+				"delete",
+				"test_role",
+				"--project-id",
+				"test",
+				"--branch",
+				"test_branch",
+				"--yes",
+			],
+			{ output: "table", snapshot: false, stderr: "" },
+		);
+		expect(stdout).toBe("Deleted role test_role.\n");
 	});
 });

--- a/packages/cli/src/commands/roles.test.ts
+++ b/packages/cli/src/commands/roles.test.ts
@@ -43,6 +43,7 @@ describe("roles", () => {
 			{
 				code: 1,
 				snapshot: false,
+				output: "table",
 				stderr: "ERROR: Deleting a role requires confirmation. Re-run interactively or pass --yes.",
 			},
 		);

--- a/packages/cli/src/commands/roles.ts
+++ b/packages/cli/src/commands/roles.ts
@@ -104,7 +104,7 @@ export const deleteRole = async (
 		yes: props.yes,
 		noun: "role",
 		message: `Delete role ${props.role}?`,
-		forceYes: isMachineOutput(props.output),
+		output: props.output,
 	});
 	const branchId = await branchIdFromProps(props);
 	const { data } = await retryOnLock(() =>

--- a/packages/cli/src/commands/roles.ts
+++ b/packages/cli/src/commands/roles.ts
@@ -1,6 +1,11 @@
 import type yargs from "yargs";
 import { retryOnLock } from "../api.js";
 import type { BranchScopeProps } from "../types.js";
+import {
+	confirmDestructive,
+	isMachineOutput,
+	yesOption,
+} from "../utils/confirm_destructive.js";
 import { branchIdFromProps, fillSingleProject } from "../utils/enrichers.js";
 import { writer } from "../writer.js";
 
@@ -50,7 +55,10 @@ export const builder = (argv: yargs.Argv) =>
 		.command(
 			"delete <role>",
 			"Delete a role",
-			(yargs) => yargs,
+			(yargs) =>
+				yargs.options({
+					yes: yesOption,
+				}),
 			(args) => deleteRole(args as any),
 		);
 
@@ -90,8 +98,14 @@ export const create = async (
 };
 
 export const deleteRole = async (
-	props: BranchScopeProps & { role: string },
+	props: BranchScopeProps & { role: string; yes: boolean },
 ) => {
+	await confirmDestructive({
+		yes: props.yes,
+		noun: "role",
+		message: `Delete role ${props.role}?`,
+		forceYes: isMachineOutput(props.output),
+	});
 	const branchId = await branchIdFromProps(props);
 	const { data } = await retryOnLock(() =>
 		props.apiClient.deleteProjectBranchRole(
@@ -101,9 +115,14 @@ export const deleteRole = async (
 		),
 	);
 	// A 204 (role already gone) carries no body; only a 200 returns the role.
-	if (data) {
+	if (!data) {
+		return;
+	}
+	if (isMachineOutput(props.output)) {
 		writer(props).end(data.role, {
 			fields: ROLES_FIELDS,
 		});
+		return;
 	}
+	writer(props).text(`Deleted role ${data.role.name}.\n`);
 };

--- a/packages/cli/src/commands/snapshots.test.ts
+++ b/packages/cli/src/commands/snapshots.test.ts
@@ -208,6 +208,25 @@ describe("snapshots", () => {
 
 	/* delete */
 
+	test("delete by id requires confirmation without --yes", async ({
+		testCliCommand,
+	}) => {
+		await testCliCommand(
+			[
+				"snapshots",
+				"delete",
+				"snap-first-snapshot-123456",
+				"--project-id",
+				"test",
+			],
+			{
+				code: 1,
+				snapshot: false,
+				stderr: "ERROR: Deleting a snapshot requires confirmation. Re-run interactively or pass --yes.",
+			},
+		);
+	});
+
 	test("delete by id", async ({ testCliCommand }) => {
 		await testCliCommand([
 			"snapshots",
@@ -215,6 +234,7 @@ describe("snapshots", () => {
 			"snap-first-snapshot-123456",
 			"--project-id",
 			"test",
+			"--yes",
 		]);
 	});
 
@@ -225,7 +245,27 @@ describe("snapshots", () => {
 			"nightly",
 			"--project-id",
 			"test",
+			"--yes",
 		]);
+	});
+
+	test("delete --yes prints Deleted in table mode", async ({
+		testCliCommand,
+	}) => {
+		const { stdout } = await testCliCommand(
+			[
+				"snapshots",
+				"delete",
+				"snap-first-snapshot-123456",
+				"--project-id",
+				"test",
+				"--yes",
+			],
+			{ output: "table", snapshot: false, stderr: "" },
+		);
+		expect(stdout).toBe(
+			"Deleted snapshot snap-first-snapshot-123456 (nightly).\n",
+		);
 	});
 
 	/* restore */

--- a/packages/cli/src/commands/snapshots.test.ts
+++ b/packages/cli/src/commands/snapshots.test.ts
@@ -222,6 +222,7 @@ describe("snapshots", () => {
 			{
 				code: 1,
 				snapshot: false,
+				output: "table",
 				stderr: "ERROR: Deleting a snapshot requires confirmation. Re-run interactively or pass --yes.",
 			},
 		);

--- a/packages/cli/src/commands/snapshots.ts
+++ b/packages/cli/src/commands/snapshots.ts
@@ -483,7 +483,7 @@ const deleteSnapshot = async (
 		yes: props.yes,
 		noun: "snapshot",
 		message: `Delete snapshot ${props.id}?`,
-		forceYes: isMachineOutput(props.output),
+		output: props.output,
 	});
 	const snapshot = await resolveSnapshot(props);
 	await retryOnLock(() =>

--- a/packages/cli/src/commands/snapshots.ts
+++ b/packages/cli/src/commands/snapshots.ts
@@ -9,6 +9,12 @@ import { retryOnLock } from "../api.js";
 import { log } from "../log.js";
 import type { ProjectScopeProps } from "../types.js";
 import {
+	confirmDestructive,
+	isMachineOutput,
+	namedResource,
+	yesOption,
+} from "../utils/confirm_destructive.js";
+import {
 	branchIdResolve,
 	fillSingleProject,
 	resolveBranchRef,
@@ -159,7 +165,10 @@ export const builder = (argv: yargs.Argv) =>
 		.command(
 			"delete <id>",
 			"Delete a snapshot by id or name",
-			(yargs) => yargs,
+			(yargs) =>
+				yargs.options({
+					yes: yesOption,
+				}),
 			(args) => deleteSnapshot(args as any),
 		)
 		.command(
@@ -467,19 +476,33 @@ const update = async (
 	});
 };
 
-const deleteSnapshot = async (props: ProjectScopeProps & { id: string }) => {
+const deleteSnapshot = async (
+	props: ProjectScopeProps & { id: string; yes: boolean },
+) => {
+	await confirmDestructive({
+		yes: props.yes,
+		noun: "snapshot",
+		message: `Delete snapshot ${props.id}?`,
+		forceYes: isMachineOutput(props.output),
+	});
 	const snapshot = await resolveSnapshot(props);
 	await retryOnLock(() =>
 		props.apiClient.deleteSnapshot(props.projectId, snapshot.id),
 	);
 	// The delete endpoint returns the tracking operations (202), not the snapshot
 	// body, so echo the snapshot we just deleted for confirmation.
-	writer(props).end(snapshot, {
-		fields: SNAPSHOT_FIELDS,
-		renderColumns: {
-			expires_at: (s) => s.expires_at || "never",
-		},
-	});
+	if (isMachineOutput(props.output)) {
+		writer(props).end(snapshot, {
+			fields: SNAPSHOT_FIELDS,
+			renderColumns: {
+				expires_at: (s) => s.expires_at || "never",
+			},
+		});
+		return;
+	}
+	writer(props).text(
+		`Deleted snapshot ${namedResource(snapshot.id, snapshot.name)}.\n`,
+	);
 };
 
 const restore = async (

--- a/packages/cli/src/utils/confirm_destructive.test.ts
+++ b/packages/cli/src/utils/confirm_destructive.test.ts
@@ -29,7 +29,12 @@ describe("confirmDestructive", () => {
 	test("returns immediately when --yes is set", async () => {
 		let prompted = false;
 		await confirmDestructive(
-			{ yes: true, noun: "project", message: "Delete project x?" },
+			{
+				yes: true,
+				noun: "project",
+				message: "Delete project x?",
+				output: "table",
+			},
 			{
 				isCi: () => true,
 				stdinIsTty: () => false,
@@ -45,7 +50,12 @@ describe("confirmDestructive", () => {
 	test("refuses when stdin is not a TTY", async () => {
 		await expect(
 			confirmDestructive(
-				{ yes: false, noun: "project", message: "Delete project x?" },
+				{
+					yes: false,
+					noun: "project",
+					message: "Delete project x?",
+					output: "table",
+				},
 				{
 					isCi: () => false,
 					stdinIsTty: () => false,
@@ -60,7 +70,12 @@ describe("confirmDestructive", () => {
 	test("refuses in CI even when stdin is a TTY", async () => {
 		await expect(
 			confirmDestructive(
-				{ yes: false, noun: "branch", message: "Delete branch x?" },
+				{
+					yes: false,
+					noun: "branch",
+					message: "Delete branch x?",
+					output: "table",
+				},
 				{
 					isCi: () => true,
 					stdinIsTty: () => true,
@@ -79,7 +94,7 @@ describe("confirmDestructive", () => {
 					yes: false,
 					noun: "project",
 					message: "Delete project x?",
-					forceYes: true,
+					output: "json",
 				},
 				{
 					isCi: () => false,
@@ -88,14 +103,19 @@ describe("confirmDestructive", () => {
 				},
 			),
 		).rejects.toThrow(
-			"Deleting a project requires confirmation. Re-run interactively or pass --yes.",
+			"Confirmation prompts are disabled with --output json; pass --yes.",
 		);
 	});
 
 	test("prompts on a TTY and throws when the answer is no", async () => {
 		await expect(
 			confirmDestructive(
-				{ yes: false, noun: "project", message: "Delete project x?" },
+				{
+					yes: false,
+					noun: "project",
+					message: "Delete project x?",
+					output: "table",
+				},
 				{
 					isCi: () => false,
 					stdinIsTty: () => true,
@@ -110,7 +130,12 @@ describe("confirmDestructive", () => {
 
 	test("prompts on a TTY and returns when the answer is yes", async () => {
 		await confirmDestructive(
-			{ yes: false, noun: "bucket", message: 'Delete bucket "logs"?' },
+			{
+				yes: false,
+				noun: "bucket",
+				message: 'Delete bucket "logs"?',
+				output: "table",
+			},
 			{
 				isCi: () => false,
 				stdinIsTty: () => true,

--- a/packages/cli/src/utils/confirm_destructive.test.ts
+++ b/packages/cli/src/utils/confirm_destructive.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "vitest";
+
+import {
+	confirmDestructive,
+	isMachineOutput,
+	namedResource,
+} from "./confirm_destructive.js";
+
+describe("namedResource", () => {
+	test("includes the name when it is present", () => {
+		expect(namedResource("proj-1", "demo")).toBe("proj-1 (demo)");
+	});
+
+	test("omits empty and missing names", () => {
+		expect(namedResource("proj-1", undefined)).toBe("proj-1");
+		expect(namedResource("proj-1", "")).toBe("proj-1");
+	});
+});
+
+describe("isMachineOutput", () => {
+	test("json and yaml require --yes even on a TTY", () => {
+		expect(isMachineOutput("json")).toBe(true);
+		expect(isMachineOutput("yaml")).toBe(true);
+		expect(isMachineOutput("table")).toBe(false);
+	});
+});
+
+describe("confirmDestructive", () => {
+	test("returns immediately when --yes is set", async () => {
+		let prompted = false;
+		await confirmDestructive(
+			{ yes: true, noun: "project", message: "Delete project x?" },
+			{
+				isCi: () => true,
+				stdinIsTty: () => false,
+				confirm: async () => {
+					prompted = true;
+					return false;
+				},
+			},
+		);
+		expect(prompted).toBe(false);
+	});
+
+	test("refuses when stdin is not a TTY", async () => {
+		await expect(
+			confirmDestructive(
+				{ yes: false, noun: "project", message: "Delete project x?" },
+				{
+					isCi: () => false,
+					stdinIsTty: () => false,
+					confirm: async () => true,
+				},
+			),
+		).rejects.toThrow(
+			"Deleting a project requires confirmation. Re-run interactively or pass --yes.",
+		);
+	});
+
+	test("refuses in CI even when stdin is a TTY", async () => {
+		await expect(
+			confirmDestructive(
+				{ yes: false, noun: "branch", message: "Delete branch x?" },
+				{
+					isCi: () => true,
+					stdinIsTty: () => true,
+					confirm: async () => true,
+				},
+			),
+		).rejects.toThrow(
+			"Deleting a branch requires confirmation. Re-run interactively or pass --yes.",
+		);
+	});
+
+	test("refuses json and yaml without --yes even on a TTY", async () => {
+		await expect(
+			confirmDestructive(
+				{
+					yes: false,
+					noun: "project",
+					message: "Delete project x?",
+					forceYes: true,
+				},
+				{
+					isCi: () => false,
+					stdinIsTty: () => true,
+					confirm: async () => true,
+				},
+			),
+		).rejects.toThrow(
+			"Deleting a project requires confirmation. Re-run interactively or pass --yes.",
+		);
+	});
+
+	test("prompts on a TTY and throws when the answer is no", async () => {
+		await expect(
+			confirmDestructive(
+				{ yes: false, noun: "project", message: "Delete project x?" },
+				{
+					isCi: () => false,
+					stdinIsTty: () => true,
+					confirm: async (message) => {
+						expect(message).toBe("Delete project x?");
+						return false;
+					},
+				},
+			),
+		).rejects.toThrow("Cancelled — project was not deleted.");
+	});
+
+	test("prompts on a TTY and returns when the answer is yes", async () => {
+		await confirmDestructive(
+			{ yes: false, noun: "bucket", message: 'Delete bucket "logs"?' },
+			{
+				isCi: () => false,
+				stdinIsTty: () => true,
+				confirm: async () => true,
+			},
+		);
+	});
+});

--- a/packages/cli/src/utils/confirm_destructive.ts
+++ b/packages/cli/src/utils/confirm_destructive.ts
@@ -59,14 +59,19 @@ export const confirmDestructive = async (
 		yes: boolean;
 		noun: string;
 		message: string;
-		forceYes?: boolean;
+		output: "yaml" | "json" | "table";
 	},
 	deps: ConfirmDestructiveDeps = defaultDeps,
 ): Promise<void> => {
 	if (options.yes) {
 		return;
 	}
-	if (options.forceYes || deps.isCi() || !deps.stdinIsTty()) {
+	if (isMachineOutput(options.output)) {
+		throw new Error(
+			`Confirmation prompts are disabled with --output ${options.output}; pass --yes.`,
+		);
+	}
+	if (deps.isCi() || !deps.stdinIsTty()) {
 		throw new Error(
 			`Deleting a ${options.noun} requires confirmation. Re-run interactively or pass --yes.`,
 		);

--- a/packages/cli/src/utils/confirm_destructive.ts
+++ b/packages/cli/src/utils/confirm_destructive.ts
@@ -1,0 +1,78 @@
+import prompts, { type InitialReturnValue } from "prompts";
+
+import { isCi } from "../env.js";
+
+export const yesOption = {
+	alias: "y",
+	type: "boolean" as const,
+	default: false,
+	describe: "Skip the confirmation prompt",
+};
+
+export const isMachineOutput = (
+	output: "yaml" | "json" | "table",
+): output is "yaml" | "json" => output === "json" || output === "yaml";
+
+export const namedResource = (
+	id: string,
+	name: string | null | undefined,
+): string => (name ? `${id} (${name})` : id);
+
+export type ConfirmDestructiveDeps = {
+	isCi: () => boolean;
+	stdinIsTty: () => boolean;
+	confirm: (message: string) => Promise<boolean>;
+};
+
+const restoreCursorOnAbort = (state: {
+	value: InitialReturnValue;
+	aborted: boolean;
+	exited: boolean;
+}) => {
+	if (state.aborted) {
+		// prompts hides the cursor; leaving it hidden after Ctrl-C looks like a hung terminal
+		process.stdout.write("\x1B[?25h");
+		process.stdout.write("\n");
+		process.exit(1);
+	}
+};
+
+const defaultConfirm = async (message: string): Promise<boolean> => {
+	const { proceed } = await prompts({
+		onState: restoreCursorOnAbort,
+		type: "confirm",
+		name: "proceed",
+		message,
+		initial: false,
+	});
+	return Boolean(proceed);
+};
+
+const defaultDeps: ConfirmDestructiveDeps = {
+	isCi,
+	stdinIsTty: () => Boolean(process.stdin.isTTY),
+	confirm: defaultConfirm,
+};
+
+export const confirmDestructive = async (
+	options: {
+		yes: boolean;
+		noun: string;
+		message: string;
+		forceYes?: boolean;
+	},
+	deps: ConfirmDestructiveDeps = defaultDeps,
+): Promise<void> => {
+	if (options.yes) {
+		return;
+	}
+	if (options.forceYes || deps.isCi() || !deps.stdinIsTty()) {
+		throw new Error(
+			`Deleting a ${options.noun} requires confirmation. Re-run interactively or pass --yes.`,
+		);
+	}
+	const proceed = await deps.confirm(options.message);
+	if (!proceed) {
+		throw new Error(`Cancelled — ${options.noun} was not deleted.`);
+	}
+};


### PR DESCRIPTION
## Problem

Destructive `neon` delete commands ran immediately with no confirmation. A single mistyped id in `neon projects delete` removed the project on the spot. Scripts and interactive use behaved the same way, so there was no safety net in either case.

## Diagnosis

The delete handlers called the API directly without any confirmation step. There was also no shared helper to decide when a prompt is possible: table output on a TTY can prompt, but json/yaml output and non-interactive contexts cannot. CI runners sometimes report a TTY on stdin, so a plain TTY check is not enough; `isCi()` now treats CI as non-interactive even if stdin looks like a TTY.

Commands gated: `projects delete`, `branches delete`, `databases delete` (and the `db` alias), `roles delete`, `snapshots delete`, `bucket delete`/`bucket rm`.

## User-facing interface

Every gated command gains a `--yes` flag:

```
neon projects delete <id>
...
-y, --yes
└────────────────>  Skip the confirmation prompt [boolean] [default: false]
```

Off-TTY, table output, no `--yes` (exit 1):

```
ERROR: Deleting a project requires confirmation. Re-run interactively or pass --yes.
```

Off-TTY, json output, no `--yes` (exit 1). The message names `--output` instead of suggesting an interactive re-run, because json and yaml never prompt:

```
ERROR: Confirmation prompts are disabled with --output json; pass --yes.
```

yaml without `--yes`:

```
ERROR: Confirmation prompts are disabled with --output yaml; pass --yes.
```

On a TTY with table output, the command asks `Delete project <id>?` with No as the default. Declining prints:

```
Cancelled — project was not deleted.
```

Table output on success prints a Deleted line instead of a get-style table. Project deletes add a recover hint:

```
Deleted project test (test).
Recoverable during the deletion grace period: neon projects recover test
```

JSON and YAML with `--yes` still emit the deleted record when the API returns one. `bucket delete` returns 204 with no body, so json/yaml stdout is empty for that command.

## Also in here

- The checkout policy-failure hint now includes `--yes`.
- The README snapshot example passes `--yes`.
- Live e2e tests already pass `--output json` on deletes, which now also requires `--yes`; the e2e helper already passes `--yes`.

## Verification

- `pnpm --filter neon build`.
- Targeted vitest on `confirm_destructive` and the six affected command test files.
- `pnpm lint:ci`.
- Live smoke: a piped delete without `--yes` exited 1 and left the project in place; with `--yes` it printed the Deleted line and the recover hint.

## For your attention

- The changeset is minor, not major, so this ships in 4.x. Scripts that omit `--yes` on delete commands now exit 1. That is a deliberate behavior break inside the 4.x line.
- `claim delete`, `profile remove`, `bucket object delete` (including `--recursive`), and functions/auth deletes are out of scope on purpose. `bucket object delete` remains ungated even though it is destructive.
- When a branch, database, or role is already gone, the API returns 204 and the CLI stays silent. That papercut is unchanged and tracked separately.