### PR TITLE
Export registerNeonToolsV1 from the MCP 1 adapter

### DIFF
--- a/.changeset/tools-t8-register-v1.md
+++ b/.changeset/tools-t8-register-v1.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": minor
+---
+
+`registerNeonToolsV1` is the MCP 1.x adapter. `registerNeonTools` on `./mcp-v1` is a deprecated alias.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -249,8 +249,10 @@ This package does not implement an OAuth authorization server. That is [mcp-serv
 Existing MCP 1.x servers can use the version-specific entry point:
 
 ```ts
-import { registerNeonTools } from "@neon/tools/mcp-v1";
+import { registerNeonToolsV1 } from "@neon/tools/mcp-v1";
 ```
+
+`registerNeonTools` on this subpath is a deprecated alias of `registerNeonToolsV1`.
 
 MCP 1.x still receives Zod input schemas, including handwritten `.describe()` copy. Generated Zod has no OpenAPI field essays. Use `compactJsonSchema` if you convert those schemas yourself and need `$schema` removed.
 

--- a/packages/tools/src/mcp-v1.ts
+++ b/packages/tools/src/mcp-v1.ts
@@ -7,9 +7,12 @@ import type { NeonTool } from "./lib/operation.js";
 
 export type { McpToolResult, McpToolServer };
 
-export const registerNeonTools = (
+export const registerNeonToolsV1 = (
 	server: McpToolServer,
 	tools: Readonly<Record<string, NeonTool>>,
 ): void => {
 	registerNeonToolsWithSchema(server, tools, (tool) => tool.inputSchema);
 };
+
+/** @deprecated Use registerNeonToolsV1. */
+export const registerNeonTools = registerNeonToolsV1;

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -12,7 +12,7 @@ import {
 	type McpToolResult,
 	registerNeonTools as registerNeonToolsV2,
 } from "./mcp.js";
-import { registerNeonTools as registerNeonToolsV1 } from "./mcp-v1.js";
+import { registerNeonTools, registerNeonToolsV1 } from "./mcp-v1.js";
 
 const closeables: Array<{ close(): Promise<void> }> = [];
 
@@ -285,6 +285,10 @@ describe("MCP request credentials", () => {
 });
 
 describe("MCP v1 compatibility", () => {
+	test("registerNeonTools is the deprecated alias of registerNeonToolsV1", () => {
+		expect(registerNeonTools).toBe(registerNeonToolsV1);
+	});
+
 	test("registers and calls the same Zod 4 tool schema", async () => {
 		const server = new McpServerV1({
 			name: "test-server",


### PR DESCRIPTION
## Problem

`@neon/tools/mcp` and `@neon/tools/mcp-v1` both export `registerNeonTools` with the same signature. The difference (JSON Schema vs Zod) is invisible. The wrong import compiles.

## Solution

`./mcp-v1` exports `registerNeonToolsV1`. `registerNeonTools` remains a deprecated alias for one release.

```ts
import { registerNeonToolsV1 } from "@neon/tools/mcp-v1";

registerNeonToolsV1(server, tools);
```

```ts
import { registerNeonTools } from "@neon/tools/mcp-v1";
```

still works. MCP 2 `./mcp` is unchanged.

## Verification

- `pnpm --filter @neon/tools tsc`
- `pnpm --filter @neon/tools exec vitest run src/mcp.test.ts`
- alias identity test

## Gaps

The alias will be removed in a later major. Dual `registerNeonTools` names across subpaths remain until then.