### PR TITLE
Return Paginated from every list and fold endpoints.listByBranch

### DIFF
--- a/.changeset/sdk-list-paginated.md
+++ b/.changeset/sdk-list-paginated.md
@@ -1,0 +1,6 @@
+---
+"@neon/sdk": major
+"@neon/tools": major
+---
+
+Every `list` method now returns `Paginated<T>`. `postgres.endpoints.listByBranch` is `list(projectId, { branchId })`. The `listByBranch` tool is gone.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -170,7 +170,7 @@ than the server asked is worse than not retrying. If honouring it would take lon
 
 ## Pagination
 
-Cursor-paginated `list()` methods return a lazy `Paginated<T>`:
+Cursor-paginated and single-page `list()` methods both return a lazy `Paginated<T>`:
 
 ```ts
 const { data: all } = await neon.projects.list().all();      // every page → { data, error }
@@ -305,7 +305,7 @@ const { data: uri } = await neon.postgres.connectionString({
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId)` | `Endpoint[]` |
+| `list(projectId, query?)` | **[P]** `Endpoint` — `query`: `{ branchId? }` |
 | `get(projectId, endpointId)` | `Endpoint` |
 | `create(projectId, input)` | `Endpoint` — `input`: `{ branch_id, type, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, suspend_timeout_seconds?, provisioner? }` |
 | `update(projectId, endpointId, input)` | `Endpoint` |
@@ -316,7 +316,7 @@ const { data: uri } = await neon.postgres.connectionString({
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId, branchId)` | `Role[]` |
+| `list(projectId, branchId)` | **[P]** `Role` |
 | `get(projectId, branchId, name)` | `Role` |
 | `create(projectId, branchId, { name, no_login? })` | `Role` |
 | `delete(projectId, branchId, name)` | **→void** |
@@ -334,7 +334,7 @@ const { data: role } = await neon.postgres.roles.resetPassword(projectId, branch
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId, branchId)` | `Database[]` |
+| `list(projectId, branchId)` | **[P]** `Database` |
 | `get(projectId, branchId, name)` | `Database` |
 | `create(projectId, branchId, { name, owner_name })` | `Database` |
 | `update(projectId, branchId, name, { name?, owner_name? })` | `Database` |
@@ -364,7 +364,7 @@ enabled and the branch S3 endpoint metadata; buckets and objects are nested unde
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId, branchId)` | `Bucket[]` |
+| `list(projectId, branchId)` | **[P]** `Bucket` |
 | `create(projectId, branchId, { name, access_level? })` | `Bucket` — `access_level`: `"private"` \| `"public_read"` |
 | `delete(projectId, branchId, bucketName)` | **→void** |
 
@@ -444,7 +444,7 @@ are returned **once** on `create`.
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, branchId)` | `CredentialMeta[]` | |
+| `list(projectId, branchId)` | **[P]** `CredentialMeta` | |
 | `create(projectId, branchId, input)` | `CreateCredentialResponse` | `input`: `{ name?, scopes, principal_type: "user" }` — scopes: `storage:read`, `storage:write`, `ai_gateway:invoke`, `functions:invoke` |
 | `revoke(projectId, branchId, tokenId)` | **→void** | |
 
@@ -564,7 +564,7 @@ the values can be trusted and unwrapping would hide it.
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId)` | `Snapshot[]` | |
+| `list(projectId)` | **[P]** `Snapshot` | |
 | `create(projectId, branchId, input?)` | `Snapshot` | `input`: `{ name?, timestamp?, lsn?, expiresAt? }` (point-in-time) |
 | `update(projectId, snapshotId, input)` | `Snapshot` | `input`: `{ name?, expiresAt? }` — pass `expiresAt: null` to clear the expiration |
 | `delete(projectId, snapshotId)` | **→void** | |
@@ -639,7 +639,7 @@ for await (const project of neon.consumption.perProject({
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list()` | `ApiKeysListResponseItem[]` | |
+| `list()` | **[P]** `ApiKeysListResponseItem` | |
 | `create(keyName)` | `ApiKeyCreateResponse` | the `key` token is shown **once** |
 | `revoke(keyId)` | `ApiKeyRevokeResponse` | |
 
