### PR TITLE
Return `{ branch, endpoint?, connectionString? }` from `neon.branches.create`

### DIFF
--- a/.changeset/sdk-branch-create-result.md
+++ b/.changeset/sdk-branch-create-result.md
@@ -1,6 +1,6 @@
 ---
-"@neon/sdk": minor
-"@neon/tools": minor
+"@neon/sdk": major
+"@neon/tools": major
 ---
 
 `neon.branches.create` now returns `{ branch, endpoint?, connectionString? }` instead of a bare `Branch`. The pooled URI is included when the API returns one. `createAndConnect` still requires a URI. The `branches.create` tool returns the same shape.

--- a/.changeset/sdk-branch-create-result.md
+++ b/.changeset/sdk-branch-create-result.md
@@ -3,4 +3,4 @@
 "@neon/tools": major
 ---
 
-`neon.branches.create` now returns `{ branch, endpoint?, connectionString? }` instead of a bare `Branch`. The pooled URI is included when the API returns one. `createAndConnect` still requires a URI. The `branches.create` tool returns the same shape.
+`neon.branches.create` now returns `{ branch, endpoints?, endpoint?, connectionUris?, connectionString? }` instead of a bare `Branch`. `createAndConnect` still requires a URI. The `branches.create` tool returns the same shape.

