### PR TITLE
Keep created resource on wait abort and timeout

### DIFF
--- a/.changeset/tools-t4-create-id.md
+++ b/.changeset/tools-t4-create-id.md
@@ -3,4 +3,4 @@
 "@neon/tools": patch
 ---
 
-A wait abort or timeout after a mutation keeps the created resource on `error.created`.
+A wait abort or timeout after a mutation keeps the created resource on `error.created`. `createdId(error)` is the top-level resource id.

--- a/.changeset/tools-t4-create-id.md
+++ b/.changeset/tools-t4-create-id.md
@@ -1,0 +1,6 @@
+---
+"@neon/sdk": patch
+"@neon/tools": patch
+---
+
+A wait abort or timeout after a mutation keeps the created resource on `error.created`.

--- a/.changeset/tools-t4-create-id.md
+++ b/.changeset/tools-t4-create-id.md
@@ -3,4 +3,4 @@
 "@neon/tools": patch
 ---
 
-A wait abort or timeout after a mutation keeps the created resource on `error.created`. `createdId(error)` returns the resource id, including nested `project.id` / `branch.id` on createAndConnect.
+A wait abort or timeout after a mutation keeps the created resource on `error.created`. `createdId(error)` returns the resource id, including nested `project.id` / `branch.id` on createAndConnect. On createAndConnect, `created` is the full 201 body (`connection_uris`, role passwords); read `createdId` rather than logging the error whole.

--- a/.changeset/tools-t4-create-id.md
+++ b/.changeset/tools-t4-create-id.md
@@ -3,4 +3,4 @@
 "@neon/tools": patch
 ---
 
-A wait abort or timeout after a mutation keeps the created resource on `error.created`. `createdId(error)` is the top-level resource id.
+A wait abort or timeout after a mutation keeps the created resource on `error.created`. `createdId(error)` returns the resource id, including nested `project.id` / `branch.id` on createAndConnect.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -150,8 +150,8 @@ cancellation is not.
 
 When a mutation has already returned a body and readiness polling then aborts, times out,
 or sees a failed operation, `error.created` is that mapped resource (the project, branch,
-or full create response). `createdId(error)` is the resource `id` when that body has a
-top-level `id`. The poll stopped; the create did not.
+or full create response). `createdId(error)` is the resource id: a top-level `id`, or
+`created.project.id` / `created.branch.id` on createAndConnect responses. The poll stopped; the create did not.
 
 `requestTimeoutMs` must be a positive number of milliseconds up to `2147483647`, or
 `Infinity`. Anything else — `0`, a negative, `NaN`, or a value past that range — is
@@ -196,7 +196,7 @@ consuming it twice gets a fresh deadline each time.
 
 Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
 
