### PR TITLE
Keep schema types on `@neon/sdk`; move raw plumbing to `/raw`

### DIFF
--- a/.changeset/sdk-main-type-exports.md
+++ b/.changeset/sdk-main-type-exports.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": major
+---
+
+Schema types and `Client` stay on `@neon/sdk`. `RawResult`, `Config`, and `RawOptions` move to `@neon/sdk/raw`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -750,10 +750,9 @@ const { project } = await raw.getProject({
 });
 ```
 
-There is no `responseStyle` switch — `throwOnError` is the only one. `neon.client` is the
-underlying configured Fetch client; `raw.*` are the wrapped generated functions, and all
-request/response/error **types** are re-exported flat from `@neon/sdk` for
-`import type { Project, Branch, … }`.
+All request/response schema types are re-exported flat from `@neon/sdk` for
+`import type { Project, Branch, … }`. Raw plumbing types (`RawResult`, `Config`,
+`RawOptions`) are on `@neon/sdk/raw`.
 
 ## Regenerating the client
 

--- a/packages/sdk/src/index.test-d.ts
+++ b/packages/sdk/src/index.test-d.ts
@@ -1,0 +1,26 @@
+import { expectTypeOf, test } from "vitest";
+import type * as sdk from "./index.js";
+import type { Client, Project } from "./index.js";
+import type { Config, RawResult } from "./raw.js";
+
+test("schema types and Client stay on the main entry", () => {
+	expectTypeOf<Project>().toMatchTypeOf<object>();
+	expectTypeOf<Client>().toMatchTypeOf<object>();
+});
+
+test("raw plumbing types are not on the main entry", () => {
+	// @ts-expect-error RawResult is exported from @neon/sdk/raw, not @neon/sdk
+	type _RawResult = sdk.RawResult;
+	// @ts-expect-error Config is exported from @neon/sdk/raw, not @neon/sdk
+	type _Config = sdk.Config;
+	// @ts-expect-error RawOptions is exported from @neon/sdk/raw, not @neon/sdk
+	type _RawOptions = sdk.RawOptions;
+});
+
+test("raw plumbing types remain on the raw entry", () => {
+	expectTypeOf<RawResult<{ id: string }>>().toMatchTypeOf<
+		| { data: { id: string }; error: undefined }
+		| { data: undefined; error: unknown }
+	>();
+	expectTypeOf<Config>().toMatchTypeOf<object>();
+});

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -9,7 +9,8 @@
  * - **`raw`** — the full generated 1:1 surface (every endpoint as a standalone,
  *   tree-shakeable function + client primitives). Also at the `@neon/sdk/raw` subpath.
  *
- * All request/response/error types are re-exported flat for `import type { … }`.
+ * Schema types (`Project`, `Branch`, …) are re-exported flat for `import type { … }`.
+ * Raw plumbing types (`RawResult`, `Config`) are on `@neon/sdk/raw`.
  *
  * @example
  * ```ts
@@ -20,6 +21,8 @@
  * ```
  */
 
+export type { Client } from "./client/client/index.js";
+export type * from "./client/types.gen.js";
 export type { NeonClient } from "./neon/client.js";
 export { createNeonClient } from "./neon/client.js";
 export type { NeonConfig } from "./neon/config.js";
@@ -66,6 +69,6 @@ export type {
 } from "./neon/resources/snapshots.js";
 export type { NeonResult, Outcome } from "./neon/result.js";
 export type { WaitForOptions } from "./neon/wait.js";
-export type * from "./raw.js";
-// The raw 1:1 surface as a namespace, and all generated types flat.
+// The raw 1:1 surface as a namespace. Plumbing types (`RawResult`, `Config`)
+// live on `@neon/sdk/raw`.
 export * as raw from "./raw.js";


### PR DESCRIPTION
## Problem

`import type { Project } from "@neon/sdk"` shares autocomplete with hey-api `Config`, `RawResult`, `RawOptions`, and `CreateClientConfig`. Spec `ClientOptions` also lands next to the hey-api `Client`.

## Diagnosis

`packages/sdk/src/index.ts` does `export type * from "./raw.js"`. That re-exports every generated schema type *and* the raw wrapper plumbing. The `@neon/sdk/raw` subpath already exists for the latter.

## Interface

```ts
import type { Branch, Client, Project } from "@neon/sdk";
import type { Config, RawOptions, RawResult } from "@neon/sdk/raw";
```

```ts
export type * from "./client/types.gen.js";
export type { Client } from "./client/client/index.js";
export * as raw from "./raw.js";
```

`export * as raw` is unchanged. Values (`createNeonClient`, `raw.getProject`, …) do not move.

## Also in here

- Major changeset for `@neon/sdk`.

## Verification

- `pnpm --filter @neon/sdk test:ci` — 141 passed
- `pnpm --filter @neon/sdk test:types` — 19 passed
- `pnpm --filter @neon/sdk build`

## For your attention

- `import type { RawResult, Config } from "@neon/sdk"` is a type error. Import them from `@neon/sdk/raw`.
- Generated `*Data` / `*Responses` / `*Errors` types still come through `types.gen.js` on the main entry. Filtering those is a different change.