### PR TITLE
Pin inject by field name; default mode is pin

### DIFF
--- a/.changeset/tools-t5-inject-pin.md
+++ b/.changeset/tools-t5-inject-pin.md
@@ -2,4 +2,4 @@
 "@neon/tools": major
 ---
 
-`inject` keys are `project_id` / `branch_id`. Default `mode` is `"pin"` (field removed from the schema). Pass `mode: "default"` for caller-wins fill.
+`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill.

--- a/.changeset/tools-t5-inject-pin.md
+++ b/.changeset/tools-t5-inject-pin.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": major
+---
+
+`inject` keys are `project_id` / `branch_id`. Default `mode` is `"pin"` (field removed from the schema). Pass `mode: "default"` for caller-wins fill.

--- a/.changeset/tools-t5-inject-pin.md
+++ b/.changeset/tools-t5-inject-pin.md
@@ -2,4 +2,4 @@
 "@neon/tools": major
 ---
 
-`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill. A `NeonToolInjectOptions` bag still types `execute` without those path keys.
+`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill. `execute` omits only path keys required on the inject object. A `NeonToolInjectOptions` union (a parameter) does not omit them.

--- a/.changeset/tools-t5-inject-pin.md
+++ b/.changeset/tools-t5-inject-pin.md
@@ -2,4 +2,4 @@
 "@neon/tools": major
 ---
 
-`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill. `execute` omits only path keys required on the inject object. A `NeonToolInjectOptions` union (a parameter) does not omit them.
+`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill. Old `inject: { projectId }` was caller-wins; renaming the key to `project_id` pins unless you add `mode: "fallback"`. `execute` omits only path keys required on the inject object. A `NeonToolInjectOptions` union (a parameter) does not omit them.

--- a/.changeset/tools-t5-inject-pin.md
+++ b/.changeset/tools-t5-inject-pin.md
@@ -2,4 +2,4 @@
 "@neon/tools": major
 ---
 
-`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill. Old `inject: { projectId }` was caller-wins; renaming the key to `project_id` pins unless you add `mode: "fallback"`. `execute` omits only path keys required on the inject object. A `NeonToolInjectOptions` union (a parameter) does not omit them.
+`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill. Old `inject: { projectId }` was caller-wins; renaming the key to `project_id` pins unless you add `mode: "fallback"`. A defined `inject` with neither key throws. `execute` omits only path keys required on the inject object. A `NeonToolInjectOptions` union (a parameter) does not omit them.

--- a/.changeset/tools-t5-inject-pin.md
+++ b/.changeset/tools-t5-inject-pin.md
@@ -2,4 +2,4 @@
 "@neon/tools": major
 ---
 
-`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill.
+`inject` keys are `project_id` / `branch_id`. Omit `mode` or pass `"pin"` (field removed from the schema). Pass `mode: "fallback"` for caller-wins fill. A `NeonToolInjectOptions` bag still types `execute` without those path keys.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -139,7 +139,7 @@ Those tools publish as `neon_create_branch` and `neon_list_projects`. The record
 
 ### Project and branch injection
 
-Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.createAndConnect`. Default `mode` is `"pin"`: the field is removed from the published schema and the injector is the only source. Pass `mode: "default"` to keep the field optional and let a caller-supplied value win.
+Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.createAndConnect`. Omit `mode`, or pass `mode: "pin"`: the field is removed from the published schema and the injector is the only source. Pass `mode: "fallback"` to keep the field optional and let a caller-supplied value win.
 
 ```ts
 const tools = createNeonTools({
@@ -152,6 +152,15 @@ const tools = createNeonTools({
 
 await tools["projects.get"].execute({});
 await tools["branches.delete"].execute({ branch_id: "br-id" });
+```
+
+`mode: "fallback"` keeps `project_id` on the schema and prefers a caller-supplied value:
+
+```ts
+inject: {
+	project_id: "project-id",
+	mode: "fallback",
+},
 ```
 
 Use a getter when the value is request-scoped. The getter can read the host's own `AsyncLocalStorage` (this package does not export one):

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -139,15 +139,14 @@ Those tools publish as `neon_create_branch` and `neon_list_projects`. The record
 
 ### Project and branch injection
 
-Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.createAndConnect`. Without `omitFromSchema`, the published field becomes optional and a caller-supplied value wins. With `omitFromSchema: true`, the field is removed from the published schema and the injector is the only source:
+Tools take path parameters as `project_id` and `branch_id`. A host that already knows those values can inject them, including on `branches.createAndConnect`. Default `mode` is `"pin"`: the field is removed from the published schema and the injector is the only source. Pass `mode: "default"` to keep the field optional and let a caller-supplied value win.
 
 ```ts
 const tools = createNeonTools({
 	apiKey,
 	tools: ["projects.get", "branches.delete"] as const,
 	inject: {
-		projectId: "project-id",
-		omitFromSchema: true,
+		project_id: "project-id",
 	},
 });
 
@@ -165,8 +164,7 @@ const grant = new AsyncLocalStorage<{ projectId: string }>();
 const tools = createNeonTools({
 	tools: ["projects.get"] as const,
 	inject: {
-		projectId: () => grant.getStore()?.projectId,
-		omitFromSchema: true,
+		project_id: () => grant.getStore()?.projectId,
 	},
 });
 
