### PR TITLE
Accept `wait: false` so tool hosts can skip readiness polling

### DIFF
--- a/.changeset/tools-t3-wait.md
+++ b/.changeset/tools-t3-wait.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": patch
+---
+
+`wait: false` on `createNeonTools` skips readiness polling so a host can return immediately with `operations`.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -75,7 +75,7 @@ const createBranch = createNeonTool("branches.createAndConnect", { apiKey });
 
 ## Writes and waiting
 
-Tools run with `waitForReadiness: true`. When a mutation response includes an `operations` array, the call waits until those operations finish. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first.
+Tools run with `waitForReadiness: true` unless you pass `wait: false`. When a mutation response includes an `operations` array, the call waits until those operations finish. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first. Pass `wait: false` to return immediately with the created resource and its `operations`.
 
 An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist, and the error does not include its id. List before retrying.
 

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -143,6 +143,40 @@ describe("createNeonTools", () => {
 		expect(tools["projects.update"].annotations.readOnlyHint).toBe(false);
 	});
 
+	test("returns immediately when wait is false", async () => {
+		const requests: Request[] = [];
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.update"] as const,
+			wait: false,
+			fetch: async (input, init) => {
+				requests.push(new Request(input, init));
+				return jsonResponse({
+					project: { id: "project-id", name: "renamed" },
+					operations: [
+						{
+							id: "op-1",
+							project_id: "project-id",
+							action: "update_project",
+							status: "running",
+						},
+					],
+				});
+			},
+		});
+
+		const result = await tools["projects.update"].execute({
+			project_id: "project-id",
+			name: "renamed",
+		});
+
+		expect(result).toEqual({
+			data: { id: "project-id", name: "renamed" },
+		});
+		expect(requests).toHaveLength(1);
+		expect(requests[0].method).toBe("PATCH");
+	});
+
 	test("does not poll functions.deploy because the response has no operations", async () => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -29,7 +29,7 @@ export interface ToolClientOptions {
 	apiKey?: NeonBearerCredential;
 	baseUrl?: string;
 	fetch?: typeof fetch;
-	wait?: NeonConfig["wait"];
+	wait?: NeonConfig["wait"] | false;
 }
 
 const ALL_PAGES = " Returns every page. Pass limit to cap how many.";
@@ -102,10 +102,12 @@ export const toolClient = (
 	createNeonClient({
 		apiKey: resolveApiKey(options, context),
 		throwOnError: true,
-		waitForReadiness: true,
+		waitForReadiness: options.wait !== false,
 		...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
 		...(options.fetch === undefined ? {} : { fetch: options.fetch }),
-		...(options.wait === undefined ? {} : { wait: options.wait }),
+		...(options.wait !== undefined && options.wait !== false
+			? { wait: options.wait }
+			: {}),
 	});
 
 const objectListPage = (


### PR DESCRIPTION
## Problem

Every write tool polls up to five minutes. Hosts with short tool timeouts can shrink `wait.timeoutMs` but cannot return immediately with `operations`.

```ts
createNeonTools({ apiKey, tools: [\"projects.update\"], wait: { timeoutMs: 1_000 } });
// still polls; still waitForReadiness: true
```

## Solution

`wait: false` turns polling off. An object still tunes the deadline.

```ts
createNeonTools({
  apiKey,
  tools: [\"projects.update\"],
  wait: false,
});
```

Default stays polling on. `wait: { timeoutMs: 30_000 }` still bounds the poller.

## Verification

`pnpm --filter @neon/tools test:ci` and `tsc`.

## Gaps

`createAndConnect` workflows still wait in the SDK unless that client flag is honoured there. That is a separate SDK change.