### PR TITLE
Take `projectId` positionally on `postgres.connectionString`

### DIFF
--- a/.changeset/sdk-connection-string-args.md
+++ b/.changeset/sdk-connection-string-args.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": major
+---
+
+`neon.postgres.connectionString` now takes `projectId` as its first argument. Selectors (`branchId`, `pooled`, …) are the optional second argument. `ConnectionStringParams` is now `ConnectionStringSelectors`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -292,11 +292,10 @@ await neon.branches.resetFromParent(projectId, data!.branch.id, undefined, {
 
 ### `neon.postgres`
 
-The Postgres data plane of a branch. `neon.postgres.connectionString(params, options?)` resolves a URI, **auto-selecting** the default branch and the sole role/database when omitted:
+The Postgres data plane of a branch. `neon.postgres.connectionString(projectId, selectors?, options?)` resolves a URI, **auto-selecting** the default branch and the sole role/database when omitted:
 
 ```ts
-const { data: uri } = await neon.postgres.connectionString({
-  projectId,
+const { data: uri } = await neon.postgres.connectionString(projectId, {
   branchId?, endpointId?, databaseName?, roleName?, pooled?,  // all optional; pooled default true
 });
 ```

--- a/packages/sdk/e2e/workflows.e2e.test.ts
+++ b/packages/sdk/e2e/workflows.e2e.test.ts
@@ -128,11 +128,10 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 
 			// Only the project id — everything else is auto-selected from the real project.
 			const pooled = expectOk(
-				await neon.postgres.connectionString({ projectId: project.id }),
+				await neon.postgres.connectionString(project.id),
 			);
 			const direct = expectOk(
-				await neon.postgres.connectionString({
-					projectId: project.id,
+				await neon.postgres.connectionString(project.id, {
 					pooled: false,
 				}),
 			);

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -48,7 +48,7 @@ export type {
 	LogFieldValuesQuery,
 	LogQueryInput,
 } from "./neon/resources/logs.js";
-export type { ConnectionStringParams } from "./neon/resources/postgres.js";
+export type { ConnectionStringSelectors } from "./neon/resources/postgres.js";
 export type {
 	ProjectConnection,
 	RemoveRoleOptions,

--- a/packages/sdk/src/neon/cancellation.test.ts
+++ b/packages/sdk/src/neon/cancellation.test.ts
@@ -115,10 +115,9 @@ describe("a caller's signal reaches the request", () => {
 		const controller = new AbortController();
 		setTimeout(() => controller.abort(), 20);
 
-		const { error } = await neon.postgres.connectionString(
-			{ projectId: "p" },
-			{ signal: controller.signal },
-		);
+		const { error } = await neon.postgres.connectionString("p", undefined, {
+			signal: controller.signal,
+		});
 		expect(error?.kind).toBe("aborted");
 	});
 });

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -140,16 +140,24 @@ it("postgres namespace + tier-2/3 resources are reachable and typed", () => {
 	expectTypeOf(
 		neon.postgres.roles.password("p", "br", "neondb_owner"),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
+	expectTypeOf(neon.postgres.connectionString("p")).resolves.toEqualTypeOf<
+		NeonResult<string>
+	>();
 	expectTypeOf(
-		neon.postgres.connectionString({ projectId: "p" }),
+		neon.postgres.connectionString("p", { pooled: false }),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
+	neon.postgres.connectionString(
+		"p",
+		// @ts-expect-error projectId is positional
+		{ projectId: "p" },
+	);
 	expectTypeOf(neon.snapshots.list("p")).resolves.toEqualTypeOf<
 		NeonResult<Snapshot[]>
 	>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
-		throwing.postgres.connectionString({ projectId: "p" }),
+		throwing.postgres.connectionString("p"),
 	).resolves.toEqualTypeOf<string>();
 	expectTypeOf(
 		throwing.postgres.dataApi.delete("p", "br", "neondb"),

--- a/packages/sdk/src/neon/resources/postgres.ts
+++ b/packages/sdk/src/neon/resources/postgres.ts
@@ -13,9 +13,8 @@ import { Databases } from "./databases.js";
 import { Endpoints } from "./endpoints.js";
 import { Roles } from "./roles.js";
 
-/** Parameters for {@link Postgres.connectionString}. */
-export interface ConnectionStringParams {
-	projectId: string;
+/** Optional selectors for {@link Postgres.connectionString}. */
+export interface ConnectionStringSelectors {
 	/** Defaults to the project's default branch. */
 	branchId?: string;
 	/** Defaults to the branch's read-write endpoint. */
@@ -27,6 +26,8 @@ export interface ConnectionStringParams {
 	/** Pooled connection string (default `true`). */
 	pooled?: boolean;
 }
+
+type ResolveInput = { projectId: string } & ConnectionStringSelectors;
 
 /**
  * The Postgres data plane of a branch: compute endpoints, roles, databases, the Data API,
@@ -54,14 +55,17 @@ export class Postgres<DThrow extends boolean> {
 	 * a `client`-kind {@link NeonError} when the selection is ambiguous.
 	 */
 	connectionString(
-		params: ConnectionStringParams,
+		projectId: string,
+		selectors?: ConnectionStringSelectors,
 	): Promise<Outcome<string, DThrow>>;
 	connectionString<Throw extends boolean = DThrow>(
-		params: ConnectionStringParams,
+		projectId: string,
+		selectors: ConnectionStringSelectors | undefined,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<string, Throw>>;
 	async connectionString(
-		params: ConnectionStringParams,
+		projectId: string,
+		selectors?: ConnectionStringSelectors,
 		opts?: CallOptions,
 	): Promise<string | NeonResult<string>> {
 		const shouldThrow =
@@ -71,7 +75,7 @@ export class Postgres<DThrow extends boolean> {
 		const deadline = this.#ctx.deadlineFor(opts);
 		try {
 			const resolved = await runBounded(deadline, () =>
-				this.#resolve(params, deadline.signal),
+				this.#resolve({ projectId, ...selectors }, deadline.signal),
 			);
 			const cancellation = cancelled(deadline);
 			// `runBounded` resolves undefined only when the deadline won the race, which
@@ -93,7 +97,7 @@ export class Postgres<DThrow extends boolean> {
 	}
 
 	async #resolve(
-		params: ConnectionStringParams,
+		params: ResolveInput,
 		signal?: AbortSignal,
 	): Promise<NeonResult<string>> {
 		const client = this.#ctx.client;

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -406,8 +406,8 @@ export const connectionStringTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) =>
 			neon.postgres.connectionString(
+				input.project_id,
 				{
-					projectId: input.project_id,
 					...(input.branch_id === undefined
 						? {}
 						: { branchId: input.branch_id }),


### PR DESCRIPTION
## Problem

Every other ergonomic method takes ids positionally, then an optional input object, then `CallOptions`. `postgres.connectionString` was the exception: the only required field lived inside `{ projectId, ... }`.

## Diagnosis

`ConnectionStringParams` bundled identity with selectors. Callers who only needed a project id still constructed an object, and `CallOptions`-only calls had to pass that object first.

## Interface

Before:

```ts
await neon.postgres.connectionString({ projectId, branchId, pooled: true }, { signal });
```

After:

```ts
await neon.postgres.connectionString(projectId);
await neon.postgres.connectionString(projectId, { branchId, pooled: true });
await neon.postgres.connectionString(projectId, { pooled: false }, { signal });
await neon.postgres.connectionString(projectId, undefined, { signal });
```

- `ConnectionStringParams` is now `ConnectionStringSelectors` (same optional fields, no `projectId`).
- Resolver behavior is unchanged.
- Tools MCP schema stays snake_case.

## Also in here

- Major changeset for `@neon/sdk`.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 141 passed
- `pnpm --filter @neon/sdk test:types` — 16 passed
- `pnpm --filter @neon/sdk build`
- `pnpm --filter @neon/tools test:ci` — 140 passed
- Live e2e not run; call sites updated so they compile.

## For your attention

- Breaking: `{ projectId }` as the first argument no longer type-checks.
- Opts-only calls use `undefined` for selectors, same as `branches.list(projectId, undefined, opts)`.