### PR TITLE
chore: release @neon/ai-sdk-provider@0.10.0

### DIFF
--- a/.changeset/catalog-neon-com-models.md
+++ b/.changeset/catalog-neon-com-models.md
@@ -1,5 +1,0 @@
----
-"@neon/ai-sdk-provider": minor
----
-
-Typed model autocomplete now follows [neon.com/models](https://neon.com/models), including `claude-fable-5-1`, `glm-5-3-flash`, `grok-4-6`, and `gpt-6-astra`. `getNeonModelCapabilities("gpt-6-astra").supportsTemperature` is `false`.

--- a/packages/ai-sdk-provider/CHANGELOG.md
+++ b/packages/ai-sdk-provider/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/ai-sdk-provider
 
+## 0.10.0
+
+### Minor Changes
+
+- e46659b: Typed model autocomplete now follows [neon.com/models](https://neon.com/models), including `claude-fable-5-1`, `glm-5-3-flash`, `grok-4-6`, and `gpt-6-astra`. `getNeonModelCapabilities("gpt-6-astra").supportsTemperature` is `false`.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/ai-sdk-provider/package.json
+++ b/packages/ai-sdk-provider/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/ai-sdk-provider",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"description": "Community Vercel AI SDK provider for the Neon AI Gateway.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Version bump + CHANGELOG only. No source changes.

- `@neon/ai-sdk-provider`: 0.9.0 → **0.10.0** (minor)

Typed model autocomplete follows [neon.com/models](https://neon.com/models), including `claude-fable-5-1`, `glm-5-3-flash`, `grok-4-6`, and `gpt-6-astra`. `getNeonModelCapabilities("gpt-6-astra").supportsTemperature` is `false`.

Nothing here publishes to npm. After merge, dispatch `neon-pkgs.yml` in `databricks/secure-public-registry-releases-eng` with `package=@neon/ai-sdk-provider` and `ref=main`.