### PR TITLE
Require `client` on every `@neon/sdk/raw` call

### DIFF
--- a/.changeset/sdk-raw-require-client.md
+++ b/.changeset/sdk-raw-require-client.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": major
+---
+
+Raw functions require `options.client`. The unauthenticated global `client` is no longer exported from `@neon/sdk/raw`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -723,7 +723,7 @@ Also on `neon.projects`: `recover(id)` (beta — recover a soft-deleted project)
 
 ## Raw layer (every endpoint, 1:1)
 
-Anything not wrapped above is available raw. Pass `neon.client` to reuse the client's auth:
+Anything not wrapped above is available raw. Pass `neon.client` on every call; it is required.
 
 ```ts
 import { raw } from "@neon/sdk";
@@ -735,6 +735,8 @@ const { data, error } = await raw.getProjectBranchSchema({
   query: { db_name: "neondb" }, // db_name is required
 });
 ```
+
+Omitting `client` is a type error. At runtime it throws `NeonError` with `kind: "client"` before any request is sent.
 
 **The raw layer speaks the exact same result contract as the ergonomic client.** By default a
 raw call resolves to a `{ data, error }` `NeonResult` with the typed `NeonError` on the error

--- a/packages/sdk/src/neon/raw-wrap.test.ts
+++ b/packages/sdk/src/neon/raw-wrap.test.ts
@@ -4,6 +4,7 @@ import { deleteProjectBranchDatabase, getProject } from "../client/raw.gen.js";
 import * as gen from "../client/sdk.gen.js";
 import { createNeonClient } from "./client.js";
 import { NeonNotFoundError } from "./errors.js";
+import { wrapRaw } from "./raw-wrap.js";
 
 /**
  * Build a real configured client whose only stubbed boundary is the network: `fetch`
@@ -70,6 +71,34 @@ describe("wrapRaw result contract", () => {
 			path: { project_id: "p-1", branch_id: "br-1", database_name: "db" },
 		});
 		expect(res.error).toBeUndefined();
+	});
+});
+
+describe("wrapRaw requires client", () => {
+	it("throws a client NeonError and does not call the generated function", async () => {
+		let calls = 0;
+		const fn = async (_options: { client?: unknown }) => {
+			calls += 1;
+			return { data: { ok: true } };
+		};
+		const wrapped = wrapRaw(fn);
+		await expect(
+			wrapped({ path: { project_id: "p-1" } } as never),
+		).rejects.toMatchObject({ kind: "client" });
+		await expect(
+			wrapped({
+				client: undefined,
+				path: { project_id: "p-1" },
+			} as never),
+		).rejects.toMatchObject({ kind: "client" });
+		await expect(
+			wrapped({ client: null, path: { project_id: "p-1" } } as never),
+		).rejects.toMatchObject({ kind: "client" });
+		expect(calls).toBe(0);
+
+		const client = clientReturning(200, { project: { id: "p-1" } });
+		await wrapped({ client });
+		expect(calls).toBe(1);
 	});
 });
 

--- a/packages/sdk/src/neon/raw-wrap.test.ts
+++ b/packages/sdk/src/neon/raw-wrap.test.ts
@@ -77,8 +77,10 @@ describe("wrapRaw result contract", () => {
 describe("wrapRaw requires client", () => {
 	it("throws a client NeonError and does not call the generated function", async () => {
 		let calls = 0;
-		const fn = async (_options: { client?: unknown }) => {
+		let received: unknown;
+		const fn = async (passed: { client?: unknown }) => {
 			calls += 1;
+			received = passed.client;
 			return { data: { ok: true } };
 		};
 		const wrapped = wrapRaw(fn);
@@ -99,6 +101,7 @@ describe("wrapRaw requires client", () => {
 		const client = clientReturning(200, { project: { id: "p-1" } });
 		await wrapped({ client });
 		expect(calls).toBe(1);
+		expect(received).toBe(client);
 	});
 });
 

--- a/packages/sdk/src/neon/raw-wrap.ts
+++ b/packages/sdk/src/neon/raw-wrap.ts
@@ -107,15 +107,22 @@ export function wrapRaw<F extends AnyRawFn>(fn: F & AnyRawFn) {
 	async function call(
 		options: RawOptions<F> & { throwOnError?: boolean },
 	): Promise<RawData<F> | RawResult<RawData<F>>> {
-		if (options == null || Reflect.get(options, "client") == null) {
-			throw new NeonError(
+		const missingClient = () =>
+			new NeonError(
 				"raw functions require options.client — pass neon.client from createNeonClient().",
 				"client",
 			);
+		if (options == null) {
+			throw missingClient();
+		}
+		const client = Reflect.get(options, "client");
+		if (client == null) {
+			throw missingClient();
 		}
 		const shouldThrow = options.throwOnError === true;
 		const raw: RawFieldsResult<RawData<F>> = await fn({
 			...options,
+			client,
 			throwOnError: false,
 			responseStyle: "fields",
 		});

--- a/packages/sdk/src/neon/raw-wrap.ts
+++ b/packages/sdk/src/neon/raw-wrap.ts
@@ -14,8 +14,8 @@
  * and headers without dropping to the low-level client.
  */
 
