### PR TITLE
Accept camelCase create and update inputs on the ergonomic SDK

### DIFF
--- a/.changeset/sdk-camelcase-create-inputs.md
+++ b/.changeset/sdk-camelcase-create-inputs.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": major
+---
+
+Create and update inputs for endpoints, projects (including createAndConnect), databases, roles, buckets, and credentials are camelCase. Autoscaling and suspend fields on endpoints live under `compute`. Request bodies and returned resource objects are unchanged.

--- a/.changeset/sdk-camelcase-create-inputs.md
+++ b/.changeset/sdk-camelcase-create-inputs.md
@@ -2,4 +2,4 @@
 "@neon/sdk": major
 ---
 
-Create and update inputs for endpoints, projects (including createAndConnect), databases, roles, buckets, and credentials are camelCase. Autoscaling and suspend fields on endpoints live under `compute`. Request bodies and returned resource objects are unchanged.
+Create and update inputs for endpoints, projects (including createAndConnect), databases, roles, buckets, and credentials are camelCase. Returned resource objects keep the API's field names (`branch_id`, `owner_name`). Autoscaling and suspend fields on endpoints live under `compute`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -195,7 +195,7 @@ Neon mutations are asynchronous (they return `operations`). `waitForReadiness` b
 
 ## API reference
 
-Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take an optional trailing `options` arg and resolve to the resource (or `{ data, error }`). Create/update inputs for projects, endpoints, databases, roles, buckets, and credentials are camelCase; returned resource objects keep API field names (`endpoint.branch_id`, `database.owner_name`).
+Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take an optional trailing `options` arg and resolve to the resource (or `{ data, error }`). Create/update inputs for projects, endpoints, databases, roles, buckets, and credentials are camelCase. Returned resource objects keep API field names forever (`endpoint.branch_id`, `database.owner_name`); do not spread a resource into an update input.
 
 ### `neon.projects`
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -195,7 +195,7 @@ Neon mutations are asynchronous (they return `operations`). `waitForReadiness` b
 
 ## API reference
 
-Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take an optional trailing `options` arg and resolve to the resource (or `{ data, error }`).
+Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take an optional trailing `options` arg and resolve to the resource (or `{ data, error }`). Create/update inputs for projects, endpoints, databases, roles, buckets, and credentials are camelCase; returned resource objects keep API field names (`endpoint.branch_id`, `database.owner_name`).
 
 ### `neon.projects`
 
@@ -203,9 +203,9 @@ Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→
 | --- | --- | --- |
 | `list(query?)` | **[P]** `ProjectListItem` | `query`: `{ search?, org_id?, limit? }` (cursor managed for you) |
 | `get(id)` | `Project` | |
-| `create(input?)` | `Project` | API always provisions default-branch compute. No connection string. Readiness polling on by default. `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
+| `create(input?)` | `Project` | API always provisions default-branch compute. No connection string. Readiness polling on by default. `input`: `{ name?, regionId?, pgVersion?, orgId?, compute?: { minCu?, maxCu? }, settings? }` |
 | `createAndConnect(input?, { pooled? })` | **[W]** `{ project, connectionString }` | one call + readiness; `pooled` default `true` |
-| `update(id, input)` | `Project` | `input`: `{ name?, settings? }` |
+| `update(id, input)` | `Project` | `input`: `{ name?, settings?, defaultEndpointSettings?, historyRetentionSeconds? }` |
 | `delete(id)` | `Project` | |
 | `transfer({ fromOrgId?, toOrgId, projectIds })` | **→void** | `fromOrgId` defaults to client `orgId` |
 | `transferFromUser({ toOrgId, projectIds })` | **→void** | personal account → org |
@@ -213,7 +213,7 @@ Legend: **[P]** returns `Paginated<T>` · **[W]** workflow (multi-step) · **→
 ```ts
 // Provision a project and get a pooled connection string in one call
 const { data } = await neon.projects.createAndConnect(
-  { name: "tenant-42", region_id: "aws-us-east-1" },
+  { name: "tenant-42", regionId: "aws-us-east-1" },
   { pooled: true },
 );
 // data: { project, connectionString }