@@ -647,7 +647,7 @@ for await (const project of neon.consumption.perProject({
 
 | Method | Returns |
 | --- | --- |
-| `regions.list()` | `RegionResponse[]` |
+| `regions.list()` | **[P]** `RegionResponse` |
 | `user.me()` | `CurrentUserInfoResponse` |
 | `user.organizations()` | `Organization[]` |
 
@@ -661,15 +661,15 @@ Branch-scoped Neon Auth (the legacy project-scoped endpoints are deprecated and 
 | `create(projectId, branchId, input)` | `NeonAuthCreateIntegrationResponse` | enable the integration |
 | `disable(projectId, branchId, { deleteData? }?)` | **→void** | |
 | `updateConfig(projectId, branchId, input)` | `NeonAuthConfigResponse` | |
-| `oauthProviders.list / add / update / delete` | `NeonAuthOauthProvider`(`[]`) / **→void** | |
-| `trustedDomains.list / add / delete` | `NeonAuthRedirectUriWhitelistDomain[]` / **→void** | redirect-URI whitelist |
+| `oauthProviders.list / add / update / delete` | **[P]** `NeonAuthOauthProvider` / `NeonAuthOauthProvider` / **→void** | |
+| `trustedDomains.list / add / delete` | **[P]** `NeonAuthRedirectUriWhitelistDomain` / **→void** | redirect-URI whitelist |
 | `users.create / delete / updateRole` | `NeonAuthCreateNewUserResponse` / **→void** / role | |
 
 ### `neon.projects.permissions`
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId)` | `ProjectPermission[]` |
+| `list(projectId)` | **[P]** `ProjectPermission` |
 | `grant(projectId, email)` | `ProjectPermission` |
 | `revoke(projectId, permissionId)` | `ProjectPermission` |
 
@@ -716,8 +716,7 @@ if (grant?.credential_rotation_recommended) { /* rotate database credentials */ 
 if (grant?.org_api_key_rotation_recommended) { /* rotate project-scoped org keys */ }
 ```
 
-Also on `neon.projects`: `recover(id)` (beta — recover a soft-deleted project), and on
-`neon.postgres.endpoints`: `listByBranch(projectId, branchId)` → `Endpoint[]`.
+Also on `neon.projects`: `recover(id)` (beta — recover a soft-deleted project).
 
 ---
 

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -82,7 +82,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		);
 		const branchId = child.branch.id;
 		const roles = expectOk(
-			await neon.postgres.roles.list(projectId, branchId),
+			await neon.postgres.roles.list(projectId, branchId).all(),
 		);
 		const owner = roles[0];
 		if (!owner) throw new Error("child branch has no role");
@@ -115,7 +115,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			),
 		);
 		const after = expectOk(
-			await neon.postgres.databases.list(projectId, branchId),
+			await neon.postgres.databases.list(projectId, branchId).all(),
 		);
 		expect(after.map((database) => database.name)).not.toContain(
 			"child_only",
@@ -149,10 +149,9 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 		// The endpoint the workflow reports must be the one the API actually attached.
 		const endpoints = expectOk(
-			await neon.postgres.endpoints.listByBranch(
-				projectId,
-				created.branch.id,
-			),
+			await neon.postgres.endpoints
+				.list(projectId, { branchId: created.branch.id })
+				.all(),
 		);
 		expect(endpoints.map((endpoint) => endpoint.id)).toContain(
 			created.endpoint.id,
@@ -173,10 +172,9 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			}),
 		);
 		const attached = expectOk(
-			await neon.postgres.endpoints.listByBranch(
-				projectId,
-				withCompute.id,
-			),
+			await neon.postgres.endpoints
+				.list(projectId, { branchId: withCompute.id })
+				.all(),
 		);
 		expect(
 			attached.filter((endpoint) => endpoint.type === "read_write"),
@@ -190,7 +188,9 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			}),
 		);
 		const none = expectOk(
-			await neon.postgres.endpoints.listByBranch(projectId, bare.id),
+			await neon.postgres.endpoints
+				.list(projectId, { branchId: bare.id })
+				.all(),
 		);
 		expect(none).toEqual([]);
 
