### PR TITLE
Reject an empty `apiKey` at construction; ignore `undefined` on execute

### DIFF
--- a/.changeset/tools-t2-apikey.md
+++ b/.changeset/tools-t2-apikey.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": patch
+---
+
+A provided empty `apiKey` is rejected at `createNeonTools`. `{ apiKey: undefined }` on `execute` keeps the constructor credential.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -51,7 +51,7 @@ const compared = await tools["branches.compareSchema"].execute({
 
 MCP and Mastra publish `tool.id` (`list_projects`), not the record key.
 
-`apiKey` is a Bearer credential: a Neon API key or a Neon OAuth access token. A function is called on every request, which is how short-lived OAuth tokens get refreshed. A credential is required when a tool executes — at construction, on `execute()`, or from MCP `authInfo` — and an empty value is rejected rather than ignored.
+`apiKey` is a Bearer credential: a Neon API key or a Neon OAuth access token. A function is called on every request, which is how short-lived OAuth tokens get refreshed. A credential is required when a tool executes — at construction, on `execute()`, or from MCP `authInfo`. A provided empty string is rejected at construction. `{ apiKey: undefined }` on `execute` is treated as absent and keeps the constructor credential.
 
 ```ts
 const tools = createNeonTools({

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -282,6 +282,27 @@ describe("Bearer credentials", () => {
 		).toEqual(["Bearer oauth-token-a", "Bearer oauth-token-b"]);
 	});
 
+	test("rejects an empty constructor credential before execute", () => {
+		expect(() =>
+			createNeonTools({
+				apiKey: "",
+				tools: ["projects.list"],
+			}),
+		).toThrow("A Neon API key or OAuth access token is required");
+	});
+
+	test("falls back to the constructor credential when execute passes apiKey: undefined", async () => {
+		const { requests, tools } = listProjects({
+			apiKey: "constructor-key",
+		});
+
+		await tools["projects.list"].execute({}, { apiKey: undefined });
+
+		expect(requests[0].headers.get("authorization")).toBe(
+			"Bearer constructor-key",
+		);
+	});
+
 	test("requires a credential at execute when none was given at construction", async () => {
 		const { requests, tools } = listProjects({});
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -9,6 +9,7 @@ import {
 	type NeonToolNameOverrides,
 } from "./lib/customize.js";
 import {
+	assertProvidedApiKey,
 	isNeonToolId,
 	type NeonToolId,
 	type PublishedId,
@@ -135,6 +136,7 @@ const bindTools = <T extends CreateNeonToolsInput>(
 	options: BindableToolsInput<T>,
 ): NeonTools<SelectedTools<T>> => {
 	assertToolCustomizeOptions(options);
+	assertProvidedApiKey(options);
 	const selected = options.tools;
 	if (selected === undefined || selected.length === 0) {
 		throw new TypeError("createNeonTools requires at least one tool");
@@ -257,6 +259,7 @@ export function createNeonTool<
 		throw unpublishedToolError(id);
 	}
 	assertToolCustomizeOptions(options);
+	assertProvidedApiKey(options);
 	const tool = factoryFor(id)(options);
 	assertKnownNameKeys(options.names, [tool]);
 	const customized = hasToolCustomization(options)

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -82,17 +82,16 @@ const resolveApiKey = (
 	options: ToolClientOptions,
 	context?: NeonToolExecutionContext,
 ): NeonBearerCredential => {
-	if (context !== undefined && "apiKey" in context) {
-		if (context.apiKey === undefined) {
-			throw new TypeError(
-				"A Neon API key or OAuth access token is required",
-			);
-		}
-		return requireBearerCredential(context.apiKey);
+	const credential = context?.apiKey ?? options.apiKey;
+	return credential === undefined
+		? missingBearerCredential()
+		: requireBearerCredential(credential);
+};
+
+export const assertProvidedApiKey = (options: ToolClientOptions): void => {
+	if (options.apiKey !== undefined) {
+		requireBearerCredential(options.apiKey);
 	}
-	return options.apiKey === undefined
-		? missingBearerCredential
-		: requireBearerCredential(options.apiKey);
 };
 
 export const toolClient = (

--- a/packages/tools/src/lib/ergonomic/index.ts
+++ b/packages/tools/src/lib/ergonomic/index.ts
@@ -1,4 +1,5 @@
 export {
+	assertProvidedApiKey,
 	type PublishedId,
 	publishedId,
 	type ToolClientOptions,

--- a/packages/tools/src/lib/operation.ts
+++ b/packages/tools/src/lib/operation.ts
@@ -117,9 +117,9 @@ export const bindOperation = <
 	async execute(input, context) {
 		const parsed = await operation.inputSchema.parseAsync(input);
 		const activeClient =
-			context !== undefined && "apiKey" in context
-				? clientWithCredential(client, context.apiKey)
-				: client;
+			context?.apiKey === undefined
+				? client
+				: clientWithCredential(client, context.apiKey);
 		const result = await operation.invoke(
 			activeClient,
 			parsed,
@@ -131,11 +131,8 @@ export const bindOperation = <
 
 const clientWithCredential = (
 	client: Client,
-	apiKey: NeonBearerCredential | undefined,
+	apiKey: NeonBearerCredential,
 ): Client => {
-	if (apiKey === undefined) {
-		throw new TypeError("A Neon API key or OAuth access token is required");
-	}
 	return createClient({
 		...client.getConfig(),
 		auth: requireBearerCredential(apiKey),


### PR DESCRIPTION
## Problem

`createNeonTools({ apiKey: \"\" })` succeeds and throws on first `execute()`. `execute(input, { apiKey: process.env.X })` with an unset env throws even when construction had a good key, because presence is `\"apiKey\" in context`.

```ts
createNeonTools({ apiKey: \"\", tools: [\"projects.list\"] }); // ok
await tools[\"projects.list\"].execute({}, { apiKey: undefined }); // TypeError, constructor key ignored
```

## Solution

A provided constructor `apiKey` is validated immediately. `undefined` on execute is absent.

```ts
createNeonTools({ apiKey: \"\", tools: [\"projects.list\"] }); // TypeError

const tools = createNeonTools({ apiKey: \"constructor-key\", tools: [\"projects.list\"] });
await tools[\"projects.list\"].execute({}, { apiKey: undefined }); // uses constructor-key
await tools[\"projects.list\"].execute({}, { apiKey: \"\" }); // TypeError, does not fall back
```

## Verification

`pnpm --filter @neon/tools test:ci` and `tsc`.

## Gaps

None. Empty string on execute still wins over the constructor key.