### PR TITLE
Name the raw layer result `RawResult`

### DIFF
--- a/.changeset/sdk-readme-rawresult.md
+++ b/.changeset/sdk-readme-rawresult.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": patch
+---
+
+README names the raw layer's result `RawResult` and shows `response` for HTTP status.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -739,8 +739,8 @@ const { data, error } = await raw.getProjectBranchSchema({
 **The raw layer uses the same `{ data, error }` contract as the ergonomic client, plus HTTP
 status and headers.** The ergonomic client returns `NeonResult`. A raw call returns
 `RawResult` (`import type { RawResult } from "@neon/sdk/raw"`): the same envelope plus
-optional `response`/`request`. `response` is unset only when the request never reached the
-server. Pass `throwOnError: true` to get the bare resource and throw instead — and the
+optional `response?: Response` and `request?: Request`. `response` is `undefined` only when
+no HTTP response was received (network error, timeout, abort). Pass `throwOnError: true` to get the bare resource and throw instead — and the
 return type narrows accordingly:
 
 ```ts

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -736,12 +736,21 @@ const { data, error } = await raw.getProjectBranchSchema({
 });
 ```
 
-**The raw layer speaks the exact same result contract as the ergonomic client.** By default a
-raw call resolves to a `{ data, error }` `NeonResult` with the typed `NeonError` on the error
-channel; pass `throwOnError: true` to get the bare resource and throw instead — and the
-return type narrows accordingly:
+**The raw layer uses the same `{ data, error }` contract as the ergonomic client, plus HTTP
+status and headers.** By default a raw call resolves to a `RawResult`: `{ data, error }` with
+the typed `NeonError` on the error channel and optional `response`/`request`. Pass
+`throwOnError: true` to get the bare resource and throw instead — and the return type
+narrows accordingly:
 
 ```ts
+import type { RawResult } from "@neon/sdk/raw";
+
+const res: RawResult<{ project: Project }> = await raw.getProject({
+  client: neon.client,
+  path: { project_id },
+});
+if (res.error) console.log(res.response?.status);
+
 // bare resource, throws the typed NeonError on failure
 const { project } = await raw.getProject({
   client: neon.client,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -737,15 +737,16 @@ const { data, error } = await raw.getProjectBranchSchema({
 ```
 
 **The raw layer uses the same `{ data, error }` contract as the ergonomic client, plus HTTP
-status and headers.** By default a raw call resolves to a `RawResult`: `{ data, error }` with
-the typed `NeonError` on the error channel and optional `response`/`request`. Pass
-`throwOnError: true` to get the bare resource and throw instead — and the return type
-narrows accordingly:
+status and headers.** The ergonomic client returns `NeonResult`. A raw call returns
+`RawResult` (`import type { RawResult } from "@neon/sdk/raw"`): the same envelope plus
+optional `response`/`request`. `response` is unset only when the request never reached the
+server. Pass `throwOnError: true` to get the bare resource and throw instead — and the
+return type narrows accordingly:
 
 ```ts
-import type { RawResult } from "@neon/sdk/raw";
+import { raw } from "@neon/sdk";
 
-const res: RawResult<{ project: Project }> = await raw.getProject({
+const res = await raw.getProject({
   client: neon.client,
   path: { project_id },
 });

--- a/packages/sdk/src/raw.ts
+++ b/packages/sdk/src/raw.ts
@@ -4,10 +4,11 @@
  * guaranteed per-function tree-shaking, via this subpath:
  * `import { listProjects } from "@neon/sdk/raw"`.
  *
- * Every operation speaks the **same result contract as the ergonomic client**: it resolves
- * to a `{ data, error }` {@link NeonResult} by default, or the bare resource when you pass
- * `throwOnError: true` (throwing the typed `NeonError`). There is no `responseStyle` switch —
- * `throwOnError` is the only one, and the return type always tracks it.
+ * Every operation speaks the **same `{ data, error }` contract as the ergonomic client**, plus
+ * HTTP status and headers: it resolves to a {@link RawResult} by default, or the bare
+ * resource when you pass `throwOnError: true` (throwing the typed `NeonError`). There is no
+ * `responseStyle` switch — `throwOnError` is the only one, and the return type always tracks
+ * it.
  */
 
 // `ClientOptions` / `Options` are intentionally not re-exported from the client


### PR DESCRIPTION
## Problem

The README says a raw call returns a `{ data, error }` `NeonResult`. The type is `RawResult`. The extra fields are `response` and `request` (HTTP status and headers). `RawResult` is exported from `@neon/sdk/raw` and covered in `raw.test-d.ts`; the README never named it.

## Solution

The raw-layer README names `RawResult`, says how it differs from `NeonResult`, and shows `response?.status`. `response` is `undefined` only when no HTTP response was received (network error, timeout, abort). The `raw.ts` module comment matches.

```ts
import { raw } from "@neon/sdk";

const res = await raw.getProject({
  client: neon.client,
  path: { project_id },
});
if (res.error) console.log(res.response?.status);
```

`import type { RawResult } from "@neon/sdk/raw"` when you need to name the type.

## Verification

Docs and JSDoc only. No runtime change.

## Gaps

None. Ergonomic methods stay `NeonResult`.