--- a/.changeset/sdk-branch-create-result.md
+++ b/.changeset/sdk-branch-create-result.md
@@ -1,0 +1,6 @@
+---
+"@neon/sdk": minor
+"@neon/tools": minor
+---
+
+`neon.branches.create` now returns `{ branch, endpoint?, connectionString? }` instead of a bare `Branch`. The pooled URI is included when the API returns one. `createAndConnect` still requires a URI. The `branches.create` tool returns the same shape.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -232,10 +232,10 @@ await neon.projects.transfer({
 | --- | --- | --- |
 | `list(projectId, query?)` | **[P]** `Branch` | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }` |
 | `get(projectId, branchId)` | `Branch` | |
-| `create(projectId, input?)` | `Branch` | RW compute on by default. `noCompute: true` skips the endpoint. No connection string. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
+| `create(projectId, input?)` | `{ branch, endpoint?, connectionString? }` | RW compute on by default. `noCompute: true` skips the endpoint. Includes the endpoint and a pooled `connectionString` when a compute is created. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
 | `update(projectId, branchId, input)` | `Branch` | `input`: `{ name?, protected?, expires_at? }` |
 | `delete(projectId, branchId)` | **→void** | |
-| `createAndConnect(projectId, input?, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
+| `createAndConnect(projectId, input?, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | Same create, but errors if there is no URI. `pooled` default `true`. `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
 | `getDefault(projectId)` | `Branch` | resolves the default branch by the `default` flag |
 | `setDefault(projectId, branchId)` | `Branch` | |
 | `resetFromParent(projectId, branchId, { preserveUnderName? }?)` | `Branch` | parent HEAD only; discards writes since the branch diverged. `preserveUnderName` is required when the branch has children. Pass `{ waitForReadiness: true }` before using the branch |
@@ -271,13 +271,19 @@ await neon.branches.create(projectId, {
   noCompute: true,
 });
 
-// Branch off it with its own compute — returns a ready connection string
-const { data } = await neon.branches.createAndConnect(projectId, {
+const { data } = await neon.branches.create(projectId, {
+  name: "preview/pr-123",
+  parent_id: prod?.id,
+  compute: { minCu: 0.25, maxCu: 2 },
+});
+// data: { branch, endpoint?, connectionString? }
+
+const { data: connected } = await neon.branches.createAndConnect(projectId, {
   name: "preview/pr-123",
   parentId: prod?.id,
   compute: { minCu: 0.25, maxCu: 2 },
 });
-// data: { branch, endpoint, connectionString }
+// connected: { branch, endpoint, connectionString } — errors if the API omitted a URI
 
 const { data: schema } = await neon.branches.compareSchema(
   projectId,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -232,7 +232,7 @@ await neon.projects.transfer({
 | --- | --- | --- |
 | `list(projectId, query?)` | **[P]** `Branch` | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }` |
 | `get(projectId, branchId)` | `Branch` | |
-| `create(projectId, input?)` | `{ branch, endpoint?, connectionString? }` | RW compute on by default. `noCompute: true` skips the endpoint. Includes the endpoint and a pooled `connectionString` when a compute is created. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
+| `create(projectId, input?)` | `{ branch, endpoints?, endpoint?, connectionUris?, connectionString? }` | RW compute on by default. `noCompute: true` skips the endpoint. Keeps the API's `endpoints` and `connectionUris`; `endpoint` is the first endpoint and `connectionString` is the pooled form of the first URI. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
 | `update(projectId, branchId, input)` | `Branch` | `input`: `{ name?, protected?, expires_at? }` |
 | `delete(projectId, branchId)` | **→void** | |
 | `createAndConnect(projectId, input?, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | Same create, but errors if there is no URI. `pooled` default `true`. `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
@@ -276,7 +276,7 @@ const { data } = await neon.branches.create(projectId, {
   parent_id: prod?.id,
   compute: { minCu: 0.25, maxCu: 2 },
 });
-// data: { branch, endpoint?, connectionString? }
+// data: { branch, endpoints?, endpoint?, connectionUris?, connectionString? }
 
 const { data: connected } = await neon.branches.createAndConnect(projectId, {
   name: "preview/pr-123",

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -46,17 +46,17 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				noCompute: true,
 			}),
 		);
-		expect(created.name).toBe("crud");
+		expect(created.branch.name).toBe("crud");
 
 		const fetched = expectOk(
-			await neon.branches.get(projectId, created.id),
+			await neon.branches.get(projectId, created.branch.id),
 		);
-		expect(fetched.id).toBe(created.id);
+		expect(fetched.id).toBe(created.branch.id);
 
 		const renamed = expectOk(
 			await neon.branches.update(
 				projectId,
-				created.id,
+				created.branch.id,
 				{ name: "crud-renamed" },
 				{ waitForReadiness: true },
 			),
@@ -64,12 +64,12 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		expect(renamed.name).toBe("crud-renamed");
 
 		expectOk(
-			await neon.branches.delete(projectId, created.id, {
+			await neon.branches.delete(projectId, created.branch.id, {
 				waitForReadiness: true,
 			}),
 		);
 
-		const { error } = await neon.branches.get(projectId, created.id);
+		const { error } = await neon.branches.get(projectId, created.branch.id);
 		expect(error).toBeInstanceOf(NeonNotFoundError);
 	});
 
@@ -172,10 +172,12 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				parent_id: defaultBranchId,
 			}),
 		);
+		expect(withCompute.endpoint?.type).toBe("read_write");
+		expect(withCompute.connectionString).toMatch(/^postgres(ql)?:\/\//);
 		const attached = expectOk(
 			await neon.postgres.endpoints.listByBranch(
 				projectId,
-				withCompute.id,
+				withCompute.branch.id,
 			),
 		);
 		expect(
@@ -189,18 +191,23 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				noCompute: true,
 			}),
 		);
+		expect(bare.endpoint).toBeUndefined();
+		expect(bare.connectionString).toBeUndefined();
 		const none = expectOk(
-			await neon.postgres.endpoints.listByBranch(projectId, bare.id),
+			await neon.postgres.endpoints.listByBranch(
+				projectId,
+				bare.branch.id,
+			),
 		);
 		expect(none).toEqual([]);
 
 		expectOk(
-			await neon.branches.delete(projectId, withCompute.id, {
+			await neon.branches.delete(projectId, withCompute.branch.id, {
 				waitForReadiness: true,
 			}),
 		);
 		expectOk(
-			await neon.branches.delete(projectId, bare.id, {
+			await neon.branches.delete(projectId, bare.branch.id, {
 				waitForReadiness: true,
 			}),
 		);

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -172,7 +172,10 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				parent_id: defaultBranchId,
 			}),
 		);
+		expect(withCompute.endpoints).toHaveLength(1);
+		expect(withCompute.endpoint?.id).toBe(withCompute.endpoints?.[0]?.id);
 		expect(withCompute.endpoint?.type).toBe("read_write");
+		expect(withCompute.connectionUris?.length).toBeGreaterThan(0);
 		expect(withCompute.connectionString).toMatch(/^postgres(ql)?:\/\//);
 		const attached = expectOk(
 			await neon.postgres.endpoints.listByBranch(
@@ -192,6 +195,8 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			}),
 		);
 		expect(bare.endpoint).toBeUndefined();
+		expect(bare.endpoints).toBeUndefined();
+		expect(bare.connectionUris).toBeUndefined();
 		expect(bare.connectionString).toBeUndefined();
 		const none = expectOk(
 			await neon.postgres.endpoints.listByBranch(

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -39,6 +39,7 @@ export {
 export type { Page, Paginated } from "./neon/paginate.js";
 export type {
 	BranchConnection,
+	BranchCreateResult,
 	CompareSchemaInput,
 	ComputeSettings,
 	CreateAndConnectInput,

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -13,7 +13,10 @@ import type {
 } from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
 import type { Paginated } from "./paginate.js";
-import type { BranchConnection } from "./resources/branches.js";
+import type {
+	BranchConnection,
+	BranchCreateResult,
+} from "./resources/branches.js";
 import type { ProjectConnection } from "./resources/projects.js";
 import type { NeonResult } from "./result.js";
 
@@ -52,10 +55,10 @@ it("branches + workflows carry the envelope and narrow under throwOnError", () =
 	>();
 	expectTypeOf(
 		neon.branches.create("p", { name: "x" }),
-	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	).resolves.toEqualTypeOf<NeonResult<BranchCreateResult>>();
 	expectTypeOf(
 		neon.branches.create("p", { name: "x", noCompute: true }),
-	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	).resolves.toEqualTypeOf<NeonResult<BranchCreateResult>>();
 	neon.branches.create("p", {
 		noCompute: true,
 		// @ts-expect-error compute is invalid when noCompute is true
@@ -72,6 +75,9 @@ it("branches + workflows carry the envelope and narrow under throwOnError", () =
 	).resolves.toEqualTypeOf<NeonResult<ProjectConnection>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
+	expectTypeOf(
+		throwing.branches.create("p", { name: "x" }),
+	).resolves.toEqualTypeOf<BranchCreateResult>();
 	expectTypeOf(
 		throwing.branches.createAndConnect("p", { name: "x" }),
 	).resolves.toEqualTypeOf<BranchConnection>();

--- a/packages/sdk/src/neon/resources/branches.test.ts
+++ b/packages/sdk/src/neon/resources/branches.test.ts
@@ -40,7 +40,7 @@ function neonRouting(
 }
 
 describe("branches.create", () => {
-	it("posts a read-write endpoint by default and unwraps the branch", async () => {
+	it("posts a read-write endpoint by default and keeps the endpoint on the result", async () => {
 		const { neon, calls } = neonRouting(() => ({
 			status: 201,
 			body: {
@@ -56,7 +56,11 @@ describe("branches.create", () => {
 		});
 
 		expect(error).toBeUndefined();
-		expect(data).toEqual({ id: "br-1", name: "feature" });
+		expect(data).toEqual({
+			branch: { id: "br-1", name: "feature" },
+			endpoint: { id: "ep-1", type: "read_write" },
+			connectionString: undefined,
+		});
 		expect(calls).toHaveLength(1);
 		expect(calls[0]?.body).toEqual({
 			branch: { name: "feature", parent_id: "br-parent" },
@@ -97,7 +101,11 @@ describe("branches.create", () => {
 		});
 
 		expect(error).toBeUndefined();
-		expect(data).toEqual({ id: "br-1", name: "bare" });
+		expect(data).toEqual({
+			branch: { id: "br-1", name: "bare" },
+			endpoint: undefined,
+			connectionString: undefined,
+		});
 		expect(calls[0]?.body).toEqual({ branch: { name: "bare" } });
 	});
 
@@ -139,6 +147,36 @@ describe("branches.create", () => {
 			message: "Pass compute settings or noCompute, not both.",
 		});
 	});
+
+	it("keeps a pooled connection string when the API returns one", async () => {
+		const { neon } = neonRouting(() => ({
+			status: 201,
+			body: {
+				branch: { id: "br-1", name: "feature" },
+				endpoints: [{ id: "ep-1", type: "read_write" }],
+				connection_uris: [
+					{
+						connection_uri: "postgresql://user:pass@ep-host/neondb",
+						connection_parameters: {
+							host: "ep-host",
+							pooler_host: "ep-pooler-host",
+						},
+					},
+				],
+			},
+		}));
+
+		const { data, error } = await neon.branches.create("p-1", {
+			name: "feature",
+		});
+
+		expect(error).toBeUndefined();
+		expect(data).toEqual({
+			branch: { id: "br-1", name: "feature" },
+			endpoint: { id: "ep-1", type: "read_write" },
+			connectionString: "postgresql://user:pass@ep-pooler-host/neondb",
+		});
+	});
 });
 
 describe("branches.createAndConnect", () => {
@@ -175,6 +213,24 @@ describe("branches.createAndConnect", () => {
 			branch: { name: "feature", parent_id: "br-parent" },
 			endpoints: [{ type: "read_write" }],
 		});
+	});
+
+	it("errors when the create response has no connection URI", async () => {
+		const { neon } = neonRouting(() => ({
+			status: 201,
+			body: {
+				branch: { id: "br-1", name: "feature" },
+				endpoints: [{ id: "ep-1", type: "read_write" }],
+			},
+		}));
+
+		const { data, error } = await neon.branches.createAndConnect("p-1", {
+			name: "feature",
+		});
+
+		expect(data).toBeUndefined();
+		expect(error?.kind).toBe("client");
+		expect(error?.message).toMatch(/did not include a connection URI/);
 	});
 });
 

--- a/packages/sdk/src/neon/resources/branches.test.ts
+++ b/packages/sdk/src/neon/resources/branches.test.ts
@@ -58,7 +58,9 @@ describe("branches.create", () => {
 		expect(error).toBeUndefined();
 		expect(data).toEqual({
 			branch: { id: "br-1", name: "feature" },
+			endpoints: [{ id: "ep-1", type: "read_write" }],
 			endpoint: { id: "ep-1", type: "read_write" },
+			connectionUris: undefined,
 			connectionString: undefined,
 		});
 		expect(calls).toHaveLength(1);
@@ -104,6 +106,8 @@ describe("branches.create", () => {
 		expect(data).toEqual({
 			branch: { id: "br-1", name: "bare" },
 			endpoint: undefined,
+			endpoints: undefined,
+			connectionUris: undefined,
 			connectionString: undefined,
 		});
 		expect(calls[0]?.body).toEqual({ branch: { name: "bare" } });
@@ -173,9 +177,63 @@ describe("branches.create", () => {
 		expect(error).toBeUndefined();
 		expect(data).toEqual({
 			branch: { id: "br-1", name: "feature" },
+			endpoints: [{ id: "ep-1", type: "read_write" }],
 			endpoint: { id: "ep-1", type: "read_write" },
+			connectionUris: [
+				{
+					connection_uri: "postgresql://user:pass@ep-host/neondb",
+					connection_parameters: {
+						host: "ep-host",
+						pooler_host: "ep-pooler-host",
+					},
+				},
+			],
 			connectionString: "postgresql://user:pass@ep-pooler-host/neondb",
 		});
+	});
+
+	it("keeps every endpoint and URI the API returned", async () => {
+		const { neon } = neonRouting(() => ({
+			status: 201,
+			body: {
+				branch: { id: "br-1", name: "feature" },
+				endpoints: [
+					{ id: "ep-rw", type: "read_write" },
+					{ id: "ep-ro", type: "read_only" },
+				],
+				connection_uris: [
+					{
+						connection_uri: "postgresql://a@ep-a/neondb",
+						connection_parameters: {
+							host: "ep-a",
+							pooler_host: "ep-a-pooler",
+						},
+					},
+					{
+						connection_uri: "postgresql://b@ep-b/neondb",
+						connection_parameters: {
+							host: "ep-b",
+							pooler_host: "ep-b-pooler",
+						},
+					},
+				],
+			},
+		}));
+
+		const { data, error } = await neon.branches.create("p-1", {
+			name: "feature",
+		});
+
+		expect(error).toBeUndefined();
+		expect(data?.endpoints?.map((endpoint) => endpoint.id)).toEqual([
+			"ep-rw",
+			"ep-ro",
+		]);
+		expect(data?.endpoint?.id).toBe("ep-rw");
+		expect(data?.connectionUris).toHaveLength(2);
+		expect(data?.connectionString).toBe(
+			"postgresql://a@ep-a-pooler/neondb",
+		);
 	});
 });
 

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -14,10 +14,11 @@ import type {
 	BranchCreateRequest,
 	BranchSchemaCompareResponse,
 	BranchUpdateRequest,
+	CreateProjectBranchResponse,
 	Endpoint,
 	ListProjectBranchesData,
 } from "../../client/types.gen.js";
-import { withConnectionString } from "../connection.js";
+import { pickConnectionString, withConnectionString } from "../connection.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { NeonError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
@@ -58,6 +59,27 @@ export interface BranchConnection {
 	branch: Branch;
 	endpoint: Endpoint;
 	connectionString: string;
+}
+
+/**
+ * `create` result. `endpoint` and `connectionString` are absent when `noCompute` is
+ * true, or when the API omitted a URI (multiple roles/databases).
+ */
+export interface BranchCreateResult {
+	branch: Branch;
+	endpoint?: Endpoint;
+	connectionString?: string;
+}
+
+function mapCreatedBranch(
+	data: CreateProjectBranchResponse,
+	pooled: boolean,
+): BranchCreateResult {
+	return {
+		branch: data.branch,
+		endpoint: data.endpoints?.[0],
+		connectionString: pickConnectionString(data.connection_uris, pooled),
+	};
 }
 
 const NO_COMPUTE_WITH_COMPUTE = "Pass compute settings or noCompute, not both.";
@@ -139,32 +161,34 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/**
-	 * This method retains its branch-only result even when it provisions compute;
-	 * use {@link Branches.createAndConnect} or `postgres.connectionString` when a
-	 * connection string is needed.
+	 * Create a branch. Posts a read-write endpoint unless `noCompute: true`.
+	 * The create response already carries that endpoint and (when present) a
+	 * pooled connection URI; those stay on the result as optional fields.
 	 *
-	 * Readiness polling stays on for `noCompute` branches because a
-	 * compute-less branch still has provisioning operations.
+	 * {@link Branches.createAndConnect} is the same create plus a required URI —
+	 * it errors when the response has none. Readiness polling stays on for
+	 * `noCompute` branches because a compute-less branch still has provisioning
+	 * operations.
 	 */
 	create(
 		projectId: string,
 		input?: CreateInput,
-	): Promise<Outcome<Branch, DThrow>>;
+	): Promise<Outcome<BranchCreateResult, DThrow>>;
 	create<Throw extends boolean = DThrow>(
 		projectId: string,
 		input: CreateInput | undefined,
 		opts: CallOptions<Throw>,
-	): Promise<Outcome<Branch, Throw>>;
+	): Promise<Outcome<BranchCreateResult, Throw>>;
 	async create(
 		projectId: string,
 		input?: CreateInput,
 		opts?: CallOptions,
-	): Promise<Branch | NeonResult<Branch>> {
+	): Promise<BranchCreateResult | NeonResult<BranchCreateResult>> {
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const parsed = parseCreateInput(input);
 		if (parsed.error) {
-			return finalize(err<Branch>(parsed.error), shouldThrow);
+			return finalize(err<BranchCreateResult>(parsed.error), shouldThrow);
 		}
 		return this.#ctx.run(
 			{
@@ -188,7 +212,7 @@ export class Branches<DThrow extends boolean> {
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.branch,
+			(data) => mapCreatedBranch(data, true),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -14,6 +14,7 @@ import type {
 	BranchCreateRequest,
 	BranchSchemaCompareResponse,
 	BranchUpdateRequest,
+	ConnectionDetails,
 	CreateProjectBranchResponse,
 	Endpoint,
 	ListProjectBranchesData,
@@ -62,12 +63,14 @@ export interface BranchConnection {
 }
 
 /**
- * `create` result. `endpoint` and `connectionString` are absent when `noCompute` is
- * true, or when the API omitted a URI (multiple roles/databases).
+ * `create` result. `endpoint` is `endpoints[0]`; `connectionString` is the pooled
+ * form of `connectionUris[0]`.
  */
 export interface BranchCreateResult {
 	branch: Branch;
+	endpoints?: Endpoint[];
 	endpoint?: Endpoint;
+	connectionUris?: ConnectionDetails[];
 	connectionString?: string;
 }
 
@@ -75,10 +78,14 @@ function mapCreatedBranch(
 	data: CreateProjectBranchResponse,
 	pooled: boolean,
 ): BranchCreateResult {
+	const endpoints = data.endpoints;
+	const connectionUris = data.connection_uris;
 	return {
 		branch: data.branch,
-		endpoint: data.endpoints?.[0],
-		connectionString: pickConnectionString(data.connection_uris, pooled),
+		endpoints,
+		endpoint: endpoints?.[0],
+		connectionUris,
+		connectionString: pickConnectionString(connectionUris, pooled),
 	};
 }
 

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -160,7 +160,7 @@ export const createBranchTool = (options: ToolClientOptions) =>
 			id: publishedId("branches.create"),
 			title: "Create branch",
 			description:
-				"Create a branch with a read-write endpoint by default. Pass no_compute to skip the endpoint. The call waits until operation-backed provisioning finishes, up to five minutes by default. Does not return a connection string; use branches.createAndConnect or postgres.connectionString for that.",
+				"Create a branch with a read-write endpoint by default. Pass no_compute to skip the endpoint. The call waits until operation-backed provisioning finishes, up to five minutes by default. Returns branch plus optional endpoint and pooled connectionString when a compute is created. Use branches.createAndConnect when a URI is required.",
 			inputSchema: createBranchInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -160,7 +160,7 @@ export const createBranchTool = (options: ToolClientOptions) =>
 			id: publishedId("branches.create"),
 			title: "Create branch",
 			description:
-				"Create a branch with a read-write endpoint by default. Pass no_compute to skip the endpoint. The call waits until operation-backed provisioning finishes, up to five minutes by default. Returns branch plus optional endpoint and pooled connectionString when a compute is created. Use branches.createAndConnect when a URI is required.",
+				"Create a branch with a read-write endpoint by default. Pass no_compute to skip the endpoint. The call waits until operation-backed provisioning finishes, up to five minutes by default. Returns branch plus optional endpoints, connectionUris, first endpoint, and pooled connectionString when a compute is created. Use branches.createAndConnect when a URI is required.",
 			inputSchema: createBranchInputSchema,
 			annotations: writeAnnotations,
 			requiresApproval: true,

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -68,7 +68,7 @@ const createBranchTools = (options: NeonToolsClientOptions = {}) => {
 };
 
 describe("branches.create", () => {
-	test("posts a read-write endpoint and returns the branch without a connection string", async () => {
+	test("posts a read-write endpoint and returns the branch, endpoint, and pooled URI", async () => {
 		const { requests, tools } = createBranchOnlyTools();
 
 		const result = await tools["branches.create"].execute({
@@ -95,9 +95,13 @@ describe("branches.create", () => {
 			],
 		});
 		expect(result).toEqual({
-			data: { id: "br-id", name: "feature-x" },
+			data: {
+				branch: { id: "br-id", name: "feature-x" },
+				endpoint: { id: "ep-id", type: "read_write" },
+				connectionString:
+					"postgresql://user:pass@ep-pooler-host/neondb",
+			},
 		});
-		expect(result.data).not.toHaveProperty("connectionString");
 	});
 
 	test("omits endpoints when no_compute is true", async () => {

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -97,7 +97,17 @@ describe("branches.create", () => {
 		expect(result).toEqual({
 			data: {
 				branch: { id: "br-id", name: "feature-x" },
+				endpoints: [{ id: "ep-id", type: "read_write" }],
 				endpoint: { id: "ep-id", type: "read_write" },
+				connectionUris: [
+					{
+						connection_uri: "postgresql://user:pass@ep-host/neondb",
+						connection_parameters: {
+							host: "ep-host",
+							pooler_host: "ep-pooler-host",
+						},
+					},
+				],
 				connectionString:
 					"postgresql://user:pass@ep-pooler-host/neondb",
 			},


### PR DESCRIPTION
## Problem

`neon.branches.create` returned only the `Branch`. The Neon API's create-branch response already includes the endpoints it provisioned and connection URIs, but the SDK dropped both. Anyone who wanted a host or connection string after creating a branch had to make a second round trip via `endpoints.listByBranch` plus `postgres.connectionString`, or switch to `createAndConnect`, which errors when no URI comes back.

## Diagnosis

The create response mapper picked `branch` off the API payload and discarded `endpoints` and `connection_uris`. `createAndConnect` had its own mapping that read those fields, so the data was available — it just wasn't surfaced through the plain `create` path.

## Interface

Before:

```ts
const { data, error } = await neon.branches.create(projectId, { name: "preview" });
data; // Branch
// host/URI required endpoints.listByBranch + postgres.connectionString, or createAndConnect
```

After:

```ts
const { data, error } = await neon.branches.create(projectId, { name: "preview" });
data?.branch;
data?.endpoints; // all endpoints the API returned
data?.endpoint; // endpoints[0]
data?.connectionUris; // all URIs the API returned
data?.connectionString; // pooled form of connectionUris[0]; undefined if none

const connected = await neon.branches.createAndConnect(projectId, { name: "preview" });
// still { branch, endpoint, connectionString }; client error if no URI
```

- `createAndConnect` contract is unchanged.
- No `pooled?` option on `create` — `connectionString` is the pooled form of the first URI.
- `BranchCreateResult` is exported from `@neon/sdk`.

## Also in here

- `@neon/tools` `branches.create` returns the same shape.
- E2e tests updated to read `.branch.id` instead of `.id`.
- Major changeset for `@neon/sdk` and `@neon/tools`.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 144 passed (includes new `create` / `createAndConnect` tests)
- `pnpm --filter @neon/sdk test:types` — 16 passed
- `pnpm --filter @neon/sdk build`
- `pnpm --filter @neon/tools exec vitest run src/workflows.test.ts` — 19 passed
- Live e2e not run; files were updated so they compile against the new shape.

## For your attention

- Breaking: callers reading `data.id` after `create` must move to `data.branch.id`.
- `connectionString` is `undefined` rather than an error when the API omits a URI. `createAndConnect` remains the strict variant.
- The `pooled?` option was left off `create`. Extra endpoints and URIs stay on `endpoints` and `connectionUris`.