@@ -177,7 +175,7 @@ await grant.run({ projectId: "project-id" }, () =>
 
 Injectors only apply to tools that have that path key. `projects.list` is unchanged. Empty inject values fail closed. Invalid ids still fail the original path schema before fetch.
 
-Injection reads the URL template, so it fills path `project_id` and `branch_id` only. Query and body fields with those names stay caller-supplied, including `postgres.connectionString`'s `branch_id`. `omitFromSchema: true` does not hide those fields.
+Injection reads the URL template, so it fills path `project_id` and `branch_id` only. Query and body fields with those names stay caller-supplied, including `postgres.connectionString`'s `branch_id`. Pinning a path key does not hide those fields.
 
 ## Request schemas
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -154,16 +154,19 @@ await tools["projects.get"].execute({});
 await tools["branches.delete"].execute({ branch_id: "br-id" });
 ```
 
-A value typed as `NeonToolInjectOptions` still injects: `execute` omits every path key that type lists (`project_id` and `branch_id`), not only the ones set on the object. At least one of `project_id` or `branch_id` is required on that type.
+`execute` omits a path key only when that key is required on the inject object. Pass `inject` inline, or name it with `satisfies NeonToolInjectOptions`. A `NeonToolInjectOptions` parameter is the union of both arms, so neither key is guaranteed and `execute` still requires them. Runtime still injects whatever was set. At least one of `project_id` or `branch_id` is required on that type.
 
 ```ts
-const inject: NeonToolInjectOptions = { project_id: "project-id" };
+import { createNeonTools, type NeonToolInjectOptions } from "@neon/tools";
+
+const inject = { project_id: "project-id" } satisfies NeonToolInjectOptions;
 const tools = createNeonTools({
 	apiKey,
-	tools: ["projects.get"] as const,
+	tools: ["projects.get", "branches.delete"] as const,
 	inject,
 });
 await tools["projects.get"].execute({});
+await tools["branches.delete"].execute({ branch_id: "br-id" });
 ```
 
 `mode: "fallback"` keeps `project_id` on the schema and prefers a caller-supplied value:

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -154,7 +154,7 @@ await tools["projects.get"].execute({});
 await tools["branches.delete"].execute({ branch_id: "br-id" });
 ```
 
-A value typed as `NeonToolInjectOptions` still injects: `execute` omits every path key that type lists (`project_id` and `branch_id`), not only the ones set on the object.
+A value typed as `NeonToolInjectOptions` still injects: `execute` omits every path key that type lists (`project_id` and `branch_id`), not only the ones set on the object. At least one of `project_id` or `branch_id` is required on that type.
 
 ```ts
 const inject: NeonToolInjectOptions = { project_id: "project-id" };

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -154,6 +154,18 @@ await tools["projects.get"].execute({});
 await tools["branches.delete"].execute({ branch_id: "br-id" });
 ```
 
+A value typed as `NeonToolInjectOptions` still injects: `execute` omits every path key that type lists (`project_id` and `branch_id`), not only the ones set on the object.
+
+```ts
+const inject: NeonToolInjectOptions = { project_id: "project-id" };
+const tools = createNeonTools({
+	apiKey,
+	tools: ["projects.get"] as const,
+	inject,
+});
+await tools["projects.get"].execute({});
+```
+
 `mode: "fallback"` keeps `project_id` on the schema and prefers a caller-supplied value:
 
 ```ts

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -154,7 +154,7 @@ await tools["projects.get"].execute({});
 await tools["branches.delete"].execute({ branch_id: "br-id" });
 ```
 
-`execute` omits a path key only when that key is required on the inject object. Pass `inject` inline, or name it with `satisfies NeonToolInjectOptions`. A `NeonToolInjectOptions` parameter is the union of both arms, so neither key is guaranteed and `execute` still requires them. Runtime still injects whatever was set. At least one of `project_id` or `branch_id` is required on that type.
+`execute` omits a path key only when that key is required on the inject object. Pass `inject` inline, or name it with `satisfies NeonToolInjectOptions`. A `NeonToolInjectOptions` parameter is the union of both arms, so neither key is guaranteed and `execute` still requires them. Runtime still injects whatever was set. A defined `inject` with neither `project_id` nor `branch_id` throws, including a leftover `{ projectId }`.
 
 ```ts
 import { createNeonTools, type NeonToolInjectOptions } from "@neon/tools";

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -136,7 +136,7 @@ describe("onExecute", () => {
 	test("observes injection, validation, and fetch failures", async () => {
 		const seen: string[] = [];
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "not valid", omitFromSchema: true },
+			inject: { project_id: "not valid" },
 			onExecute: async ({ execute }) => {
 				seen.push("start");
 				try {
@@ -150,6 +150,7 @@ describe("onExecute", () => {
 			},
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow();
 		expect(seen[0]).toBe("start");
 		expect(seen[1]).toEqual(expect.stringMatching(/Invalid|project_id/i));
@@ -159,8 +160,7 @@ describe("onExecute", () => {
 	test("does not let mutated event.input change a grant-locked project", async () => {
 		const { requests, tools } = getProjectTools({
 			inject: {
-				projectId: "granted-project",
-				omitFromSchema: true,
+				project_id: "granted-project",
 			},
 			onExecute: async ({ input, execute }) => {
 				(input as { project_id?: string }).project_id =
@@ -169,6 +169,7 @@ describe("onExecute", () => {
 			},
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(
@@ -212,9 +213,10 @@ describe("onExecute", () => {
 describe("path injection", () => {
 	test("fills a missing project_id and optionalizes it on the published schema", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project", mode: "default" },
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(
@@ -234,10 +236,11 @@ describe("path injection", () => {
 		let getterCalls = 0;
 		const { requests, tools } = getProjectTools({
 			inject: {
-				projectId: () => {
+				project_id: () => {
 					getterCalls += 1;
 					return "granted-project";
 				},
+				mode: "default",
 			},
 		});
 
@@ -254,8 +257,7 @@ describe("path injection", () => {
 	test("omits injected keys from the published schema and always uses the injector", async () => {
 		const { requests, tools } = getProjectTools({
 			inject: {
-				projectId: "granted-project",
-				omitFromSchema: true,
+				project_id: "granted-project",
 			},
 		});
 
@@ -277,8 +279,7 @@ describe("path injection", () => {
 			apiKey: "test-key",
 			tools: ["branches.delete"] as const,
 			inject: {
-				projectId: "granted-project",
-				omitFromSchema: true,
+				project_id: "granted-project",
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -304,9 +305,8 @@ describe("path injection", () => {
 			apiKey: "test-key",
 			tools: ["branches.delete"] as const,
 			inject: {
-				projectId: "granted-project",
-				branchId: "granted-branch",
-				omitFromSchema: true,
+				project_id: "granted-project",
+				branch_id: "granted-branch",
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -328,7 +328,7 @@ describe("path injection", () => {
 			apiKey: "test-key",
 			tools: ["projects.list"] as const,
 			inject: {
-				projectId: () => {
+				project_id: () => {
 					getterCalls += 1;
 					return "granted-project";
 				},
@@ -355,49 +355,48 @@ describe("path injection", () => {
 			createNeonTools({
 				apiKey: "test-key",
 				tools: ["projects.get"] as const,
-				inject: { projectId: "" },
+				inject: { project_id: "" },
 			}),
-		).toThrow("A projectId inject value is required");
+		).toThrow("A project_id inject value is required");
 	});
 
-	test("rejects omitFromSchema without an injector at construction", () => {
+	test("rejects mode without an injector at construction", () => {
 		expect(() =>
 			createNeonTools({
 				apiKey: "test-key",
 				tools: ["projects.get"] as const,
-				inject: { omitFromSchema: true },
+				inject: { mode: "pin" },
 			}),
-		).toThrow(
-			"omitFromSchema requires inject.projectId or inject.branchId",
-		);
+		).toThrow("inject.mode requires inject.project_id or inject.branch_id");
 	});
 
 	test("fails closed when an omitted injector returns nothing", async () => {
 		const { requests, tools } = getProjectTools({
 			inject: {
-				projectId: () => undefined,
-				omitFromSchema: true,
+				project_id: () => undefined,
 			},
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
-			"A projectId inject value is required",
+			"A project_id inject value is required",
 		);
 		expect(requests).toHaveLength(0);
 	});
 
 	test("lets the original schema reject an invalid injected id before fetch", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "NOT VALID", omitFromSchema: true },
+			inject: { project_id: "NOT VALID" },
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow();
 		expect(requests).toHaveLength(0);
 	});
 
 	test("does not normalize a malformed path into a valid request", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project" },
 		});
 
 		await expect(
@@ -409,11 +408,11 @@ describe("path injection", () => {
 	test("resolves async getters", async () => {
 		const { requests, tools } = getProjectTools({
 			inject: {
-				projectId: async () => "granted-project",
-				omitFromSchema: true,
+				project_id: async () => "granted-project",
 			},
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(
@@ -425,7 +424,7 @@ describe("path injection", () => {
 		const requests: Request[] = [];
 		const tool = createNeonTool("projects.get", {
 			apiKey: "test-key",
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
 				return jsonResponse({ project: { id: "project-id" } });
@@ -559,13 +558,14 @@ describe("onExecute failure and isolation", () => {
 	test("passes the caller input to the hook, not the injected path", async () => {
 		const seen: unknown[] = [];
 		const { tools } = getProjectTools({
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 			onExecute: async ({ input, execute }) => {
 				seen.push(input);
 				return execute();
 			},
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(seen).toEqual([{}]);
@@ -573,7 +573,7 @@ describe("onExecute failure and isolation", () => {
 
 	test("does not let a mutated clone change a caller-supplied fill-mode id", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project", mode: "default" },
 			onExecute: async ({ input, execute }) => {
 				(input as { project_id: string }).project_id =
 					"mutated-project";
@@ -613,11 +613,12 @@ describe("onExecute failure and isolation", () => {
 });
 
 describe("path injection (fill, omit, and non-path fields)", () => {
-	test("treats inject.projectId: undefined as no injector", async () => {
+	test("treats inject.project_id: undefined as no injector", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: undefined },
+			inject: { project_id: undefined },
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow();
 		expect(requests).toHaveLength(0);
 		expect(
@@ -630,26 +631,27 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			createNeonTools({
 				apiKey: "test-key",
 				tools: ["projects.get"] as const,
-				inject: { projectId: 1 as unknown as string },
+				inject: { project_id: 1 as unknown as string },
 			}),
-		).toThrow("A projectId inject value is required");
+		).toThrow("A project_id inject value is required");
 	});
 
-	test("rejects an empty static branchId at construction", () => {
+	test("rejects an empty static branch_id at construction", () => {
 		expect(() =>
 			createNeonTools({
 				apiKey: "test-key",
 				tools: ["branches.delete"] as const,
-				inject: { branchId: "" },
+				inject: { branch_id: "" },
 			}),
-		).toThrow("A branchId inject value is required");
+		).toThrow("A branch_id inject value is required");
 	});
 
 	test("in fill mode, a missing getter leaves original schema validation", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: () => undefined },
+			inject: { project_id: () => undefined, mode: "default" },
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
 			/invalid_type|required|project_id/i,
 		);
@@ -658,11 +660,12 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("rejects an empty getter result before fetch", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: () => "" },
+			inject: { project_id: () => "" },
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
-			"A projectId inject value is required",
+			"A project_id inject value is required",
 		);
 		expect(requests).toHaveLength(0);
 	});
@@ -670,12 +673,13 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 	test("rejects a non-string getter result before fetch", async () => {
 		const { requests, tools } = getProjectTools({
 			inject: {
-				projectId: () => 1 as unknown as string,
+				project_id: () => 1 as unknown as string,
 			},
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
-			"A projectId inject value is required",
+			"A project_id inject value is required",
 		);
 		expect(requests).toHaveLength(0);
 	});
@@ -683,22 +687,23 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 	test("in omit mode, rejects an empty getter result", async () => {
 		const { requests, tools } = getProjectTools({
 			inject: {
-				projectId: () => "",
-				omitFromSchema: true,
+				project_id: () => "",
 			},
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
-			"A projectId inject value is required",
+			"A project_id inject value is required",
 		);
 		expect(requests).toHaveLength(0);
 	});
 
 	test("fills path: {} in fill mode", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project", mode: "default" },
 		});
 
+		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(
@@ -708,7 +713,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("does not normalize null, arrays, or non-objects", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project" },
 		});
 
 		await expect(
@@ -725,7 +730,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("still rejects unknown fields after injection", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 		});
 
 		await expect(
@@ -739,7 +744,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["branches.delete", "branches.createAndConnect"] as const,
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
 				return jsonResponse(branchWithComputeBody);
@@ -773,12 +778,11 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			apiKey: "test-key",
 			tools: ["postgres.connectionString"] as const,
 			inject: {
-				projectId: "granted-project",
-				branchId: () => {
+				project_id: "granted-project",
+				branch_id: () => {
 					branchGetterCalls += 1;
 					return "injected-branch";
 				},
-				omitFromSchema: true,
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -806,8 +810,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			apiKey: "test-key",
 			tools: ["branches.delete"] as const,
 			inject: {
-				branchId: "granted-branch",
-				omitFromSchema: true,
+				branch_id: "granted-branch",
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -834,11 +837,12 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			apiKey: "test-key",
 			tools: ["branches.delete"] as const,
 			inject: {
-				projectId: "granted-project",
-				branchId: () => {
+				project_id: "granted-project",
+				branch_id: () => {
 					branchGetterCalls += 1;
 					return "granted-branch";
 				},
+				mode: "default",
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -858,7 +862,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("published omit schema accepts {} and rejects a supplied project_id object", () => {
 		const { tools } = getProjectTools({
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 		});
 
 		expect(tools["projects.get"].inputSchema.safeParse({}).success).toBe(
@@ -873,7 +877,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("published fill schema accepts omitted and supplied project_id", () => {
 		const { tools } = getProjectTools({
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project", mode: "default" },
 		});
 
 		expect(tools["projects.get"].inputSchema.safeParse({}).success).toBe(
@@ -893,7 +897,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("keeps published schemas closed", () => {
 		const { tools } = getProjectTools({
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project" },
 		});
 
 		expect(
@@ -911,7 +915,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["branches.create"] as const,
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 		});
 
 		const schema = z.toJSONSchema(tools["branches.create"].inputSchema);
@@ -926,7 +930,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["branches.createAndConnect"] as const,
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 		});
 
 		const schema = z.toJSONSchema(
@@ -948,8 +952,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			apiKey: "test-key",
 			tools: ["projects.get"] as const,
 			inject: {
-				projectId: () => grant.getStore()?.projectId,
-				omitFromSchema: true,
+				project_id: () => grant.getStore()?.projectId,
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -370,6 +370,20 @@ describe("path injection", () => {
 		).toThrow("inject.mode requires inject.project_id or inject.branch_id");
 	});
 
+	test("rejects an unknown inject mode at construction", () => {
+		expect(() =>
+			createNeonTools({
+				apiKey: "test-key",
+				tools: ["projects.get"] as const,
+				inject: {
+					project_id: "granted-project",
+					// @ts-expect-error only "pin" and "default" are valid
+					mode: "pni",
+				},
+			}),
+		).toThrow('inject.mode must be "pin" or "default"');
+	});
+
 	test("fails closed when an omitted injector returns nothing", async () => {
 		const { requests, tools } = getProjectTools({
 			inject: {

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -213,7 +213,7 @@ describe("onExecute", () => {
 describe("path injection", () => {
 	test("fills a missing project_id and optionalizes it on the published schema", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { project_id: "granted-project", mode: "default" },
+			inject: { project_id: "granted-project", mode: "fallback" },
 		});
 
 		// @ts-expect-error getProjectTools widens inject
@@ -240,7 +240,7 @@ describe("path injection", () => {
 					getterCalls += 1;
 					return "granted-project";
 				},
-				mode: "default",
+				mode: "fallback",
 			},
 		});
 
@@ -377,11 +377,11 @@ describe("path injection", () => {
 				tools: ["projects.get"] as const,
 				inject: {
 					project_id: "granted-project",
-					// @ts-expect-error only "pin" and "default" are valid
+					// @ts-expect-error only "pin" and "fallback" are valid
 					mode: "pni",
 				},
 			}),
-		).toThrow('inject.mode must be "pin" or "default"');
+		).toThrow('inject.mode must be "pin" or "fallback"');
 	});
 
 	test("fails closed when an omitted injector returns nothing", async () => {
@@ -587,7 +587,7 @@ describe("onExecute failure and isolation", () => {
 
 	test("does not let a mutated clone change a caller-supplied fill-mode id", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { project_id: "granted-project", mode: "default" },
+			inject: { project_id: "granted-project", mode: "fallback" },
 			onExecute: async ({ input, execute }) => {
 				(input as { project_id: string }).project_id =
 					"mutated-project";
@@ -662,7 +662,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("in fill mode, a missing getter leaves original schema validation", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { project_id: () => undefined, mode: "default" },
+			inject: { project_id: () => undefined, mode: "fallback" },
 		});
 
 		// @ts-expect-error getProjectTools widens inject
@@ -714,7 +714,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("fills path: {} in fill mode", async () => {
 		const { requests, tools } = getProjectTools({
-			inject: { project_id: "granted-project", mode: "default" },
+			inject: { project_id: "granted-project", mode: "fallback" },
 		});
 
 		// @ts-expect-error getProjectTools widens inject
@@ -856,7 +856,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 					branchGetterCalls += 1;
 					return "granted-branch";
 				},
-				mode: "default",
+				mode: "fallback",
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -891,7 +891,7 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 
 	test("published fill schema accepts omitted and supplied project_id", () => {
 		const { tools } = getProjectTools({
-			inject: { project_id: "granted-project", mode: "default" },
+			inject: { project_id: "granted-project", mode: "fallback" },
 		});
 
 		expect(tools["projects.get"].inputSchema.safeParse({}).success).toBe(

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -375,6 +375,17 @@ describe("path injection", () => {
 		).toThrow("inject.mode requires inject.project_id or inject.branch_id");
 	});
 
+	test("rejects a defined inject with no project_id or branch_id", () => {
+		expect(() =>
+			createNeonTools({
+				apiKey: "test-key",
+				tools: ["projects.get"] as const,
+				// @ts-expect-error inject keys are the field names
+				inject: { projectId: "granted-project" },
+			}),
+		).toThrow("inject requires inject.project_id or inject.branch_id");
+	});
+
 	test("rejects an unknown inject mode at construction", () => {
 		expect(() =>
 			createNeonTools({
@@ -628,18 +639,13 @@ describe("onExecute failure and isolation", () => {
 });
 
 describe("path injection (fill, omit, and non-path fields)", () => {
-	test("treats inject.project_id: undefined as no injector", async () => {
-		const { requests, tools } = getProjectTools({
-			// @ts-expect-error undefined is not an inject value
-			inject: { project_id: undefined },
-		});
-
-		// @ts-expect-error no injector, project_id still required
-		await expect(tools["projects.get"].execute({})).rejects.toThrow();
-		expect(requests).toHaveLength(0);
-		expect(
-			z.toJSONSchema(tools["projects.get"].inputSchema).required,
-		).toEqual(["project_id"]);
+	test("rejects inject.project_id: undefined at construction", () => {
+		expect(() =>
+			getProjectTools({
+				// @ts-expect-error undefined is not an inject value
+				inject: { project_id: undefined },
+			}),
+		).toThrow("inject requires inject.project_id or inject.branch_id");
 	});
 
 	test("rejects a non-string static inject value at construction", () => {

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -3,6 +3,7 @@ import * as z from "zod";
 import {
 	createNeonTool,
 	createNeonTools,
+	type NeonToolInjectOptions,
 	type NeonToolsClientOptions,
 } from "./index.js";
 
@@ -26,7 +27,13 @@ const branchWithComputeBody = {
 	],
 };
 
-const getProjectTools = (options: NeonToolsClientOptions = {}) => {
+const getProjectTools = <
+	const I extends NeonToolInjectOptions | undefined = undefined,
+>(
+	options: Omit<NeonToolsClientOptions, "inject"> & {
+		inject?: I;
+	} = {} as Omit<NeonToolsClientOptions, "inject"> & { inject?: I },
+) => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({
 		apiKey: "test-key",
@@ -150,7 +157,6 @@ describe("onExecute", () => {
 			},
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow();
 		expect(seen[0]).toBe("start");
 		expect(seen[1]).toEqual(expect.stringMatching(/Invalid|project_id/i));
@@ -169,7 +175,6 @@ describe("onExecute", () => {
 			},
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(
@@ -216,7 +221,6 @@ describe("path injection", () => {
 			inject: { project_id: "granted-project", mode: "fallback" },
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(
@@ -391,7 +395,6 @@ describe("path injection", () => {
 			},
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
 			"A project_id inject value is required",
 		);
@@ -403,7 +406,6 @@ describe("path injection", () => {
 			inject: { project_id: "NOT VALID" },
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow();
 		expect(requests).toHaveLength(0);
 	});
@@ -426,7 +428,6 @@ describe("path injection", () => {
 			},
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(
@@ -579,7 +580,6 @@ describe("onExecute failure and isolation", () => {
 			},
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(seen).toEqual([{}]);
@@ -632,7 +632,6 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			inject: { project_id: undefined },
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow();
 		expect(requests).toHaveLength(0);
 		expect(
@@ -665,7 +664,6 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			inject: { project_id: () => undefined, mode: "fallback" },
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
 			/invalid_type|required|project_id/i,
 		);
@@ -677,7 +675,6 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			inject: { project_id: () => "" },
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
 			"A project_id inject value is required",
 		);
@@ -691,7 +688,6 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			},
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
 			"A project_id inject value is required",
 		);
@@ -705,7 +701,6 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			},
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await expect(tools["projects.get"].execute({})).rejects.toThrow(
 			"A project_id inject value is required",
 		);
@@ -717,7 +712,6 @@ describe("path injection (fill, omit, and non-path fields)", () => {
 			inject: { project_id: "granted-project", mode: "fallback" },
 		});
 
-		// @ts-expect-error getProjectTools widens inject
 		await tools["projects.get"].execute({});
 
 		expect(requests[0].url).toBe(

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -369,6 +369,7 @@ describe("path injection", () => {
 			createNeonTools({
 				apiKey: "test-key",
 				tools: ["projects.get"] as const,
+				// @ts-expect-error mode requires project_id or branch_id
 				inject: { mode: "pin" },
 			}),
 		).toThrow("inject.mode requires inject.project_id or inject.branch_id");
@@ -629,9 +630,11 @@ describe("onExecute failure and isolation", () => {
 describe("path injection (fill, omit, and non-path fields)", () => {
 	test("treats inject.project_id: undefined as no injector", async () => {
 		const { requests, tools } = getProjectTools({
+			// @ts-expect-error undefined is not an inject value
 			inject: { project_id: undefined },
 		});
 
+		// @ts-expect-error no injector, project_id still required
 		await expect(tools["projects.get"].execute({})).rejects.toThrow();
 		expect(requests).toHaveLength(0);
 		expect(

--- a/packages/tools/src/frameworks.test.ts
+++ b/packages/tools/src/frameworks.test.ts
@@ -76,7 +76,7 @@ describe("Mastra compatibility", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",
 			tools: ["projects.get"],
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 		});
 
 		expect(toMastraTools(tools).get_projects.inputSchema).toBe(
@@ -93,7 +93,7 @@ describe("Mastra compatibility", () => {
 			apiKey: "test-key",
 			tools: ["projects.get"],
 			descriptions: { get_projects: "Granted project details." },
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
 				return jsonResponse({ project: { id: "granted-project" } });

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -124,7 +124,7 @@ createNeonTools({
 const filledProject = createNeonTools({
 	apiKey: "test-key",
 	tools: ["projects.get"] as const,
-	inject: { project_id: "granted-project", mode: "default" },
+	inject: { project_id: "granted-project", mode: "fallback" },
 });
 filledProject["projects.get"].execute({});
 filledProject["projects.get"].execute({ project_id: "caller-project" });

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -106,16 +106,25 @@ revokeCredential
 const omittedProject = createNeonTools({
 	apiKey: "test-key",
 	tools: ["projects.get"] as const,
-	inject: { projectId: "granted-project", omitFromSchema: true },
+	inject: { project_id: "granted-project" },
 });
 omittedProject["projects.get"].execute({}).then((result) => {
 	expectTypeOf(result.data.id).toEqualTypeOf<string>();
 });
 
+createNeonTools({
+	apiKey: "test-key",
+	tools: ["projects.get"] as const,
+	inject: {
+		// @ts-expect-error inject keys are the field names
+		projectId: "granted-project",
+	},
+});
+
 const filledProject = createNeonTools({
 	apiKey: "test-key",
 	tools: ["projects.get"] as const,
-	inject: { projectId: "granted-project" },
+	inject: { project_id: "granted-project", mode: "default" },
 });
 filledProject["projects.get"].execute({});
 filledProject["projects.get"].execute({ project_id: "caller-project" });
@@ -123,7 +132,7 @@ filledProject["projects.get"].execute({ project_id: "caller-project" });
 const omittedBranch = createNeonTools({
 	apiKey: "test-key",
 	tools: ["branches.delete"] as const,
-	inject: { projectId: "granted-project", omitFromSchema: true },
+	inject: { project_id: "granted-project" },
 });
 omittedBranch["branches.delete"].execute({ branch_id: "br-id" });
 
@@ -146,16 +155,15 @@ const omittedBoth = createNeonTools({
 	apiKey: "test-key",
 	tools: ["branches.delete"] as const,
 	inject: {
-		projectId: "granted-project",
-		branchId: "granted-branch",
-		omitFromSchema: true,
+		project_id: "granted-project",
+		branch_id: "granted-branch",
 	},
 });
 omittedBoth["branches.delete"].execute({});
 
 const omittedCreateNeonTool = createNeonTool("projects.get", {
 	apiKey: "test-key",
-	inject: { projectId: "granted-project", omitFromSchema: true },
+	inject: { project_id: "granted-project" },
 });
 omittedCreateNeonTool.execute({});
 
@@ -260,7 +268,7 @@ createBranchAndConnect.execute({
 const omittedWorkflow = createNeonTools({
 	apiKey: "test-key",
 	tools: ["branches.createAndConnect"] as const,
-	inject: { projectId: "granted-project", omitFromSchema: true },
+	inject: { project_id: "granted-project" },
 });
 omittedWorkflow["branches.createAndConnect"].execute({ name: "feature-x" });
 

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -4,6 +4,7 @@ import {
 	type CreateNeonToolsOptions,
 	createNeonTool,
 	createNeonTools,
+	type NeonToolInjectOptions,
 	publishedId,
 } from "./index.js";
 import { toMastraTools } from "./mastra.js";
@@ -128,6 +129,17 @@ const filledProject = createNeonTools({
 });
 filledProject["projects.get"].execute({});
 filledProject["projects.get"].execute({ project_id: "caller-project" });
+
+const injectBag: NeonToolInjectOptions = {
+	project_id: "granted-project",
+	mode: "fallback",
+};
+const fromBag = createNeonTools({
+	apiKey: "test-key",
+	tools: ["projects.get"] as const,
+	inject: injectBag,
+});
+fromBag["projects.get"].execute({});
 
 const omittedBranch = createNeonTools({
 	apiKey: "test-key",

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -141,6 +141,13 @@ const fromBag = createNeonTools({
 });
 fromBag["projects.get"].execute({});
 
+createNeonTools({
+	apiKey: "test-key",
+	tools: ["projects.get"] as const,
+	// @ts-expect-error undefined is not an inject value
+	inject: { project_id: undefined },
+});
+
 const omittedBranch = createNeonTools({
 	apiKey: "test-key",
 	tools: ["branches.delete"] as const,

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -130,16 +130,67 @@ const filledProject = createNeonTools({
 filledProject["projects.get"].execute({});
 filledProject["projects.get"].execute({ project_id: "caller-project" });
 
-const injectBag: NeonToolInjectOptions = {
-	project_id: "granted-project",
-	mode: "fallback",
-};
-const fromBag = createNeonTools({
+declare const wideInject: NeonToolInjectOptions;
+const fromWideGet = createNeonTools({
 	apiKey: "test-key",
 	tools: ["projects.get"] as const,
-	inject: injectBag,
+	inject: wideInject,
 });
-fromBag["projects.get"].execute({});
+// @ts-expect-error union inject does not guarantee project_id
+fromWideGet["projects.get"].execute({});
+fromWideGet["projects.get"].execute({ project_id: "project-id" });
+
+const fromWideDelete = createNeonTools({
+	apiKey: "test-key",
+	tools: ["branches.delete"] as const,
+	inject: wideInject,
+});
+fromWideDelete["branches.delete"].execute({
+	project_id: "project-id",
+	branch_id: "br-id",
+});
+// @ts-expect-error union inject does not guarantee project_id
+fromWideDelete["branches.delete"].execute({ branch_id: "br-id" });
+// @ts-expect-error union inject does not guarantee branch_id
+fromWideDelete["branches.delete"].execute({ project_id: "project-id" });
+
+const injectProject: NeonToolInjectOptions = {
+	project_id: "granted-project",
+};
+const fromProjectDelete = createNeonTools({
+	apiKey: "test-key",
+	tools: ["branches.delete"] as const,
+	inject: injectProject,
+});
+fromProjectDelete["branches.delete"].execute({ branch_id: "br-id" });
+// @ts-expect-error project-only inject still requires branch_id
+fromProjectDelete["branches.delete"].execute({});
+
+const injectBranch: NeonToolInjectOptions = {
+	branch_id: "granted-branch",
+};
+const fromBranchDelete = createNeonTools({
+	apiKey: "test-key",
+	tools: ["branches.delete"] as const,
+	inject: injectBranch,
+});
+fromBranchDelete["branches.delete"].execute({ project_id: "project-id" });
+// @ts-expect-error branch-only inject still requires project_id
+fromBranchDelete["branches.delete"].execute({});
+// @ts-expect-error branch-only inject still requires project_id
+fromBranchDelete["branches.delete"].execute({ branch_id: "br-id" });
+
+const injectSatisfies = {
+	project_id: "granted-project",
+} satisfies NeonToolInjectOptions;
+const fromSatisfies = createNeonTools({
+	apiKey: "test-key",
+	tools: ["branches.delete"] as const,
+	inject: injectSatisfies,
+});
+fromSatisfies["branches.delete"].execute({ branch_id: "br-id" });
+// @ts-expect-error project_id is injected
+fromSatisfies["branches.delete"].execute({});
 
 createNeonTools({
 	apiKey: "test-key",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -80,8 +80,9 @@ type SelectedTools<T> = T extends {
 	? S
 	: [];
 
+// Tuple so a NeonToolInjectOptions union does not split into both arms.
 type NeonToolsFor<T, Inject> = T extends CreateNeonToolsInput
-	? Inject extends NeonToolInjectOptions
+	? [Inject] extends [NeonToolInjectOptions]
 		? InjectedNeonTools<SelectedTools<T>, Inject>
 		: NeonTools<SelectedTools<T>>
 	: never;
@@ -178,14 +179,14 @@ const bindTools = <T extends CreateNeonToolsInput>(
 
 type NamedNeonTools<Tools extends readonly NeonToolId[], Inject> = {
 	[Tool in Tools[number]]: WithPublishedId<
-		Inject extends NeonToolInjectOptions
+		[Inject] extends [NeonToolInjectOptions]
 			? InjectedNeonTool<ReturnType<ToolFactories[Tool]>, Inject>
 			: ReturnType<ToolFactories[Tool]>
 	>;
 };
 
 type NamedNeonTool<Id extends NeonToolId, Inject> = WithPublishedId<
-	Inject extends NeonToolInjectOptions
+	[Inject] extends [NeonToolInjectOptions]
 		? InjectedNeonTool<ToolForId<Id>, Inject>
 		: ToolForId<Id>
 >;
@@ -236,7 +237,7 @@ export function createNeonTool<
 >(
 	id: Id,
 	options: NeonToolsClientOptions & { inject?: Inject },
-): Inject extends NeonToolInjectOptions
+): [Inject] extends [NeonToolInjectOptions]
 	? InjectedNeonTool<ToolForId<Id>, Inject>
 	: ToolForId<Id>;
 export function createNeonTool<

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -222,9 +222,19 @@ function resolveInject(
 	return {
 		project_id,
 		branch_id,
-		mode: inject.mode ?? "pin",
+		mode: requireInjectMode(inject.mode),
 		hasAny,
 	};
+}
+
+function requireInjectMode(mode: unknown): "pin" | "default" {
+	if (mode === undefined) {
+		return "pin";
+	}
+	if (mode === "pin" || mode === "default") {
+		return mode;
+	}
+	throw new TypeError('inject.mode must be "pin" or "default"');
 }
 
 function requireInjectValue(

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -12,8 +12,8 @@ export type NeonToolInjectValue =
 export interface NeonToolInjectOptions {
 	project_id?: NeonToolInjectValue;
 	branch_id?: NeonToolInjectValue;
-	/** `pin` (default) removes the field from the schema. `default` keeps it optional. */
-	mode?: "pin" | "default";
+	/** When omitted, `"pin"`: field removed from the schema. `"fallback"`: field stays optional, caller value wins. */
+	mode?: "pin" | "fallback";
 }
 
 export interface NeonToolDescriptionSource {
@@ -74,7 +74,7 @@ type ApplyInjectToInput<Input, Inject> = [
 	InjectedRequiredKey<Input, Inject>,
 ] extends [never]
 	? Input
-	: Inject extends { mode: "default" }
+	: Inject extends { mode: "fallback" }
 		? Omit<Input, InjectedRequiredKey<Input, Inject>> &
 				Partial<
 					Pick<
@@ -97,7 +97,7 @@ export type InjectedNeonTool<Tool, Inject> =
 interface ResolvedInject {
 	project_id?: NeonToolInjectValue;
 	branch_id?: NeonToolInjectValue;
-	mode: "pin" | "default";
+	mode: "pin" | "fallback";
 	hasAny: boolean;
 }
 
@@ -227,14 +227,14 @@ function resolveInject(
 	};
 }
 
-function requireInjectMode(mode: unknown): "pin" | "default" {
+function requireInjectMode(mode: unknown): "pin" | "fallback" {
 	if (mode === undefined) {
 		return "pin";
 	}
-	if (mode === "pin" || mode === "default") {
+	if (mode === "pin" || mode === "fallback") {
 		return mode;
 	}
-	throw new TypeError('inject.mode must be "pin" or "default"');
+	throw new TypeError('inject.mode must be "pin" or "fallback"');
 }
 
 function requireInjectValue(

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -10,9 +10,10 @@ export type NeonToolInjectValue =
 	| (() => string | undefined | Promise<string | undefined>);
 
 export interface NeonToolInjectOptions {
-	projectId?: NeonToolInjectValue;
-	branchId?: NeonToolInjectValue;
-	omitFromSchema?: boolean;
+	project_id?: NeonToolInjectValue;
+	branch_id?: NeonToolInjectValue;
+	/** `pin` (default) removes the field from the schema. `default` keeps it optional. */
+	mode?: "pin" | "default";
 }
 
 export interface NeonToolDescriptionSource {
@@ -55,16 +56,10 @@ export interface NeonToolCustomizeOptions {
 }
 
 type InjectedPathKey<Inject> =
-	| ("projectId" extends keyof Inject
-			? Inject["projectId"] extends undefined
-				? never
-				: "project_id"
+	| (Inject extends { project_id: NeonToolInjectValue }
+			? "project_id"
 			: never)
-	| ("branchId" extends keyof Inject
-			? Inject["branchId"] extends undefined
-				? never
-				: "branch_id"
-			: never);
+	| (Inject extends { branch_id: NeonToolInjectValue } ? "branch_id" : never);
 
 type RequiredKeys<Input> = {
 	[Key in keyof Input]-?: object extends Pick<Input, Key> ? never : Key;
@@ -79,15 +74,15 @@ type ApplyInjectToInput<Input, Inject> = [
 	InjectedRequiredKey<Input, Inject>,
 ] extends [never]
 	? Input
-	: Inject extends { omitFromSchema: true }
-		? Omit<Input, InjectedRequiredKey<Input, Inject>>
-		: Omit<Input, InjectedRequiredKey<Input, Inject>> &
+	: Inject extends { mode: "default" }
+		? Omit<Input, InjectedRequiredKey<Input, Inject>> &
 				Partial<
 					Pick<
 						Input,
 						Extract<InjectedRequiredKey<Input, Inject>, keyof Input>
 					>
-				>;
+				>
+		: Omit<Input, InjectedRequiredKey<Input, Inject>>;
 
 export type InjectedNeonTool<Tool, Inject> =
 	Tool extends NeonTool<infer Schema, string, infer Output>
@@ -100,20 +95,17 @@ export type InjectedNeonTool<Tool, Inject> =
 		: Tool;
 
 interface ResolvedInject {
-	projectId?: NeonToolInjectValue;
-	branchId?: NeonToolInjectValue;
-	omitFromSchema: boolean;
+	project_id?: NeonToolInjectValue;
+	branch_id?: NeonToolInjectValue;
+	mode: "pin" | "default";
 	hasAny: boolean;
 }
 
-const PATH_INJECT = [
-	["projectId", "project_id"],
-	["branchId", "branch_id"],
-] as const;
+const PATH_INJECT = ["project_id", "branch_id"] as const;
 
 const PUBLISHED_ID = /^[a-z][a-z0-9_]*$/;
 
-const missingInjectMessage = (name: "projectId" | "branchId") =>
+const missingInjectMessage = (name: "project_id" | "branch_id") =>
 	`A ${name} inject value is required`;
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
@@ -215,24 +207,28 @@ function resolveInject(
 	inject: NeonToolInjectOptions | undefined,
 ): ResolvedInject {
 	if (inject === undefined) {
-		return { omitFromSchema: false, hasAny: false };
+		return { mode: "pin", hasAny: false };
 	}
 
-	const projectId = requireInjectValue("projectId", inject.projectId);
-	const branchId = requireInjectValue("branchId", inject.branchId);
-	const hasAny = projectId !== undefined || branchId !== undefined;
-	const omitFromSchema = inject.omitFromSchema === true;
-	if (omitFromSchema && !hasAny) {
+	const project_id = requireInjectValue("project_id", inject.project_id);
+	const branch_id = requireInjectValue("branch_id", inject.branch_id);
+	const hasAny = project_id !== undefined || branch_id !== undefined;
+	if (inject.mode !== undefined && !hasAny) {
 		throw new TypeError(
-			"omitFromSchema requires inject.projectId or inject.branchId",
+			"inject.mode requires inject.project_id or inject.branch_id",
 		);
 	}
 
-	return { projectId, branchId, omitFromSchema, hasAny };
+	return {
+		project_id,
+		branch_id,
+		mode: inject.mode ?? "pin",
+		hasAny,
+	};
 }
 
 function requireInjectValue(
-	name: "projectId" | "branchId",
+	name: "project_id" | "branch_id",
 	value: NeonToolInjectValue | undefined,
 ): NeonToolInjectValue | undefined {
 	if (value === undefined) {
@@ -290,7 +286,7 @@ function wrapToolExecute(
 ): NeonTool["execute"] {
 	const originalExecute = tool.execute.bind(tool);
 	const availableKeys = pathTemplateParams(tool.metadata.path);
-	const mode = inject.omitFromSchema ? "override" : "fill";
+	const mode = inject.mode === "pin" ? "override" : "fill";
 
 	return async (input, context) => {
 		const run = async () =>
@@ -330,11 +326,11 @@ async function resolveInjectedFields(
 	const present = isPlainObject(input) ? input : undefined;
 	const patch: Record<string, string> = {};
 
-	for (const [name, pathKey] of PATH_INJECT) {
+	for (const pathKey of PATH_INJECT) {
 		if (!availableKeys.has(pathKey)) {
 			continue;
 		}
-		const injector = inject[name];
+		const injector = inject[pathKey];
 		if (injector === undefined) {
 			continue;
 		}
@@ -346,12 +342,12 @@ async function resolveInjectedFields(
 			typeof injector === "function" ? await injector() : injector;
 		if (value === undefined) {
 			if (mode === "override") {
-				throw new TypeError(missingInjectMessage(name));
+				throw new TypeError(missingInjectMessage(pathKey));
 			}
 			continue;
 		}
 		if (typeof value !== "string" || value.length === 0) {
-			throw new TypeError(missingInjectMessage(name));
+			throw new TypeError(missingInjectMessage(pathKey));
 		}
 		patch[pathKey] = value;
 	}
@@ -416,15 +412,15 @@ function publishInputSchema(
 
 	const nextShape: Record<string, z.ZodType> = { ...shape };
 	let changed = false;
-	for (const [name, pathKey] of PATH_INJECT) {
-		if (inject[name] === undefined || !pathKeys.has(pathKey)) {
+	for (const pathKey of PATH_INJECT) {
+		if (inject[pathKey] === undefined || !pathKeys.has(pathKey)) {
 			continue;
 		}
 		if (nextShape[pathKey] === undefined) {
 			continue;
 		}
 		changed = true;
-		if (inject.omitFromSchema) {
+		if (inject.mode === "pin") {
 			delete nextShape[pathKey];
 		} else {
 			nextShape[pathKey] = nextShape[pathKey].optional();

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -223,9 +223,11 @@ function resolveInject(
 	const project_id = requireInjectValue("project_id", inject.project_id);
 	const branch_id = requireInjectValue("branch_id", inject.branch_id);
 	const hasAny = project_id !== undefined || branch_id !== undefined;
-	if (inject.mode !== undefined && !hasAny) {
+	if (!hasAny) {
 		throw new TypeError(
-			"inject.mode requires inject.project_id or inject.branch_id",
+			inject.mode !== undefined
+				? "inject.mode requires inject.project_id or inject.branch_id"
+				: "inject requires inject.project_id or inject.branch_id",
 		);
 	}
 

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -62,15 +62,18 @@ export interface NeonToolCustomizeOptions {
 	inject?: NeonToolInjectOptions;
 }
 
-type InjectedPathKey<Inject> = Inject extends NeonToolInjectOptions
-	?
-			| ("project_id" extends keyof Inject ? "project_id" : never)
-			| ("branch_id" extends keyof Inject ? "branch_id" : never)
-	: never;
-
 type RequiredKeys<Input> = {
 	[Key in keyof Input]-?: object extends Pick<Input, Key> ? never : Key;
 }[keyof Input];
+
+// Tuple so a NeonToolInjectOptions union does not count optional arm keys as injected.
+type InjectedPathKey<Inject> =
+	| ([Inject] extends [{ project_id: NeonToolInjectValue }]
+			? "project_id"
+			: never)
+	| ([Inject] extends [{ branch_id: NeonToolInjectValue }]
+			? "branch_id"
+			: never);
 
 type InjectedRequiredKey<Input, Inject> = Extract<
 	InjectedPathKey<Inject>,
@@ -81,7 +84,7 @@ type ApplyInjectToInput<Input, Inject> = [
 	InjectedRequiredKey<Input, Inject>,
 ] extends [never]
 	? Input
-	: Inject extends { mode: "fallback" }
+	: [Inject] extends [{ mode: "fallback" }]
 		? Omit<Input, InjectedRequiredKey<Input, Inject>> &
 				Partial<
 					Pick<

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -55,11 +55,11 @@ export interface NeonToolCustomizeOptions {
 	inject?: NeonToolInjectOptions;
 }
 
-type InjectedPathKey<Inject> =
-	| (Inject extends { project_id: NeonToolInjectValue }
-			? "project_id"
-			: never)
-	| (Inject extends { branch_id: NeonToolInjectValue } ? "branch_id" : never);
+type InjectedPathKey<Inject> = Inject extends NeonToolInjectOptions
+	?
+			| ("project_id" extends keyof Inject ? "project_id" : never)
+			| ("branch_id" extends keyof Inject ? "branch_id" : never)
+	: never;
 
 type RequiredKeys<Input> = {
 	[Key in keyof Input]-?: object extends Pick<Input, Key> ? never : Key;

--- a/packages/tools/src/lib/customize.ts
+++ b/packages/tools/src/lib/customize.ts
@@ -9,12 +9,19 @@ export type NeonToolInjectValue =
 	| string
 	| (() => string | undefined | Promise<string | undefined>);
 
-export interface NeonToolInjectOptions {
-	project_id?: NeonToolInjectValue;
-	branch_id?: NeonToolInjectValue;
-	/** When omitted, `"pin"`: field removed from the schema. `"fallback"`: field stays optional, caller value wins. */
-	mode?: "pin" | "fallback";
-}
+export type NeonToolInjectOptions =
+	| {
+			project_id: NeonToolInjectValue;
+			branch_id?: NeonToolInjectValue;
+			/** When omitted, `"pin"`: field removed from the schema. `"fallback"`: field stays optional, caller value wins. */
+			mode?: "pin" | "fallback";
+	  }
+	| {
+			branch_id: NeonToolInjectValue;
+			project_id?: NeonToolInjectValue;
+			/** When omitted, `"pin"`: field removed from the schema. `"fallback"`: field stays optional, caller value wins. */
+			mode?: "pin" | "fallback";
+	  };
 
 export interface NeonToolDescriptionSource {
 	operationId: string;

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -317,8 +317,7 @@ describe("MCP path injection", () => {
 			apiKey: "test-key",
 			tools: ["projects.get"],
 			inject: {
-				projectId: "granted-project",
-				omitFromSchema: true,
+				project_id: "granted-project",
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
@@ -368,7 +367,7 @@ describe("MCP path injection", () => {
 			descriptions: {
 				"projects.get": "Get details of the granted Neon project.",
 			},
-			inject: { projectId: "granted-project" },
+			inject: { project_id: "granted-project", mode: "default" },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
 				return new Response(
@@ -418,8 +417,7 @@ describe("MCP path injection", () => {
 			apiKey: "test-key",
 			tools: ["projects.get"],
 			inject: {
-				projectId: "granted-project",
-				omitFromSchema: true,
+				project_id: "granted-project",
 			},
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -367,7 +367,7 @@ describe("MCP path injection", () => {
 			descriptions: {
 				"projects.get": "Get details of the granted Neon project.",
 			},
-			inject: { project_id: "granted-project", mode: "default" },
+			inject: { project_id: "granted-project", mode: "fallback" },
 			fetch: async (input, init) => {
 				requests.push(new Request(input, init));
 				return new Response(

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -291,9 +291,10 @@ describe("branches.createAndConnect", () => {
 
 	test("injects project_id from a grant", async () => {
 		const { requests, tools } = createBranchTools({
-			inject: { projectId: "granted-project", omitFromSchema: true },
+			inject: { project_id: "granted-project" },
 		});
 
+		// @ts-expect-error createBranchTools widens inject
 		await tools["branches.createAndConnect"].execute({
 			name: "feature-x",
 		});

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -3,6 +3,7 @@ import * as z from "zod";
 import {
 	createNeonTool,
 	createNeonTools,
+	type NeonToolInjectOptions,
 	type NeonToolsClientOptions,
 } from "./index.js";
 
@@ -39,7 +40,9 @@ const projectWithUriBody = {
 	],
 };
 
-const createBranchOnlyTools = (options: NeonToolsClientOptions = {}) => {
+const createBranchOnlyTools = (
+	options: Omit<NeonToolsClientOptions, "inject"> = {},
+) => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({
 		apiKey: "test-key",
@@ -53,7 +56,13 @@ const createBranchOnlyTools = (options: NeonToolsClientOptions = {}) => {
 	return { requests, tools };
 };
 
-const createBranchTools = (options: NeonToolsClientOptions = {}) => {
+const createBranchTools = <
+	const I extends NeonToolInjectOptions | undefined = undefined,
+>(
+	options: Omit<NeonToolsClientOptions, "inject"> & {
+		inject?: I;
+	} = {} as Omit<NeonToolsClientOptions, "inject"> & { inject?: I },
+) => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({
 		apiKey: "test-key",
@@ -294,7 +303,6 @@ describe("branches.createAndConnect", () => {
 			inject: { project_id: "granted-project" },
 		});
 
-		// @ts-expect-error createBranchTools widens inject
 		await tools["branches.createAndConnect"].execute({
 			name: "feature-x",
 		});


### PR DESCRIPTION
## Problem

`@neon/tools` lets a host inject `project_id` and `branch_id` so the model never has to supply them. The option had two problems.

The inject keys were camelCase (`projectId`, `branchId`) while every published tool field is snake_case. The option named fields that exist on no tool.

The default was caller-wins fill: the injected field stayed in the published schema as optional and a caller-supplied value beat the injector. A host granting one project to an agent had to add `omitFromSchema: true` to keep the model from pointing the tool at another project. The safe behavior was opt-in.

## Interface

`inject` takes the field names. Pinning is the default:

```ts
const tools = createNeonTools({
	apiKey,
	tools: ["projects.get", "branches.delete"] as const,
	inject: { project_id: "project-id" },
});

await tools["projects.get"].execute({});
await tools["branches.delete"].execute({ branch_id: "br-id" });
```

| `mode` | Published schema | Conflict |
|---|---|---|
| omitted or `"pin"` | field removed, injector is the only source | injector wins |
| `"fallback"` | field stays optional | caller value wins, injector fills the gap |

Getter injectors are unchanged: `inject: { project_id: () => grant.getStore()?.projectId }`. In pin mode a getter that returns `undefined` throws at execute; in fallback mode it skips the fill. `createNeonTool` takes the same options.

A defined `inject` with neither `project_id` nor `branch_id` throws at construction. That covers a leftover `{ projectId }`, `{ project_id: undefined }` and a bare `{ mode: "pin" }`. An empty string or a non-string value also throws, and `mode` rejects anything other than `"pin"` and `"fallback"`.

Injection still reads the URL template, so it fills path `project_id` and `branch_id` only. Query and body fields with those names stay caller-supplied, including `postgres.connectionString`'s `branch_id`.

## Migration

The old `inject: { projectId }` was caller-wins fill. Renaming the key to `project_id` flips the semantics to pin. A host that wants the old behavior adds `mode: "fallback"`:

```ts
// before: caller value wins, field stays in the schema
inject: { projectId: "project-id" }

// after, same behavior
inject: { project_id: "project-id", mode: "fallback" }

// after, pin (the new default): field leaves the schema, injector wins
inject: { project_id: "project-id" }
```

Old code fails loudly rather than drifting: `{ projectId }` has no recognized key, so construction throws. `omitFromSchema` is gone.

## Type-level omission on `execute`

`execute` omits a path key only when that key is required on the inject object's type. Pass `inject` inline, or name it with `satisfies`:

```ts
const inject = { project_id: "project-id" } satisfies NeonToolInjectOptions;
const tools = createNeonTools({ apiKey, tools: ["branches.delete"] as const, inject });
await tools["branches.delete"].execute({ branch_id: "br-id" });
```

A locally assigned const with the annotation `const inject: NeonToolInjectOptions = { project_id }` is narrowed by TypeScript and also omits `project_id`. A `NeonToolInjectOptions` parameter, or a value imported as that union, is the union of both arms; neither key is guaranteed, so `execute` still requires them. Runtime still injects whatever was set, so the union case over-requires a key rather than dropping one.

The conditional types now test `[Inject] extends [NeonToolInjectOptions]` as a tuple so a union inject does not distribute into both arms and count optional keys as injected.

## Also in here

- The README injection section documents the modes, the migration and the `satisfies` guidance.
- A major changeset for `@neon/tools`.

## Verification

`pnpm exec tsc --noEmit` in `packages/tools` passes on this branch, which checks the type-level assertions in `index.test-d.ts`:

- an inline `{ project_id }` inject omits `project_id` from `execute`, on `createNeonTools` and `createNeonTool`
- `satisfies NeonToolInjectOptions` and an annotated local const both omit the injected key
- a `NeonToolInjectOptions`-typed union value omits nothing and `execute` still requires both path keys
- project-only and branch-only injects keep the other path key required
- `{ projectId }` and `{ project_id: undefined }` are type errors

Runtime tests in `customize.test.ts` cover: pin removes the field from the published schema and the injector always wins, fallback keeps it optional and prefers the caller value, both keys inject together, construction throws for a keyless inject, an unknown mode, empty and non-string values, a pin getter returning `undefined` throws at execute, injection skips tools without the path key, unknown fields are still rejected after injection and `onExecute` sees the caller input rather than the injected patch. The vitest suite was not run for this description; CI runs it.

## For your attention

- Breaking for every existing `inject` caller: the keys renamed and the default flipped from caller-wins fill to pin. The construction throw makes a missed migration a hard failure at startup rather than a silent behavior change.
- Whether `execute` omits a key depends on how TypeScript sees the inject value. A host that threads inject through a `NeonToolInjectOptions` parameter keeps the path keys required at the type level even though runtime injects them.