@@ -208,7 +208,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 	it("manages roles, including the two different password shapes", async () => {
 		const before = expectOk(
-			await neon.postgres.roles.list(projectId, defaultBranchId),
+			await neon.postgres.roles.list(projectId, defaultBranchId).all(),
 		);
 		expect(before.length).toBeGreaterThan(0);
 
@@ -254,14 +254,14 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			),
 		);
 		const after = expectOk(
-			await neon.postgres.roles.list(projectId, defaultBranchId),
+			await neon.postgres.roles.list(projectId, defaultBranchId).all(),
 		);
 		expect(after.map((role) => role.name)).not.toContain("e2e_role");
 	});
 
 	it("round-trips a database", async () => {
 		const roles = expectOk(
-			await neon.postgres.roles.list(projectId, defaultBranchId),
+			await neon.postgres.roles.list(projectId, defaultBranchId).all(),
 		);
 		const owner = roles[0];
 		if (!owner) throw new Error("project has no role to own a database");
@@ -294,18 +294,21 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			),
 		);
 		const after = expectOk(
-			await neon.postgres.databases.list(projectId, defaultBranchId),
+			await neon.postgres.databases
+				.list(projectId, defaultBranchId)
+				.all(),
 		);
 		expect(after.map((db) => db.name)).not.toContain("e2e_db");
 	});
 
 	it("lists and fetches the default branch's endpoint", async () => {
-		const all = expectOk(await neon.postgres.endpoints.list(projectId));
+		const all = expectOk(
+			await neon.postgres.endpoints.list(projectId).all(),
+		);
 		const byBranch = expectOk(
-			await neon.postgres.endpoints.listByBranch(
-				projectId,
-				defaultBranchId,
-			),
+			await neon.postgres.endpoints
+				.list(projectId, { branchId: defaultBranchId })
+				.all(),
 		);
 		expect(byBranch.length).toBeGreaterThan(0);
 		expect(all.map((endpoint) => endpoint.id)).toEqual(

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -134,18 +134,28 @@ it("cancellation and deadline options are accepted on the client and per call", 
 
 it("postgres namespace + tier-2/3 resources are reachable and typed", () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	expectTypeOf(neon.postgres.endpoints.list("p")).resolves.toEqualTypeOf<
-		NeonResult<Endpoint[]>
+	expectTypeOf(neon.postgres.endpoints.list("p")).toEqualTypeOf<
+		Paginated<Endpoint>
 	>();
+	expectTypeOf(
+		neon.postgres.endpoints.list("p", { branchId: "br" }),
+	).toEqualTypeOf<Paginated<Endpoint>>();
+	expectTypeOf(
+		neon.postgres.endpoints.list("p", undefined, {
+			signal: new AbortController().signal,
+		}),
+	).toEqualTypeOf<Paginated<Endpoint>>();
+	neon.postgres.endpoints.list("p", {
+		// @ts-expect-error — CallOptions is the third argument
+		signal: new AbortController().signal,
+	});
 	expectTypeOf(
 		neon.postgres.roles.password("p", "br", "neondb_owner"),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
 	expectTypeOf(
 		neon.postgres.connectionString({ projectId: "p" }),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
-	expectTypeOf(neon.snapshots.list("p")).resolves.toEqualTypeOf<
-		NeonResult<Snapshot[]>
-	>();
+	expectTypeOf(neon.snapshots.list("p")).toEqualTypeOf<Paginated<Snapshot>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
@@ -203,14 +213,14 @@ it("phase-1 namespaces (auth, permissions, recover, branch endpoints) are typed"
 	expectTypeOf(neon.auth.get("p", "br")).resolves.toEqualTypeOf<
 		NeonResult<NeonAuthIntegration>
 	>();
-	expectTypeOf(
-		neon.auth.oauthProviders.list("p", "br"),
-	).resolves.toEqualTypeOf<NeonResult<NeonAuthOauthProvider[]>>();
+	expectTypeOf(neon.auth.oauthProviders.list("p", "br")).toEqualTypeOf<
+		Paginated<NeonAuthOauthProvider>
+	>();
 	expectTypeOf(
 		neon.auth.oauthProviders.add("p", "br", { id: "google" }),
 	).resolves.toEqualTypeOf<NeonResult<NeonAuthOauthProvider>>();
-	expectTypeOf(neon.projects.permissions.list("p")).resolves.toEqualTypeOf<
-		NeonResult<ProjectPermission[]>
+	expectTypeOf(neon.projects.permissions.list("p")).toEqualTypeOf<
+		Paginated<ProjectPermission>
 	>();
 	expectTypeOf(
 		neon.projects.permissions.grant("p", "user@example.com"),
@@ -218,9 +228,8 @@ it("phase-1 namespaces (auth, permissions, recover, branch endpoints) are typed"
 	expectTypeOf(neon.projects.recover("p")).resolves.toEqualTypeOf<
 		NeonResult<Project>
 	>();
-	expectTypeOf(
-		neon.postgres.endpoints.listByBranch("p", "br"),
-	).resolves.toEqualTypeOf<NeonResult<Endpoint[]>>();
+	// @ts-expect-error — listByBranch folded into list(projectId, { branchId })
+	neon.postgres.endpoints.listByBranch("p", "br");
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
@@ -229,9 +238,9 @@ it("phase-1 namespaces (auth, permissions, recover, branch endpoints) are typed"
 	expectTypeOf(
 		throwing.auth.oauthProviders.delete("p", "br", "google"),
 	).resolves.toEqualTypeOf<void>();
-	expectTypeOf(
-		throwing.projects.permissions.list("p"),
-	).resolves.toEqualTypeOf<ProjectPermission[]>();
+	expectTypeOf(throwing.projects.permissions.list("p")).toEqualTypeOf<
+		Paginated<ProjectPermission>
+	>();
 });
 
 it("functions.customDomains is typed", () => {

--- a/packages/sdk/src/neon/client.ts
+++ b/packages/sdk/src/neon/client.ts
@@ -38,7 +38,7 @@ export interface NeonClient<DThrow extends boolean> {
 	readonly auth: Auth<DThrow>;
 	readonly consumption: Consumption;
 	readonly apiKeys: ApiKeys<DThrow>;
-	readonly regions: Regions<DThrow>;
+	readonly regions: Regions;
 	readonly user: User<DThrow>;
 	/**
 	 * The underlying configured raw client. Pass it to any raw function
@@ -76,7 +76,7 @@ export function createNeonClient<Throw extends boolean = false>(
 		auth: new Auth<Throw>(ctx),
 		consumption: new Consumption(ctx),
 		apiKeys: new ApiKeys<Throw>(ctx),
-		regions: new Regions<Throw>(ctx),
+		regions: new Regions(ctx),
 		user: new User<Throw>(ctx),
 		client: ctx.client,
 	};

--- a/packages/sdk/src/neon/resources/account.ts
+++ b/packages/sdk/src/neon/resources/account.ts
@@ -15,6 +15,7 @@ import type {
 	RegionResponse,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 /** Current user / account resource. */
@@ -63,7 +64,7 @@ export class User<DThrow extends boolean> {
 }
 
 /** Active regions. */
-export class Regions<DThrow extends boolean> {
+export class Regions {
 	readonly #ctx: RequestContext;
 
 	constructor(ctx: RequestContext) {
@@ -71,18 +72,16 @@ export class Regions<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /regions */
-	list(): Promise<Outcome<RegionResponse[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<RegionResponse[], Throw>>;
-	list(
-		opts?: CallOptions,
-	): Promise<RegionResponse[] | NeonResult<RegionResponse[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
-				getActiveRegions({ client, throwOnError: false, signal }),
-			(data) => data.regions,
+	list(opts?: CallOptions): Paginated<RegionResponse> {
+		return paginate(
+			(_cursor, signal) =>
+				getActiveRegions({
+					client: this.#ctx.client,
+					throwOnError: false,
+					signal,
+				}),
+			(data) => ({ items: data?.regions ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 }
@@ -96,20 +95,16 @@ export class ApiKeys<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /api_keys */
-	list(): Promise<Outcome<ApiKeysListResponseItem[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<ApiKeysListResponseItem[], Throw>>;
-	list(
-		opts?: CallOptions,
-	): Promise<
-		ApiKeysListResponseItem[] | NeonResult<ApiKeysListResponseItem[]>
-	> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
-				listApiKeys({ client, throwOnError: false, signal }),
-			(data) => data,
+	list(opts?: CallOptions): Paginated<ApiKeysListResponseItem> {
+		return paginate(
+			(_cursor, signal) =>
+				listApiKeys({
+					client: this.#ctx.client,
+					throwOnError: false,
+					signal,
+				}),
+			(data) => ({ items: data ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/auth.ts
+++ b/packages/sdk/src/neon/resources/auth.ts
@@ -32,6 +32,7 @@ import type {
 	UpdateNeonAuthUserRoleResponse,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 /** Branch-scoped Neon Auth OAuth providers (Google, GitHub, …). */
@@ -46,27 +47,18 @@ export class AuthOauthProviders<DThrow extends boolean> {
 	list(
 		projectId: string,
 		branchId: string,
-	): Promise<Outcome<NeonAuthOauthProvider[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<NeonAuthOauthProvider[], Throw>>;
-	list(
-		projectId: string,
-		branchId: string,
 		opts?: CallOptions,
-	): Promise<NeonAuthOauthProvider[] | NeonResult<NeonAuthOauthProvider[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	): Paginated<NeonAuthOauthProvider> {
+		return paginate(
+			(_cursor, signal) =>
 				listBranchNeonAuthOauthProviders({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.providers,
+			(data) => ({ items: data?.providers ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 
@@ -186,30 +178,18 @@ export class AuthTrustedDomains<DThrow extends boolean> {
 	list(
 		projectId: string,
 		branchId: string,
-	): Promise<Outcome<NeonAuthRedirectUriWhitelistDomain[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<NeonAuthRedirectUriWhitelistDomain[], Throw>>;
-	list(
-		projectId: string,
-		branchId: string,
 		opts?: CallOptions,
-	): Promise<
-		| NeonAuthRedirectUriWhitelistDomain[]
-		| NeonResult<NeonAuthRedirectUriWhitelistDomain[]>
-	> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	): Paginated<NeonAuthRedirectUriWhitelistDomain> {
+		return paginate(
+			(_cursor, signal) =>
 				listBranchNeonAuthTrustedDomains({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.domains,
+			(data) => ({ items: data?.domains ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/buckets.ts
+++ b/packages/sdk/src/neon/resources/buckets.ts
@@ -9,6 +9,7 @@ import type {
 	BucketCreateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = BucketCreateRequest;
@@ -25,27 +26,18 @@ export class Buckets<DThrow extends boolean> {
 	list(
 		projectId: string,
 		branchId: string,
-	): Promise<Outcome<Bucket[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<Bucket[], Throw>>;
-	list(
-		projectId: string,
-		branchId: string,
 		opts?: CallOptions,
-	): Promise<Bucket[] | NeonResult<Bucket[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	): Paginated<Bucket> {
+		return paginate(
+			(_cursor, signal) =>
 				listProjectBranchBuckets({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.buckets,
+			(data) => ({ items: data?.buckets ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/credentials.ts
+++ b/packages/sdk/src/neon/resources/credentials.ts
@@ -9,6 +9,7 @@ import type {
 	CredentialMeta,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = CreateCredentialRequest;
@@ -25,27 +26,18 @@ export class Credentials<DThrow extends boolean> {
 	list(
 		projectId: string,
 		branchId: string,
-	): Promise<Outcome<CredentialMeta[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<CredentialMeta[], Throw>>;
-	list(
-		projectId: string,
-		branchId: string,
 		opts?: CallOptions,
-	): Promise<CredentialMeta[] | NeonResult<CredentialMeta[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	): Paginated<CredentialMeta> {
+		return paginate(
+			(_cursor, signal) =>
 				listCredentials({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.credentials,
+			(data) => ({ items: data?.credentials ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/databases.ts
+++ b/packages/sdk/src/neon/resources/databases.ts
@@ -11,6 +11,7 @@ import type {
 	DatabaseUpdateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = DatabaseCreateRequest["database"];
@@ -28,27 +29,18 @@ export class Databases<DThrow extends boolean> {
 	list(
 		projectId: string,
 		branchId: string,
-	): Promise<Outcome<Database[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<Database[], Throw>>;
-	list(
-		projectId: string,
-		branchId: string,
 		opts?: CallOptions,
-	): Promise<Database[] | NeonResult<Database[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	): Paginated<Database> {
+		return paginate(
+			(_cursor, signal) =>
 				listProjectBranchDatabases({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.databases,
+			(data) => ({ items: data?.databases ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/endpoints.list.test.ts
+++ b/packages/sdk/src/neon/resources/endpoints.list.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createNeonClient } from "../client.js";
+
+function neonRouting(
+	respond: (request: { url: string; method: string }) => {
+		status: number;
+		body: unknown;
+	},
+) {
+	const calls: Array<{ url: string; method: string }> = [];
+	const neon = createNeonClient({
+		apiKey: "test",
+		retries: 0,
+		fetch: async (input, init) => {
+			const request = input instanceof Request ? input : undefined;
+			const url = request ? request.url : String(input);
+			const method = (
+				request?.method ??
+				init?.method ??
+				"GET"
+			).toUpperCase();
+			calls.push({ url, method });
+			const { status, body } = respond({ url, method });
+			return new Response(JSON.stringify(body), {
+				status,
+				headers: { "content-type": "application/json" },
+			});
+		},
+	});
+	return { neon, calls };
+}
+
+describe("endpoints.list", () => {
+	it("lists project endpoints", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { endpoints: [{ id: "ep-1" }] },
+		}));
+		const { data, error } = await neon.postgres.endpoints.list("p-1").all();
+		expect(error).toBeUndefined();
+		expect(data).toEqual([{ id: "ep-1" }]);
+		expect(calls).toHaveLength(1);
+		expect(calls[0]?.url).toContain("/projects/p-1/endpoints");
+		expect(calls[0]?.url).not.toContain("/branches/");
+	});
+
+	it("lists endpoints for a branch", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { endpoints: [{ id: "ep-2" }] },
+		}));
+		const { data, error } = await neon.postgres.endpoints
+			.list("p-1", { branchId: "br-1" })
+			.all();
+		expect(error).toBeUndefined();
+		expect(data).toEqual([{ id: "ep-2" }]);
+		expect(calls[0]?.url).toContain(
+			"/projects/p-1/branches/br-1/endpoints",
+		);
+	});
+
+	it("stops after one page when the API has no cursor", async () => {
+		const { neon, calls } = neonRouting(() => ({
+			status: 200,
+			body: { endpoints: [{ id: "ep-1" }, { id: "ep-2" }] },
+		}));
+		const { data, error } = await neon.postgres.endpoints.list("p-1").all();
+		expect(error).toBeUndefined();
+		expect(data).toHaveLength(2);
+		expect(calls).toHaveLength(1);
+	});
+
+	it("returns an envelope on API error", async () => {
+		const { neon } = neonRouting(() => ({
+			status: 403,
+			body: { message: "forbidden" },
+		}));
+		const { data, error } = await neon.postgres.endpoints.list("p-1").all();
+		expect(data).toBeUndefined();
+		expect(error?.kind).toBe("auth");
+	});
+});

--- a/packages/sdk/src/neon/resources/endpoints.ts
+++ b/packages/sdk/src/neon/resources/endpoints.ts
@@ -15,6 +15,7 @@ import type {
 	EndpointUpdateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = EndpointCreateRequest["endpoint"];
@@ -29,53 +30,32 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/endpoints */
-	list(projectId: string): Promise<Outcome<Endpoint[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<Endpoint[], Throw>>;
 	list(
 		projectId: string,
+		query?: { branchId?: string },
 		opts?: CallOptions,
-	): Promise<Endpoint[] | NeonResult<Endpoint[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
-				listProjectEndpoints({
-					client,
-					path: { project_id: projectId },
-					throwOnError: false,
-					signal,
-				}),
-			(data) => data.endpoints,
-		);
-	}
-
-	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/endpoints */
-	listByBranch(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<Endpoint[], DThrow>>;
-	listByBranch<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<Endpoint[], Throw>>;
-	listByBranch(
-		projectId: string,
-		branchId: string,
-		opts?: CallOptions,
-	): Promise<Endpoint[] | NeonResult<Endpoint[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
-				listProjectBranchEndpoints({
-					client,
-					path: { project_id: projectId, branch_id: branchId },
-					throwOnError: false,
-					signal,
-				}),
-			(data) => data.endpoints,
+	): Paginated<Endpoint> {
+		const branchId = query?.branchId;
+		return paginate(
+			(_cursor, signal) =>
+				branchId === undefined
+					? listProjectEndpoints({
+							client: this.#ctx.client,
+							path: { project_id: projectId },
+							throwOnError: false,
+							signal,
+						})
+					: listProjectBranchEndpoints({
+							client: this.#ctx.client,
+							path: {
+								project_id: projectId,
+								branch_id: branchId,
+							},
+							throwOnError: false,
+							signal,
+						}),
+			(data) => ({ items: data?.endpoints ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/phase1.test.ts
+++ b/packages/sdk/src/neon/resources/phase1.test.ts
@@ -27,7 +27,9 @@ describe("phase-1 namespaces map responses to the ergonomic shape", () => {
 
 	it("auth.oauthProviders.list unwraps the providers array", async () => {
 		const neon = neonReturning(200, { providers: [{ id: "google" }] });
-		const { data } = await neon.auth.oauthProviders.list("p-1", "br-1");
+		const { data } = await neon.auth.oauthProviders
+			.list("p-1", "br-1")
+			.all();
 		expect(data).toEqual([{ id: "google" }]);
 	});
 
@@ -37,7 +39,7 @@ describe("phase-1 namespaces map responses to the ergonomic shape", () => {
 				{ id: "perm-1", granted_to_email: "a@b.c", granted_at: "now" },
 			],
 		});
-		const { data } = await neon.projects.permissions.list("p-1");
+		const { data } = await neon.projects.permissions.list("p-1").all();
 		expect(data).toHaveLength(1);
 		expect(data?.[0]?.granted_to_email).toBe("a@b.c");
 	});
@@ -51,18 +53,19 @@ describe("phase-1 namespaces map responses to the ergonomic shape", () => {
 		expect(data).toEqual({ id: "p-1" });
 	});
 
-	it("postgres.endpoints.listByBranch unwraps endpoints", async () => {
+	it("postgres.endpoints.list({ branchId }) unwraps endpoints", async () => {
 		const neon = neonReturning(200, { endpoints: [{ id: "ep-1" }] });
-		const { data } = await neon.postgres.endpoints.listByBranch(
-			"p-1",
-			"br-1",
-		);
+		const { data } = await neon.postgres.endpoints
+			.list("p-1", { branchId: "br-1" })
+			.all();
 		expect(data).toEqual([{ id: "ep-1" }]);
 	});
 
 	it("propagates typed errors through the ergonomic channel", async () => {
 		const neon = neonReturning(403, { message: "forbidden" });
-		const { data, error } = await neon.projects.permissions.list("p-1");
+		const { data, error } = await neon.projects.permissions
+			.list("p-1")
+			.all();
 		expect(data).toBeUndefined();
 		expect(error?.kind).toBe("auth");
 	});

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -90,25 +90,17 @@ export class Permissions<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/permissions */
-	list(projectId: string): Promise<Outcome<ProjectPermission[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<ProjectPermission[], Throw>>;
-	list(
-		projectId: string,
-		opts?: CallOptions,
-	): Promise<ProjectPermission[] | NeonResult<ProjectPermission[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	list(projectId: string, opts?: CallOptions): Paginated<ProjectPermission> {
+		return paginate(
+			(_cursor, signal) =>
 				listProjectPermissions({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.project_permissions,
+			(data) => ({ items: data?.project_permissions ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/roles.ts
+++ b/packages/sdk/src/neon/resources/roles.ts
@@ -8,6 +8,7 @@ import {
 } from "../../client/sdk.gen.js";
 import type { Role, RoleCreateRequest } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { type Paginated, paginate } from "../paginate.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = RoleCreateRequest["role"];
@@ -21,27 +22,21 @@ export class Roles<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/roles */
-	list(projectId: string, branchId: string): Promise<Outcome<Role[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<Role[], Throw>>;
 	list(
 		projectId: string,
 		branchId: string,
 		opts?: CallOptions,
-	): Promise<Role[] | NeonResult<Role[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	): Paginated<Role> {
+		return paginate(
+			(_cursor, signal) =>
 				listProjectBranchRoles({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.roles,
+			(data) => ({ items: data?.roles ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { NeonAbortError, NeonError } from "../errors.js";
+import { type Paginated, paginate } from "../paginate.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 /**
@@ -115,25 +116,17 @@ export class Snapshots<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/snapshots */
-	list(projectId: string): Promise<Outcome<Snapshot[], DThrow>>;
-	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		opts: CallOptions<Throw>,
-	): Promise<Outcome<Snapshot[], Throw>>;
-	list(
-		projectId: string,
-		opts?: CallOptions,
-	): Promise<Snapshot[] | NeonResult<Snapshot[]>> {
-		return this.#ctx.run(
-			opts,
-			(client, signal) =>
+	list(projectId: string, opts?: CallOptions): Paginated<Snapshot> {
+		return paginate(
+			(_cursor, signal) =>
 				listSnapshots({
-					client,
+					client: this.#ctx.client,
 					path: { project_id: projectId },
 					throwOnError: false,
 					signal,
 				}),
-			(data) => data.snapshots,
+			(data) => ({ items: data?.snapshots ?? [] }),
+			() => this.#ctx.deadlineFor(opts),
 		);
 	}
 

--- a/packages/tools/src/catalog.test.ts
+++ b/packages/tools/src/catalog.test.ts
@@ -256,6 +256,36 @@ describe("special mappings", () => {
 		expect(tool.inputSchema.safeParse({}).success).toBe(true);
 	});
 
+	test("endpoints.list accepts optional branch_id", async () => {
+		const requests: Request[] = [];
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["postgres.endpoints.list"] as const,
+			fetch: async (input, init) => {
+				requests.push(new Request(input, init));
+				return jsonResponse({ endpoints: [] });
+			},
+		});
+		const list = tools["postgres.endpoints.list"];
+		expect(list.inputSchema.safeParse({ project_id: "p-1" }).success).toBe(
+			true,
+		);
+		expect(
+			list.inputSchema.safeParse({
+				project_id: "p-1",
+				branch_id: "br-1",
+			}).success,
+		).toBe(true);
+
+		await list.execute({ project_id: "p-1" });
+		await list.execute({ project_id: "p-1", branch_id: "br-1" });
+		expect(requests[0]?.url).toContain("/projects/p-1/endpoints");
+		expect(requests[0]?.url).not.toContain("/branches/");
+		expect(requests[1]?.url).toContain(
+			"/projects/p-1/branches/br-1/endpoints",
+		);
+	});
+
 	test("resetFromParent is destructive; compareSchema is read-only", () => {
 		const reset = createNeonTool("branches.resetFromParent", {
 			apiKey: "test-key",

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -1,4 +1,5 @@
 import * as z from "zod";
+import * as zod from "../../generated/zod.gen.js";
 import { decodeBase64 } from "../binary.js";
 import {
 	bindTool,
@@ -126,7 +127,11 @@ export const toolFactories = {
 			id: "projects.permissions.list",
 			generated: "listProjectPermissions",
 			run: (neon, input, signal) =>
-				neon.projects.permissions.list(input.project_id, { signal }),
+				collectPages(
+					neon.projects.permissions.list(input.project_id, {
+						signal,
+					}),
+				),
 		}),
 	"projects.permissions.grant": (options) =>
 		fromGenerated(options, {
@@ -282,23 +287,43 @@ export const toolFactories = {
 		}),
 	"postgres.connectionString": connectionStringTool,
 	"postgres.endpoints.list": (options) =>
-		fromGenerated(options, {
-			id: "postgres.endpoints.list",
-			generated: "listProjectEndpoints",
-			run: (neon, input, signal) =>
-				neon.postgres.endpoints.list(input.project_id, { signal }),
-		}),
-	"postgres.endpoints.listByBranch": (options) =>
-		fromGenerated(options, {
-			id: "postgres.endpoints.listByBranch",
-			generated: "listProjectBranchEndpoints",
-			run: (neon, input, signal) =>
-				neon.postgres.endpoints.listByBranch(
-					input.project_id,
-					input.branch_id,
-					{ signal },
+		bindTool(
+			options,
+			{
+				operationId: "postgres.endpoints.list",
+				id: publishedId("postgres.endpoints.list"),
+				title: "List compute endpoints",
+				description:
+					"Retrieves a list of compute endpoints for the specified project. Pass branch_id to list that branch only.",
+				inputSchema: z.strictObject({
+					project_id: zod.zListProjectEndpointsPath.shape.project_id,
+					branch_id:
+						zod.zListProjectBranchEndpointsPath.shape.branch_id.optional(),
+				}),
+				annotations: {
+					readOnlyHint: true,
+					openWorldHint: false,
+				},
+				requiresApproval: false,
+				metadata: {
+					method: "GET",
+					path: "/projects/{project_id}/endpoints",
+					stability: "stable",
+					deprecated: false,
+					tags: ["Endpoint"],
+				},
+			},
+			(neon, input, signal) =>
+				collectPages(
+					neon.postgres.endpoints.list(
+						input.project_id,
+						input.branch_id === undefined
+							? undefined
+							: { branchId: input.branch_id },
+						{ signal },
+					),
 				),
-		}),
+		),
 	"postgres.endpoints.get": (options) =>
 		fromGenerated(options, {
 			id: "postgres.endpoints.get",
@@ -412,9 +437,15 @@ export const toolFactories = {
 			id: "postgres.roles.list",
 			generated: "listProjectBranchRoles",
 			run: (neon, input, signal) =>
-				neon.postgres.roles.list(input.project_id, input.branch_id, {
-					signal,
-				}),
+				collectPages(
+					neon.postgres.roles.list(
+						input.project_id,
+						input.branch_id,
+						{
+							signal,
+						},
+					),
+				),
 		}),
 	"postgres.roles.get": (options) =>
 		fromGenerated(options, {
@@ -469,12 +500,12 @@ export const toolFactories = {
 			id: "postgres.databases.list",
 			generated: "listProjectBranchDatabases",
 			run: (neon, input, signal) =>
-				neon.postgres.databases.list(
-					input.project_id,
-					input.branch_id,
-					{
-						signal,
-					},
+				collectPages(
+					neon.postgres.databases.list(
+						input.project_id,
+						input.branch_id,
+						{ signal },
+					),
 				),
 		}),
 	"postgres.databases.get": (options) =>
@@ -611,9 +642,15 @@ export const toolFactories = {
 			id: "storage.buckets.list",
 			generated: "listProjectBranchBuckets",
 			run: (neon, input, signal) =>
-				neon.storage.buckets.list(input.project_id, input.branch_id, {
-					signal,
-				}),
+				collectPages(
+					neon.storage.buckets.list(
+						input.project_id,
+						input.branch_id,
+						{
+							signal,
+						},
+					),
+				),
 		}),
 	"storage.buckets.create": (options) =>
 		fromGenerated(options, {
@@ -827,9 +864,11 @@ export const toolFactories = {
 			id: "credentials.list",
 			generated: "listCredentials",
 			run: (neon, input, signal) =>
-				neon.credentials.list(input.project_id, input.branch_id, {
-					signal,
-				}),
+				collectPages(
+					neon.credentials.list(input.project_id, input.branch_id, {
+						signal,
+					}),
+				),
 		}),
 	"credentials.create": (options) =>
 		fromGenerated(options, {
@@ -932,7 +971,7 @@ export const toolFactories = {
 			id: "snapshots.list",
 			generated: "listSnapshots",
 			run: (neon, input, signal) =>
-				neon.snapshots.list(input.project_id, { signal }),
+				collectPages(neon.snapshots.list(input.project_id, { signal })),
 		}),
 	"snapshots.create": (options) =>
 		fromGenerated(options, {
@@ -1058,12 +1097,12 @@ export const toolFactories = {
 			id: "auth.oauthProviders.list",
 			generated: "listBranchNeonAuthOauthProviders",
 			run: (neon, input, signal) =>
-				neon.auth.oauthProviders.list(
-					input.project_id,
-					input.branch_id,
-					{
-						signal,
-					},
+				collectPages(
+					neon.auth.oauthProviders.list(
+						input.project_id,
+						input.branch_id,
+						{ signal },
+					),
 				),
 		}),
 	"auth.oauthProviders.add": (options) =>
@@ -1117,12 +1156,12 @@ export const toolFactories = {
 			id: "auth.trustedDomains.list",
 			generated: "listBranchNeonAuthTrustedDomains",
 			run: (neon, input, signal) =>
-				neon.auth.trustedDomains.list(
-					input.project_id,
-					input.branch_id,
-					{
-						signal,
-					},
+				collectPages(
+					neon.auth.trustedDomains.list(
+						input.project_id,
+						input.branch_id,
+						{ signal },
+					),
 				),
 		}),
 	"auth.trustedDomains.add": (options) =>
@@ -1267,7 +1306,8 @@ export const toolFactories = {
 		fromGenerated(options, {
 			id: "apiKeys.list",
 			generated: "listApiKeys",
-			run: (neon, _input, signal) => neon.apiKeys.list({ signal }),
+			run: (neon, _input, signal) =>
+				collectPages(neon.apiKeys.list({ signal })),
 		}),
 	"apiKeys.create": (options) =>
 		fromGenerated(options, {
@@ -1303,7 +1343,8 @@ export const toolFactories = {
 					tags: ["Region"],
 				},
 			},
-			(neon, _input, signal) => neon.regions.list({ signal }),
+			(neon, _input, signal) =>
+				collectPages(neon.regions.list({ signal })),
 		),
 	"user.me": (options) =>
 		fromGenerated(options, {

--- a/packages/tools/src/lib/ergonomic/ids.ts
+++ b/packages/tools/src/lib/ergonomic/ids.ts
@@ -35,7 +35,6 @@ export const toolIds = [
 	"branches.finalizeRestore",
 	"postgres.connectionString",
 	"postgres.endpoints.list",
-	"postgres.endpoints.listByBranch",
 	"postgres.endpoints.get",
 	"postgres.endpoints.create",
 	"postgres.endpoints.update",


### PR DESCRIPTION
## Problem

Some `list` methods return `Paginated<T>` (`.all()` / `.page()`). Others return `Promise<Outcome<T[]>>`. Endpoints also split project vs branch across `list` and `listByBranch`.

## Diagnosis

Cursor-backed lists already go through `paginate()`. The rest unwrap a single JSON array in `ctx.run`. Callers have to remember which resource is which, and `{ signal }` as the second argument to `endpoints.list` is `CallOptions` today but becomes the query after the fold.

## Interface

```ts
const { data: all } = await neon.postgres.endpoints.list(projectId).all();
const { data: onBranch } = await neon.postgres.endpoints
  .list(projectId, { branchId })
  .all();
await neon.postgres.endpoints.list(projectId, undefined, { signal }).all();

const { data: roles } = await neon.postgres.roles.list(projectId, branchId).all();
```

`listByBranch` is gone. APIs that do not send a next cursor still return `Paginated`; `.all()` stops after one page.

The `postgres.endpoints.list` tool takes optional `branch_id` and drops `postgres.endpoints.listByBranch`.

`page()` / `.all()` still return the `{ data, error }` envelope regardless of `throwOnError`.

## Also in here

- Major changeset for `@neon/sdk` and `@neon/tools`.
- `Regions` is no longer generic: `list` is its only method.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 145 passed
- `pnpm --filter @neon/sdk test:types` — 16 passed
- `pnpm --filter @neon/sdk build`
- `pnpm --filter @neon/tools test:ci` — 141 passed
- `pnpm --filter @neon/tools tsc`

## For your attention

- Generated MCP `listProjectBranchEndpoints` is unchanged. Only the ergonomic catalog id is gone.
- `storage.objects.list` still returns `BucketObjectsListResponse`, not `T[]`.
- `user.organizations()` is not named `list` and still returns an array.