-import type { NeonError } from "./errors.js";
-import { NeonAbortError, toNeonError } from "./errors.js";
+import type { Client } from "../client/client/index.js";
+import { NeonAbortError, NeonError, toNeonError } from "./errors.js";
 
 /**
  * Did the caller's own signal end this call?
@@ -66,8 +66,8 @@ export type RawData<F extends AnyRawFn> =
 /** The call options for a wrapped raw function, minus the removed hey-api switches. */
 export type RawOptions<F extends AnyRawFn> = Omit<
 	NonNullable<Parameters<F>[0]>,
-	"throwOnError" | "responseStyle"
->;
+	"throwOnError" | "responseStyle" | "client"
+> & { client: Client };
 
 /**
  * The non-throwing result of a wrapped raw call: the ergonomic `{ data, error }` union
@@ -85,6 +85,8 @@ export type RawResult<T> =
 
 /**
  * Wrap a generated raw function so it speaks the ergonomic result contract.
+ * `options.client` is required; omitting it is a type error and throws
+ * {@link NeonError} with `kind: "client"` before any request is sent.
  *
  * @example
  * ```ts
@@ -105,6 +107,12 @@ export function wrapRaw<F extends AnyRawFn>(fn: F & AnyRawFn) {
 	async function call(
 		options: RawOptions<F> & { throwOnError?: boolean },
 	): Promise<RawData<F> | RawResult<RawData<F>>> {
+		if (options == null || Reflect.get(options, "client") == null) {
+			throw new NeonError(
+				"raw functions require options.client — pass neon.client from createNeonClient().",
+				"client",
+			);
+		}
 		const shouldThrow = options.throwOnError === true;
 		const raw: RawFieldsResult<RawData<F>> = await fn({
 			...options,

--- a/packages/sdk/src/raw.test-d.ts
+++ b/packages/sdk/src/raw.test-d.ts
@@ -1,8 +1,10 @@
 import { describe, expectTypeOf, test } from "vitest";
 import type { ProjectResponse, ProjectsResponse } from "./client/types.gen.js";
+import * as sdk from "./index.js";
 import { createNeonClient } from "./neon/client.js";
 import type { NeonError } from "./neon/errors.js";
-import type { RawResult } from "./neon/raw-wrap.js";
+import type { RawOptions, RawResult } from "./neon/raw-wrap.js";
+import * as rawNs from "./raw.js";
 import { getProject, listProjects } from "./raw.js";
 
 // Type-level tests for the wrapped raw surface. Run via `pnpm --filter @neon/sdk test:types`
@@ -68,5 +70,29 @@ describe("raw result contract (negative types)", () => {
 	test("throwOnError only accepts a boolean", () => {
 		// @ts-expect-error throwOnError must be a boolean
 		getProject({ client, path: { project_id: "p" }, throwOnError: "yes" });
+	});
+
+	test("client is required", () => {
+		// @ts-expect-error raw operations require an explicit client
+		getProject({ path: { project_id: "p" } });
+		getProject({
+			// @ts-expect-error client is Client, not undefined
+			client: undefined,
+			path: { project_id: "p" },
+		});
+	});
+
+	test("the unauthenticated singleton is not exported", () => {
+		// @ts-expect-error client is no longer exported from the raw entry
+		rawNs.client;
+		// @ts-expect-error raw.client is no longer public
+		sdk.raw.client;
+	});
+
+	test("RawOptions requires Client and still omits hey-api switches", () => {
+		type Opts = RawOptions<typeof getProject>;
+		expectTypeOf<Opts["client"]>().toEqualTypeOf<typeof client>();
+		expectTypeOf<Opts>().not.toHaveProperty("throwOnError");
+		expectTypeOf<Opts>().not.toHaveProperty("responseStyle");
 	});
 });

--- a/packages/sdk/src/raw.ts
+++ b/packages/sdk/src/raw.ts
@@ -20,7 +20,6 @@ export {
 	createClient,
 	createConfig,
 } from "./client/client/index.js";
-export { client } from "./client/client.gen.js";
 // Every operation, wrapped to the ergonomic result contract.
 export * from "./client/raw.gen.js";
 // Every generated request/response/schema type, flat.


### PR DESCRIPTION
## Problem

`getProject({ path: { project_id } })` type-checks. The generated client then uses the unauthenticated global singleton (`baseUrl` only) and the call 401s.

## Diagnosis

Generated ops resolve `options?.client ?? client`. `wrapRaw` forwarded options unchanged, and `RawOptions` kept `client` optional. `@neon/sdk/raw` also re-exported that singleton as `client` / `raw.client`.

## Interface

```ts
import { createNeonClient, raw } from "@neon/sdk";

const neon = createNeonClient({ apiKey });
await raw.getProject({ client: neon.client, path: { project_id } });
```

`client` is required on `RawOptions`. Omitting it is a type error. At runtime it throws `NeonError` with `kind: "client"` before any request. `import { client } from "@neon/sdk/raw"` and `raw.client` are gone.

```ts
export type RawOptions<F extends AnyRawFn> = Omit<
  NonNullable<Parameters<F>[0]>,
  "throwOnError" | "responseStyle" | "client"
> & { client: Client };
```

## Also in here

- Major changeset for `@neon/sdk`.
- Generated `client.gen.ts` singleton is unchanged and unreachable through wrapRaw.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 142 passed
- `pnpm --filter @neon/sdk test:types` — 19 passed
- `pnpm --filter @neon/sdk build`

## For your attention

- JavaScript callers that omit `client` now throw instead of 401.
- `createClient` / `createConfig` are still exported from `@neon/sdk/raw` for hosts that build their own client.