### PR TITLE
Point the AI SDK provider catalog at neon.com/models.json

### DIFF
--- a/.changeset/catalog-neon-com-models.md
+++ b/.changeset/catalog-neon-com-models.md
@@ -2,4 +2,4 @@
 "@neon/ai-sdk-provider": minor
 ---
 
-Typed model autocomplete now follows [neon.com/models](https://neon.com/models), including `claude-fable-5-1`, `glm-5-3-flash`, `grok-4-6`, and `gpt-6-astra`.
+Typed model autocomplete now follows [neon.com/models](https://neon.com/models), including `claude-fable-5-1`, `glm-5-3-flash`, `grok-4-6`, and `gpt-6-astra`. `getNeonModelCapabilities("gpt-6-astra").supportsTemperature` is `false`.

--- a/.changeset/catalog-neon-com-models.md
+++ b/.changeset/catalog-neon-com-models.md
@@ -1,0 +1,5 @@
+---
+"@neon/ai-sdk-provider": minor
+---
+
+Typed model autocomplete now follows [neon.com/models](https://neon.com/models), including `claude-fable-5-1`, `glm-5-3-flash`, `grok-4-6`, and `gpt-6-astra`.

--- a/.github/workflows/catalog-drift.yml
+++ b/.github/workflows/catalog-drift.yml
@@ -1,7 +1,7 @@
 name: Catalog Drift
 
 # Maintainer guard: fails when @neon/ai-sdk-provider's pinned model
-# catalog (NEON_MODELS_DEV_IDS) drifts from the live models.dev `neon` provider.
+# catalog (NEON_MODELS_DEV_IDS) drifts from https://neon.com/models.json.
 
 on:
     schedule:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
     drift:
-        name: models.dev catalog drift
+        name: neon.com/models.json catalog drift
         runs-on:
             group: neondatabase-protected-runner-group
             labels: linux-ubuntu-latest

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -104,7 +104,7 @@ getNeonModelCapabilities('gpt-6-astra').supportsTemperature; // false
 getNeonModelCapabilities('glm-5-2').supportsPenalties; // false
 ```
 
-**The rules are per model, not per family.** Two Gemini ids reject penalties while their siblings accept them, and `gemini-3-6-flash` rejects `temperature` and `topP` outright, so reading a row for "Gemini" is not enough — check the id. Every entry above is measured against the gateway rather than inherited from the upstream provider's own documentation, which disagrees in both directions.
+**The rules are per model, not per family.** Two Gemini ids reject penalties while their siblings accept them, and `gemini-3-6-flash` rejects `temperature` and `topP` outright, so reading a row for "Gemini" is not enough — check the id. Every dropped-options table row was measured against the gateway rather than inherited from the upstream provider's own documentation, which disagrees in both directions. `getNeonModelCapabilities('gpt-6-astra').supportsTemperature` is `false` because [neon.com/models.json](https://neon.com/models.json) lists `temperature: false` for that id; it is not a live gateway measurement.
 
 A model none of these rules match is left untouched, so a brand-new id gets the gateway's own error rather than a guess. That is also why the table can lag: an id added since the last release inherits the permissive default until someone measures it.
 

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -100,6 +100,7 @@ Query the rules directly rather than hardcoding them:
 import { getNeonModelCapabilities } from '@neon/ai-sdk-provider';
 
 getNeonModelCapabilities('claude-opus-5').supportsTemperature; // false
+getNeonModelCapabilities('gpt-6-astra').supportsTemperature; // false
 getNeonModelCapabilities('glm-5-2').supportsPenalties; // false
 ```
 

--- a/packages/ai-sdk-provider/README.md
+++ b/packages/ai-sdk-provider/README.md
@@ -4,7 +4,7 @@ Community [Vercel AI SDK](https://ai-sdk.dev) provider for the [Neon](https://ne
 
 The Neon AI Gateway is **branch-scoped**: each Neon project branch gets its own gateway host, and a platform token authorizes requests for that branch. Use the same `neon(modelId)` API across the branch's model catalog; the provider selects Anthropic Messages, OpenAI Responses, or Chat Completions for each model.
 
-Use canonical model ids such as `gpt-5-mini`, `llama-4-maverick`, and `gemini-3-flash`, matching the [`neon` provider on models.dev](https://models.dev). The typed catalog includes the known model ids, and arbitrary strings are accepted so newly available models work before the types update.
+Use canonical model ids such as `gpt-5-mini`, `llama-4-maverick`, and `gemini-3-flash`, matching [neon.com/models](https://neon.com/models). The typed catalog includes the known model ids, and arbitrary strings are accepted so newly available models work before the types update.
 
 ## Install
 
@@ -73,11 +73,11 @@ These rules apply on the Anthropic Messages and Chat Completions routes. The Res
 
 | Models | Dropped |
 | --- | --- |
-| Claude 4.7 and newer (`claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`) | `temperature`, `topP` |
+| Claude 4.7 and newer (`claude-opus-4-7`, `claude-opus-4-8`, `claude-opus-5`, `claude-sonnet-5`, `claude-fable-5`, `claude-fable-5-1`) | `temperature`, `topP` |
 | All Claude | `frequencyPenalty`, `presencePenalty`, `seed`, `reasoningEffort`, and `topP` when you set both `temperature` and `topP` (Anthropic accepts only one) |
 | `gpt-oss` | `frequencyPenalty`, `presencePenalty`, `seed`, `stopSequences` |
 | Qwen, Gemma | `frequencyPenalty`, `presencePenalty`, `seed` |
-| `glm-5-2`, `inkling`, `kimi-k3` | `frequencyPenalty`, `presencePenalty` |
+| `glm-5-2`, `glm-5-3-flash`, `inkling`, `kimi-k3` | `frequencyPenalty`, `presencePenalty` |
 | Meta Llama | `frequencyPenalty`, `presencePenalty`, `seed` |
 | `gemini-3-5-flash-lite` | `frequencyPenalty`, `presencePenalty` |
 | `gemini-3-6-flash` | `temperature`, `topP`, `frequencyPenalty`, `presencePenalty` |
@@ -229,4 +229,4 @@ pnpm test:e2e
 
 A run with neither **fails**; it does not skip. The gateway is on every branch and needs no provisioning, so the API-key path is the one CI uses — no gateway token is stored as a secret.
 
-The matrix covers one models.dev `neon` model per family (Anthropic, OpenAI, Codex, Gemini, Meta, Alibaba, Zhipu, Thinking Machines) across `generateText`, `streamText`, `generateObject`, tool calling, and `neon.tools.imageGeneration`. `generateObject` and tool calling run on the subset of families where they are verified (see [Capabilities](#capabilities)). A family whose representative id the branch does not serve skips its cases, and a single assertion fails the run listing exactly which pinned ids went missing — so a shrinking catalog is reported rather than silently reducing coverage. Model access is granted per account, so the account behind the key needs every id in `MATRIX_MODELS`. The suite also fetches the live `/v1/models` catalog and calls every currently enabled model with both AI SDK 6 and AI SDK 7.
+The matrix covers one published catalog model per family (Anthropic, OpenAI, Codex, Gemini, Meta, Alibaba, Zhipu, Thinking Machines) across `generateText`, `streamText`, `generateObject`, tool calling, and `neon.tools.imageGeneration`. `generateObject` and tool calling run on the subset of families where they are verified (see [Capabilities](#capabilities)). A family whose representative id the branch does not serve skips its cases, and a single assertion fails the run listing exactly which pinned ids went missing — so a shrinking catalog is reported rather than silently reducing coverage. Model access is granted per account, so the account behind the key needs every id in `MATRIX_MODELS`. The suite also fetches the live `/v1/models` catalog and calls every currently enabled model with both AI SDK 6 and AI SDK 7.

--- a/packages/ai-sdk-provider/e2e/helpers.ts
+++ b/packages/ai-sdk-provider/e2e/helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Representative models from the models.dev `neon` provider — one per gateway route
+ * Representative models from the published catalog — one per gateway route
  * family. See `NEON_MODELS_DEV_IDS` in neon-chat-options.ts.
  */
 import { expect } from "vitest";

--- a/packages/ai-sdk-provider/src/lib/neon-catalog-drift.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-catalog-drift.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { NEON_MODELS_DEV_IDS } from "./neon-chat-options.js";
+import { getNeonModelCapabilities } from "./neon-model-capabilities.js";
 
 /**
  * Maintainer-only guard against catalog drift. https://neon.com/models.json is
@@ -18,7 +19,7 @@ interface NeonModelsJson {
 	neon?: { models?: Record<string, unknown> };
 }
 
-async function fetchNeonCatalogIds(): Promise<Set<string>> {
+async function fetchNeonCatalogModels(): Promise<Record<string, unknown>> {
 	const response = await fetch(NEON_MODELS_JSON);
 	if (!response.ok) {
 		throw new Error(
@@ -30,12 +31,22 @@ async function fetchNeonCatalogIds(): Promise<Set<string>> {
 	if (models == null) {
 		throw new Error("neon.com/models.json has no neon.models");
 	}
-	return new Set(Object.keys(models));
+	return models;
+}
+
+function catalogTemperature(entry: unknown): boolean {
+	if (entry === null || typeof entry !== "object") {
+		throw new Error("neon.com/models.json model entry is not an object");
+	}
+	if (!("temperature" in entry) || typeof entry.temperature !== "boolean") {
+		throw new Error("neon.com/models.json temperature is not a boolean");
+	}
+	return entry.temperature;
 }
 
 describe.skipIf(!ENABLED)("neon.com/models.json catalog drift", () => {
 	it("keeps NEON_MODELS_DEV_IDS in sync with the published catalog", async () => {
-		const live = await fetchNeonCatalogIds();
+		const live = new Set(Object.keys(await fetchNeonCatalogModels()));
 		expect(live.size).toBeGreaterThan(0);
 
 		const declared = new Set<string>(NEON_MODELS_DEV_IDS);
@@ -51,6 +62,17 @@ describe.skipIf(!ENABLED)("neon.com/models.json catalog drift", () => {
 		expect({ missingFromProvider, removedUpstream }).toEqual({
 			missingFromProvider: [],
 			removedUpstream: [],
+		});
+	});
+
+	it("keeps gpt-6-astra temperature aligned with the catalog", async () => {
+		const models = await fetchNeonCatalogModels();
+		const catalog = catalogTemperature(models["gpt-6-astra"]);
+		const reported =
+			getNeonModelCapabilities("gpt-6-astra").supportsTemperature;
+		expect({ catalog, reported }).toEqual({
+			catalog: false,
+			reported: false,
 		});
 	});
 });

--- a/packages/ai-sdk-provider/src/lib/neon-catalog-drift.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-catalog-drift.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { NEON_MODELS_DEV_IDS } from "./neon-chat-options.js";
 
 /**
- * Maintainer-only guard against models.dev drift. The `neon` provider on
- * models.dev is the source of truth for the gateway's published catalog; this
- * test fails when our `NEON_MODELS_DEV_IDS` no longer mirrors it.
+ * Maintainer-only guard against catalog drift. https://neon.com/models.json is
+ * the published catalog this package's typed id list must match; this test
+ * fails when `NEON_MODELS_DEV_IDS` no longer mirrors it.
  *
  * It hits the network, so it is opt-in: it runs only when `NEON_DRIFT_CHECK=1`
  * (see the `test:drift` script and the scheduled `catalog-drift` CI workflow),
@@ -12,29 +12,29 @@ import { NEON_MODELS_DEV_IDS } from "./neon-chat-options.js";
  * deterministic.
  */
 const ENABLED = process.env.NEON_DRIFT_CHECK === "1";
-const MODELS_DEV_API = "https://models.dev/api.json";
+const NEON_MODELS_JSON = "https://neon.com/models.json";
 
-interface ModelsDevApi {
+interface NeonModelsJson {
 	neon?: { models?: Record<string, unknown> };
 }
 
 async function fetchNeonCatalogIds(): Promise<Set<string>> {
-	const response = await fetch(MODELS_DEV_API);
+	const response = await fetch(NEON_MODELS_JSON);
 	if (!response.ok) {
 		throw new Error(
-			`models.dev returned ${response.status} ${response.statusText}`,
+			`neon.com/models.json returned ${response.status} ${response.statusText}`,
 		);
 	}
-	const data: ModelsDevApi = await response.json();
+	const data: NeonModelsJson = await response.json();
 	const models = data.neon?.models;
 	if (models == null) {
-		throw new Error("models.dev response has no `neon` provider models");
+		throw new Error("neon.com/models.json has no neon.models");
 	}
 	return new Set(Object.keys(models));
 }
 
-describe.skipIf(!ENABLED)("models.dev catalog drift", () => {
-	it("keeps NEON_MODELS_DEV_IDS in sync with the live neon catalog", async () => {
+describe.skipIf(!ENABLED)("neon.com/models.json catalog drift", () => {
+	it("keeps NEON_MODELS_DEV_IDS in sync with the published catalog", async () => {
 		const live = await fetchNeonCatalogIds();
 		expect(live.size).toBeGreaterThan(0);
 
@@ -47,7 +47,7 @@ describe.skipIf(!ENABLED)("models.dev catalog drift", () => {
 			.sort();
 
 		// `missingFromProvider`: add these to NEON_MODELS_DEV_IDS.
-		// `removedUpstream`: models.dev dropped these — remove or move to extras.
+		// `removedUpstream`: neon.com/models.json dropped these; remove them from the array.
 		expect({ missingFromProvider, removedUpstream }).toEqual({
 			missingFromProvider: [],
 			removedUpstream: [],

--- a/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-chat-options.ts
@@ -2,27 +2,22 @@
 // to their provider-native endpoints; everything else uses the unified MLflow
 // (OpenAI-compatible) endpoint.
 //
-// Ids use the canonical Neon (unprefixed) form, matching the `neon` provider on
-// models.dev. The gateway also accepts the legacy `databricks-` prefixed form
-// (the `databricks` provider on models.dev), which still resolves via the
-// `(string & {})` fallback on `NeonChatModelId`.
+// Ids use the canonical Neon (unprefixed) form, matching
+// https://neon.com/models.json. The gateway also accepts the legacy
+// `databricks-` prefixed form, which still resolves via the `(string & {})`
+// fallback on `NeonChatModelId`.
 //
-// `NEON_MODELS_DEV_IDS` mirrors the models.dev `neon` catalog exactly — the
-// `neon-catalog-drift.test.ts` maintainer check fails if the two diverge. The
-// authoritative, always-current catalog is shown in the Neon Console under the
-// branch's "AI Gateway" tab.
-//
-// There is deliberately no second list for ids the gateway serves ahead of
-// models.dev. Such an id already works — `NeonChatModelId` accepts any string —
-// so a hand-maintained list would buy autocomplete for a few days at the cost of
-// a surface that silently rots, which is what happened last time. The fix for a
-// gateway model missing here is to add it to models.dev; Orbit's catalog-parity
-// job reports that gap daily.
+// `NEON_MODELS_DEV_IDS` mirrors neon.com/models.json `neon.models` exactly —
+// `neon-catalog-drift.test.ts` fails if the two diverge. A branch's live list
+// is `GET $NEON_AI_GATEWAY_BASE_URL/v1/models`. There is deliberately no second
+// list for ids the gateway serves ahead of the published catalog: such an id
+// already works because `NeonChatModelId` accepts any string.
 
-/** The models.dev `neon` catalog (canonical, unprefixed ids). */
+/** Published catalog ids from https://neon.com/models.json (canonical, unprefixed). */
 export const NEON_MODELS_DEV_IDS = [
 	// Anthropic (native Messages API)
 	"claude-fable-5",
+	"claude-fable-5-1",
 	"claude-haiku-4-5",
 	"claude-opus-4-1",
 	"claude-opus-4-5",
@@ -48,6 +43,7 @@ export const NEON_MODELS_DEV_IDS = [
 	"gpt-5-6-terra",
 	"gpt-5-mini",
 	"gpt-5-nano",
+	"gpt-6-astra",
 	// OpenAI open-weight (unified MLflow endpoint)
 	"gpt-oss-120b",
 	"gpt-oss-20b",
@@ -68,6 +64,9 @@ export const NEON_MODELS_DEV_IDS = [
 	"qwen35-122b-a10b",
 	// Zhipu (unified MLflow endpoint)
 	"glm-5-2",
+	"glm-5-3-flash",
+	// xAI (unified MLflow endpoint)
+	"grok-4-6",
 	// Thinking Machines (unified MLflow endpoint)
 	"inkling",
 	// Moonshot (unified MLflow endpoint)

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
@@ -63,6 +63,12 @@ describe("getNeonModelCapabilities", () => {
 		expect(caps.supportsTopP).toBe(true);
 	});
 
+	it("marks gpt-6-astra without temperature support", () => {
+		const caps = getNeonModelCapabilities("gpt-6-astra");
+		expect(caps.family).toBe("openai");
+		expect(caps.supportsTemperature).toBe(false);
+	});
+
 	it("marks Meta models without penalties/seed support", () => {
 		const caps = getNeonModelCapabilities("llama-4-maverick");
 		expect(caps.family).toBe("meta");
@@ -300,6 +306,7 @@ describe("getNeonModelCapabilities", () => {
 			"claude-haiku-4-5",
 			"gpt-5-mini",
 			"gpt-5-1",
+			"gpt-6-astra",
 			"gemini-3-flash",
 			"llama-4-maverick",
 			"qwen35-122b-a10b",

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.test.ts
@@ -69,6 +69,12 @@ describe("getNeonModelCapabilities", () => {
 		expect(caps.supportsTemperature).toBe(false);
 	});
 
+	it("does not inherit gpt-6-astra temperature onto other gpt-6 ids", () => {
+		const caps = getNeonModelCapabilities("gpt-6-future");
+		expect(caps.family).toBe("other");
+		expect(caps.supportsTemperature).toBe(true);
+	});
+
 	it("marks Meta models without penalties/seed support", () => {
 		const caps = getNeonModelCapabilities("llama-4-maverick");
 		expect(caps.family).toBe("meta");

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
@@ -212,6 +212,21 @@ export function getNeonModelCapabilities(
 		};
 	}
 
+	// Catalog `temperature: false` on gpt-6-astra; the gpt-5 minor-version rule
+	// does not match gpt-6.
+	if (/gpt-6/.test(id)) {
+		return {
+			family: "openai",
+			supportsTemperature: false,
+			supportsTopP: true,
+			temperatureTopPMutuallyExclusive: false,
+			supportsPenalties: true,
+			supportsSeed: true,
+			supportsStopSequences: true,
+			supportsReasoningEffort: true,
+		};
+	}
+
 	// Meta (Llama): rejects penalties and seed; accepts sampling params and stop.
 	if (id.includes("llama")) {
 		return {

--- a/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
+++ b/packages/ai-sdk-provider/src/lib/neon-model-capabilities.ts
@@ -213,8 +213,8 @@ export function getNeonModelCapabilities(
 	}
 
 	// Catalog `temperature: false` on gpt-6-astra; the gpt-5 minor-version rule
-	// does not match gpt-6.
-	if (/gpt-6/.test(id)) {
+	// does not match gpt-6. Exact id: a future gpt-6-* is unmeasured.
+	if (canonicalId(id) === "gpt-6-astra") {
 		return {
 			family: "openai",
 			supportsTemperature: false,


### PR DESCRIPTION
## Problem

`@neon/ai-sdk-provider` ships a typed id list, `NEON_MODELS_DEV_IDS`, that drives `NeonChatModelId` autocomplete, and a weekly `catalog-drift` workflow that fails when the list stops matching an upstream catalog. Both pointed at the `neon` provider on models.dev. Neon now publishes its own catalog at [neon.com/models](https://neon.com/models) and [neon.com/models.json](https://neon.com/models.json), and that catalog carries four ids the typed list does not: `claude-fable-5-1`, `glm-5-3-flash`, `grok-4-6` and `gpt-6-astra`. Those ids already work at runtime through the `(string & {})` fallback, so the gap is autocomplete and the drift signal, which was measuring against a mirror rather than the source.

One of the four also has a capability the provider gets wrong. neon.com/models.json lists `temperature: false` for `gpt-6-astra`. The existing OpenAI rule in `getNeonModelCapabilities` is scoped to `/gpt-5/`, so `gpt-6-astra` fell through to the permissive default: `family: "other"`, `supportsTemperature: true`.

## What changed

The typed catalog, the drift test and the workflow now read neon.com/models.json. The export name `NEON_MODELS_DEV_IDS` is unchanged. The four ids are added to the list, and `gpt-6-astra` gets an exact-match capability rule.

```ts
import { getNeonModelCapabilities, NEON_MODELS_DEV_IDS } from '@neon/ai-sdk-provider';

NEON_MODELS_DEV_IDS.includes('grok-4-6'); // true, along with claude-fable-5-1, glm-5-3-flash, gpt-6-astra

getNeonModelCapabilities('gpt-6-astra');
// { family: 'openai', supportsTemperature: false, supportsTopP: true, supportsPenalties: true, ... }

getNeonModelCapabilities('databricks-gpt-6-astra').supportsTemperature; // false, prefix stripped before the exact match

getNeonModelCapabilities('gpt-6-future');
// { family: 'other', supportsTemperature: true, ... } permissive default, unmeasured
```

The rule matches the canonical id exactly rather than `/gpt-6/`. The `gpt-5` rule encodes a version pattern that was measured across several ids; there is one `gpt-6` id and one catalog fact about it, so a family-wide rule would be a guess.

`gpt-6-astra` routes to the Responses API like every other `gpt-*` id except `gpt-oss`. The Responses route does not drop `temperature`; `getNeonModelCapabilities` reports it and the upstream model's own stripping applies, the same as the `gpt-5` row in the README.

### Behavior change for existing callers

Callers who already pass `"gpt-6-astra"` as a string see a different answer from `getNeonModelCapabilities`. Before: `family: "other"`, `supportsTemperature: true`. After: `family: "openai"`, `supportsTemperature: false`. Every id that was already in the list keeps its previous capabilities.

### Weekly drift check

`pnpm --filter @neon/ai-sdk-provider test:drift` (and the scheduled `catalog-drift` workflow) now runs two assertions:

- the ids in `NEON_MODELS_DEV_IDS` equal the keys of `neon.models` in neon.com/models.json, in both directions
- `gpt-6-astra` has `temperature: false` in the catalog and `getNeonModelCapabilities("gpt-6-astra").supportsTemperature` is `false`

The second assertion is pinned to one id. It is not a sweep of every catalog `temperature` value against the SDK: `gpt-5-5`, `gpt-5-6-luna`, `gpt-5-6-sol` and `gpt-5-6-terra` are `temperature: false` in the catalog today while the SDK's gateway-measured `gpt-5` rule reports `true` for them. Reconciling those is separate work and a general sweep would fail on day one for reasons this PR does not touch.

## Also in here

- README: the catalog link points at neon.com/models, the two new ids appear in the dropped-options table rows for their families, and a `gpt-6-astra` example joins the `getNeonModelCapabilities` snippet. The table rows remain gateway measurements. The README says explicitly that the `gpt-6-astra` value comes from neon.com/models.json, since it is the only capability in the package sourced from the catalog rather than a live call.
- `e2e/helpers.ts` comment and the `neon-chat-options.ts` header comment drop the models.dev reference.
- Changeset: minor bump for `@neon/ai-sdk-provider`.

## Verification

From this branch, against the live neon.com/models.json:

```
pnpm --filter @neon/ai-sdk-provider test:drift   # 2 passed
pnpm --filter @neon/ai-sdk-provider test:ci      # 104 passed, 2 skipped (the drift file, opt-in)
```

Unit tests added:

- `gpt-6-astra` reports `family: "openai"` and `supportsTemperature: false`
- `gpt-6-future` stays on the permissive default, so the rule does not leak onto other `gpt-6` ids
- `gpt-6-astra` is included in the "every cataloged id resolves to a family" sweep

Not verified: a live gateway call with `gpt-6-astra` and `temperature` set. The `supportsTemperature: false` value is taken from the catalog, not measured, and the README says so.

## For your attention

- `gpt-6-astra` is the first capability in this package sourced from neon.com/models.json instead of a gateway measurement. If the catalog value turns out wrong, the drift test will still pass because it compares the SDK to the catalog, not to the gateway.
- The catalog disagrees with the SDK on `temperature` for `gpt-5-5` and the three `gpt-5-6-*` ids. Out of scope here; the drift test deliberately does not cover them.
- `NEON_MODELS_DEV_IDS` keeps its name even though models.dev is no longer the source. Renaming it is a breaking change to a public export and is not part of this PR.
