### PR TITLE
Let execute return { error } when throwOnError is false

### DIFF
--- a/.changeset/tools-t6-throw-on-error.md
+++ b/.changeset/tools-t6-throw-on-error.md
@@ -2,4 +2,4 @@
 "@neon/tools": patch
 ---
 
-`throwOnError: false` on `createNeonTools` returns `{ data } | { error }` from `execute` instead of throwing.
+`throwOnError: false` on `createNeonTools` and `createNeonTool` returns `{ data } | { error }` from `execute` instead of throwing.

--- a/.changeset/tools-t6-throw-on-error.md
+++ b/.changeset/tools-t6-throw-on-error.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": patch
+---
+
+`throwOnError: false` on `createNeonTools` returns `{ data } | { error }` from `execute` instead of throwing.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -65,7 +65,18 @@ await tools["projects.list"].execute(
 );
 ```
 
-Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, safety annotations, stability metadata, and `execute()`. Inputs are snake_case at the tool boundary. `execute()` strictly validates the input, rejects unknown fields, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller.
+Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, safety annotations, stability metadata, and `execute()`. Inputs are snake_case at the tool boundary. `execute()` strictly validates the input, rejects unknown fields, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller. Pass `throwOnError: false` to get `{ data } | { error }` instead of a throw.
+
+```ts
+const tools = createNeonTools({
+	apiKey,
+	tools: ["projects.get"] as const,
+	throwOnError: false,
+});
+const { data, error } = await tools["projects.get"].execute({
+	project_id: "project-id",
+});
+```
 
 Paginated lists call `.all()` and return the item array. Do not pass a cursor; those fields are omitted from the input schema.
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -65,7 +65,7 @@ await tools["projects.list"].execute(
 );
 ```
 
-Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, safety annotations, stability metadata, and `execute()`. Inputs are snake_case at the tool boundary. `execute()` strictly validates the input, rejects unknown fields, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller. Pass `throwOnError: false` on `createNeonTools` or `createNeonTool` to get `{ data } | { error }` instead of a throw. Zod parse failures still throw.
+Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, safety annotations, stability metadata, and `execute()`. Inputs are snake_case at the tool boundary. `execute()` strictly validates the input, rejects unknown fields, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller. Pass `throwOnError: false` on `createNeonTools` or `createNeonTool` to get `{ data } | { error }` instead of a throw. Zod parse failures still throw. MCP, Eve, and Mastra adapters accept those tools. When the options object is typed as `CreateNeonToolsOptions`, `throwOnError` is optional, so `execute` types both outcomes.
 
 ```ts
 const tools = createNeonTools({

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -65,7 +65,7 @@ await tools["projects.list"].execute(
 );
 ```
 
-Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, safety annotations, stability metadata, and `execute()`. Inputs are snake_case at the tool boundary. `execute()` strictly validates the input, rejects unknown fields, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller. Pass `throwOnError: false` to get `{ data } | { error }` instead of a throw.
+Each tool includes its Zod 4 `inputSchema`, published `id`, title, description, safety annotations, stability metadata, and `execute()`. Inputs are snake_case at the tool boundary. `execute()` strictly validates the input, rejects unknown fields, and returns typed, JSON-safe `{ data }`. Neon SDK errors remain typed and are thrown to the caller. Pass `throwOnError: false` on `createNeonTools` or `createNeonTool` to get `{ data } | { error }` instead of a throw. Zod parse failures still throw.
 
 ```ts
 const tools = createNeonTools({

--- a/packages/tools/src/customize.test.ts
+++ b/packages/tools/src/customize.test.ts
@@ -6,6 +6,8 @@ import {
 	type NeonToolsClientOptions,
 } from "./index.js";
 
+type TestClientOptions = Omit<NeonToolsClientOptions, "throwOnError">;
+
 const jsonResponse = (body: unknown, status = 200) =>
 	new Response(JSON.stringify(body), {
 		status,
@@ -26,7 +28,7 @@ const branchWithComputeBody = {
 	],
 };
 
-const getProjectTools = (options: NeonToolsClientOptions = {}) => {
+const getProjectTools = (options: TestClientOptions = {}) => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({
 		apiKey: "test-key",

--- a/packages/tools/src/eve.ts
+++ b/packages/tools/src/eve.ts
@@ -1,22 +1,13 @@
-import type * as z from "zod";
-import type {
-	NeonToolExecutionContext,
-	NeonToolResult,
-} from "./lib/operation.js";
+import type { NeonExecutableTool } from "./lib/operation.js";
 
 export interface EveToolContext {
 	abortSignal: AbortSignal;
 }
 
-type EveToolSource = {
-	description: string;
-	inputSchema: z.ZodType;
-	requiresApproval: boolean;
-	execute: (
-		input: never,
-		context?: NeonToolExecutionContext,
-	) => Promise<NeonToolResult<unknown>>;
-};
+type EveToolSource = Pick<
+	NeonExecutableTool,
+	"description" | "inputSchema" | "requiresApproval" | "execute"
+>;
 
 export const toEveTool = <const Tool extends EveToolSource>(tool: Tool) => ({
 	description: tool.description,

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -1,3 +1,4 @@
+import type { NeonError } from "@neon/sdk";
 import { expectTypeOf } from "vitest";
 import { toEveTool } from "./eve.js";
 import {
@@ -294,3 +295,16 @@ createProjectOnly.execute({ name: "x", no_compute: true });
 
 // @ts-expect-error tools is required
 createNeonTools({ apiKey: "test-key" });
+
+const enveloped = createNeonTools({
+	apiKey: "test-key",
+	tools: ["projects.get"] as const,
+	throwOnError: false,
+});
+enveloped["projects.get"].execute({ project_id: "p" }).then((result) => {
+	if (result.error) {
+		expectTypeOf(result.error).toEqualTypeOf<NeonError>();
+	} else {
+		expectTypeOf(result.data.id).toEqualTypeOf<string>();
+	}
+});

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -323,3 +323,21 @@ envelopedOne.execute({ project_id: "p" }).then((result) => {
 		expectTypeOf(result.data.id).toEqualTypeOf<string>();
 	}
 });
+
+const annotatedEnvelope: CreateNeonToolsOptions<["projects.get"]> = {
+	apiKey: "test-key",
+	tools: ["projects.get"],
+	throwOnError: false,
+};
+createNeonTools(annotatedEnvelope)
+	["projects.get"].execute({ project_id: "p" })
+	.then((result) => {
+		if ("error" in result && result.error) {
+			expectTypeOf(result.error).toEqualTypeOf<NeonError>();
+		} else {
+			expectTypeOf(result.data.id).toEqualTypeOf<string>();
+		}
+	});
+
+toEveTool(enveloped["projects.get"]);
+toMastraTools(enveloped);

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -8,6 +8,7 @@ import {
 	publishedId,
 } from "./index.js";
 import { toMastraTools } from "./mastra.js";
+import { registerNeonTools } from "./mcp.js";
 
 expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"list_projects">();
 expectTypeOf(
@@ -302,6 +303,20 @@ const enveloped = createNeonTools({
 	throwOnError: false,
 });
 enveloped["projects.get"].execute({ project_id: "p" }).then((result) => {
+	if (result.error) {
+		expectTypeOf(result.error).toEqualTypeOf<NeonError>();
+	} else {
+		expectTypeOf(result.data.id).toEqualTypeOf<string>();
+	}
+});
+
+registerNeonTools({ registerTool() {} }, enveloped);
+
+const envelopedOne = createNeonTool("projects.get", {
+	apiKey: "test-key",
+	throwOnError: false,
+});
+envelopedOne.execute({ project_id: "p" }).then((result) => {
 	if (result.error) {
 		expectTypeOf(result.error).toEqualTypeOf<NeonError>();
 	} else {

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -1,3 +1,4 @@
+import { NeonError } from "@neon/sdk";
 import { describe, expect, test } from "vitest";
 import {
 	createNeonTool,
@@ -166,6 +167,40 @@ describe("createNeonTools", () => {
 			data: { id: "deployment-id", status: "pending" },
 		});
 		expect(requests).toHaveLength(1);
+	});
+
+	test("returns { error } when throwOnError is false", async () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.get"] as const,
+			throwOnError: false,
+			fetch: async () =>
+				jsonResponse({ message: "Project not found" }, 404),
+		});
+
+		const result = await tools["projects.get"].execute({
+			project_id: "missing",
+		});
+
+		expect("error" in result && result.error !== undefined).toBe(true);
+		if (!("error" in result) || result.error === undefined) {
+			throw new Error("expected error envelope");
+		}
+		expect(result.error).toBeInstanceOf(NeonError);
+		expect(result.error.kind).toBe("not_found");
+	});
+
+	test("throws when throwOnError is omitted", async () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.get"] as const,
+			fetch: async () =>
+				jsonResponse({ message: "Project not found" }, 404),
+		});
+
+		await expect(
+			tools["projects.get"].execute({ project_id: "missing" }),
+		).rejects.toBeInstanceOf(NeonError);
 	});
 
 	test("rejects a call with no tools", () => {

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -190,6 +190,55 @@ describe("createNeonTools", () => {
 		expect(result.error.kind).toBe("not_found");
 	});
 
+	test("returns { error } from createNeonTool when throwOnError is false", async () => {
+		const tool = createNeonTool("projects.get", {
+			apiKey: "test-key",
+			throwOnError: false,
+			fetch: async () =>
+				jsonResponse({ message: "Project not found" }, 404),
+		});
+
+		const result = await tool.execute({ project_id: "missing" });
+		expect("error" in result && result.error !== undefined).toBe(true);
+	});
+
+	test("still throws Zod failures when throwOnError is false", async () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.get"] as const,
+			throwOnError: false,
+		});
+
+		await expect(
+			tools["projects.get"].execute({ project_id: 1 as never }),
+		).rejects.toThrow();
+	});
+
+	test("onExecute still sees a thrown NeonError when throwOnError is false", async () => {
+		let thrown: unknown;
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.get"] as const,
+			throwOnError: false,
+			fetch: async () =>
+				jsonResponse({ message: "Project not found" }, 404),
+			onExecute: async ({ execute }) => {
+				try {
+					return await execute();
+				} catch (error) {
+					thrown = error;
+					throw error;
+				}
+			},
+		});
+
+		const result = await tools["projects.get"].execute({
+			project_id: "missing",
+		});
+		expect(thrown).toBeInstanceOf(NeonError);
+		expect("error" in result && result.error !== undefined).toBe(true);
+	});
+
 	test("throws when throwOnError is omitted", async () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",

--- a/packages/tools/src/index.test.ts
+++ b/packages/tools/src/index.test.ts
@@ -288,7 +288,9 @@ describe("createNeonTools", () => {
 });
 
 describe("Bearer credentials", () => {
-	const listProjects = (options: NeonToolsClientOptions) => {
+	const listProjects = (
+		options: Omit<NeonToolsClientOptions, "throwOnError">,
+	) => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({
 			...options,

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -19,7 +19,7 @@ import {
 	toolIds,
 	unpublishedToolError,
 } from "./lib/ergonomic/index.js";
-import type { NeonToolResult } from "./lib/operation.js";
+import type { NeonTool, NeonToolResult } from "./lib/operation.js";
 
 export type { NeonBearerCredential } from "./lib/auth.js";
 export type {
@@ -48,7 +48,13 @@ export { NeonError, publishedId, toolIds };
 
 type ToolFactories = typeof toolFactories;
 
-type ThrowsFrom<T> = T extends { throwOnError: false } ? false : true;
+type ThrowsFrom<T> = T extends { throwOnError: false }
+	? false
+	: T extends { throwOnError: true }
+		? true
+		: T extends { throwOnError: boolean }
+			? boolean
+			: true;
 
 type WithThrowMode<Tool, Throws extends boolean> = Tool extends {
 	execute: (
@@ -197,8 +203,35 @@ const bindTools = <T extends CreateNeonToolsInput>(
 	}
 	const tools: unknown = Object.fromEntries(entries);
 	assertNeonTools(tools, selected);
+	if (options.throwOnError === false) {
+		const enveloped = Object.fromEntries(
+			Object.entries(tools as Record<string, NeonTool>).map(
+				([id, tool]) => [
+					id,
+					{
+						...tool,
+						execute: envelopeExecute(tool.execute.bind(tool)),
+					},
+				],
+			),
+		);
+		assertNeonTools(enveloped, selected);
+		return enveloped as NeonTools<SelectedTools<T>>;
+	}
 	return tools as NeonTools<SelectedTools<T>>;
 };
+
+const envelopeExecute = (execute: NeonTool["execute"]): NeonTool["execute"] =>
+	(async (input, context) => {
+		try {
+			return await execute(input, context);
+		} catch (error) {
+			if (!(error instanceof NeonError)) {
+				throw error;
+			}
+			return { error };
+		}
+	}) as NeonTool["execute"];
 
 type NamedNeonTools<
 	Tools extends readonly NeonToolId[],
@@ -309,7 +342,16 @@ export function createNeonTool<
 	const customized = hasToolCustomization(options)
 		? applyToolCustomization(tool, options)
 		: tool;
-	return customized as
+	const executed =
+		options.throwOnError === false
+			? {
+					...customized,
+					execute: envelopeExecute(
+						customized.execute.bind(customized),
+					),
+				}
+			: customized;
+	return executed as
 		| NamedNeonTool<Id, Inject, boolean>
 		| InjectedNeonTool<ToolForId<Id>, Inject>
 		| ToolForId<Id>;

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -19,6 +19,7 @@ import {
 	toolIds,
 	unpublishedToolError,
 } from "./lib/ergonomic/index.js";
+import type { NeonToolResult } from "./lib/operation.js";
 
 export type { NeonBearerCredential } from "./lib/auth.js";
 export type {
@@ -46,6 +47,26 @@ export type { NeonToolId, PublishedId };
 export { NeonError, publishedId, toolIds };
 
 type ToolFactories = typeof toolFactories;
+
+type ThrowsFrom<T> = T extends { throwOnError: false } ? false : true;
+
+type WithThrowMode<Tool, Throws extends boolean> = Tool extends {
+	execute: (
+		input: infer Input,
+		context?: infer Context,
+	) => Promise<{ data: infer Data }>;
+}
+	? Omit<Tool, "execute"> & {
+			execute(
+				input: Input,
+				context?: Context,
+			): Promise<NeonToolResult<Data, Throws>>;
+		}
+	: Tool;
+
+type ToolsWithThrow<Tools, Throws extends boolean> = {
+	[Key in keyof Tools]: WithThrowMode<Tools[Key], Throws>;
+};
 
 export type NeonTools<Tools extends readonly NeonToolId[] = []> = {
 	[Tool in Tools[number]]: ReturnType<ToolFactories[Tool]>;
@@ -81,9 +102,12 @@ type SelectedTools<T> = T extends {
 	: [];
 
 type NeonToolsFor<T, Inject> = T extends CreateNeonToolsInput
-	? Inject extends NeonToolInjectOptions
-		? InjectedNeonTools<SelectedTools<T>, Inject>
-		: NeonTools<SelectedTools<T>>
+	? ToolsWithThrow<
+			Inject extends NeonToolInjectOptions
+				? InjectedNeonTools<SelectedTools<T>, Inject>
+				: NeonTools<SelectedTools<T>>,
+			ThrowsFrom<T>
+		>
 	: never;
 
 type ToolForId<Id extends NeonToolId> = ReturnType<ToolFactories[Id]>;
@@ -176,22 +200,36 @@ const bindTools = <T extends CreateNeonToolsInput>(
 	return tools as NeonTools<SelectedTools<T>>;
 };
 
-type NamedNeonTools<Tools extends readonly NeonToolId[], Inject> = {
+type NamedNeonTools<
+	Tools extends readonly NeonToolId[],
+	Inject,
+	Throws extends boolean,
+> = {
 	[Tool in Tools[number]]: WithPublishedId<
-		Inject extends NeonToolInjectOptions
-			? InjectedNeonTool<ReturnType<ToolFactories[Tool]>, Inject>
-			: ReturnType<ToolFactories[Tool]>
+		WithThrowMode<
+			Inject extends NeonToolInjectOptions
+				? InjectedNeonTool<ReturnType<ToolFactories[Tool]>, Inject>
+				: ReturnType<ToolFactories[Tool]>,
+			Throws
+		>
 	>;
 };
 
-type NamedNeonTool<Id extends NeonToolId, Inject> = WithPublishedId<
-	Inject extends NeonToolInjectOptions
-		? InjectedNeonTool<ToolForId<Id>, Inject>
-		: ToolForId<Id>
+type NamedNeonTool<
+	Id extends NeonToolId,
+	Inject,
+	Throws extends boolean,
+> = WithPublishedId<
+	WithThrowMode<
+		Inject extends NeonToolInjectOptions
+			? InjectedNeonTool<ToolForId<Id>, Inject>
+			: ToolForId<Id>,
+		Throws
+	>
 >;
 
 type NamedNeonToolsFor<T, Inject> = T extends CreateNeonToolsInput
-	? NamedNeonTools<SelectedTools<T>, Inject>
+	? NamedNeonTools<SelectedTools<T>, Inject, ThrowsFrom<T>>
 	: never;
 
 export function createNeonTools<
@@ -221,24 +259,33 @@ export function createNeonTools<
 export function createNeonTool<
 	const Id extends NeonToolId,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
+	const Throws extends boolean = true,
 >(
 	id: Id,
 	options: NeonToolsClientOptions & {
 		inject?: Inject;
+		throwOnError?: Throws;
 	} & (
 			| { name: (id: string) => string; names?: NeonToolNameOverrides }
 			| { names: NeonToolNameOverrides; name?: (id: string) => string }
 		),
-): NamedNeonTool<Id, Inject>;
+): NamedNeonTool<Id, Inject, Throws>;
 export function createNeonTool<
 	const Id extends NeonToolId,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
+	const Throws extends boolean = true,
 >(
 	id: Id,
-	options: NeonToolsClientOptions & { inject?: Inject },
-): Inject extends NeonToolInjectOptions
-	? InjectedNeonTool<ToolForId<Id>, Inject>
-	: ToolForId<Id>;
+	options: NeonToolsClientOptions & {
+		inject?: Inject;
+		throwOnError?: Throws;
+	},
+): WithThrowMode<
+	Inject extends NeonToolInjectOptions
+		? InjectedNeonTool<ToolForId<Id>, Inject>
+		: ToolForId<Id>,
+	Throws
+>;
 export function createNeonTool<
 	const Id extends NeonToolId,
 	const Inject extends NeonToolInjectOptions | undefined = undefined,
@@ -250,7 +297,7 @@ export function createNeonTool<
 		names?: NeonToolNameOverrides;
 	},
 ):
-	| NamedNeonTool<Id, Inject>
+	| NamedNeonTool<Id, Inject, boolean>
 	| InjectedNeonTool<ToolForId<Id>, Inject>
 	| ToolForId<Id> {
 	if (!isNeonToolId(id)) {
@@ -263,7 +310,7 @@ export function createNeonTool<
 		? applyToolCustomization(tool, options)
 		: tool;
 	return customized as
-		| NamedNeonTool<Id, Inject>
+		| NamedNeonTool<Id, Inject, boolean>
 		| InjectedNeonTool<ToolForId<Id>, Inject>
 		| ToolForId<Id>;
 }

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -37,6 +37,7 @@ export type {
 export type {
 	JsonSafe,
 	JsonSafeBlob,
+	NeonExecutableTool,
 	NeonTool,
 	NeonToolAnnotations,
 	NeonToolExecutionContext,
@@ -52,7 +53,7 @@ type ThrowsFrom<T> = T extends { throwOnError: false }
 	? false
 	: T extends { throwOnError: true }
 		? true
-		: T extends { throwOnError: boolean }
+		: "throwOnError" extends keyof T
 			? boolean
 			: true;
 

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -21,7 +21,6 @@ import type {
 	NeonTool,
 	NeonToolAnnotations,
 	NeonToolExecutionContext,
-	NeonToolResult,
 } from "../operation.js";
 import { toToolResult } from "../result.js";
 import type { NeonToolId } from "./ids.js";
@@ -241,20 +240,6 @@ export const collectPages = async <T>(
 	return items;
 };
 
-const runToolExecute = async <Output>(
-	options: ToolClientOptions,
-	run: () => Promise<Output>,
-): Promise<{ data: JsonSafe<Awaited<Output>> } | { error: NeonError }> => {
-	try {
-		return await toToolResult(await run());
-	} catch (error) {
-		if (options.throwOnError !== false || !(error instanceof NeonError)) {
-			throw error;
-		}
-		return { error };
-	}
-};
-
 export const bindTool = <
 	const InputSchema extends z.ZodType,
 	const Id extends string,
@@ -271,9 +256,12 @@ export const bindTool = <
 	...tool,
 	async execute(input, context) {
 		const parsed = await tool.inputSchema.parseAsync(input);
-		return runToolExecute(options, () =>
-			run(toolClient(options, context), parsed, context?.signal),
-		) as Promise<NeonToolResult<JsonSafe<Awaited<Output>>>>;
+		const result = await run(
+			toolClient(options, context),
+			parsed,
+			context?.signal,
+		);
+		return toToolResult(result);
 	},
 });
 
@@ -370,13 +358,12 @@ export function fromGenerated(
 		metadata: generated.metadata,
 		async execute(input, context) {
 			const parsed = await inputSchema.parseAsync(input);
-			return runToolExecute(options, () =>
-				spec.run(
-					toolClient(options, context),
-					parsed as never,
-					context?.signal,
-				),
-			) as Promise<NeonToolResult>;
+			const result = await spec.run(
+				toolClient(options, context),
+				parsed as never,
+				context?.signal,
+			);
+			return toToolResult(result);
 		},
 	};
 }

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -21,6 +21,7 @@ import type {
 	NeonTool,
 	NeonToolAnnotations,
 	NeonToolExecutionContext,
+	NeonToolResult,
 } from "../operation.js";
 import { toToolResult } from "../result.js";
 import type { NeonToolId } from "./ids.js";
@@ -30,6 +31,7 @@ export interface ToolClientOptions {
 	baseUrl?: string;
 	fetch?: typeof fetch;
 	wait?: NeonConfig["wait"];
+	throwOnError?: boolean;
 }
 
 const ALL_PAGES = " Returns every page. Pass limit to cap how many.";
@@ -239,6 +241,20 @@ export const collectPages = async <T>(
 	return items;
 };
 
+const runToolExecute = async <Output>(
+	options: ToolClientOptions,
+	run: () => Promise<Output>,
+): Promise<{ data: JsonSafe<Awaited<Output>> } | { error: NeonError }> => {
+	try {
+		return await toToolResult(await run());
+	} catch (error) {
+		if (options.throwOnError !== false || !(error instanceof NeonError)) {
+			throw error;
+		}
+		return { error };
+	}
+};
+
 export const bindTool = <
 	const InputSchema extends z.ZodType,
 	const Id extends string,
@@ -255,12 +271,9 @@ export const bindTool = <
 	...tool,
 	async execute(input, context) {
 		const parsed = await tool.inputSchema.parseAsync(input);
-		const result = await run(
-			toolClient(options, context),
-			parsed,
-			context?.signal,
-		);
-		return toToolResult(result);
+		return runToolExecute(options, () =>
+			run(toolClient(options, context), parsed, context?.signal),
+		) as Promise<NeonToolResult<JsonSafe<Awaited<Output>>>>;
 	},
 });
 
@@ -357,12 +370,13 @@ export function fromGenerated(
 		metadata: generated.metadata,
 		async execute(input, context) {
 			const parsed = await inputSchema.parseAsync(input);
-			const result = await spec.run(
-				toolClient(options, context),
-				parsed as never,
-				context?.signal,
-			);
-			return toToolResult(result);
+			return runToolExecute(options, () =>
+				spec.run(
+					toolClient(options, context),
+					parsed as never,
+					context?.signal,
+				),
+			) as Promise<NeonToolResult>;
 		},
 	};
 }

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -1,10 +1,18 @@
-import type { NeonTool } from "./operation.js";
+import type { NeonError } from "@neon/sdk";
+import type { NeonTool, NeonToolExecutionContext } from "./operation.js";
 
 export interface McpToolResult {
 	content: Array<{ type: "text"; text: string }>;
 	structuredContent: Record<string, unknown>;
 	isError?: boolean;
 }
+
+export type McpRegistrableTool = Omit<NeonTool, "execute"> & {
+	execute(
+		input: unknown,
+		context?: NeonToolExecutionContext,
+	): Promise<{ data: unknown } | { data?: undefined; error: NeonError }>;
+};
 
 export interface McpToolServer {
 	registerTool: object;
@@ -63,7 +71,7 @@ const signalFrom = (context: unknown): AbortSignal | undefined => {
 };
 
 const createToolHandler =
-	(tool: NeonTool) =>
+	(tool: McpRegistrableTool) =>
 	async (input: unknown, context: unknown): Promise<McpToolResult> => {
 		try {
 			const apiKey = bearerCredentialFromMcpContext(context);
@@ -103,8 +111,8 @@ const createToolHandler =
 
 export const registerNeonToolsWithSchema = (
 	server: McpToolServer,
-	tools: Readonly<Record<string, NeonTool>>,
-	inputSchema: (tool: NeonTool) => unknown,
+	tools: Readonly<Record<string, McpRegistrableTool>>,
+	inputSchema: (tool: McpRegistrableTool) => unknown,
 ): void => {
 	if (typeof server.registerTool !== "function") {
 		throw new TypeError("Expected an MCP server with registerTool().");

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -71,6 +71,9 @@ const createToolHandler =
 				signal: signalFrom(context),
 				...(apiKey === undefined ? {} : { apiKey }),
 			});
+			if ("error" in result && result.error !== undefined) {
+				throw result.error;
+			}
 			const structuredContent = { data: result.data };
 			return {
 				content: [

--- a/packages/tools/src/lib/operation.ts
+++ b/packages/tools/src/lib/operation.ts
@@ -76,6 +76,13 @@ export interface NeonTool<
 	): Promise<NeonToolResult<Output>>;
 }
 
+export type NeonExecutableTool = Omit<NeonTool, "execute"> & {
+	execute(
+		input: never,
+		context?: NeonToolExecutionContext,
+	): Promise<NeonToolResult<unknown, boolean>>;
+};
+
 export interface NeonOperation<
 	InputSchema extends z.ZodType,
 	Id extends string = string,

--- a/packages/tools/src/lib/operation.ts
+++ b/packages/tools/src/lib/operation.ts
@@ -1,3 +1,4 @@
+import type { NeonError } from "@neon/sdk";
 import { type Client, createClient } from "@neon/sdk/raw";
 import type * as z from "zod";
 import { type NeonBearerCredential, requireBearerCredential } from "./auth.js";
@@ -47,9 +48,14 @@ export type JsonSafe<Value> = unknown extends Value
 								? { [Key in keyof Value]: JsonSafe<Value[Key]> }
 								: unknown;
 
-export interface NeonToolResult<Data = unknown> {
-	data: Data;
-}
+export type NeonToolResult<
+	Data = unknown,
+	Throws extends boolean = true,
+> = Throws extends true
+	? { data: Data }
+	:
+			| { data: Data; error?: undefined }
+			| { data?: undefined; error: NeonError };
 
 export interface NeonTool<
 	InputSchema extends z.ZodType = z.ZodType,

--- a/packages/tools/src/mastra.ts
+++ b/packages/tools/src/mastra.ts
@@ -1,15 +1,10 @@
-import type * as z from "zod";
-import type {
-	NeonTool,
-	NeonToolExecutionContext,
-	NeonToolResult,
-} from "./lib/operation.js";
+import type { NeonExecutableTool } from "./lib/operation.js";
 
 export interface MastraToolContext {
 	abortSignal?: AbortSignal;
 }
 
-export type MastraToolConfig<Tool extends NeonTool> = {
+export type MastraToolConfig<Tool extends NeonExecutableTool> = {
 	id: Tool["id"];
 	description: string;
 	inputSchema: Tool["inputSchema"];
@@ -20,20 +15,16 @@ export type MastraToolConfig<Tool extends NeonTool> = {
 	): ReturnType<Tool["execute"]>;
 };
 
-export type MastraTools<Tools extends Readonly<Record<string, NeonTool>>> = {
+export type MastraTools<
+	Tools extends Readonly<Record<string, NeonExecutableTool>>,
+> = {
 	[Tool in Tools[keyof Tools] as Tool["id"]]: MastraToolConfig<Tool>;
 };
 
-type MastraToolSource = {
-	id: string;
-	description: string;
-	inputSchema: z.ZodType;
-	requiresApproval: boolean;
-	execute: (
-		input: never,
-		context?: NeonToolExecutionContext,
-	) => Promise<NeonToolResult<unknown>>;
-};
+type MastraToolSource = Pick<
+	NeonExecutableTool,
+	"id" | "description" | "inputSchema" | "requiresApproval" | "execute"
+>;
 
 export const toMastraTool = <const Tool extends MastraToolSource>(
 	tool: Tool,
@@ -51,10 +42,9 @@ export const toMastraTool = <const Tool extends MastraToolSource>(
 		>,
 });
 
-function assertMastraTools<Tools extends Readonly<Record<string, NeonTool>>>(
-	value: unknown,
-	tools: Tools,
-): asserts value is MastraTools<Tools> {
+function assertMastraTools<
+	Tools extends Readonly<Record<string, NeonExecutableTool>>,
+>(value: unknown, tools: Tools): asserts value is MastraTools<Tools> {
 	if (typeof value !== "object" || value === null) {
 		throw new TypeError("Expected Mastra tools to be an object.");
 	}
@@ -66,7 +56,7 @@ function assertMastraTools<Tools extends Readonly<Record<string, NeonTool>>>(
 }
 
 export const toMastraTools = <
-	const Tools extends Readonly<Record<string, NeonTool>>,
+	const Tools extends Readonly<Record<string, NeonExecutableTool>>,
 >(
 	tools: Tools,
 ): MastraTools<Tools> => {

--- a/packages/tools/src/mcp-v1.ts
+++ b/packages/tools/src/mcp-v1.ts
@@ -1,15 +1,15 @@
 import {
+	type McpRegistrableTool,
 	type McpToolResult,
 	type McpToolServer,
 	registerNeonToolsWithSchema,
 } from "./lib/mcp-register.js";
-import type { NeonTool } from "./lib/operation.js";
 
 export type { McpToolResult, McpToolServer };
 
 export const registerNeonTools = (
 	server: McpToolServer,
-	tools: Readonly<Record<string, NeonTool>>,
+	tools: Readonly<Record<string, McpRegistrableTool>>,
 ): void => {
 	registerNeonToolsWithSchema(server, tools, (tool) => tool.inputSchema);
 };

--- a/packages/tools/src/mcp.ts
+++ b/packages/tools/src/mcp.ts
@@ -1,10 +1,10 @@
 import { compactJsonSchema, toMcpInputSchema } from "./lib/mcp-json-schema.js";
 import {
+	type McpRegistrableTool,
 	type McpToolResult,
 	type McpToolServer,
 	registerNeonToolsWithSchema,
 } from "./lib/mcp-register.js";
-import type { NeonTool } from "./lib/operation.js";
 
 export type { McpStandardSchema } from "./lib/mcp-json-schema.js";
 export type { McpToolResult, McpToolServer };
@@ -12,7 +12,7 @@ export { compactJsonSchema, toMcpInputSchema };
 
 export const registerNeonTools = (
 	server: McpToolServer,
-	tools: Readonly<Record<string, NeonTool>>,
+	tools: Readonly<Record<string, McpRegistrableTool>>,
 ): void => {
 	registerNeonToolsWithSchema(server, tools, (tool) =>
 		toMcpInputSchema(tool.inputSchema),

--- a/packages/tools/src/workflows.test.ts
+++ b/packages/tools/src/workflows.test.ts
@@ -6,6 +6,8 @@ import {
 	type NeonToolsClientOptions,
 } from "./index.js";
 
+type TestClientOptions = Omit<NeonToolsClientOptions, "throwOnError">;
+
 const jsonResponse = (body: unknown, status = 201) =>
 	new Response(JSON.stringify(body), {
 		status,
@@ -39,7 +41,7 @@ const projectWithUriBody = {
 	],
 };
 
-const createBranchOnlyTools = (options: NeonToolsClientOptions = {}) => {
+const createBranchOnlyTools = (options: TestClientOptions = {}) => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({
 		apiKey: "test-key",
@@ -53,7 +55,7 @@ const createBranchOnlyTools = (options: NeonToolsClientOptions = {}) => {
 	return { requests, tools };
 };
 
-const createBranchTools = (options: NeonToolsClientOptions = {}) => {
+const createBranchTools = (options: TestClientOptions = {}) => {
 	const requests: Request[] = [];
 	const tools = createNeonTools({
 		apiKey: "test-key",


### PR DESCRIPTION
## Problem

Every `@neon/tools` tool throws `NeonError` when the Neon API returns an error. Agent frameworks usually want the failure back as a tool result the model can read, and callers who want to branch on the error have to wrap every `execute` in try/catch. There was no way to get the error as a typed value.

## What changed

`createNeonTools` and `createNeonTool` take `throwOnError?: boolean`. Omitted or `true` is the current behavior: `execute` returns `{ data }` and throws `NeonError` on API failures. With `throwOnError: false`, `execute` catches `NeonError` and returns it as `{ error }`, and the result type becomes `{ data } | { error }`. Zod input-validation failures and non-Neon exceptions still throw in both modes.

The envelope wraps outside `onExecute`, so an `onExecute` interceptor still observes the thrown `NeonError` before it becomes a value.

## Interface

```ts
import { createNeonTools } from "@neon/tools";

