### PR TITLE
Publish tool ids resource-first and rename `operationId` to `selector`

### DIFF
--- a/.changeset/tools-t1-published-id.md
+++ b/.changeset/tools-t1-published-id.md
@@ -2,4 +2,4 @@
 "@neon/tools": major
 ---
 
-Published tool ids are now resource-first (`projects.list` → `projects_list`). The SDK path lives on `tool.selector` instead of `operationId`. MCP and Mastra hosts pinned to the old verb-first names need a `names` map.
+Published tool ids are now resource-first (`projects.list` → `projects_list`, was `list_projects`). The SDK path lives on `tool.selector` instead of `operationId`. MCP and Mastra hosts pinned to the old names can pass `names`.

--- a/.changeset/tools-t1-published-id.md
+++ b/.changeset/tools-t1-published-id.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": major
+---
+
+Published tool ids are now resource-first (`projects.list` → `projects_list`). The SDK path lives on `tool.selector` instead of `operationId`. MCP and Mastra hosts pinned to the old verb-first names need a `names` map.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -8,13 +8,13 @@ npm install @neon/tools
 
 ## Create tools
 
-Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the last path segment, then the resource, in snake_case (`projects.list` → `list_projects`, `postgres.roles.resetPassword` → `reset_password_postgres_roles`, `postgres.connectionString` → `connection_string_postgres`). `publishedId` derives that string. `toolIds` lists every published selector.
+Selectors are SDK paths. The returned record is keyed by those paths. Each tool's published `id` is the resource, then the last path segment, in snake_case (`projects.list` → `projects_list`, `postgres.roles.resetPassword` → `postgres_roles_reset_password`, `postgres.connectionString` → `postgres_connection_string`). `tool.selector` is that SDK path. `publishedId` derives the published `id`. `toolIds` lists every published selector.
 
 ```ts
 import { createNeonTools, publishedId } from "@neon/tools";
 
-publishedId("projects.list"); // "list_projects"
-publishedId("postgres.roles.resetPassword"); // "reset_password_postgres_roles"
+publishedId("projects.list"); // "projects_list"
+publishedId("postgres.roles.resetPassword"); // "postgres_roles_reset_password"
 
 const apiKey = process.env.NEON_API_KEY;
 if (!apiKey) throw new Error("NEON_API_KEY is required");
@@ -49,7 +49,7 @@ const compared = await tools["branches.compareSchema"].execute({
 
 `limit` on a list tool caps how many items come back.
 
-MCP and Mastra publish `tool.id` (`list_projects`), not the record key.
+MCP and Mastra publish `tool.id` (`projects_list`), not the record key.
 
 `apiKey` is a Bearer credential: a Neon API key or a Neon OAuth access token. A function is called on every request, which is how short-lived OAuth tokens get refreshed. A credential is required when a tool executes — at construction, on `execute()`, or from MCP `authInfo` — and an empty value is rejected rather than ignored.
 
@@ -100,7 +100,7 @@ const tools = createNeonTools({
 	descriptions: {
 		"projects.list":
 			"List Neon projects in your account. Do not use for projects shared with you.",
-		delete_projects:
+		projects_delete:
 			"Delete a Neon project and all its data. NEVER run autonomously; always ask the user first.",
 	},
 });
@@ -135,7 +135,7 @@ const tools = createNeonTools({
 });
 ```
 