@@ -307,7 +307,7 @@ const { data: uri } = await neon.postgres.connectionString({
 | --- | --- |
 | `list(projectId)` | `Endpoint[]` |
 | `get(projectId, endpointId)` | `Endpoint` |
-| `create(projectId, input)` | `Endpoint` — `input`: `{ branch_id, type, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, suspend_timeout_seconds?, provisioner? }` |
+| `create(projectId, input)` | `Endpoint` — `input`: `{ branchId, type, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, provisioner? }` |
 | `update(projectId, endpointId, input)` | `Endpoint` |
 | `delete(projectId, endpointId)` | **→void** |
 | `start` / `suspend` / `restart(projectId, endpointId)` | `Endpoint` |
@@ -318,7 +318,7 @@ const { data: uri } = await neon.postgres.connectionString({
 | --- | --- |
 | `list(projectId, branchId)` | `Role[]` |
 | `get(projectId, branchId, name)` | `Role` |
-| `create(projectId, branchId, { name, no_login? })` | `Role` |
+| `create(projectId, branchId, { name, noLogin? })` | `Role` |
 | `delete(projectId, branchId, name)` | **→void** |
 | `password(projectId, branchId, name)` | `string` (reveals the password) |
 | `resetPassword(projectId, branchId, name)` | `Role` (carries the new password) |
@@ -336,8 +336,8 @@ const { data: role } = await neon.postgres.roles.resetPassword(projectId, branch
 | --- | --- |
 | `list(projectId, branchId)` | `Database[]` |
 | `get(projectId, branchId, name)` | `Database` |
-| `create(projectId, branchId, { name, owner_name })` | `Database` |
-| `update(projectId, branchId, name, { name?, owner_name? })` | `Database` |
+| `create(projectId, branchId, { name, ownerName })` | `Database` |
+| `update(projectId, branchId, name, { name?, ownerName? })` | `Database` |
 | `delete(projectId, branchId, name)` | **→void** |
 
 #### `neon.postgres.dataApi`
@@ -365,7 +365,7 @@ enabled and the branch S3 endpoint metadata; buckets and objects are nested unde
 | Method | Returns |
 | --- | --- |
 | `list(projectId, branchId)` | `Bucket[]` |
-| `create(projectId, branchId, { name, access_level? })` | `Bucket` — `access_level`: `"private"` \| `"public_read"` |
+| `create(projectId, branchId, { name, accessLevel? })` | `Bucket` — `accessLevel`: `"private"` \| `"public_read"` |
 | `delete(projectId, branchId, bucketName)` | **→void** |
 
 #### `neon.storage.objects`
@@ -445,7 +445,7 @@ are returned **once** on `create`.
 | Method | Returns | Notes |
 | --- | --- | --- |
 | `list(projectId, branchId)` | `CredentialMeta[]` | |
-| `create(projectId, branchId, input)` | `CreateCredentialResponse` | `input`: `{ name?, scopes, principal_type: "user" }` — scopes: `storage:read`, `storage:write`, `ai_gateway:invoke`, `functions:invoke` |
+| `create(projectId, branchId, input)` | `CreateCredentialResponse` | `input`: `{ name?, scopes }` — scopes: `storage:read`, `storage:write`, `ai_gateway:invoke`, `functions:invoke`. `principal_type` is always `user`. |
 | `revoke(projectId, branchId, tokenId)` | **→void** | |
 
 ### `neon.aiGateway`

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -99,7 +99,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			await neon.postgres.databases.create(
 				projectId,
 				branchId,
-				{ name: "child_only", owner_name: owner.name },
+				{ name: "child_only", ownerName: owner.name },
 				{ waitForReadiness: true },
 			),
 		);
@@ -270,7 +270,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			await neon.postgres.databases.create(
 				projectId,
 				defaultBranchId,
-				{ name: "e2e_db", owner_name: owner.name },
+				{ name: "e2e_db", ownerName: owner.name },
 				{ waitForReadiness: true },
 			),
 		);

--- a/packages/sdk/e2e/workflows.e2e.test.ts
+++ b/packages/sdk/e2e/workflows.e2e.test.ts
@@ -25,7 +25,7 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			const created = expectOk(
 				await neon.projects.createAndConnect({
 					name: uniqueProjectName("sdk"),
-					region_id: DEFAULT_REGION,
+					regionId: DEFAULT_REGION,
 				}),
 			);
 			track(created.project.id);
@@ -54,7 +54,7 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			const project = expectOk(
 				await neon.projects.create({
 					name: uniqueProjectName("sdk-org"),
-					region_id: DEFAULT_REGION,
+					regionId: DEFAULT_REGION,
 				}),
 			);
 			track(project.id);
@@ -75,7 +75,7 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			const project = expectOk(
 				await neon.projects.create({
 					name: uniqueProjectName("sdk-page"),
-					region_id: DEFAULT_REGION,
+					regionId: DEFAULT_REGION,
 				}),
 			);
 			track(project.id);
@@ -121,7 +121,7 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			const project = expectOk(
 				await neon.projects.create({
 					name: uniqueProjectName("sdk-conn"),
-					region_id: DEFAULT_REGION,
+					regionId: DEFAULT_REGION,
 				}),
 			);
 			track(project.id);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -44,6 +44,16 @@ export type {
 	CreateAndConnectInput,
 	ResetFromParentInput,
 } from "./neon/resources/branches.js";
+export type { BucketCreateInput } from "./neon/resources/buckets.js";
+export type { CredentialCreateInput } from "./neon/resources/credentials.js";
+export type {
+	DatabaseCreateInput,
+	DatabaseUpdateInput,
+} from "./neon/resources/databases.js";
+export type {
+	EndpointCreateInput,
+	EndpointUpdateInput,
+} from "./neon/resources/endpoints.js";
 export type {
 	LogFieldValuesQuery,
 	LogQueryInput,
@@ -51,10 +61,13 @@ export type {
 export type { ConnectionStringParams } from "./neon/resources/postgres.js";
 export type {
 	ProjectConnection,
+	ProjectCreateInput,
+	ProjectUpdateInput,
 	RemoveRoleOptions,
 	SetRoleOptions,
 	TransferProjectsInput,
 } from "./neon/resources/projects.js";
+export type { RoleCreateInput } from "./neon/resources/roles.js";
 export type {
 	BackupScheduleItemInput,
 	CreateSnapshotInput,

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -14,6 +14,7 @@ import type {
 import { createNeonClient } from "./client.js";
 import type { Paginated } from "./paginate.js";
 import type { BranchConnection } from "./resources/branches.js";
+import type { EndpointCreateInput } from "./resources/endpoints.js";
 import type { ProjectConnection } from "./resources/projects.js";
 import type { NeonResult } from "./result.js";
 
@@ -137,6 +138,26 @@ it("postgres namespace + tier-2/3 resources are reachable and typed", () => {
 	expectTypeOf(neon.postgres.endpoints.list("p")).resolves.toEqualTypeOf<
 		NeonResult<Endpoint[]>
 	>();
+	expectTypeOf(
+		neon.postgres.endpoints.create("p", {
+			branchId: "br",
+			type: "read_write",
+			compute: { minCu: 0.25 },
+		}),
+	).resolves.toEqualTypeOf<NeonResult<Endpoint>>();
+	neon.postgres.endpoints.create("p", {
+		// @ts-expect-error generated snake_case is not an input field
+		branch_id: "br",
+		type: "read_write",
+	});
+	expectTypeOf<EndpointCreateInput>().not.toHaveProperty("branch_id");
+	expectTypeOf(
+		neon.projects.create({ regionId: "aws-us-east-1" }),
+	).resolves.toEqualTypeOf<NeonResult<Project>>();
+	neon.projects.create({
+		// @ts-expect-error generated snake_case is not an input field
+		region_id: "aws-us-east-1",
+	});
 	expectTypeOf(
 		neon.postgres.roles.password("p", "br", "neondb_owner"),
 	).resolves.toEqualTypeOf<NeonResult<string>>();

--- a/packages/sdk/src/neon/resources/buckets.ts
+++ b/packages/sdk/src/neon/resources/buckets.ts
@@ -3,15 +3,23 @@ import {
 	deleteProjectBranchBucket,
 	listProjectBranchBuckets,
 } from "../../client/sdk.gen.js";
-import type {
-	Bucket,
-	BucketAccessLevel,
-	BucketCreateRequest,
-} from "../../client/types.gen.js";
+import type { Bucket, BucketAccessLevel } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import type { NeonResult, Outcome } from "../result.js";
 
-type CreateInput = BucketCreateRequest;
+export interface BucketCreateInput {
+	name: string;
+	accessLevel?: BucketAccessLevel;
+}
+
+function mapBucketCreate(input: BucketCreateInput) {
+	return {
+		name: input.name,
+		...(input.accessLevel !== undefined
+			? { access_level: input.accessLevel }
+			: {}),
+	};
+}
 
 /** Branch-scoped object-storage buckets. */
 export class Buckets<DThrow extends boolean> {
@@ -53,18 +61,18 @@ export class Buckets<DThrow extends boolean> {
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: BucketCreateInput,
 	): Promise<Outcome<Bucket, DThrow>>;
 	create<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: BucketCreateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Bucket, Throw>>;
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: BucketCreateInput,
 		opts?: CallOptions,
 	): Promise<Bucket | NeonResult<Bucket>> {
 		return this.#ctx.run(
@@ -73,7 +81,7 @@ export class Buckets<DThrow extends boolean> {
 				createProjectBranchBucket({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					body: input,
+					body: mapBucketCreate(input),
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/sdk/src/neon/resources/camelcase-inputs.test.ts
+++ b/packages/sdk/src/neon/resources/camelcase-inputs.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "../client.js";
+
+function neonRouting(
+	respond: (request: { url: string; method: string; body: unknown }) => {
+		status: number;
+		body: unknown;
+	},
+) {
+	const calls: Array<{ url: string; method: string; body: unknown }> = [];
+	const neon = createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		fetch: async (input, init) => {
+			const request = input instanceof Request ? input : undefined;
+			const url = request ? request.url : String(input);
+			const method = (
+				request?.method ??
+				init?.method ??
+				"GET"
+			).toUpperCase();
+			const raw = request ? await request.clone().text() : init?.body;
+			const call = {
+				url,
+				method,
+				body:
+					typeof raw === "string" && raw.length > 0
+						? JSON.parse(raw)
+						: raw,
+			};
+			calls.push(call);
+			const { status, body } = respond(call);
+			return new Response(JSON.stringify(body), {
+				status,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+	return { neon, calls };
+}
+
+describe("camelCase create/update inputs", () => {
+	it("maps endpoints.create to snake_case and groups compute", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { endpoint: { id: "ep-1", branch_id: "br-1" } },
+		}));
+
+		const { data, error } = await neon.postgres.endpoints.create("p-1", {
+			branchId: "br-1",
+			type: "read_write",
+			regionId: "aws-us-west-2",
+			compute: { minCu: 0.25, maxCu: 2, suspendTimeoutSeconds: 300 },
+			poolerEnabled: true,
+			passwordlessAccess: false,
+		});
+
+		expect(error).toBeUndefined();
+		expect(data?.branch_id).toBe("br-1");
+		expect(calls[0]?.body).toEqual({
+			endpoint: {
+				branch_id: "br-1",
+				type: "read_write",
+				region_id: "aws-us-west-2",
+				autoscaling_limit_min_cu: 0.25,
+				autoscaling_limit_max_cu: 2,
+				suspend_timeout_seconds: 300,
+				pooler_enabled: true,
+				passwordless_access: false,
+			},
+		});
+	});
+
+	it("maps endpoints.update compute fields", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { endpoint: { id: "ep-1" } },
+		}));
+
+		await neon.postgres.endpoints.update("p-1", "ep-1", {
+			compute: { minCu: 1 },
+		});
+
+		expect(calls[0]?.body).toEqual({
+			endpoint: { autoscaling_limit_min_cu: 1 },
+		});
+	});
+
+	it("maps projects.create including orgId override and compute", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { project: { id: "p-1" } },
+		}));
+
+		await neon.projects.create({
+			name: "app",
+			regionId: "aws-us-east-1",
+			pgVersion: 17,
+			orgId: "org-explicit",
+			compute: { minCu: 0.25, maxCu: 1 },
+			branch: { roleName: "app_owner", databaseName: "app" },
+			storePasswords: true,
+			historyRetentionSeconds: 86400,
+		});
+
+		expect(calls[0]?.body).toEqual({
+			project: {
+				name: "app",
+				region_id: "aws-us-east-1",
+				pg_version: 17,
+				org_id: "org-explicit",
+				autoscaling_limit_min_cu: 0.25,
+				autoscaling_limit_max_cu: 1,
+				branch: { role_name: "app_owner", database_name: "app" },
+				store_passwords: true,
+				history_retention_seconds: 86400,
+			},
+		});
+	});
+
+	it("injects the client orgId when projects.create omits orgId", async () => {
+		const calls: unknown[] = [];
+		const neon = createNeonClient({
+			apiKey: "test",
+			orgId: "org-default",
+			retries: 0,
+			fetch: async (input, init) => {
+				const request = input instanceof Request ? input : undefined;
+				const raw = request ? await request.clone().text() : init?.body;
+				calls.push(
+					typeof raw === "string" && raw.length > 0
+						? JSON.parse(raw)
+						: raw,
+				);
+				return new Response(
+					JSON.stringify({ project: { id: "p-1" } }),
+					{
+						status: 201,
+						headers: { "content-type": "application/json" },
+					},
+				);
+			},
+		});
+
+		await neon.projects.create({ name: "app" });
+
+		expect(calls[0]).toEqual({
+			project: { name: "app", org_id: "org-default" },
+		});
+	});
+
+	it("maps projects.update defaultEndpointSettings", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { project: { id: "p-1" } },
+		}));
+
+		await neon.projects.update("p-1", {
+			name: "renamed",
+			historyRetentionSeconds: 3600,
+			defaultEndpointSettings: { suspend_timeout_seconds: 60 },
+		});
+
+		expect(calls[0]?.body).toEqual({
+			project: {
+				name: "renamed",
+				history_retention_seconds: 3600,
+				default_endpoint_settings: { suspend_timeout_seconds: 60 },
+			},
+		});
+	});
+
+	it("maps databases.create ownerName", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { database: { name: "app", owner_name: "app_owner" } },
+		}));
+
+		await neon.postgres.databases.create("p-1", "br-1", {
+			name: "app",
+			ownerName: "app_owner",
+		});
+
+		expect(calls[0]?.body).toEqual({
+			database: { name: "app", owner_name: "app_owner" },
+		});
+	});
+
+	it("maps roles.create noLogin", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { role: { name: "reader" } },
+		}));
+
+		await neon.postgres.roles.create("p-1", "br-1", {
+			name: "reader",
+			noLogin: true,
+		});
+
+		expect(calls[0]?.body).toEqual({
+			role: { name: "reader", no_login: true },
+		});
+	});
+
+	it("maps buckets.create accessLevel", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { bucket: { name: "assets" } },
+		}));
+
+		await neon.storage.buckets.create("p-1", "br-1", {
+			name: "assets",
+			accessLevel: "public_read",
+		});
+
+		expect(calls[0]?.body).toEqual({
+			name: "assets",
+			access_level: "public_read",
+		});
+	});
+
+	it("injects principal_type on credentials.create", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 201,
+			body: { token_id: "tok", api_token: "secret" },
+		}));
+
+		await neon.credentials.create("p-1", "br-1", {
+			name: "gateway",
+			scopes: ["ai_gateway:invoke"],
+		});
+
+		expect(calls[0]?.body).toEqual({
+			name: "gateway",
+			scopes: ["ai_gateway:invoke"],
+			principal_type: "user",
+		});
+	});
+});