const tools = createNeonTools({
	apiKey,
	tools: ["projects.get"] as const,
	throwOnError: false,
});

const { data, error } = await tools["projects.get"].execute({
	project_id: "project-id",
});
if (error) {
	// error: NeonError
} else {
	// data.id: string
}
```

The `{ data, error }` destructure works because the literal `throwOnError: false` narrows the result to the envelope union. When the options object is annotated as `CreateNeonToolsOptions`, `throwOnError` stays optional and `execute` types both outcomes; narrow with `"error" in result`:

```ts
const options: CreateNeonToolsOptions<["projects.get"]> = {
	apiKey,
	tools: ["projects.get"],
	throwOnError: false,
};

const result = await createNeonTools(options)["projects.get"].execute({
	project_id: "project-id",
});
if ("error" in result && result.error) {
	// NeonError
}
```

### Adapters

`registerNeonTools` (both `@neon/tools/mcp` and `@neon/tools/mcp-v1`), `toEveTool` and `toMastraTools` accept envelope-typed tools. The MCP handler re-throws a returned `{ error }`, so an enveloped tool produces the same `isError` MCP result as a throwing one.

`NeonExecutableTool` is a new export: the execute-capable tool type whose result covers both throw modes. The adapters type their inputs with it, replacing the private per-adapter execute shapes.

Nothing changes for existing callers. `throwOnError` omitted keeps `execute` typed as `Promise<{ data }>` and throwing.

## Also in here

- `throwOnError` is on `ToolClientOptions` in the generated-tools binding, so `NeonToolsClientOptions` carries the flag.
- Test helpers that spread a `NeonToolsClientOptions` value into `createNeonTools` now take `Omit<NeonToolsClientOptions, "throwOnError">`; spreading a `boolean`-typed flag would erase the literal narrowing the tests assert on.
- Changeset: `@neon/tools` patch.
- README documents the flag with the destructure example.

## Verification

`pnpm --filter @neon/tools exec vitest run --typecheck` at 398f876: 12 files, 145 tests, type tests included, all green. Behaviors covered:

- a 404 with `throwOnError: false` returns `{ error }` with `error instanceof NeonError` and `kind: "not_found"`
- same envelope from a single `createNeonTool`
- Zod input failures still throw with `throwOnError: false`
- `onExecute` sees the thrown `NeonError` and the caller still gets `{ error }`
- omitted `throwOnError` still rejects with `NeonError`
- type-level: literal `false` narrows to the envelope, an annotated `CreateNeonToolsOptions` types both outcomes, and enveloped tools pass `registerNeonTools`, `toEveTool` and `toMastraTools`

The suite runs against an injected `fetch` returning canned responses; no live API run.

## For your attention

- The envelope covers `NeonError` only. Network faults from a custom `fetch` and other exceptions still throw with `throwOnError: false`, so a `{ error }` result always means a Neon API error.
- `WithThrowMode` rewrites `execute` by inferring the `Promise<{ data }>` shape from the tool type; a tool whose `execute` does not match that shape passes through untouched.