-Those tools publish as `neon_create_branch` and `neon_list_projects`. The record is still keyed by SDK path (`tools["branches.createAndConnect"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
+Those tools publish as `neon_create_branch` and `neon_projects_list`. The record is still keyed by SDK path (`tools["branches.createAndConnect"]`). MCP and Mastra publish `tool.id`. Eve uses the filename as the model-facing name, so name the file after the published `id`. Duplicate or non-snake-case ids throw, and a `names` key that matches no selected tool throws.
 
 ### Project and branch injection
 
@@ -262,7 +262,7 @@ MCP annotations are advisory; the protocol does not enforce approval. Tools expo
 
 Eve requires Node.js 24 or later.
 
-`create_and_connect_projects.ts`:
+`projects_create_and_connect.ts`:
 
 ```ts
 import { defineTool } from "eve/tools";
@@ -301,8 +301,8 @@ const neonTools = createNeonTools({
 });
 const configs = toMastraTools(neonTools);
 
-const listProjects = createTool(configs.list_projects);
-const createProject = createTool(configs.create_and_connect_projects);
+const listProjects = createTool(configs.projects_list);
+const createProject = createTool(configs.projects_create_and_connect);
 ```
 
 The adapter maps approval requirements to Mastra's `requireApproval` field and forwards its abort signal.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -49,7 +49,14 @@ const compared = await tools["branches.compareSchema"].execute({
 
 `limit` on a list tool caps how many items come back.
 
-MCP and Mastra publish `tool.id` (`projects_list`), not the record key.
+MCP and Mastra publish `tool.id` (`projects_list`), not the record key. Hosts pinned to 1.x verb-first ids can keep them with `names`:
+
+| selector | 1.x `tool.id` | now |
+| --- | --- | --- |
+| `projects.list` | `list_projects` | `projects_list` |
+| `projects.createAndConnect` | `create_and_connect_projects` | `projects_create_and_connect` |
+| `postgres.connectionString` | `connection_string_postgres` | `postgres_connection_string` |
+| `postgres.roles.resetPassword` | `reset_password_postgres_roles` | `postgres_roles_reset_password` |
 
 `apiKey` is a Bearer credential: a Neon API key or a Neon OAuth access token. A function is called on every request, which is how short-lived OAuth tokens get refreshed. A credential is required when a tool executes — at construction, on `execute()`, or from MCP `authInfo` — and an empty value is rejected rather than ignored.
 

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -44,7 +44,7 @@ const getProjectTools = (options: NeonToolsClientOptions = {}) => {
 };
 
 describe("description overrides", () => {
-	test("replaces by operationId and leaves unmatched tools unchanged", () => {
+	test("replaces by selector and leaves unmatched tools unchanged", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["projects.list", "projects.get"] as const,
@@ -61,12 +61,12 @@ describe("description overrides", () => {
 		);
 	});
 
-	test("replaces by snake-case id when operationId is absent", () => {
+	test("replaces by snake-case id when selector is absent", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["projects.list"] as const,
 			descriptions: {
-				list_projects: "List Neon projects in your account.",
+				projects_list: "List Neon projects in your account.",
 			},
 		});
 
@@ -75,17 +75,17 @@ describe("description overrides", () => {
 		);
 	});
 
-	test("prefers operationId over snake-case id", () => {
+	test("prefers selector over snake-case id", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["projects.list"] as const,
 			descriptions: {
-				"projects.list": "from operationId",
-				list_projects: "from id",
+				"projects.list": "from selector",
+				projects_list: "from id",
 			},
 		});
 
-		expect(tools["projects.list"].description).toBe("from operationId");
+		expect(tools["projects.list"].description).toBe("from selector");
 	});
 
 	test("lets a function alter the generated description", () => {
@@ -116,8 +116,8 @@ describe("onExecute", () => {
 	test("wraps execute so the host can track the call", async () => {
 		const events: string[] = [];
 		const { requests, tools } = getProjectTools({
-			onExecute: async ({ operationId, id, execute }) => {
-				events.push(`start:${operationId}:${id}`);
+			onExecute: async ({ selector, id, execute }) => {
+				events.push(`start:${selector}:${id}`);
 				const result = await execute();
 				events.push("success");
 				return result;
@@ -128,7 +128,7 @@ describe("onExecute", () => {
 			project_id: "project-id",
 		});
 
-		expect(events).toEqual(["start:projects.get:get_projects", "success"]);
+		expect(events).toEqual(["start:projects.get:projects_get", "success"]);
 		expect(result).toEqual({ data: { id: "project-id" } });
 		expect(requests).toHaveLength(1);
 	});
@@ -452,7 +452,7 @@ describe("description overrides (createNeonTool and contracts)", () => {
 		expect(tool.description).toBe("List Neon projects in your account.");
 	});
 
-	test("passes operationId, id, title, and the generated description to a function", () => {
+	test("passes selector, id, title, and the generated description to a function", () => {
 		const generated = createNeonTool("projects.delete", {
 			apiKey: "test-key",
 		});
@@ -469,8 +469,8 @@ describe("description overrides (createNeonTool and contracts)", () => {
 
 		expect(seen).toEqual([
 			{
-				operationId: "projects.delete",
-				id: "delete_projects",
+				selector: "projects.delete",
+				id: "projects_delete",
 				title: generated.title,
 				description: generated.description,
 			},
@@ -607,7 +607,7 @@ describe("onExecute failure and isolation", () => {
 
 		await tool.execute({ project_id: "project-id" });
 
-		expect(events).toEqual(["get_projects"]);
+		expect(events).toEqual(["projects_get"]);
 		expect(requests).toHaveLength(1);
 	});
 });
@@ -985,14 +985,14 @@ describe("tool names", () => {
 		expect(tools["branches.createAndConnect"].id).toBe(
 			"neon_create_branch",
 		);
-		expect(tools["projects.list"].id).toBe("neon_list_projects");
+		expect(tools["projects.list"].id).toBe("neon_projects_list");
 	});
 
 	test("lets a function rename from the generated id", () => {
 		const tool = createNeonTool("branches.createAndConnect", {
 			apiKey: "test-key",
 			names: ({ id }) =>
-				id === "create_and_connect_branches" ? "create_branch" : id,
+				id === "branches_create_and_connect" ? "create_branch" : id,
 		});
 
 		expect(tool.id).toBe("create_branch");

--- a/packages/tools/src/frameworks.test.ts
+++ b/packages/tools/src/frameworks.test.ts
@@ -63,12 +63,12 @@ describe("Mastra compatibility", () => {
 		});
 
 		const configs = toMastraTools(tools);
-		const listProjects = createTool(configs.list_projects);
-		const createProject = createTool(configs.create_and_connect_projects);
+		const listProjects = createTool(configs.projects_list);
+		const createProject = createTool(configs.projects_create_and_connect);
 
-		expect(listProjects.id).toBe("list_projects");
+		expect(listProjects.id).toBe("projects_list");
 		expect(listProjects.requireApproval).toBe(false);
-		expect(createProject.id).toBe("create_and_connect_projects");
+		expect(createProject.id).toBe("projects_create_and_connect");
 		expect(createProject.requireApproval).toBe(true);
 	});
 
@@ -79,7 +79,7 @@ describe("Mastra compatibility", () => {
 			inject: { projectId: "granted-project", omitFromSchema: true },
 		});
 
-		expect(toMastraTools(tools).get_projects.inputSchema).toBe(
+		expect(toMastraTools(tools).projects_get.inputSchema).toBe(
 			tools["projects.get"].inputSchema,
 		);
 		expect(toEveTool(tools["projects.get"]).inputSchema).toBe(
@@ -92,7 +92,7 @@ describe("Mastra compatibility", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["projects.get"],
-			descriptions: { get_projects: "Granted project details." },
+			descriptions: { projects_get: "Granted project details." },
 			inject: { projectId: "granted-project", omitFromSchema: true },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -101,7 +101,7 @@ describe("Mastra compatibility", () => {
 		});
 
 		const eve = toEveTool(tools["projects.get"]);
-		const mastra = toMastraTools(tools).get_projects;
+		const mastra = toMastraTools(tools).projects_get;
 		expect(eve.description).toBe("Granted project details.");
 		expect(mastra.description).toBe("Granted project details.");
 

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -8,19 +8,19 @@ import {
 } from "./index.js";
 import { toMastraTools } from "./mastra.js";
 
-expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"list_projects">();
+expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"projects_list">();
 expectTypeOf(
 	publishedId("projects.createAndConnect"),
-).toEqualTypeOf<"create_and_connect_projects">();
+).toEqualTypeOf<"projects_create_and_connect">();
 expectTypeOf(
 	publishedId("postgres.roles.resetPassword"),
-).toEqualTypeOf<"reset_password_postgres_roles">();
+).toEqualTypeOf<"postgres_roles_reset_password">();
 expectTypeOf(
 	publishedId("branches.resetFromParent"),
-).toEqualTypeOf<"reset_from_parent_branches">();
+).toEqualTypeOf<"branches_reset_from_parent">();
 expectTypeOf(
 	publishedId("branches.compareSchema"),
-).toEqualTypeOf<"compare_schema_branches">();
+).toEqualTypeOf<"branches_compare_schema">();
 
 const tools = createNeonTools({
 	apiKey: "test-key",
@@ -55,14 +55,14 @@ oauthTools["projects.list"].execute(
 listProjects.execute({ name: "wrong-operation" });
 
 const mastraTools = toMastraTools(tools);
-expectTypeOf(mastraTools).toHaveProperty("list_projects");
-expectTypeOf(mastraTools).toHaveProperty("create_and_connect_projects");
+expectTypeOf(mastraTools).toHaveProperty("projects_list");
+expectTypeOf(mastraTools).toHaveProperty("projects_create_and_connect");
 
 // @ts-expect-error unselected tools are absent from the Mastra tool record
-mastraTools.delete_projects;
+mastraTools.projects_delete;
 
 // @ts-expect-error Mastra configs preserve tool-specific request types
-mastraTools.list_projects.execute({ limit: "one" }, {});
+mastraTools.projects_list.execute({ limit: "one" }, {});
 
 const eveListProjects = toEveTool(tools["projects.list"]);
 eveListProjects
@@ -138,7 +138,7 @@ eveOmitted
 	});
 
 const mastraOmitted = toMastraTools(omittedProject);
-mastraOmitted.get_projects.execute({}, {}).then((result) => {
+mastraOmitted.projects_get.execute({}, {}).then((result) => {
 	expectTypeOf(result.data.id).toEqualTypeOf<string>();
 });
 
@@ -181,11 +181,12 @@ const renamed = createNeonTools({
 });
 expectTypeOf(renamed["projects.list"].id).toEqualTypeOf<string>();
 expectTypeOf(renamed["branches.createAndConnect"].id).toEqualTypeOf<string>();
-expectTypeOf(tools["projects.list"].id).toEqualTypeOf<"list_projects">();
+expectTypeOf(tools["projects.list"].id).toEqualTypeOf<"projects_list">();
+expectTypeOf(tools["projects.list"].selector).toEqualTypeOf<string>();
 
 const mastraRenamed = toMastraTools(renamed);
 expectTypeOf(mastraRenamed.neon_create_branch.id).toEqualTypeOf<string>();
-expectTypeOf(mastraRenamed.neon_list_projects.id).toEqualTypeOf<string>();
+expectTypeOf(mastraRenamed.neon_projects_list.id).toEqualTypeOf<string>();
 
 const renamedOne = createNeonTool("branches.createAndConnect", {
 	apiKey: "test-key",

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -22,9 +22,9 @@ describe("createNeonTools", () => {
 			"projects.list",
 			"projects.createAndConnect",
 		]);
-		expect(tools["projects.list"].id).toBe("list_projects");
+		expect(tools["projects.list"].id).toBe("projects_list");
 		expect(tools["projects.createAndConnect"].id).toBe(
-			"create_and_connect_projects",
+			"projects_create_and_connect",
 		);
 	});
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -95,12 +95,12 @@ type BindableToolsInput<T extends CreateNeonToolsInput> = T & {
 
 const assertKnownNameKeys = (
 	names: NeonToolNameOverrides | undefined,
-	tools: ReadonlyArray<{ operationId: string; id: string }>,
+	tools: ReadonlyArray<{ selector: string; id: string }>,
 ): void => {
 	if (names === undefined || typeof names === "function") {
 		return;
 	}
-	const known = new Set(tools.flatMap((tool) => [tool.operationId, tool.id]));
+	const known = new Set(tools.flatMap((tool) => [tool.selector, tool.id]));
 	const unknown = Object.keys(names).filter((key) => !known.has(key));
 	if (unknown.length > 0) {
 		throw new TypeError(

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -16,7 +16,7 @@ export interface NeonToolInjectOptions {
 }
 
 export interface NeonToolDescriptionSource {
-	operationId: string;
+	selector: string;
 	id: string;
 	title: string;
 	description: string;
@@ -28,7 +28,7 @@ export type NeonToolDescriptionOverrides =
 
 export type NeonToolNameSource = Pick<
 	NeonToolDescriptionSource,
-	"operationId" | "id"
+	"selector" | "id"
 >;
 
 export type NeonToolNameOverrides =
@@ -36,7 +36,7 @@ export type NeonToolNameOverrides =
 	| ((tool: NeonToolNameSource) => string);
 
 export interface NeonToolOnExecuteEvent<Output = unknown> {
-	operationId: string;
+	selector: string;
 	id: string;
 	input: unknown;
 	execute: () => Promise<NeonToolResult<Output>>;
@@ -184,17 +184,17 @@ function publishedId(
 	if (options.names !== undefined) {
 		if (typeof options.names === "function") {
 			id = options.names({
-				operationId: tool.operationId,
+				selector: tool.selector,
 				id: tool.id,
 			});
 			if (typeof id !== "string") {
 				throw new TypeError(
-					`Neon tool name overrides must return a string for ${tool.operationId}`,
+					`Neon tool name overrides must return a string for ${tool.selector}`,
 				);
 			}
 		} else {
 			const override =
-				options.names[tool.operationId] ?? options.names[tool.id];
+				options.names[tool.selector] ?? options.names[tool.id];
 			if (override !== undefined) {
 				id = override;
 			}
@@ -205,7 +205,7 @@ function publishedId(
 	}
 	if (typeof id !== "string" || !PUBLISHED_ID.test(id)) {
 		throw new TypeError(
-			`Neon tool id must match ${PUBLISHED_ID} for ${tool.operationId}: received ${JSON.stringify(id)}`,
+			`Neon tool id must match ${PUBLISHED_ID} for ${tool.selector}: received ${JSON.stringify(id)}`,
 		);
 	}
 	return id;
@@ -260,7 +260,7 @@ function applyDescription(
 
 	if (typeof descriptions === "function") {
 		const description = descriptions({
-			operationId: tool.operationId,
+			selector: tool.selector,
 			id: tool.id,
 			title: tool.title,
 			description: tool.description,
@@ -273,7 +273,7 @@ function applyDescription(
 		return description;
 	}
 
-	const description = descriptions[tool.operationId] ?? descriptions[tool.id];
+	const description = descriptions[tool.selector] ?? descriptions[tool.id];
 	if (description === undefined) {
 		return tool.description;
 	}
@@ -313,7 +313,7 @@ function wrapToolExecute(
 		}
 
 		return onExecute({
-			operationId: tool.operationId,
+			selector: tool.selector,
 			id: tool.id,
 			input: cloneInput(input),
 			execute: run,

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -62,7 +62,7 @@ type SnakeDots<Id extends string> = Id extends `${infer Head}.${infer Rest}`
 	: Snake<Id>;
 
 export type PublishedId<Id extends string> = Id extends `${string}.${string}`
-	? `${Snake<LastSegment<Id>>}_${SnakeDots<ResourcePath<Id>>}`
+	? `${SnakeDots<ResourcePath<Id>>}_${Snake<LastSegment<Id>>}`
 	: Snake<Id>;
 
 const snakeSegment = (segment: string) =>
@@ -75,7 +75,7 @@ export const publishedId = <Id extends string>(id: Id): PublishedId<Id> => {
 	}
 	const verb = snakeSegment(id.slice(dot + 1));
 	const resource = id.slice(0, dot).split(".").map(snakeSegment).join("_");
-	return `${verb}_${resource}` as PublishedId<Id>;
+	return `${resource}_${verb}` as PublishedId<Id>;
 };
 
 const resolveApiKey = (
@@ -345,7 +345,7 @@ export function fromGenerated(
 			? schema
 			: omitObjectKeys(schema, spec.omit);
 	return {
-		operationId: spec.id,
+		selector: spec.id,
 		id: publishedId(spec.id),
 		title: generated.title,
 		description: spec.list

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -1287,7 +1287,7 @@ export const toolFactories = {
 		bindTool(
 			options,
 			{
-				operationId: "regions.list",
+				selector: "regions.list",
 				id: publishedId("regions.list"),
 				title: "List regions",
 				description:

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -156,7 +156,7 @@ export const createBranchTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "branches.create",
+			selector: "branches.create",
 			id: publishedId("branches.create"),
 			title: "Create branch",
 			description:
@@ -200,7 +200,7 @@ export const createBranchAndConnectTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "branches.createAndConnect",
+			selector: "branches.createAndConnect",
 			id: publishedId("branches.createAndConnect"),
 			title: "Create branch and connect",
 			description:
@@ -237,7 +237,7 @@ export const createProjectTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "projects.create",
+			selector: "projects.create",
 			id: publishedId("projects.create"),
 			title: "Create project",
 			description:
@@ -260,7 +260,7 @@ export const createProjectAndConnectTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "projects.createAndConnect",
+			selector: "projects.createAndConnect",
 			id: publishedId("projects.createAndConnect"),
 			title: "Create project and connect",
 			description:
@@ -289,7 +289,7 @@ export const getDefaultTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "branches.getDefault",
+			selector: "branches.getDefault",
 			id: publishedId("branches.getDefault"),
 			title: "Get default branch",
 			description:
@@ -313,7 +313,7 @@ export const resetFromParentTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "branches.resetFromParent",
+			selector: "branches.resetFromParent",
 			id: publishedId("branches.resetFromParent"),
 			title: "Reset branch from parent",
 			description:
@@ -344,7 +344,7 @@ export const compareSchemaTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "branches.compareSchema",
+			selector: "branches.compareSchema",
 			id: publishedId("branches.compareSchema"),
 			title: "Compare database schema",
 			description:
@@ -388,7 +388,7 @@ export const connectionStringTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "postgres.connectionString",
+			selector: "postgres.connectionString",
 			id: publishedId("postgres.connectionString"),
 			title: "Get connection string",
 			description:
@@ -432,7 +432,7 @@ export const restoreSnapshotTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "snapshots.restore",
+			selector: "snapshots.restore",
 			id: publishedId("snapshots.restore"),
 			title: "Restore snapshot",
 			description:
@@ -465,7 +465,7 @@ export const setScheduleTool = (options: ToolClientOptions) =>
 	bindTool(
 		options,
 		{
-			operationId: "snapshots.setSchedule",
+			selector: "snapshots.setSchedule",
 			id: publishedId("snapshots.setSchedule"),
 			title: "Set snapshot schedule",
 			description:

--- a/packages/tools/src/lib/operation.ts
+++ b/packages/tools/src/lib/operation.ts
@@ -56,7 +56,7 @@ export interface NeonTool<
 	Id extends string = string,
 	Output = unknown,
 > {
-	operationId: string;
+	selector: string;
 	id: Id;
 	title: string;
 	description: string;
@@ -106,7 +106,7 @@ export const bindOperation = <
 	operation: NeonOperation<InputSchema, Id, Output>,
 	client: Client,
 ): NeonTool<InputSchema, Id, JsonSafe<Awaited<Output>>> => ({
-	operationId: operation.operationId,
+	selector: operation.operationId,
 	id: operation.id,
 	title: operation.title,
 	description: operation.description,

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -52,13 +52,13 @@ describe("MCP v2 compatibility", () => {
 
 		const listed = await client.listTools();
 		expect(listed.tools.map((tool) => tool.name)).toEqual([
-			"list_projects",
+			"projects_list",
 		]);
 		expect(listed.tools[0].annotations?.readOnlyHint).toBe(true);
 		expect(listed.tools[0]._meta?.["neon/requiresApproval"]).toBe(false);
 
 		const called = await client.callTool({
-			name: "list_projects",
+			name: "projects_list",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({
@@ -66,7 +66,7 @@ describe("MCP v2 compatibility", () => {
 		});
 
 		const invalid = await client.callTool({
-			name: "list_projects",
+			name: "projects_list",
 			arguments: { limit: "one" },
 		});
 		expect(invalid.isError).toBe(true);
@@ -301,7 +301,7 @@ describe("MCP v1 compatibility", () => {
 		closeables.push(client, server);
 
 		const called = await client.callTool({
-			name: "list_projects",
+			name: "projects_list",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({
@@ -349,7 +349,7 @@ describe("MCP path injection", () => {
 		});
 
 		const called = await client.callTool({
-			name: "get_projects",
+			name: "projects_get",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({
@@ -403,7 +403,7 @@ describe("MCP path injection", () => {
 		});
 
 		const called = await client.callTool({
-			name: "get_projects",
+			name: "projects_get",
 			arguments: {},
 		});
 		expect(called.isError).toBeFalsy();
@@ -444,7 +444,7 @@ describe("MCP path injection", () => {
 		closeables.push(client, server);
 
 		const called = await client.callTool({
-			name: "get_projects",
+			name: "projects_get",
 			arguments: {},
 		});
 		expect(called.structuredContent).toEqual({

--- a/packages/tools/src/published-id.test.ts
+++ b/packages/tools/src/published-id.test.ts
@@ -4,28 +4,28 @@ import { publishedId } from "./lib/ergonomic/bind.js";
 import { toolIds } from "./lib/ergonomic/ids.js";
 
 describe("publishedId", () => {
-	test("moves the last path segment in front", () => {
-		expect(publishedId("projects.list")).toBe("list_projects");
+	test("resource first, then the last path segment", () => {
+		expect(publishedId("projects.list")).toBe("projects_list");
 		expect(publishedId("projects.createAndConnect")).toBe(
-			"create_and_connect_projects",
+			"projects_create_and_connect",
 		);
 		expect(publishedId("branches.createAndConnect")).toBe(
-			"create_and_connect_branches",
+			"branches_create_and_connect",
 		);
 		expect(publishedId("postgres.roles.resetPassword")).toBe(
-			"reset_password_postgres_roles",
+			"postgres_roles_reset_password",
 		);
-		expect(publishedId("logs.query")).toBe("query_logs");
-		expect(publishedId("user.me")).toBe("me_user");
-		expect(publishedId("regions.list")).toBe("list_regions");
+		expect(publishedId("logs.query")).toBe("logs_query");
+		expect(publishedId("user.me")).toBe("user_me");
+		expect(publishedId("regions.list")).toBe("regions_list");
 		expect(publishedId("functions.customDomains.list")).toBe(
-			"list_functions_custom_domains",
+			"functions_custom_domains_list",
 		);
 		expect(publishedId("functions.customDomains.register")).toBe(
-			"register_functions_custom_domains",
+			"functions_custom_domains_register",
 		);
 		expect(publishedId("functions.customDomains.delete")).toBe(
-			"delete_functions_custom_domains",
+			"functions_custom_domains_delete",
 		);
 	});
 

--- a/packages/tools/src/published-id.test.ts
+++ b/packages/tools/src/published-id.test.ts
@@ -29,11 +29,20 @@ describe("publishedId", () => {
 		);
 	});
 
-	test("every catalog tool publishes publishedId(selector)", () => {
+	test("every catalog tool publishes a unique wire id that maps back to one selector", () => {
+		const wire = new Map<string, string>();
 		for (const id of toolIds) {
+			const published = publishedId(id);
+			expect(published).toMatch(/^[a-z0-9_]{1,64}$/);
+			expect(wire.get(published)).toBeUndefined();
+			wire.set(published, id);
 			expect(createNeonTool(id, { apiKey: "test-key" }).id).toBe(
-				publishedId(id),
+				published,
+			);
+			expect(createNeonTool(id, { apiKey: "test-key" }).selector).toBe(
+				id,
 			);
 		}
+		expect(wire.size).toBe(toolIds.length);
 	});
 });

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -186,9 +186,9 @@ describe("branches.createAndConnect", () => {
 
 		expect(Object.keys(tools)).toEqual(["branches.createAndConnect"]);
 		expect(tools["branches.createAndConnect"].id).toBe(
-			"create_and_connect_branches",
+			"branches_create_and_connect",
 		);
-		expect(tools["branches.createAndConnect"].operationId).toBe(
+		expect(tools["branches.createAndConnect"].selector).toBe(
 			"branches.createAndConnect",
 		);
 		expect(tools["branches.createAndConnect"].requiresApproval).toBe(true);
@@ -410,7 +410,7 @@ describe("createNeonTool", () => {
 
 		await tool.execute({ project_id: "project-id", name: "feature-x" });
 
-		expect(tool.id).toBe("create_and_connect_branches");
+		expect(tool.id).toBe("branches_create_and_connect");
 		expect(requests[0].url).toBe(
 			"https://console.neon.tech/api/v2/projects/project-id/branches",
 		);


### PR DESCRIPTION
## Problem

Each tool has two ids. The record is keyed by selector (`tools["projects.list"]`). `tool.id` is verb-first snake (`list_projects`, `connection_string_postgres`). The selector lived on `operationId`. MCP and Mastra publish `tool.id`, so hosts need a different spelling on the wire than in TypeScript.

```ts
publishedId("projects.list"); // "list_projects"
tools["projects.list"].id;    // "list_projects"
tools["projects.list"].operationId; // "projects.list"
```

## Solution

`publishedId` is resource-first. The SDK path is `tool.selector`. The record is still keyed by the dotted selector.

```ts
publishedId("projects.list"); // "projects_list"
publishedId("postgres.connectionString"); // "postgres_connection_string"

const tools = createNeonTools({ apiKey, tools: ["projects.list"] });
tools["projects.list"].selector; // "projects.list"
tools["projects.list"].id;       // "projects_list"
```

| selector | 1.x `tool.id` | now |
| --- | --- | --- |
| `projects.list` | `list_projects` | `projects_list` |
| `projects.createAndConnect` | `create_and_connect_projects` | `projects_create_and_connect` |
| `postgres.connectionString` | `connection_string_postgres` | `postgres_connection_string` |

MCP and Mastra still publish `tool.id`. `names` still accepts the selector or the published id, including a 1.x id. Generated OpenAPI operations keep `operationId` on `NeonOperation`; `bindOperation` copies it onto `selector`.

## Verification

`pnpm --filter @neon/tools test:ci` and `tsc`. Every catalog `publishedId` is unique and matches `[a-z0-9_]{1,64}`.

## Gaps

Breaking for MCP/Mastra clients pinned to the old names. Use `names` to keep a historical id.