### PR TITLE
Default `CallOptions` to the envelope

### DIFF
--- a/.changeset/sdk-calloptions-throw-default.md
+++ b/.changeset/sdk-calloptions-throw-default.md
@@ -1,0 +1,5 @@
+---
+"@neon/sdk": major
+---
+
+`CallOptions` now defaults `Throw` to `false`, matching the client. A `CallOptions` variable keeps the `{ data, error }` envelope. Use `CallOptions<true>` when `throwOnError` is true.

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -45,6 +45,11 @@ it("a CallOptions variable keeps the envelope; CallOptions<true> throws", () => 
 		neon.projects.get("p", throwing),
 	).resolves.toEqualTypeOf<Project>();
 
+	const mixed: CallOptions<boolean> = {};
+	expectTypeOf(neon.projects.get("p", mixed)).resolves.toEqualTypeOf<
+		Project | NeonResult<Project>
+	>();
+
 	const invalid: CallOptions = {
 		// @ts-expect-error bare CallOptions is the envelope, not throwOnError: true
 		throwOnError: true,

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -12,6 +12,7 @@ import type {
 	Snapshot,
 } from "../client/types.gen.js";
 import { createNeonClient } from "./client.js";
+import type { CallOptions } from "./context.js";
 import type { Paginated } from "./paginate.js";
 import type { BranchConnection } from "./resources/branches.js";
 import type { ProjectConnection } from "./resources/projects.js";
@@ -30,6 +31,25 @@ it("default client returns the { data, error } envelope", () => {
 it("throwOnError on the client narrows methods to the bare resource", () => {
 	const neon = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(neon.projects.get("p")).resolves.toEqualTypeOf<Project>();
+});
+
+it("a CallOptions variable keeps the envelope; CallOptions<true> throws", () => {
+	const neon = createNeonClient({ apiKey: "x" });
+	const opts: CallOptions = { signal: new AbortController().signal };
+	expectTypeOf(neon.projects.get("p", opts)).resolves.toEqualTypeOf<
+		NeonResult<Project>
+	>();
+
+	const throwing: CallOptions<true> = { throwOnError: true };
+	expectTypeOf(
+		neon.projects.get("p", throwing),
+	).resolves.toEqualTypeOf<Project>();
+
+	const invalid: CallOptions = {
+		// @ts-expect-error bare CallOptions is the envelope, not throwOnError: true
+		throwOnError: true,
+	};
+	void invalid;
 });
 
 it("per-call throwOnError overrides the client default and narrows", () => {

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -40,6 +40,11 @@ it("a CallOptions variable keeps the envelope; CallOptions<true> throws", () => 
 		NeonResult<Project>
 	>();
 
+	const envelope: CallOptions = { throwOnError: false };
+	expectTypeOf(neon.projects.get("p", envelope)).resolves.toEqualTypeOf<
+		NeonResult<Project>
+	>();
+
 	const throwing: CallOptions<true> = { throwOnError: true };
 	expectTypeOf(
 		neon.projects.get("p", throwing),

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -27,10 +27,20 @@ export interface ResolvedConfig {
 	orgId?: string;
 }
 
-/** Per-call overrides accepted by every ergonomic method.
+/**
+ * Per-call overrides accepted by every ergonomic method.
  *
- * `Throw` defaults to `false` so a `CallOptions` variable keeps the `{ data, error }`
- * envelope. Use `CallOptions<true>` when the object sets `throwOnError: true`.
+ * `Throw` defaults to `false` to match `NeonConfig.throwOnError`. A `CallOptions`
+ * variable keeps the `{ data, error }` envelope. For throwing behaviour, write
+ * `CallOptions<true>`:
+ *
+ * ```ts
+ * const opts: CallOptions = { signal };
+ * await neon.projects.get(id, opts); // NeonResult<Project>
+ *
+ * const throwing: CallOptions<true> = { throwOnError: true };
+ * await neon.projects.get(id, throwing); // Project
+ * ```
  */
 export interface CallOptions<Throw extends boolean = false> {
 	/** Override the client's `throwOnError` for this call. */

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -27,8 +27,12 @@ export interface ResolvedConfig {
 	orgId?: string;
 }
 
-/** Per-call overrides accepted by every ergonomic method. */
-export interface CallOptions<Throw extends boolean = boolean> {
+/** Per-call overrides accepted by every ergonomic method.
+ *
+ * `Throw` defaults to `false` so a `CallOptions` variable keeps the `{ data, error }`
+ * envelope. Use `CallOptions<true>` when the object sets `throwOnError: true`.
+ */
+export interface CallOptions<Throw extends boolean = false> {
 	/** Override the client's `throwOnError` for this call. */
 	throwOnError?: Throw;
 	/** Override the client's `waitForReadiness` for this call (mutations only). */
@@ -87,7 +91,7 @@ export class RequestContext {
 	 * `requestTimeoutMs: NaN` meaning *unbounded* and a value past `setTimeout`'s range
 	 * meaning *1ms*, both silently.
 	 */
-	deadlineFor(opts: CallOptions | undefined): Deadline {
+	deadlineFor(opts: CallOptions<boolean> | undefined): Deadline {
 		const timeoutMs =
 			opts?.requestTimeoutMs === undefined
 				? this.#config.requestTimeoutMs
@@ -97,7 +101,7 @@ export class RequestContext {
 
 	/** Run a raw call and map its body; applies the resolved `throwOnError` policy. */
 	async run<D, T>(
-		opts: CallOptions | undefined,
+		opts: CallOptions<boolean> | undefined,
 		exec: Exec<D>,
 		map: (data: D) => T,
 	): Promise<T | NeonResult<T>> {
@@ -107,7 +111,7 @@ export class RequestContext {
 
 	/** Like {@link run} but for endpoints that may return an empty (204) body. */
 	async runVoid<D>(
-		opts: CallOptions | undefined,
+		opts: CallOptions<boolean> | undefined,
 		exec: Exec<D>,
 	): Promise<void | NeonResult<void>> {
 		const shouldThrow = opts?.throwOnError ?? this.#config.throwOnError;
@@ -126,7 +130,7 @@ export class RequestContext {
 	 * throw). Used by `run` and by workflows that post-process the result.
 	 */
 	async execute<D, T>(
-		opts: CallOptions | undefined,
+		opts: CallOptions<boolean> | undefined,
 		exec: Exec<D>,
 		map: (data: D) => T,
 	): Promise<NeonResult<T>> {
@@ -146,7 +150,7 @@ export class RequestContext {
 	 * budget cannot cut short the separate `wait` budget.
 	 */
 	async #request<D>(
-		opts: CallOptions | undefined,
+		opts: CallOptions<boolean> | undefined,
 		exec: Exec<D>,
 	): Promise<Requested<D>> {
 		const deadline = this.deadlineFor(opts);
@@ -182,7 +186,7 @@ export class RequestContext {
 
 	/** Poll provisioning operations when `waitForReadiness` is on and the body has any. */
 	async #maybeWait(
-		opts: CallOptions | undefined,
+		opts: CallOptions<boolean> | undefined,
 		data: unknown,
 	): Promise<NeonResult<void> | undefined> {
 		const wait = opts?.waitForReadiness ?? this.#config.waitForReadiness;

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -115,7 +115,7 @@ export class RequestContext {
 
 	/** Per-call, then client, then the method's own default. */
 	resolveWait(
-		opts: CallOptions | undefined,
+		opts: CallOptions<boolean> | undefined,
 		methodDefault: boolean,
 	): boolean {
 		return (
@@ -126,7 +126,7 @@ export class RequestContext {
 	}
 
 	/** The `throwOnError` policy for one call: the per-call override if given, else the client's. */
-	shouldThrow(opts: CallOptions | undefined): boolean {
+	shouldThrow(opts: CallOptions<boolean> | undefined): boolean {
 		return opts?.throwOnError ?? this.#config.throwOnError;
 	}
 


### PR DESCRIPTION
## Problem

`CallOptions` defaults `Throw` to `boolean`. A stored options object un-narrows the call:

```ts
const opts: CallOptions = { signal };
const result = await neon.projects.get(id, opts);
// Project | NeonResult<Project> — destructuring { data, error } fails
```

Inline `{ signal }` is fine. `NeonConfig` already defaults `Throw` to `false`.

## Solution

Default `Throw` to `false`. RequestContext still accepts `CallOptions<boolean>` so per-call `throwOnError: true` keeps working.

```ts
const opts: CallOptions = { signal };
await neon.projects.get(id, opts); // NeonResult<Project>

const throwing: CallOptions<true> = { throwOnError: true };
await neon.projects.get(id, throwing); // Project
```

`const opts: CallOptions = { throwOnError: true }` is now a type error. Use `CallOptions<true>`. `CallOptions<boolean>` stays the union, for pass-through wrappers.

## Verification

`pnpm --filter @neon/sdk test:types` and `test:ci`.

## Gaps

Breaking for code that annotated `CallOptions` and put `throwOnError: true` inside it.