-If that wait is aborted or times out, the error keeps the created resource on `created`. `createdId(error)` is the id when the body has a top-level `id`. Do not create again from the same input without reading it.
+If that wait is aborted or times out, the error keeps the created resource on `created`. `createdId(error)` is the resource id, including `createAndConnect` nested `project.id` / `branch.id`. Do not create again from the same input without reading it.
 
 ---
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -77,7 +77,7 @@ The `error` channel carries a typed hierarchy (all `Error` subclasses with a `ki
 
 | Class | `kind` | Notable fields |
 | --- | --- | --- |
-| `NeonError` | (base) | `message`, `kind` |
+| `NeonError` | (base) | `message`, `kind`, `created?` |
 | `NeonApiError` | `"api"` | `status`, `code`, `requestId`, `response`, `body` |
 | `NeonNotFoundError` | `"not_found"` | (404) — extends `NeonApiError` |
 | `NeonAuthError` | `"auth"` | (401/403) |
@@ -148,6 +148,10 @@ await neon.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
 `"aborted"` and `"timeout"` are deliberately distinct: a timeout is worth retrying, a
 cancellation is not.
 
+When a mutation has already returned a body and readiness polling then aborts, times out,
+or sees a failed operation, `error.created` is that mapped resource (the project, branch,
+or full create response). The poll stopped; the create did not.
+
 `requestTimeoutMs` must be a positive number of milliseconds up to `2147483647`, or
 `Infinity`. Anything else — `0`, a negative, `NaN`, or a value past that range — is
 rejected with a `client`-kind error when the client is created or the call is made, rather
@@ -190,6 +194,8 @@ consuming it twice gets a fresh deadline each time.
 ## Readiness & workflows
 
 Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
+
+If that wait is aborted or times out, the error keeps the created resource on `created`. Do not create again from the same input without reading it.
 
 ---
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -150,7 +150,8 @@ cancellation is not.
 
 When a mutation has already returned a body and readiness polling then aborts, times out,
 or sees a failed operation, `error.created` is that mapped resource (the project, branch,
-or full create response). The poll stopped; the create did not.
+or full create response). `createdId(error)` is the resource `id` when that body has a
+top-level `id`. The poll stopped; the create did not.
 
 `requestTimeoutMs` must be a positive number of milliseconds up to `2147483647`, or
 `Infinity`. Anything else — `0`, a negative, `NaN`, or a value past that range — is
@@ -195,7 +196,7 @@ consuming it twice gets a fresh deadline each time.
 
 Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
 
-If that wait is aborted or times out, the error keeps the created resource on `created`. Do not create again from the same input without reading it.
+If that wait is aborted or times out, the error keeps the created resource on `created`. `createdId(error)` is the id when the body has a top-level `id`. Do not create again from the same input without reading it.
 
 ---
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -150,8 +150,10 @@ cancellation is not.
 
 When a mutation has already returned a body and readiness polling then aborts, times out,
 or sees a failed operation, `error.created` is that mapped resource (the project, branch,
-or full create response). `createdId(error)` is the resource id: a top-level `id`, or
-`created.project.id` / `created.branch.id` on createAndConnect responses. The poll stopped; the create did not.
+or full create response). On `createAndConnect` that full response includes `connection_uris`
+and role passwords; read `createdId(error)` rather than logging the error whole.
+`createdId(error)` is the resource id: a top-level `id`, or `created.project.id` /
+`created.branch.id` on createAndConnect responses. The poll stopped; the create did not.
 
 `requestTimeoutMs` must be a positive number of milliseconds up to `2147483647`, or
 `Infinity`. Anything else — `0`, a negative, `NaN`, or a value past that range — is
@@ -196,7 +198,7 @@ consuming it twice gets a fresh deadline each time.
 
 Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle. `projects.create`, `branches.create`, and the `createAndConnect` workflows default it on. The connect workflows also hand back a connection string. The primitive is `neon.operations.waitFor(operations)`.
 
-If that wait is aborted or times out, the error keeps the created resource on `created`. `createdId(error)` is the resource id, including `createAndConnect` nested `project.id` / `branch.id`. Do not create again from the same input without reading it.
+If that wait is aborted or times out, the error keeps the created resource on `created`. On `createAndConnect` that value includes `connection_uris` and role passwords; read `createdId(error)` rather than logging the error whole. `createdId(error)` is the resource id, including `createAndConnect` nested `project.id` / `branch.id`. Do not create again from the same input without reading it.
 
 ---
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -25,6 +25,7 @@ export { createNeonClient } from "./neon/client.js";
 export type { NeonConfig } from "./neon/config.js";
 export type { CallOptions } from "./neon/context.js";
 export {
+	createdId,
 	NeonAbortError,
 	NeonApiError,
 	NeonAuthError,

--- a/packages/sdk/src/neon/cancellation.server.test.ts
+++ b/packages/sdk/src/neon/cancellation.server.test.ts
@@ -240,6 +240,7 @@ describe("readiness polling", () => {
 		);
 		expect(behaviour.operationPolls).toBeGreaterThan(0);
 		expect(error?.kind).toBe("aborted");
+		expect(error?.created).toEqual({ id: "p-1", name: "test" });
 		resetBehaviour();
 	});
 
@@ -259,6 +260,7 @@ describe("readiness polling", () => {
 		const { error } = await neon.projects.create({ name: "test" });
 		expect(behaviour.operationPolls).toBeGreaterThan(0);
 		expect(error?.kind).toBe("timeout");
+		expect(error?.created).toEqual({ id: "p-1", name: "test" });
 		expect(Date.now() - startedAt).toBeLessThan(2_000);
 		resetBehaviour();
 	});
@@ -275,6 +277,7 @@ describe("readiness polling", () => {
 
 		const { error } = await neon.projects.create({ name: "test" });
 		expect(error?.kind).toBe("timeout");
+		expect(error?.created).toEqual({ id: "p-1", name: "test" });
 	});
 
 	it("resolves once the operations finish", async () => {

--- a/packages/sdk/src/neon/context.ts
+++ b/packages/sdk/src/neon/context.ts
@@ -6,7 +6,7 @@ import {
 	resolveTimeoutMs,
 	runBounded,
 } from "./deadline.js";
-import { type NeonError, toNeonError } from "./errors.js";
+import { type NeonError, toNeonError, withCreated } from "./errors.js";
 import { err, finalize, type NeonResult, ok } from "./result.js";
 import { withRetries } from "./retry.js";
 import {
@@ -135,9 +135,10 @@ export class RequestContext {
 		if (requested.data === undefined) {
 			return err(toNeonError(undefined, requested.response));
 		}
+		const mapped = map(requested.data);
 		const readiness = await this.#maybeWait(opts, requested.data);
-		if (readiness?.error) return err(readiness.error);
-		return ok(map(requested.data));
+		if (readiness?.error) return err(withCreated(readiness.error, mapped));
+		return ok(mapped);
 	}
 
 	/**

--- a/packages/sdk/src/neon/errors.test.ts
+++ b/packages/sdk/src/neon/errors.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getProject } from "../client/raw.gen.js";
 import { createNeonClient } from "./client.js";
 import {
+	createdId,
 	describeTransportFailure,
 	NeonApiError,
 	NeonAuthError,
@@ -171,5 +172,19 @@ describe("withCreated", () => {
 		expect(withCreated(error, { id: "second" }).created).toEqual({
 			id: "first",
 		});
+	});
+});
+
+describe("createdId", () => {
+	it("returns the top-level id on a created resource", () => {
+		const error = new NeonTimeoutError("wait timed out");
+		error.created = { id: "p-1", name: "test" };
+		expect(createdId(error)).toBe("p-1");
+	});
+
+	it("returns undefined when the id is nested", () => {
+		const error = new NeonTimeoutError("wait timed out");
+		error.created = { project: { id: "p-1" } };
+		expect(createdId(error)).toBeUndefined();
 	});
 });

--- a/packages/sdk/src/neon/errors.test.ts
+++ b/packages/sdk/src/neon/errors.test.ts
@@ -182,9 +182,15 @@ describe("createdId", () => {
 		expect(createdId(error)).toBe("p-1");
 	});
 
-	it("returns undefined when the id is nested", () => {
+	it("returns a nested project id from createAndConnect", () => {
 		const error = new NeonTimeoutError("wait timed out");
 		error.created = { project: { id: "p-1" } };
-		expect(createdId(error)).toBeUndefined();
+		expect(createdId(error)).toBe("p-1");
+	});
+
+	it("returns a nested branch id from createAndConnect", () => {
+		const error = new NeonTimeoutError("wait timed out");
+		error.created = { branch: { id: "br-1" } };
+		expect(createdId(error)).toBe("br-1");
 	});
 });

--- a/packages/sdk/src/neon/errors.test.ts
+++ b/packages/sdk/src/neon/errors.test.ts
@@ -12,6 +12,7 @@ import {
 	NeonRateLimitError,
 	NeonTimeoutError,
 	toNeonError,
+	withCreated,
 } from "./errors.js";
 
 /**
@@ -147,5 +148,28 @@ describe("transport failures end to end", () => {
 		expect(res.error).toBeInstanceOf(NeonNetworkError);
 		expect(res.error?.message).toContain("(ECONNRESET)");
 		expect((res.error as NeonNetworkError).reason).toBe("ECONNRESET");
+	});
+});
+
+describe("withCreated", () => {
+	it("keeps the wait error's subclass and kind", () => {
+		const error = new NeonTimeoutError(
+			"Timed out after 80ms waiting for 1 operation(s) to finish.",
+		);
+		const created = { id: "p-1", name: "test" };
+		const attached = withCreated(error, created);
+		expect(attached).toBe(error);
+		expect(attached).toBeInstanceOf(NeonTimeoutError);
+		expect(attached.kind).toBe("timeout");
+		expect(attached.created).toEqual(created);
+	});
+
+	it("does not replace a created resource already on the error", () => {
+		const error = new NeonError("x", "timeout", {
+			created: { id: "first" },
+		});
+		expect(withCreated(error, { id: "second" }).created).toEqual({
+			id: "first",
+		});
 	});
 });

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -29,17 +29,33 @@ export type NeonErrorKind =
  */
 export class NeonError extends Error {
 	readonly kind: NeonErrorKind;
+	/**
+	 * The mapped resource from a mutation that succeeded before readiness polling
+	 * failed. Set on abort, timeout, and failed-operation errors after create and
+	 * other writes that already returned a body.
+	 */
+	created?: unknown;
 
 	constructor(
 		message: string,
 		kind: NeonErrorKind,
-		options?: { cause?: unknown },
+		options?: { cause?: unknown; created?: unknown },
 	) {
 		super(message, options);
 		this.name = "NeonError";
 		this.kind = kind;
+		this.created = options?.created;
 	}
 }
+
+/** Attach a created resource to a wait error without changing its subclass or kind. */
+export const withCreated = (error: NeonError, created: unknown): NeonError => {
+	if (error.created !== undefined) {
+		return error;
+	}
+	error.created = created;
+	return error;
+};
 
 /** A non-2xx HTTP response from the Neon API. */
 export class NeonApiError extends NeonError {

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -59,15 +59,31 @@ export const withCreated = (error: NeonError, created: unknown): NeonError => {
 
 export const createdId = (error: NeonError): string | undefined => {
 	const created = error.created;
-	if (
-		typeof created !== "object" ||
-		created === null ||
-		!("id" in created) ||
-		typeof created.id !== "string"
-	) {
+	if (typeof created !== "object" || created === null) {
 		return undefined;
 	}
-	return created.id;
+	if ("id" in created && typeof created.id === "string") {
+		return created.id;
+	}
+	if (
+		"project" in created &&
+		typeof created.project === "object" &&
+		created.project !== null &&
+		"id" in created.project &&
+		typeof created.project.id === "string"
+	) {
+		return created.project.id;
+	}
+	if (
+		"branch" in created &&
+		typeof created.branch === "object" &&
+		created.branch !== null &&
+		"id" in created.branch &&
+		typeof created.branch.id === "string"
+	) {
+		return created.branch.id;
+	}
+	return undefined;
 };
 
 /** A non-2xx HTTP response from the Neon API. */

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -33,6 +33,9 @@ export class NeonError extends Error {
 	 * The mapped resource from a mutation that succeeded before readiness polling
 	 * failed. Set on abort, timeout, and failed-operation errors after create and
 	 * other writes that already returned a body.
+	 *
+	 * On createAndConnect this is the full 201 body, including `connection_uris`
+	 * and role passwords. Read `createdId(error)` rather than logging the error whole.
 	 */
 	created?: unknown;
 

--- a/packages/sdk/src/neon/errors.ts
+++ b/packages/sdk/src/neon/errors.ts
@@ -57,6 +57,19 @@ export const withCreated = (error: NeonError, created: unknown): NeonError => {
 	return error;
 };
 
+export const createdId = (error: NeonError): string | undefined => {
+	const created = error.created;
+	if (
+		typeof created !== "object" ||
+		created === null ||
+		!("id" in created) ||
+		typeof created.id !== "string"
+	) {
+		return undefined;
+	}
+	return created.id;
+};
+
 /** A non-2xx HTTP response from the Neon API. */
 export class NeonApiError extends NeonError {
 	/** HTTP status code. */

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -77,7 +77,7 @@ const createBranch = createNeonTool("branches.createAndConnect", { apiKey });
 
 Tools run with `waitForReadiness: true`. When a mutation response includes an `operations` array, the call waits until those operations finish. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first.
 
-An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist, and the error does not include its id. List before retrying.
+An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist. The thrown error keeps that resource on `created` (`error.created.id` for `projects.create` / `branches.create`). Do not retry the same create without reading it.
 
 `functions.deploy` can still return `pending`. Its response has no `operations` array, so the tool does not poll.
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -77,7 +77,19 @@ const createBranch = createNeonTool("branches.createAndConnect", { apiKey });
 
 Tools run with `waitForReadiness: true`. When a mutation response includes an `operations` array, the call waits until those operations finish. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first.
 
-An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist. The thrown error keeps that resource on `created` (`error.created.id` for `projects.create` / `branches.create`). Do not retry the same create without reading it.
+An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist. The thrown error keeps that resource on `created`. `createdId(error)` is the id when the body has a top-level `id` (`projects.create`, `branches.create`). Do not retry the same create without reading it.
+
+```ts
+import { createdId, NeonError } from "@neon/tools";
+
+try {
+	await tools["projects.create"].execute({ name: "agent-project" }, { signal });
+} catch (error) {
+	if (error instanceof NeonError) {
+		createdId(error); // "project-id"
+	}
+}
+```
 
 `functions.deploy` can still return `pending`. Its response has no `operations` array, so the tool does not poll.
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -77,7 +77,7 @@ const createBranch = createNeonTool("branches.createAndConnect", { apiKey });
 
 Tools run with `waitForReadiness: true`. When a mutation response includes an `operations` array, the call waits until those operations finish. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first.
 
-An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist. The thrown error keeps that resource on `created`. `createdId(error)` is the resource id: top-level `id` for `projects.create` / `branches.create`, or `created.project.id` / `created.branch.id` for `createAndConnect`. Do not retry the same create without reading it.
+An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist. The thrown error keeps that resource on `created`. On `createAndConnect` that value includes `connection_uris` and role passwords; read `createdId(error)` rather than logging the error whole. `createdId(error)` is the resource id: top-level `id` for `projects.create` / `branches.create`, or `created.project.id` / `created.branch.id` for `createAndConnect`. Do not retry the same create without reading it.
 
 ```ts
 import { createdId, NeonError } from "@neon/tools";

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -77,7 +77,7 @@ const createBranch = createNeonTool("branches.createAndConnect", { apiKey });
 
 Tools run with `waitForReadiness: true`. When a mutation response includes an `operations` array, the call waits until those operations finish. The default deadline is five minutes (`wait.timeoutMs`). Pass `wait: { timeoutMs: 30_000 }` on `createNeonTools` or `createNeonTool` to bound that. Set it below the host's own tool-call timeout, otherwise the host gives up first.
 
-An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist. The thrown error keeps that resource on `created`. `createdId(error)` is the id when the body has a top-level `id` (`projects.create`, `branches.create`). Do not retry the same create without reading it.
+An abort `signal` on `execute` or a wait timeout stops the poll, not the create: the branch or project may already exist. The thrown error keeps that resource on `created`. `createdId(error)` is the resource id: top-level `id` for `projects.create` / `branches.create`, or `created.project.id` / `created.branch.id` for `createAndConnect`. Do not retry the same create without reading it.
 
 ```ts
 import { createdId, NeonError } from "@neon/tools";

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "vitest";
 import {
+	createdId,
 	createNeonTool,
 	createNeonTools,
+	NeonError,
 	type NeonToolsClientOptions,
 } from "./index.js";
 
@@ -176,12 +178,22 @@ describe("createNeonTools", () => {
 			},
 		});
 
-		await expect(
-			tools["projects.create"].execute({ name: "agent-project" }),
-		).rejects.toMatchObject({
-			kind: "timeout",
-			created: { id: "project-id", name: "agent-project" },
+		let caught: unknown;
+		try {
+			await tools["projects.create"].execute({ name: "agent-project" });
+		} catch (error) {
+			caught = error;
+		}
+		expect(caught).toBeInstanceOf(NeonError);
+		if (!(caught instanceof NeonError)) {
+			throw new Error("expected NeonError");
+		}
+		expect(caught.kind).toBe("timeout");
+		expect(caught.created).toEqual({
+			id: "project-id",
+			name: "agent-project",
 		});
+		expect(createdId(caught)).toBe("project-id");
 	});
 
 	test("does not poll functions.deploy because the response has no operations", async () => {

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -143,6 +143,47 @@ describe("createNeonTools", () => {
 		expect(tools["projects.update"].annotations.readOnlyHint).toBe(false);
 	});
 
+	test("keeps the created project on the error when wait times out", async () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.create"] as const,
+			wait: { pollIntervalMs: 1, timeoutMs: 50 },
+			fetch: async (input, init) => {
+				const request =
+					input instanceof Request ? input : new Request(input, init);
+				const url = new URL(request.url);
+				if (url.pathname.endsWith("/operations/op-1")) {
+					return jsonResponse({
+						operation: {
+							id: "op-1",
+							project_id: "project-id",
+							action: "create_project",
+							status: "running",
+						},
+					});
+				}
+				return jsonResponse({
+					project: { id: "project-id", name: "agent-project" },
+					operations: [
+						{
+							id: "op-1",
+							project_id: "project-id",
+							action: "create_project",
+							status: "running",
+						},
+					],
+				});
+			},
+		});
+
+		await expect(
+			tools["projects.create"].execute({ name: "agent-project" }),
+		).rejects.toMatchObject({
+			kind: "timeout",
+			created: { id: "project-id", name: "agent-project" },
+		});
+	});
+
 	test("does not poll functions.deploy because the response has no operations", async () => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,4 +1,4 @@
-import { NeonError } from "@neon/sdk";
+import { createdId, NeonError } from "@neon/sdk";
 import {
 	applyToolCustomization,
 	assertToolCustomizeOptions,
@@ -43,7 +43,7 @@ export type {
 	NeonToolResult,
 } from "./lib/operation.js";
 export type { NeonToolId, PublishedId };
-export { NeonError, publishedId, toolIds };
+export { createdId, NeonError, publishedId, toolIds };
 
 type ToolFactories = typeof toolFactories;
 


### PR DESCRIPTION
## Problem

`projects.create`, `branches.create`, and both `createAndConnect` workflows default `waitForReadiness` on. The create request returns a 201 body, then the SDK polls the operations in that body until they settle. If that poll aborts, times out, or sees a failed operation, the call fails with a `NeonAbortError`, `NeonTimeoutError`, or `NeonOperationError`.

The resource exists at that point. The API already returned it. The error carried nothing about it, so a caller that catches the error and creates again ends up with two projects or two branches. `@neon/tools` documented the only workaround: list before retrying.

Agents hit this most. Tools run with `waitForReadiness: true` and a five-minute default deadline, and a host that gives up on a tool call aborts the poll, not the create.

## Solution

`RequestContext.execute` maps the response body before it polls. When the wait fails, `withCreated` sets that mapped value on the error's `created` field without changing the subclass or the `kind`. An error that already has `created` is left alone.

`createdId(error)` reads the id out of `created`. The three mapping shapes in this repo decide what it looks for:

| Call | `created` | `createdId(error)` |
| --- | --- | --- |
| `projects.create`, `branches.create` | the project or branch | `created.id` |
| `projects.createAndConnect` | the full 201 body | `created.project.id` |
| `branches.createAndConnect` | the full 201 body | `created.branch.id` |
| anything else | the mapped body | `undefined` unless one of the above matches |

### `created` on createAndConnect is sensitive

The `createAndConnect` workflows map the raw body through as-is and pull the connection string out afterwards. So on those calls `created` is the whole 201 response: `connection_uris`, and `roles[].password` when the API returns it. The `NeonError` doc comment, both READMEs, and the changeset say the same thing: read `createdId(error)` rather than logging the error whole.

## Interface

`@neon/sdk` exports `createdId` next to the error classes. `@neon/tools` re-exports it with `NeonError`.

```ts
class NeonError extends Error {
	readonly kind: NeonErrorKind;
	/**
	 * The mapped resource from a mutation that succeeded before readiness polling failed.
	 * On createAndConnect this is the full 201 body, including connection_uris and role passwords.
	 */
	created?: unknown;
	constructor(message: string, kind: NeonErrorKind, options?: { cause?: unknown; created?: unknown });
}

const createdId: (error: NeonError) => string | undefined;
```

Result channel:

```ts
const { data, error } = await neon.projects.create({ name: "demo" }, { signal });
if (error?.kind === "timeout" || error?.kind === "aborted") {
	createdId(error); // "project-id" when the create returned, undefined when it never did
}
```

Thrown, through `@neon/tools`:

```ts
import { createdId, NeonError } from "@neon/tools";

try {
	await tools["projects.create"].execute({ name: "agent-project" }, { signal });
} catch (error) {
	if (error instanceof NeonError) {
		createdId(error); // "project-id"
	}
}
```

Nothing changes for callers that do not read `created`. Error classes, `kind` values, messages, and the `throwOnError` policy stay as they are. `created` is `undefined` when the request itself failed and on every error that is not a readiness wait. `runVoid` (204 endpoints) has no body to keep and is unchanged.

## Also in here

- `packages/sdk/README.md`: `created?` in the error table, a paragraph under readiness on when it is set, what it holds on `createAndConnect`, and `createdId`.
- `packages/tools/README.md`: the "list before retrying" sentence becomes `createdId` plus the example above, with the same note on `connection_uris` and passwords.
- Changeset: patch for `@neon/sdk` and `@neon/tools`.

## Verification

Run on this branch:

```
pnpm --filter @neon/sdk exec vitest run src/neon/errors.test.ts src/neon/cancellation.server.test.ts   # 33 passed
pnpm --filter @neon/tools exec vitest run src/index.test.ts                                              # 15 passed
```

Tests added or extended:

- readiness polling that aborts, times out with an explicit `wait.timeoutMs`, and times out from the client default all leave `created` equal to the project the local fake server returned (`cancellation.server.test.ts`, real HTTP)
- `withCreated` returns the same error instance, keeps `NeonTimeoutError` and `kind: "timeout"`, and does not overwrite an existing `created`
- `createdId` reads a top-level `id`, a nested `project.id`, and a nested `branch.id`
- `@neon/tools`: `projects.create` against a fetch whose operation never leaves `running` throws a `NeonError` with `kind: "timeout"`, `created` equal to the project, and `createdId` returning its id

Not verified against the live API. The failure needs an operation that stays running past the deadline, which the fake server produces and a real project does not on demand. The e2e suites still cover the success path of every call touched here. No test asserts the `createAndConnect` shape of `created` end to end; the nested `createdId` cases are unit tests on hand-built values.

## For your attention

- **`created` on `createAndConnect` carries credentials.** Anything that serialises a `NeonError` (a logger, an MCP host echoing the thrown error, Sentry) now serialises `connection_uris` and role passwords with it. This is the same data the success path returns to the same caller, so it is not a new grant, but it is a new place it shows up. Redacting inside the SDK would leave the id and drop the credentials; that is a decision, not done here.
- **`created` is typed `unknown`.** `RequestContext.execute` is generic over the mapped type and `NeonError` is not, so the field cannot carry the per-call type without threading a type parameter through every error class. `createdId` is the typed accessor for the one value that matters, the id to reuse or delete.
- **`createdId` knows three shapes.** Top-level `id`, `project.id`, `branch.id`. A future workflow that maps to a different shape gets `undefined` and has to add its case here.
- **`NeonOperationError` also carries `created`.** A failed operation after a create is a wait failure on the same code path. The resource exists in whatever state the failed operation left it, and the id is still what a caller needs to inspect or delete it.
