### PR TITLE
Rename `roles.password` to `revealPassword`

### DIFF
--- a/.changeset/sdk-role-password-shapes.md
+++ b/.changeset/sdk-role-password-shapes.md
@@ -1,0 +1,6 @@
+---
+"@neon/sdk": major
+"@neon/tools": major
+---
+
+`postgres.roles.password` is now `revealPassword`. `resetPassword` returns the new password string instead of a `Role`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -320,14 +320,12 @@ const { data: uri } = await neon.postgres.connectionString({
 | `get(projectId, branchId, name)` | `Role` |
 | `create(projectId, branchId, { name, no_login? })` | `Role` |
 | `delete(projectId, branchId, name)` | **→void** |
-| `password(projectId, branchId, name)` | `string` (reveals the password) |
-| `resetPassword(projectId, branchId, name)` | `Role` (carries the new password) |
+| `revealPassword(projectId, branchId, name)` | `string` |
+| `resetPassword(projectId, branchId, name)` | `string` |
 
 ```ts
-// Reveal a role's password, or rotate it
-const { data: password } = await neon.postgres.roles.password(projectId, branchId, "neondb_owner");
-const { data: role } = await neon.postgres.roles.resetPassword(projectId, branchId, "neondb_owner");
-// role.password holds the new secret
+const { data: password } = await neon.postgres.roles.revealPassword(projectId, branchId, "neondb_owner");
+const { data: rotated } = await neon.postgres.roles.resetPassword(projectId, branchId, "neondb_owner");
 ```
 
 #### `neon.postgres.databases`

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -222,10 +222,8 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		);
 		expect(created.name).toBe("e2e_role");
 
-		// `password` unwraps to a bare string, `resetPassword` returns the whole Role —
-		// an asymmetry that's easy to break when the response mapping is touched.
 		const password = expectOk(
-			await neon.postgres.roles.password(
+			await neon.postgres.roles.revealPassword(
 				projectId,
 				defaultBranchId,
 				"e2e_role",
@@ -242,8 +240,9 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 				{ waitForReadiness: true },
 			),
 		);
-		expect(reset.name).toBe("e2e_role");
-		expect(reset.password).not.toBe(password);
+		expect(typeof reset).toBe("string");
+		expect(reset.length).toBeGreaterThan(0);
+		expect(reset).not.toBe(password);
 
 		expectOk(
 			await neon.postgres.roles.delete(

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -138,8 +138,13 @@ it("postgres namespace + tier-2/3 resources are reachable and typed", () => {
 		NeonResult<Endpoint[]>
 	>();
 	expectTypeOf(
-		neon.postgres.roles.password("p", "br", "neondb_owner"),
+		neon.postgres.roles.revealPassword("p", "br", "neondb_owner"),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
+	expectTypeOf(
+		neon.postgres.roles.resetPassword("p", "br", "neondb_owner"),
+	).resolves.toEqualTypeOf<NeonResult<string>>();
+	// @ts-expect-error — password was renamed to revealPassword
+	neon.postgres.roles.password("p", "br", "neondb_owner");
 	expectTypeOf(
 		neon.postgres.connectionString({ projectId: "p" }),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
@@ -150,6 +155,12 @@ it("postgres namespace + tier-2/3 resources are reachable and typed", () => {
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
 		throwing.postgres.connectionString({ projectId: "p" }),
+	).resolves.toEqualTypeOf<string>();
+	expectTypeOf(
+		throwing.postgres.roles.revealPassword("p", "br", "neondb_owner"),
+	).resolves.toEqualTypeOf<string>();
+	expectTypeOf(
+		throwing.postgres.roles.resetPassword("p", "br", "neondb_owner"),
 	).resolves.toEqualTypeOf<string>();
 	expectTypeOf(
 		throwing.postgres.dataApi.delete("p", "br", "neondb"),

--- a/packages/sdk/src/neon/resources/roles.password.test.ts
+++ b/packages/sdk/src/neon/resources/roles.password.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "../client.js";
+import type { NeonConfig } from "../config.js";
+
+function neonRouting(
+	respond: (request: { url: string; method: string; body: unknown }) => {
+		status: number;
+		body: unknown;
+	},
+	config?: Pick<NeonConfig, "waitForReadiness" | "wait">,
+) {
+	const calls: Array<{ url: string; method: string; body: unknown }> = [];
+	const neon = createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		...config,
+		fetch: async (input, init) => {
+			const request = input instanceof Request ? input : undefined;
+			const url = request ? request.url : String(input);
+			const method = (
+				request?.method ??
+				init?.method ??
+				"GET"
+			).toUpperCase();
+			const raw = request ? await request.clone().text() : init?.body;
+			const call = {
+				url,
+				method,
+				body:
+					typeof raw === "string" && raw.length > 0
+						? JSON.parse(raw)
+						: raw,
+			};
+			calls.push(call);
+			const { status, body } = respond(call);
+			return new Response(JSON.stringify(body), {
+				status,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+	return { neon, calls };
+}
+
+const runningOp = {
+	id: "op-1",
+	project_id: "p-1",
+	action: "apply_config",
+	status: "running",
+	failures_count: 0,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("roles.revealPassword / resetPassword", () => {
+	it("maps revealPassword to the password string", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { password: "s3cret" },
+		}));
+
+		const { data, error } = await neon.postgres.roles.revealPassword(
+			"p-1",
+			"br-1",
+			"app_owner",
+		);
+
+		expect(error).toBeUndefined();
+		expect(data).toBe("s3cret");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.method).toBe("GET");
+		expect(calls[0]?.url).toContain(
+			"/projects/p-1/branches/br-1/roles/app_owner/reveal_password",
+		);
+	});
+
+	it("maps resetPassword to the new password string", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: {
+				role: {
+					name: "app_owner",
+					branch_id: "br-1",
+					password: "n3w",
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+				},
+				operations: [],
+			},
+		}));
+
+		const { data, error } = await neon.postgres.roles.resetPassword(
+			"p-1",
+			"br-1",
+			"app_owner",
+		);
+
+		expect(error).toBeUndefined();
+		expect(data).toBe("n3w");
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.method).toBe("POST");
+		expect(calls[0]?.url).toContain(
+			"/projects/p-1/branches/br-1/roles/app_owner/reset_password",
+		);
+	});
+
+	it("returns a client error when reset omits the password", async () => {
+		const { neon } = neonRouting(() => ({
+			status: 200,
+			body: {
+				role: {
+					name: "app_owner",
+					branch_id: "br-1",
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+				},
+				operations: [],
+			},
+		}));
+
+		const { data, error } = await neon.postgres.roles.resetPassword(
+			"p-1",
+			"br-1",
+			"app_owner",
+		);
+
+		expect(data).toBeUndefined();
+		expect(error?.kind).toBe("client");
+		expect(error?.message).toBe(
+			"Reset returned a role without a password.",
+		);
+	});
+
+	it("returns a client error when reset returns an empty password", async () => {
+		const { neon } = neonRouting(() => ({
+			status: 200,
+			body: {
+				role: {
+					name: "app_owner",
+					branch_id: "br-1",
+					password: "",
+					created_at: "2026-01-01T00:00:00Z",
+					updated_at: "2026-01-01T00:00:00Z",
+				},
+				operations: [],
+			},
+		}));
+
+		const { data, error } = await neon.postgres.roles.resetPassword(
+			"p-1",
+			"br-1",
+			"app_owner",
+		);
+
+		expect(data).toBeUndefined();
+		expect(error?.kind).toBe("client");
+		expect(error?.message).toBe(
+			"Reset returned a role without a password.",
+		);
+	});
+
+	it("waits for reset operations before returning the password", async () => {
+		const { neon, calls } = neonRouting(
+			({ url }) => {
+				if (url.includes("/operations/op-1")) {
+					return {
+						status: 200,
+						body: {
+							operation: { ...runningOp, status: "finished" },
+						},
+					};
+				}
+				return {
+					status: 200,
+					body: {
+						role: {
+							name: "app_owner",
+							branch_id: "br-1",
+							password: "n3w",
+							created_at: "2026-01-01T00:00:00Z",
+							updated_at: "2026-01-01T00:00:00Z",
+						},
+						operations: [runningOp],
+					},
+				};
+			},
+			{ waitForReadiness: true, wait: { pollIntervalMs: 1 } },
+		);
+
+		const { data, error } = await neon.postgres.roles.resetPassword(
+			"p-1",
+			"br-1",
+			"app_owner",
+		);
+
+		expect(error).toBeUndefined();
+		expect(data).toBe("n3w");
+		expect(
+			calls.some((call) => call.url.includes("/operations/op-1")),
+		).toBe(true);
+	});
+});

--- a/packages/sdk/src/neon/resources/roles.ts
+++ b/packages/sdk/src/neon/resources/roles.ts
@@ -8,7 +8,8 @@ import {
 } from "../../client/sdk.gen.js";
 import type { Role, RoleCreateRequest } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
-import type { NeonResult, Outcome } from "../result.js";
+import { NeonError } from "../errors.js";
+import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 type CreateInput = RoleCreateRequest["role"];
 
@@ -149,18 +150,18 @@ export class Roles<DThrow extends boolean> {
 	 *
 	 * @apiCall GET /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reveal_password
 	 */
-	password(
+	revealPassword(
 		projectId: string,
 		branchId: string,
 		name: string,
 	): Promise<Outcome<string, DThrow>>;
-	password<Throw extends boolean = DThrow>(
+	revealPassword<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
 		name: string,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<string, Throw>>;
-	password(
+	revealPassword(
 		projectId: string,
 		branchId: string,
 		name: string,
@@ -183,29 +184,27 @@ export class Roles<DThrow extends boolean> {
 		);
 	}
 
-	/**
-	 * Reset the role's password; the returned `Role` carries the new `password`.
-	 *
-	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password
-	 */
+	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password */
 	resetPassword(
 		projectId: string,
 		branchId: string,
 		name: string,
-	): Promise<Outcome<Role, DThrow>>;
+	): Promise<Outcome<string, DThrow>>;
 	resetPassword<Throw extends boolean = DThrow>(
 		projectId: string,
 		branchId: string,
 		name: string,
 		opts: CallOptions<Throw>,
-	): Promise<Outcome<Role, Throw>>;
-	resetPassword(
+	): Promise<Outcome<string, Throw>>;
+	async resetPassword(
 		projectId: string,
 		branchId: string,
 		name: string,
 		opts?: CallOptions,
-	): Promise<Role | NeonResult<Role>> {
-		return this.#ctx.run(
+	): Promise<string | NeonResult<string>> {
+		const shouldThrow =
+			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
+		const result = await this.#ctx.execute(
 			opts,
 			(client, signal) =>
 				resetProjectBranchRolePassword({
@@ -218,7 +217,22 @@ export class Roles<DThrow extends boolean> {
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.role,
+			(data) => data.role?.password,
 		);
+		if (result.error) {
+			return finalize(err<string>(result.error), shouldThrow);
+		}
+		if (!result.data) {
+			return finalize(
+				err<string>(
+					new NeonError(
+						"Reset returned a role without a password.",
+						"client",
+					),
+				),
+				shouldThrow,
+			);
+		}
+		return finalize(ok(result.data), shouldThrow);
 	}
 }

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -83,7 +83,7 @@ An abort `signal` on `execute` or a wait timeout stops the poll, not the create:
 
 `metadata.method` and `metadata.path` name the first request; extra readiness GETs are not listed there.
 
-These public client methods are not tools: `operations.waitFor`, `postgres.roles.password`, and `storage.objects.get`. Waiting is what the write tools already do. `projects.create` and `branches.create` return the created resource without a connection string; `createAndConnect` returns a URI.
+These public client methods are not tools: `operations.waitFor`, `postgres.roles.revealPassword`, and `storage.objects.get`. Waiting is what the write tools already do. `projects.create` and `branches.create` return the created resource without a connection string; `createAndConnect` returns a URI.
 
 ## Optional host add-ons
 

--- a/packages/tools/src/lib/ergonomic/ids.ts
+++ b/packages/tools/src/lib/ergonomic/ids.ts
@@ -1,6 +1,6 @@
 export const hiddenToolIds = [
 	"operations.waitFor",
-	"postgres.roles.password",
+	"postgres.roles.revealPassword",
 	"storage.objects.get",
 ] as const;
 
@@ -122,7 +122,8 @@ export const isNeonToolId = (id: string): id is NeonToolId =>
 const hiddenToolHint: Record<HiddenToolId, string> = {
 	"operations.waitFor":
 		"Write tools wait for readiness. operations.waitFor is not a tool.",
-	"postgres.roles.password": "Role passwords are not published as a tool.",
+	"postgres.roles.revealPassword":
+		"Role passwords are not published as a tool.",
 	"storage.objects.get": "Object bytes are not published as a tool.",
 };
 


### PR DESCRIPTION
## Problem

`roles.password()` reads like a property and is a network call. `resetPassword` returns a `Role` whose `password` field is optional, so callers dig out the secret.

## Diagnosis

Two operations that exist to hand back a password returned different types, and one of the names hid that it does I/O.

## Interface

Before:

```ts
await neon.postgres.roles.password(projectId, branchId, name);
await neon.postgres.roles.resetPassword(projectId, branchId, name);
// Role.password is optional
```

After:

```ts
await neon.postgres.roles.revealPassword(projectId, branchId, name);
await neon.postgres.roles.resetPassword(projectId, branchId, name);
```

Both resolve to `string` (or `{ data, error }` when `throwOnError` is off). A reset response with a missing or empty password is a client `NeonError`. Readiness polling still runs on the raw `operations` array before that string is returned.

`postgres.roles.password` is unpublished as a tool; the hidden selector is now `postgres.roles.revealPassword`. The `resetPassword` tool returns the string.

## Also in here

- Major changeset for `@neon/sdk` and `@neon/tools`.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 146 passed
- `pnpm --filter @neon/sdk test:types` — 16 passed
- `pnpm --filter @neon/sdk build`
- `pnpm --filter @neon/tools test:ci` — 140 passed
- Live e2e not run; call sites updated so they compile.

## For your attention

- Breaking: `roles.password` is gone. `resetPassword` is no longer a `Role`.
- No `roles.connectionString` helper in this PR.