### PR TITLE
Type MCP registerNeonTools against the matching McpServer

### DIFF
--- a/.changeset/tools-t7-mcp-server.md
+++ b/.changeset/tools-t7-mcp-server.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": major
+---
+
+`registerNeonTools` types `server` as `Pick<McpServer, "registerTool">` for that MCP version.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -220,6 +220,8 @@ const tools = createNeonTools({
 registerNeonTools(server, tools);
 ```
 
+`server` is typed as `Pick<McpServer, "registerTool">` from `@modelcontextprotocol/server`. `@neon/tools/mcp-v1` types that argument against `@modelcontextprotocol/sdk`. Both packages are optional peers.
+
 `registerNeonTools` publishes that catalog. MCP 2 `inputSchema` is JSON Schema without `$schema`. Generated fields have types, enums, `required`, and constraints, and no OpenAPI property docs. Fields this package described with `.describe()` (`pooled`, `finalize`, `zip`) keep that copy.
 
 Hosts that convert Zod themselves:

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -220,7 +220,7 @@ const tools = createNeonTools({
 registerNeonTools(server, tools);
 ```
 
-`server` is typed as `Pick<McpServer, "registerTool">` from `@modelcontextprotocol/server`. `@neon/tools/mcp-v1` types that argument against `@modelcontextprotocol/sdk`. Both packages are optional peers.
+`server` is typed as `Pick<McpServer, "registerTool">` from `@modelcontextprotocol/server`. `@neon/tools/mcp-v1` types that argument against `@modelcontextprotocol/sdk`. Both packages are optional peers. The type check only runs when that peer is installed; with `skipLibCheck` and no MCP 2 package, an MCP 1 server type-checks against `@neon/tools/mcp`.
 
 `registerNeonTools` publishes that catalog. MCP 2 `inputSchema` is JSON Schema without `$schema`. Generated fields have types, enums, `required`, and constraints, and no OpenAPI property docs. Fields this package described with `.describe()` (`pooled`, `finalize`, `zip`) keep that copy.
 

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -80,10 +80,23 @@
 		"@neon/sdk": "workspace:*",
 		"zod": "^4.4.3"
 	},
+	"peerDependencies": {
+		"@modelcontextprotocol/sdk": "^1.0.0",
+		"@modelcontextprotocol/server": "^2.0.0"
+	},
+	"peerDependenciesMeta": {
+		"@modelcontextprotocol/sdk": {
+			"optional": true
+		},
+		"@modelcontextprotocol/server": {
+			"optional": true
+		}
+	},
 	"devDependencies": {
 		"@hey-api/openapi-ts": "0.98.2",
 		"@mastra/core": "1.56.0-alpha.5",
 		"@modelcontextprotocol/client": "2.0.0",
+		"@modelcontextprotocol/sdk": "1.30.0",
 		"@modelcontextprotocol/server": "2.0.0",
 		"@modelcontextprotocol/sdk-v1": "npm:@modelcontextprotocol/sdk@1.30.0",
 		"@types/node": "catalog:",

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -6,9 +6,9 @@ export interface McpToolResult {
 	isError?: boolean;
 }
 
-export interface McpToolServer {
-	registerTool: object;
-}
+type McpToolRegistrar = {
+	registerTool: unknown;
+};
 
 const errorMessage = (error: unknown): string =>
 	error instanceof Error ? error.message : String(error);
@@ -99,7 +99,7 @@ const createToolHandler =
 	};
 
 export const registerNeonToolsWithSchema = (
-	server: McpToolServer,
+	server: McpToolRegistrar,
 	tools: Readonly<Record<string, NeonTool>>,
 	inputSchema: (tool: NeonTool) => unknown,
 ): void => {

--- a/packages/tools/src/mcp-v1.ts
+++ b/packages/tools/src/mcp-v1.ts
@@ -1,11 +1,13 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
 	type McpToolResult,
-	type McpToolServer,
 	registerNeonToolsWithSchema,
 } from "./lib/mcp-register.js";
 import type { NeonTool } from "./lib/operation.js";
 
-export type { McpToolResult, McpToolServer };
+export type McpToolServer = Pick<McpServer, "registerTool">;
+
+export type { McpToolResult };
 
 export const registerNeonTools = (
 	server: McpToolServer,

--- a/packages/tools/src/mcp.test-d.ts
+++ b/packages/tools/src/mcp.test-d.ts
@@ -1,0 +1,22 @@
+import type { McpServer as McpServerV1 } from "@modelcontextprotocol/sdk-v1/server/mcp.js";
+import type { McpServer as McpServerV2 } from "@modelcontextprotocol/server";
+import { createNeonTools } from "./index.js";
+import { registerNeonTools as registerNeonToolsV2 } from "./mcp.js";
+import { registerNeonTools as registerNeonToolsV1 } from "./mcp-v1.js";
+
+const mcpTools = createNeonTools({
+	apiKey: "test-key",
+	tools: ["projects.list"] as const,
+});
+
+declare const mcpV2: McpServerV2;
+declare const mcpV1: McpServerV1;
+
+registerNeonToolsV2(mcpV2, mcpTools);
+registerNeonToolsV1(mcpV1, mcpTools);
+
+// @ts-expect-error MCP 2 registerTool is not a dummy object
+registerNeonToolsV2({ registerTool: {} }, mcpTools);
+
+// @ts-expect-error MCP 1 registerTool is not a dummy object
+registerNeonToolsV1({ registerTool: {} }, mcpTools);

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -10,9 +10,13 @@ import { afterEach, describe, expect, test } from "vitest";
 import { createNeonTools, publishedId, toolIds } from "./index.js";
 import {
 	type McpToolResult,
+	type McpToolServer as McpToolServerV2,
 	registerNeonTools as registerNeonToolsV2,
 } from "./mcp.js";
-import { registerNeonTools as registerNeonToolsV1 } from "./mcp-v1.js";
+import {
+	type McpToolServer as McpToolServerV1,
+	registerNeonTools as registerNeonToolsV1,
+} from "./mcp-v1.js";
 
 const closeables: Array<{ close(): Promise<void> }> = [];
 
@@ -132,20 +136,7 @@ describe("MCP v2 compatibility", () => {
 	});
 
 	test("returns API failures as structured MCP errors", async () => {
-		type ToolHandler = (
-			input: unknown,
-			context: unknown,
-		) => Promise<McpToolResult>;
-		let handler: ToolHandler | undefined;
-		const server = {
-			registerTool(
-				_name: string,
-				_config: unknown,
-				registeredHandler: ToolHandler,
-			) {
-				handler = registeredHandler;
-			},
-		};
+		const { v2, handler } = captureHandler();
 		const failingTools = createNeonTools({
 			apiKey: "bad-key",
 			tools: ["projects.list"],
@@ -158,12 +149,9 @@ describe("MCP v2 compatibility", () => {
 					},
 				),
 		});
-		registerNeonToolsV2(server, failingTools);
-		if (handler === undefined) {
-			throw new Error("Expected MCP tool registration.");
-		}
+		registerNeonToolsV2(v2, failingTools);
 
-		const result = await handler({}, {});
+		const result = await handler()({}, {});
 		expect(result).toMatchObject({
 			isError: true,
 			structuredContent: {
@@ -181,17 +169,18 @@ const captureHandler = () => {
 		context: unknown,
 	) => Promise<McpToolResult>;
 	let handler: ToolHandler | undefined;
-	const server = {
-		registerTool(
-			_name: string,
-			_config: unknown,
-			registeredHandler: ToolHandler,
-		) {
-			handler = registeredHandler;
+	const stub = {
+		registerTool(...args: unknown[]) {
+			const registeredHandler = args[2];
+			if (typeof registeredHandler !== "function") {
+				throw new TypeError("Expected registerTool handler");
+			}
+			handler = registeredHandler as ToolHandler;
 		},
 	};
 	return {
-		server,
+		v2: stub as McpToolServerV2,
+		v1: stub as McpToolServerV1,
 		handler: () => {
 			if (handler === undefined) {
 				throw new Error("Expected MCP tool registration.");
@@ -222,9 +211,9 @@ const toolsWithCapturedAuth = () => {
 
 describe("MCP request credentials", () => {
 	test("sends MCP v2 http.authInfo.token as the Bearer credential", async () => {
-		const { server, handler } = captureHandler();
+		const { v2, handler } = captureHandler();
 		const { requests, tools } = toolsWithCapturedAuth();
-		registerNeonToolsV2(server, tools);
+		registerNeonToolsV2(v2, tools);
 
 		await handler()(
 			{},
@@ -237,9 +226,9 @@ describe("MCP request credentials", () => {
 	});
 
 	test("sends MCP v1 authInfo.token as the Bearer credential", async () => {
-		const { server, handler } = captureHandler();
+		const { v1, handler } = captureHandler();
 		const { requests, tools } = toolsWithCapturedAuth();
-		registerNeonToolsV1(server, tools);
+		registerNeonToolsV1(v1, tools);
 
 		await handler()({}, { authInfo: { token: "oauth-access-token" } });
 
@@ -249,9 +238,9 @@ describe("MCP request credentials", () => {
 	});
 
 	test("uses the constructor credential when MCP extra has no authInfo", async () => {
-		const { server, handler } = captureHandler();
+		const { v2, handler } = captureHandler();
 		const { requests, tools } = toolsWithCapturedAuth();
-		registerNeonToolsV2(server, tools);
+		registerNeonToolsV2(v2, tools);
 
 		await handler()({}, {});
 
@@ -261,9 +250,9 @@ describe("MCP request credentials", () => {
 	});
 
 	test("does not fall back to the constructor credential when authInfo is present without a token", async () => {
-		const { server, handler } = captureHandler();
+		const { v2, handler } = captureHandler();
 		const { requests, tools } = toolsWithCapturedAuth();
-		registerNeonToolsV2(server, tools);
+		registerNeonToolsV2(v2, tools);
 
 		const result = await handler()(
 			{},

--- a/packages/tools/src/mcp.ts
+++ b/packages/tools/src/mcp.ts
@@ -1,13 +1,15 @@
+import type { McpServer } from "@modelcontextprotocol/server";
 import { compactJsonSchema, toMcpInputSchema } from "./lib/mcp-json-schema.js";
 import {
 	type McpToolResult,
-	type McpToolServer,
 	registerNeonToolsWithSchema,
 } from "./lib/mcp-register.js";
 import type { NeonTool } from "./lib/operation.js";
 
+export type McpToolServer = Pick<McpServer, "registerTool">;
+
 export type { McpStandardSchema } from "./lib/mcp-json-schema.js";
-export type { McpToolResult, McpToolServer };
+export type { McpToolResult };
 export { compactJsonSchema, toMcpInputSchema };
 
 export const registerNeonTools = (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -618,6 +618,9 @@ importers:
       '@modelcontextprotocol/client':
         specifier: 2.0.0
         version: 2.0.0
+      '@modelcontextprotocol/sdk':
+        specifier: 1.30.0
+        version: 1.30.0(zod@4.4.3)
       '@modelcontextprotocol/sdk-v1':
         specifier: npm:@modelcontextprotocol/sdk@1.30.0
         version: '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)'
@@ -1661,8 +1664,8 @@ packages:
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
-  '@oxc-project/types@0.143.0':
-    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+  '@oxc-project/types@0.147.0':
+    resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1704,14 +1707,20 @@ packages:
   '@quansync/fs@0.1.4':
     resolution: {integrity: sha512-vy/41FCdnIalPTQCb2Wl0ic1caMdzGus4ktDp+gpZesQNydXcx8nhh8qB3qMPbGkictOTaXgXEUUfQEm8DQYoA==}
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    resolution: {integrity: sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@rolldown/binding-android-arm64@1.2.1':
     resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.2.3':
-    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+  '@rolldown/binding-android-arm64@1.2.6':
+    resolution: {integrity: sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1722,8 +1731,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.2.3':
-    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1734,8 +1743,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.3':
-    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+  '@rolldown/binding-darwin-x64@1.2.6':
+    resolution: {integrity: sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1746,8 +1755,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.2.3':
-    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1758,8 +1767,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
-    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1771,8 +1780,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.3':
-    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    resolution: {integrity: sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1785,8 +1794,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.3':
-    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1799,8 +1808,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
-    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1813,8 +1822,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.3':
-    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
@@ -1827,8 +1836,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.3':
-    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1841,8 +1850,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.2.3':
-    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1854,8 +1863,8 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.2.3':
-    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1870,8 +1879,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.3':
-    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1882,8 +1891,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.2.3':
-    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
+    resolution: {integrity: sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -4549,8 +4558,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  rolldown@1.2.3:
-    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+  rolldown@1.2.6:
+    resolution: {integrity: sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -6310,7 +6319,7 @@ snapshots:
 
   '@oxc-project/types@0.142.0': {}
 
-  '@oxc-project/types@0.143.0': {}
+  '@oxc-project/types@0.147.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -6345,76 +6354,79 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  '@rolldown/binding-android-arm-eabi@1.2.6':
+    optional: true
+
   '@rolldown/binding-android-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.2.3':
+  '@rolldown/binding-android-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.3':
+  '@rolldown/binding-darwin-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.2.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.3':
+  '@rolldown/binding-darwin-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.2.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.3':
+  '@rolldown/binding-freebsd-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.3':
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.3':
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.3':
+  '@rolldown/binding-linux-x64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.2.3':
+  '@rolldown/binding-openharmony-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.2.1':
@@ -6427,13 +6439,13 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.2.1':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.2.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.2.3':
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -9323,7 +9335,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.15.6(rolldown@1.2.3)(typescript@5.9.3):
+  rolldown-plugin-dts@0.15.6(rolldown@1.2.6)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -9333,7 +9345,7 @@ snapshots:
       debug: 4.4.3
       dts-resolver: 2.1.1
       get-tsconfig: 4.14.0
-      rolldown: 1.2.3
+      rolldown: 1.2.6
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -9361,25 +9373,26 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.2.1
       '@rolldown/binding-win32-x64-msvc': 1.2.1
 
-  rolldown@1.2.3:
+  rolldown@1.2.6:
     dependencies:
-      '@oxc-project/types': 0.143.0
+      '@oxc-project/types': 0.147.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.3
-      '@rolldown/binding-darwin-arm64': 1.2.3
-      '@rolldown/binding-darwin-x64': 1.2.3
-      '@rolldown/binding-freebsd-x64': 1.2.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
-      '@rolldown/binding-linux-arm64-gnu': 1.2.3
-      '@rolldown/binding-linux-arm64-musl': 1.2.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
-      '@rolldown/binding-linux-s390x-gnu': 1.2.3
-      '@rolldown/binding-linux-x64-gnu': 1.2.3
-      '@rolldown/binding-linux-x64-musl': 1.2.3
-      '@rolldown/binding-openharmony-arm64': 1.2.3
-      '@rolldown/binding-win32-arm64-msvc': 1.2.3
-      '@rolldown/binding-win32-x64-msvc': 1.2.3
+      '@rolldown/binding-android-arm-eabi': 1.2.6
+      '@rolldown/binding-android-arm64': 1.2.6
+      '@rolldown/binding-darwin-arm64': 1.2.6
+      '@rolldown/binding-darwin-x64': 1.2.6
+      '@rolldown/binding-freebsd-x64': 1.2.6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.6
+      '@rolldown/binding-linux-arm64-gnu': 1.2.6
+      '@rolldown/binding-linux-arm64-musl': 1.2.6
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.6
+      '@rolldown/binding-linux-s390x-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-musl': 1.2.6
+      '@rolldown/binding-openharmony-arm64': 1.2.6
+      '@rolldown/binding-win32-arm64-msvc': 1.2.6
+      '@rolldown/binding-win32-x64-msvc': 1.2.6
 
   rollup@3.29.4:
     optionalDependencies:
@@ -9863,8 +9876,8 @@ snapshots:
       diff: 8.0.2
       empathic: 2.0.0
       hookable: 5.5.3
-      rolldown: 1.2.3
-      rolldown-plugin-dts: 0.15.6(rolldown@1.2.3)(typescript@5.9.3)
+      rolldown: 1.2.6
+      rolldown-plugin-dts: 0.15.6(rolldown@1.2.6)(typescript@5.9.3)
       semver: 7.7.2
       tinyexec: 1.0.1
       tinyglobby: 0.2.15


### PR DESCRIPTION
## Problem

`@neon/tools` ships two MCP entry points that publish tool schemas in different formats: `@neon/tools/mcp` converts each tool's Zod input schema to JSON Schema for MCP 2.x and `@neon/tools/mcp-v1` passes the Zod schema through for MCP 1.x. Both typed `server` as `{ registerTool: object }`, so any object with a `registerTool` property satisfied either entry. Registering an MCP 1 `McpServer` through `@neon/tools/mcp` compiled clean and the mistake only surfaced at runtime, when the server received schemas in the other version's format.

## What changed

Each entry now types `server` against the `McpServer` of its own SDK:

```ts
// @neon/tools/mcp
import type { McpServer } from "@modelcontextprotocol/server";
export type McpToolServer = Pick<McpServer, "registerTool">;

// @neon/tools/mcp-v1
import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
export type McpToolServer = Pick<McpServer, "registerTool">;
```

`@modelcontextprotocol/server` (^2.0.0) and `@modelcontextprotocol/sdk` (^1.0.0) are optional peer dependencies. A consumer installs the one their server uses.

The correct pairing is unchanged:

```ts
import { McpServer } from "@modelcontextprotocol/server";
import { createNeonTools } from "@neon/tools";
import { registerNeonTools } from "@neon/tools/mcp";

const server = new McpServer({ name: "neon", version: "1.0.0" });
const tools = createNeonTools({ apiKey, tools: ["projects.list"] as const });
registerNeonTools(server, tools);
```

The wrong pairing now fails to compile:

```text
error TS2345: Argument of type 'McpServer' is not assignable to parameter of type 'McpToolServer'.
```

This is a breaking type change. `McpToolServer` was one shared export with shape `{ registerTool: object }`; each entry now exports its own `Pick` over the matching SDK, and hand-rolled stubs that satisfied the old shape need a cast. The changeset marks `@neon/tools` major. Runtime behavior is unchanged: `registerNeonToolsWithSchema` still treats `registerTool` as `unknown` internally, so JavaScript consumers see no difference.

## Residual gap

The guard needs the matching peer installed. When it is missing and `skipLibCheck` is on, the `McpServer` import fails to resolve, the type degrades and an MCP 1 server type-checks against `@neon/tools/mcp` again. Both peers are optional, so package managers do not warn about the missing one. The README documents this next to the MCP example.

## Also in here

- The internal type in `lib/mcp-register.ts` is renamed to `McpToolRegistrar` (`registerTool: unknown`) since the public `McpToolServer` exports moved into the entry points.
- `@modelcontextprotocol/sdk` 1.30.0 is added as a devDependency so the repo type-checks the v1 entry against the real SDK; `pnpm-lock.yaml` updated.
- `src/mcp.test.ts` stubs are consolidated into `captureHandler()`, which returns the stub cast to each entry's `McpToolServer`.

## Verification

- `pnpm --filter @neon/tools exec tsc --noEmit` passes. It includes the new `src/mcp.test-d.ts`, which asserts both real servers type-check against their entry and a bare `{ registerTool: {} }` object fails both.
- A scratch type test passing the MCP 1 `McpServer` to the MCP 2 entry and the MCP 2 `McpServer` to the MCP 1 entry fails both directions with TS2345.
- `pnpm --filter @neon/tools exec vitest run src/mcp.test.ts`: 13 tests pass.
- Not verified: the missing-peer degrade in a consumer project with `skipLibCheck` on. The README note is the only mitigation in this PR.