--- a/packages/sdk/src/neon/resources/credentials.ts
+++ b/packages/sdk/src/neon/resources/credentials.ts
@@ -60,7 +60,11 @@ export class Credentials<DThrow extends boolean> {
 		);
 	}
 
-	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/credentials */
+	/**
+	 * The API only issues customer credentials as `principal_type: "user"`.
+	 *
+	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/credentials
+	 */
 	create(
 		projectId: string,
 		branchId: string,

--- a/packages/sdk/src/neon/resources/credentials.ts
+++ b/packages/sdk/src/neon/resources/credentials.ts
@@ -4,14 +4,25 @@ import {
 	revokeCredential,
 } from "../../client/sdk.gen.js";
 import type {
-	CreateCredentialRequest,
 	CreateCredentialResponse,
 	CredentialMeta,
+	CredentialScope,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import type { NeonResult, Outcome } from "../result.js";
 
-type CreateInput = CreateCredentialRequest;
+export interface CredentialCreateInput {
+	name?: string;
+	scopes: Array<CredentialScope>;
+}
+
+function mapCredentialCreate(input: CredentialCreateInput) {
+	return {
+		...(input.name !== undefined ? { name: input.name } : {}),
+		scopes: input.scopes,
+		principal_type: "user" as const,
+	};
+}
 
 /** Branch-scoped scoped credentials. */
 export class Credentials<DThrow extends boolean> {
@@ -53,18 +64,18 @@ export class Credentials<DThrow extends boolean> {
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: CredentialCreateInput,
 	): Promise<Outcome<CreateCredentialResponse, DThrow>>;
 	create<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: CredentialCreateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<CreateCredentialResponse, Throw>>;
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: CredentialCreateInput,
 		opts?: CallOptions,
 	): Promise<
 		CreateCredentialResponse | NeonResult<CreateCredentialResponse>
@@ -75,7 +86,7 @@ export class Credentials<DThrow extends boolean> {
 				createCredential({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					body: input,
+					body: mapCredentialCreate(input),
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/sdk/src/neon/resources/databases.ts
+++ b/packages/sdk/src/neon/resources/databases.ts
@@ -5,16 +5,32 @@ import {
 	listProjectBranchDatabases,
 	updateProjectBranchDatabase,
 } from "../../client/sdk.gen.js";
-import type {
-	Database,
-	DatabaseCreateRequest,
-	DatabaseUpdateRequest,
-} from "../../client/types.gen.js";
+import type { Database } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import type { NeonResult, Outcome } from "../result.js";
 
-type CreateInput = DatabaseCreateRequest["database"];
-type UpdateInput = DatabaseUpdateRequest["database"];
+export interface DatabaseCreateInput {
+	name: string;
+	ownerName: string;
+}
+
+export interface DatabaseUpdateInput {
+	name?: string;
+	ownerName?: string;
+}
+
+function mapDatabaseCreate(input: DatabaseCreateInput) {
+	return { name: input.name, owner_name: input.ownerName };
+}
+
+function mapDatabaseUpdate(input: DatabaseUpdateInput) {
+	return {
+		...(input.name !== undefined ? { name: input.name } : {}),
+		...(input.ownerName !== undefined
+			? { owner_name: input.ownerName }
+			: {}),
+	};
+}
 
 /** Database resource (branch-scoped). */
 export class Databases<DThrow extends boolean> {
@@ -91,18 +107,18 @@ export class Databases<DThrow extends boolean> {
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: DatabaseCreateInput,
 	): Promise<Outcome<Database, DThrow>>;
 	create<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: DatabaseCreateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Database, Throw>>;
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: DatabaseCreateInput,
 		opts?: CallOptions,
 	): Promise<Database | NeonResult<Database>> {
 		return this.#ctx.run(
@@ -111,7 +127,7 @@ export class Databases<DThrow extends boolean> {
 				createProjectBranchDatabase({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					body: { database: input },
+					body: { database: mapDatabaseCreate(input) },
 					throwOnError: false,
 					signal,
 				}),
@@ -124,20 +140,20 @@ export class Databases<DThrow extends boolean> {
 		projectId: string,
 		branchId: string,
 		name: string,
-		input: UpdateInput,
+		input: DatabaseUpdateInput,
 	): Promise<Outcome<Database, DThrow>>;
 	update<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
 		name: string,
-		input: UpdateInput,
+		input: DatabaseUpdateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Database, Throw>>;
 	update(
 		projectId: string,
 		branchId: string,
 		name: string,
-		input: UpdateInput,
+		input: DatabaseUpdateInput,
 		opts?: CallOptions,
 	): Promise<Database | NeonResult<Database>> {
 		return this.#ctx.run(
@@ -150,7 +166,7 @@ export class Databases<DThrow extends boolean> {
 						branch_id: branchId,
 						database_name: name,
 					},
-					body: { database: input },
+					body: { database: mapDatabaseUpdate(input) },
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/sdk/src/neon/resources/endpoints.ts
+++ b/packages/sdk/src/neon/resources/endpoints.ts
@@ -11,14 +11,102 @@ import {
 } from "../../client/sdk.gen.js";
 import type {
 	Endpoint,
-	EndpointCreateRequest,
-	EndpointUpdateRequest,
+	EndpointPoolerMode,
+	EndpointSettingsData,
+	EndpointType,
+	Provisioner,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import type { NeonResult, Outcome } from "../result.js";
+import type { ComputeSettings } from "./branches.js";
 
-type CreateInput = EndpointCreateRequest["endpoint"];
-type UpdateInput = EndpointUpdateRequest["endpoint"];
+export interface EndpointCreateInput {
+	branchId: string;
+	type: EndpointType;
+	name?: string;
+	regionId?: string;
+	compute?: ComputeSettings;
+	provisioner?: Provisioner;
+	settings?: EndpointSettingsData;
+	poolerEnabled?: boolean;
+	poolerMode?: EndpointPoolerMode;
+	disabled?: boolean;
+	passwordlessAccess?: boolean;
+}
+
+export interface EndpointUpdateInput {
+	branchId?: string;
+	name?: string;
+	compute?: ComputeSettings;
+	provisioner?: Provisioner;
+	settings?: EndpointSettingsData;
+	poolerEnabled?: boolean;
+	poolerMode?: EndpointPoolerMode;
+	disabled?: boolean;
+	passwordlessAccess?: boolean;
+}
+
+function mapEndpointCreate(input: EndpointCreateInput) {
+	return {
+		branch_id: input.branchId,
+		type: input.type,
+		...(input.name !== undefined ? { name: input.name } : {}),
+		...(input.regionId !== undefined ? { region_id: input.regionId } : {}),
+		...(input.compute?.minCu !== undefined
+			? { autoscaling_limit_min_cu: input.compute.minCu }
+			: {}),
+		...(input.compute?.maxCu !== undefined
+			? { autoscaling_limit_max_cu: input.compute.maxCu }
+			: {}),
+		...(input.compute?.suspendTimeoutSeconds !== undefined
+			? { suspend_timeout_seconds: input.compute.suspendTimeoutSeconds }
+			: {}),
+		...(input.provisioner !== undefined
+			? { provisioner: input.provisioner }
+			: {}),
+		...(input.settings !== undefined ? { settings: input.settings } : {}),
+		...(input.poolerEnabled !== undefined
+			? { pooler_enabled: input.poolerEnabled }
+			: {}),
+		...(input.poolerMode !== undefined
+			? { pooler_mode: input.poolerMode }
+			: {}),
+		...(input.disabled !== undefined ? { disabled: input.disabled } : {}),
+		...(input.passwordlessAccess !== undefined
+			? { passwordless_access: input.passwordlessAccess }
+			: {}),
+	};
+}
+
+function mapEndpointUpdate(input: EndpointUpdateInput) {
+	return {
+		...(input.branchId !== undefined ? { branch_id: input.branchId } : {}),
+		...(input.name !== undefined ? { name: input.name } : {}),
+		...(input.compute?.minCu !== undefined
+			? { autoscaling_limit_min_cu: input.compute.minCu }
+			: {}),
+		...(input.compute?.maxCu !== undefined
+			? { autoscaling_limit_max_cu: input.compute.maxCu }
+			: {}),
+		...(input.compute?.suspendTimeoutSeconds !== undefined
+			? { suspend_timeout_seconds: input.compute.suspendTimeoutSeconds }
+			: {}),
+		...(input.provisioner !== undefined
+			? { provisioner: input.provisioner }
+			: {}),
+		...(input.settings !== undefined ? { settings: input.settings } : {}),
+		...(input.poolerEnabled !== undefined
+			? { pooler_enabled: input.poolerEnabled }
+			: {}),
+		...(input.poolerMode !== undefined
+			? { pooler_mode: input.poolerMode }
+			: {}),
+		...(input.disabled !== undefined ? { disabled: input.disabled } : {}),
+		...(input.passwordlessAccess !== undefined
+			? { passwordless_access: input.passwordlessAccess }
+			: {}),
+	};
+}
 
 /** Compute endpoint resource (project-scoped). */
 export class Endpoints<DThrow extends boolean> {
@@ -110,16 +198,16 @@ export class Endpoints<DThrow extends boolean> {
 	/** @apiCall POST /projects/{project_id}/endpoints */
 	create(
 		projectId: string,
-		input: CreateInput,
+		input: EndpointCreateInput,
 	): Promise<Outcome<Endpoint, DThrow>>;
 	create<Throw extends boolean = DThrow>(
 		projectId: string,
-		input: CreateInput,
+		input: EndpointCreateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	create(
 		projectId: string,
-		input: CreateInput,
+		input: EndpointCreateInput,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
@@ -128,7 +216,7 @@ export class Endpoints<DThrow extends boolean> {
 				createProjectEndpoint({
 					client,
 					path: { project_id: projectId },
-					body: { endpoint: input },
+					body: { endpoint: mapEndpointCreate(input) },
 					throwOnError: false,
 					signal,
 				}),
@@ -140,18 +228,18 @@ export class Endpoints<DThrow extends boolean> {
 	update(
 		projectId: string,
 		endpointId: string,
-		input: UpdateInput,
+		input: EndpointUpdateInput,
 	): Promise<Outcome<Endpoint, DThrow>>;
 	update<Throw extends boolean = DThrow>(
 		projectId: string,
 		endpointId: string,
-		input: UpdateInput,
+		input: EndpointUpdateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	update(
 		projectId: string,
 		endpointId: string,
-		input: UpdateInput,
+		input: EndpointUpdateInput,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
 		return this.#ctx.run(
@@ -160,7 +248,7 @@ export class Endpoints<DThrow extends boolean> {
 				updateProjectEndpoint({
 					client,
 					path: { project_id: projectId, endpoint_id: endpointId },
-					body: { endpoint: input },
+					body: { endpoint: mapEndpointUpdate(input) },
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -15,22 +15,26 @@ import {
 	updateProject,
 } from "../../client/sdk.gen.js";
 import type {
+	AnnotationValueData,
+	DefaultEndpointSettings,
 	ListProjectMembersData,
 	ListProjectsData,
+	PgVersion,
 	Project,
-	ProjectCreateRequest,
 	ProjectListItem,
 	ProjectMember,
 	ProjectMemberRoleResponse,
 	ProjectPermission,
 	ProjectRole,
-	ProjectUpdateRequest,
+	ProjectSettingsData,
+	Provisioner,
 } from "../../client/types.gen.js";
 import { withConnectionString } from "../connection.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { NeonError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
 import { err, finalize, type NeonResult, type Outcome } from "../result.js";
+import type { ComputeSettings } from "./branches.js";
 
 /** Input for {@link Projects.transfer} (org → org). */
 export interface TransferProjectsInput {
@@ -42,12 +46,102 @@ export interface TransferProjectsInput {
 }
 
 type ListQuery = Omit<NonNullable<ListProjectsData["query"]>, "cursor">;
-type CreateInput = ProjectCreateRequest["project"];
-type UpdateInput = ProjectUpdateRequest["project"];
 type MemberListQuery = Omit<
 	NonNullable<ListProjectMembersData["query"]>,
 	"cursor"
 >;
+
+export interface ProjectCreateInput {
+	name?: string;
+	regionId?: string;
+	pgVersion?: PgVersion;
+	provisioner?: Provisioner;
+	orgId?: string;
+	compute?: Pick<ComputeSettings, "minCu" | "maxCu">;
+	branch?: {
+		name?: string;
+		roleName?: string;
+		databaseName?: string;
+		annotations?: AnnotationValueData;
+	};
+	defaultEndpointSettings?: DefaultEndpointSettings;
+	settings?: ProjectSettingsData;
+	storePasswords?: boolean;
+	historyRetentionSeconds?: number;
+}
+
+export interface ProjectUpdateInput {
+	name?: string;
+	settings?: ProjectSettingsData;
+	defaultEndpointSettings?: DefaultEndpointSettings;
+	historyRetentionSeconds?: number;
+}
+
+function mapProjectCreate(
+	input: ProjectCreateInput | undefined,
+	defaultOrgId: string | undefined,
+) {
+	const orgId = input?.orgId ?? defaultOrgId;
+	const branch = input?.branch;
+	return {
+		...(input?.name !== undefined ? { name: input.name } : {}),
+		...(input?.settings !== undefined ? { settings: input.settings } : {}),
+		...(branch !== undefined
+			? {
+					branch: {
+						...(branch.name !== undefined
+							? { name: branch.name }
+							: {}),
+						...(branch.roleName !== undefined
+							? { role_name: branch.roleName }
+							: {}),
+						...(branch.databaseName !== undefined
+							? { database_name: branch.databaseName }
+							: {}),
+						...(branch.annotations !== undefined
+							? { annotations: branch.annotations }
+							: {}),
+					},
+				}
+			: {}),
+		...(input?.compute?.minCu !== undefined
+			? { autoscaling_limit_min_cu: input.compute.minCu }
+			: {}),
+		...(input?.compute?.maxCu !== undefined
+			? { autoscaling_limit_max_cu: input.compute.maxCu }
+			: {}),
+		...(input?.provisioner !== undefined
+			? { provisioner: input.provisioner }
+			: {}),
+		...(input?.regionId !== undefined ? { region_id: input.regionId } : {}),
+		...(input?.defaultEndpointSettings !== undefined
+			? { default_endpoint_settings: input.defaultEndpointSettings }
+			: {}),
+		...(input?.pgVersion !== undefined
+			? { pg_version: input.pgVersion }
+			: {}),
+		...(input?.storePasswords !== undefined
+			? { store_passwords: input.storePasswords }
+			: {}),
+		...(input?.historyRetentionSeconds !== undefined
+			? { history_retention_seconds: input.historyRetentionSeconds }
+			: {}),
+		...(orgId !== undefined ? { org_id: orgId } : {}),
+	};
+}
+
+function mapProjectUpdate(input: ProjectUpdateInput) {
+	return {
+		...(input.name !== undefined ? { name: input.name } : {}),
+		...(input.settings !== undefined ? { settings: input.settings } : {}),
+		...(input.defaultEndpointSettings !== undefined
+			? { default_endpoint_settings: input.defaultEndpointSettings }
+			: {}),
+		...(input.historyRetentionSeconds !== undefined
+			? { history_retention_seconds: input.historyRetentionSeconds }
+			: {}),
+	};
+}
 
 /** Per-call options for {@link Members.setRole}. */
 export interface SetRoleOptions<Throw extends boolean = boolean>
@@ -371,13 +465,13 @@ export class Projects<DThrow extends boolean> {
 	 * {@link Projects.createAndConnect} or `postgres.connectionString` when a
 	 * connection string is needed.
 	 */
-	create(input?: CreateInput): Promise<Outcome<Project, DThrow>>;
+	create(input?: ProjectCreateInput): Promise<Outcome<Project, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		input: CreateInput | undefined,
+		input: ProjectCreateInput | undefined,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Project, Throw>>;
 	create(
-		input?: CreateInput,
+		input?: ProjectCreateInput,
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
@@ -389,12 +483,10 @@ export class Projects<DThrow extends boolean> {
 				createProject({
 					client,
 					body: {
-						project: {
-							...(this.#ctx.defaults.orgId
-								? { org_id: this.#ctx.defaults.orgId }
-								: {}),
-							...input,
-						},
+						project: mapProjectCreate(
+							input,
+							this.#ctx.defaults.orgId,
+						),
 					},
 					throwOnError: false,
 					signal,
@@ -411,14 +503,14 @@ export class Projects<DThrow extends boolean> {
 	 * @workflow createProject + waitForReadiness
 	 */
 	createAndConnect(
-		input?: CreateInput,
+		input?: ProjectCreateInput,
 	): Promise<Outcome<ProjectConnection, DThrow>>;
 	createAndConnect<Throw extends boolean = DThrow>(
-		input: CreateInput | undefined,
+		input: ProjectCreateInput | undefined,
 		opts: WorkflowOptions<Throw>,
 	): Promise<Outcome<ProjectConnection, Throw>>;
 	async createAndConnect(
-		input?: CreateInput,
+		input?: ProjectCreateInput,
 		opts?: WorkflowOptions<boolean>,
 	): Promise<ProjectConnection | NeonResult<ProjectConnection>> {
 		const shouldThrow =
@@ -429,12 +521,10 @@ export class Projects<DThrow extends boolean> {
 				createProject({
 					client,
 					body: {
-						project: {
-							...(this.#ctx.defaults.orgId
-								? { org_id: this.#ctx.defaults.orgId }
-								: {}),
-							...input,
-						},
+						project: mapProjectCreate(
+							input,
+							this.#ctx.defaults.orgId,
+						),
 					},
 					throwOnError: false,
 					signal,
@@ -454,15 +544,18 @@ export class Projects<DThrow extends boolean> {
 	}
 
 	/** @apiCall PATCH /projects/{project_id} */
-	update(id: string, input: UpdateInput): Promise<Outcome<Project, DThrow>>;
+	update(
+		id: string,
+		input: ProjectUpdateInput,
+	): Promise<Outcome<Project, DThrow>>;
 	update<Throw extends boolean = DThrow>(
 		id: string,
-		input: UpdateInput,
+		input: ProjectUpdateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Project, Throw>>;
 	update(
 		id: string,
-		input: UpdateInput,
+		input: ProjectUpdateInput,
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
@@ -471,7 +564,7 @@ export class Projects<DThrow extends boolean> {
 				updateProject({
 					client,
 					path: { project_id: id },
-					body: { project: input },
+					body: { project: mapProjectUpdate(input) },
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/sdk/src/neon/resources/roles.ts
+++ b/packages/sdk/src/neon/resources/roles.ts
@@ -6,11 +6,21 @@ import {
 	listProjectBranchRoles,
 	resetProjectBranchRolePassword,
 } from "../../client/sdk.gen.js";
-import type { Role, RoleCreateRequest } from "../../client/types.gen.js";
+import type { Role } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import type { NeonResult, Outcome } from "../result.js";
 
-type CreateInput = RoleCreateRequest["role"];
+export interface RoleCreateInput {
+	name: string;
+	noLogin?: boolean;
+}
+
+function mapRoleCreate(input: RoleCreateInput) {
+	return {
+		name: input.name,
+		...(input.noLogin !== undefined ? { no_login: input.noLogin } : {}),
+	};
+}
 
 /** Role resource (branch-scoped). */
 export class Roles<DThrow extends boolean> {
@@ -84,18 +94,18 @@ export class Roles<DThrow extends boolean> {
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: RoleCreateInput,
 	): Promise<Outcome<Role, DThrow>>;
 	create<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: RoleCreateInput,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Role, Throw>>;
 	create(
 		projectId: string,
 		branchId: string,
-		input: CreateInput,
+		input: RoleCreateInput,
 		opts?: CallOptions,
 	): Promise<Role | NeonResult<Role>> {
 		return this.#ctx.run(
@@ -104,7 +114,7 @@ export class Roles<DThrow extends boolean> {
 				createProjectBranchRole({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					body: { role: input },
+					body: { role: mapRoleCreate(input) },
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -29,6 +29,25 @@ const logReadAnnotations = {
 	openWorldHint: false,
 } as const;
 
+function toComputeSettings(input: {
+	autoscaling_limit_min_cu?: number;
+	autoscaling_limit_max_cu?: number;
+	suspend_timeout_seconds?: number;
+}) {
+	if (
+		input.autoscaling_limit_min_cu === undefined &&
+		input.autoscaling_limit_max_cu === undefined &&
+		input.suspend_timeout_seconds === undefined
+	) {
+		return undefined;
+	}
+	return {
+		minCu: input.autoscaling_limit_min_cu,
+		maxCu: input.autoscaling_limit_max_cu,
+		suspendTimeoutSeconds: input.suspend_timeout_seconds,
+	};
+}
+
 export type ToolFactory = (typeof toolFactories)[NeonToolId];
 
 export const toolFactories = {
@@ -72,9 +91,9 @@ export const toolFactories = {
 					{
 						settings: input.settings,
 						name: input.name,
-						default_endpoint_settings:
+						defaultEndpointSettings:
 							input.default_endpoint_settings,
-						history_retention_seconds:
+						historyRetentionSeconds:
 							input.history_retention_seconds,
 					},
 					{ signal },
@@ -318,20 +337,16 @@ export const toolFactories = {
 				neon.postgres.endpoints.create(
 					input.project_id,
 					{
-						branch_id: input.branch_id,
-						region_id: input.region_id,
+						branchId: input.branch_id,
+						regionId: input.region_id,
 						type: input.type,
 						settings: input.settings,
-						autoscaling_limit_min_cu:
-							input.autoscaling_limit_min_cu,
-						autoscaling_limit_max_cu:
-							input.autoscaling_limit_max_cu,
+						compute: toComputeSettings(input),
 						provisioner: input.provisioner,
-						pooler_enabled: input.pooler_enabled,
-						pooler_mode: input.pooler_mode,
+						poolerEnabled: input.pooler_enabled,
+						poolerMode: input.pooler_mode,
 						disabled: input.disabled,
-						passwordless_access: input.passwordless_access,
-						suspend_timeout_seconds: input.suspend_timeout_seconds,
+						passwordlessAccess: input.passwordless_access,
 						name: input.name,
 					},
 					{ signal },
@@ -346,18 +361,14 @@ export const toolFactories = {
 					input.project_id,
 					input.endpoint_id,
 					{
-						branch_id: input.branch_id,
-						autoscaling_limit_min_cu:
-							input.autoscaling_limit_min_cu,
-						autoscaling_limit_max_cu:
-							input.autoscaling_limit_max_cu,
+						branchId: input.branch_id,
+						compute: toComputeSettings(input),
 						provisioner: input.provisioner,
 						settings: input.settings,
-						pooler_enabled: input.pooler_enabled,
-						pooler_mode: input.pooler_mode,
+						poolerEnabled: input.pooler_enabled,
+						poolerMode: input.pooler_mode,
 						disabled: input.disabled,
-						passwordless_access: input.passwordless_access,
-						suspend_timeout_seconds: input.suspend_timeout_seconds,
+						passwordlessAccess: input.passwordless_access,
 						name: input.name,
 					},
 					{ signal },
@@ -436,7 +447,7 @@ export const toolFactories = {
 				neon.postgres.roles.create(
 					input.project_id,
 					input.branch_id,
-					{ name: input.name, no_login: input.no_login },
+					{ name: input.name, noLogin: input.no_login },
 					{ signal },
 				),
 		}),
@@ -497,7 +508,7 @@ export const toolFactories = {
 				neon.postgres.databases.create(
 					input.project_id,
 					input.branch_id,
-					{ name: input.name, owner_name: input.owner_name },
+					{ name: input.name, ownerName: input.owner_name },
 					{ signal },
 				),
 		}),
@@ -510,7 +521,7 @@ export const toolFactories = {
 					input.project_id,
 					input.branch_id,
 					input.database_name,
-					{ name: input.name, owner_name: input.owner_name },
+					{ name: input.name, ownerName: input.owner_name },
 					{ signal },
 				),
 		}),
@@ -623,7 +634,7 @@ export const toolFactories = {
 				neon.storage.buckets.create(
 					input.project_id,
 					input.branch_id,
-					{ name: input.name, access_level: input.access_level },
+					{ name: input.name, accessLevel: input.access_level },
 					{ signal },
 				),
 		}),
@@ -842,7 +853,6 @@ export const toolFactories = {
 					{
 						name: input.name,
 						scopes: input.scopes,
-						principal_type: input.principal_type,
 					},
 					{ signal },
 				),

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -91,6 +91,39 @@ export const createProjectAndConnectInputSchema = z.strictObject({
 	pooled: pooledField,
 });
 
+function mapProjectCreateInput(
+	input: z.infer<typeof createProjectInputSchema>,
+) {
+	return {
+		name: input.name,
+		settings: input.settings,
+		regionId: input.region_id,
+		pgVersion: input.pg_version,
+		provisioner: input.provisioner,
+		orgId: input.org_id,
+		compute:
+			input.autoscaling_limit_min_cu === undefined &&
+			input.autoscaling_limit_max_cu === undefined
+				? undefined
+				: {
+						minCu: input.autoscaling_limit_min_cu,
+						maxCu: input.autoscaling_limit_max_cu,
+					},
+		branch:
+			input.branch === undefined
+				? undefined
+				: {
+						name: input.branch.name,
+						roleName: input.branch.role_name,
+						databaseName: input.branch.database_name,
+						annotations: input.branch.annotations,
+					},
+		defaultEndpointSettings: input.default_endpoint_settings,
+		storePasswords: input.store_passwords,
+		historyRetentionSeconds: input.history_retention_seconds,
+	};
+}
+
 export const getDefaultInputSchema = z.strictObject({
 	project_id: zod.zListProjectBranchesPath.shape.project_id,
 });
@@ -253,7 +286,8 @@ export const createProjectTool = (options: ToolClientOptions) =>
 				tags: ["Project"],
 			},
 		},
-		(neon, input, signal) => neon.projects.create(input, { signal }),
+		(neon, input, signal) =>
+			neon.projects.create(mapProjectCreateInput(input), { signal }),
 	);
 
 export const createProjectAndConnectTool = (options: ToolClientOptions) =>
@@ -278,10 +312,13 @@ export const createProjectAndConnectTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) => {
 			const { pooled, ...project } = input;
-			return neon.projects.createAndConnect(project, {
-				signal,
-				...(pooled === undefined ? {} : { pooled }),
-			});
+			return neon.projects.createAndConnect(
+				mapProjectCreateInput(project),
+				{
+					signal,
+					...(pooled === undefined ? {} : { pooled }),
+				},
+			);
 		},
 	);
 


### PR DESCRIPTION
## Problem

Most `create` / `update` methods on the ergonomic client took the generated OpenAPI body types unchanged. Callers mixed positional camelCase ids (`projectId`) with snake_case fields (`branch_id`, `autoscaling_limit_min_cu`, `owner_name`). `branches.create` already grouped compute as `{ minCu, maxCu, suspendTimeoutSeconds }`; siblings did not.

## Diagnosis

`endpoints`, `projects`, `databases`, `roles`, `buckets`, and `credentials` aliased `*CreateRequest` / `*UpdateRequest` and forwarded those objects as the HTTP body.

## Interface

Before:

```ts
await neon.postgres.endpoints.create(projectId, {
  branch_id: branchId,
  type: "read_write",
  autoscaling_limit_min_cu: 0.25,
});

await neon.projects.create({ name: "app", region_id: "aws-us-east-1" });
await neon.postgres.databases.create(projectId, branchId, {
  name: "app",
  owner_name: "app_owner",
});
await neon.postgres.roles.create(projectId, branchId, { name: "reader", no_login: true });
await neon.storage.buckets.create(projectId, branchId, { name: "assets", access_level: "public_read" });
await neon.credentials.create(projectId, branchId, {
  scopes: ["ai_gateway:invoke"],
  principal_type: "user",
});
```

After:

```ts
await neon.postgres.endpoints.create(projectId, {
  branchId,
  type: "read_write",
  compute: { minCu: 0.25 },
});

await neon.projects.create({ name: "app", regionId: "aws-us-east-1" });
await neon.postgres.databases.create(projectId, branchId, {
  name: "app",
  ownerName: "app_owner",
});
await neon.postgres.roles.create(projectId, branchId, { name: "reader", noLogin: true });
await neon.storage.buckets.create(projectId, branchId, { name: "assets", accessLevel: "public_read" });
await neon.credentials.create(projectId, branchId, {
  scopes: ["ai_gateway:invoke"],
});
```

- HTTP bodies stay snake_case.
- Returned resources keep API field names (`endpoint.branch_id`, `database.owner_name`). Do not spread a resource into an update input.
- Project `compute` is `{ minCu?, maxCu? }` only. Suspend stays on `defaultEndpointSettings`.
- `credentials.create` always sends `principal_type: "user"`.
- Tools MCP schemas stay snake_case; adapters map into the SDK.

## Also in here

- Exported `EndpointCreateInput`, `EndpointUpdateInput`, `ProjectCreateInput`, `ProjectUpdateInput`, `DatabaseCreateInput`, `DatabaseUpdateInput`, `RoleCreateInput`, `BucketCreateInput`, `CredentialCreateInput`.
- Major changeset for `@neon/sdk`.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 150 passed
- `pnpm --filter @neon/sdk test:types` — 16 passed
- `pnpm --filter @neon/sdk build`
- `pnpm --filter @neon/tools test:ci` — 140 passed
- Live e2e not run; call sites updated to camelCase so they compile.

## For your attention

- Breaking for anyone passing generated snake_case into these methods.
- Resource responses stay API-native. That is the settled story for this major, not a halfway step toward camelCase responses.
- `branches.create` still accepts generated branch fields (`parent_id`). Same leak, separate PR, should land before this major is cut.
- Nested `settings` / `defaultEndpointSettings` bags stay generated (pass-through).