### PR TITLE
Rename MCP and Mastra tools at register time

### DIFF
--- a/.changeset/tools-t9-adapter-names.md
+++ b/.changeset/tools-t9-adapter-names.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": patch
+---
+
+`registerNeonTools` and `toMastraTools` accept `{ name }` and reject duplicate published ids.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -49,7 +49,7 @@ const compared = await tools["branches.compareSchema"].execute({
 
 `limit` on a list tool caps how many items come back.
 
-MCP and Mastra publish `tool.id` (`list_projects`), not the record key.
+MCP and Mastra publish `tool.id` (`list_projects`), not the record key. Pass `{ name: (tool) => string }` to `registerNeonTools` or `toMastraTools` to publish a different name. Duplicate names throw.
 
 `apiKey` is a Bearer credential: a Neon API key or a Neon OAuth access token. A function is called on every request, which is how short-lived OAuth tokens get refreshed. A credential is required when a tool executes — at construction, on `execute()`, or from MCP `authInfo` — and an empty value is rejected rather than ignored.
 
@@ -220,6 +220,12 @@ const tools = createNeonTools({
 registerNeonTools(server, tools);
 ```
 
+Pass `{ name }` to publish a different MCP name. Duplicate names throw before `registerTool`.
+
+```ts
+registerNeonTools(server, tools, { name: (tool) => `neon_${tool.id}` });
+```
+
 `registerNeonTools` publishes that catalog. MCP 2 `inputSchema` is JSON Schema without `$schema`. Generated fields have types, enums, `required`, and constraints, and no OpenAPI property docs. Fields this package described with `.describe()` (`pooled`, `finalize`, `zip`) keep that copy.
 
 Hosts that convert Zod themselves:
@@ -303,6 +309,10 @@ const configs = toMastraTools(neonTools);
 
 const listProjects = createTool(configs.list_projects);
 const createProject = createTool(configs.create_and_connect_projects);
+```
+
+```ts
+toMastraTools(neonTools, { name: (tool) => `neon_${tool.id}` });
 ```
 
 The adapter maps approval requirements to Mastra's `requireApproval` field and forwards its abort signal.

--- a/packages/tools/src/frameworks.test.ts
+++ b/packages/tools/src/frameworks.test.ts
@@ -91,7 +91,7 @@ describe("Mastra compatibility", () => {
 			tools: ["projects.list", "projects.get"],
 		});
 		expect(() => toMastraTools(tools, { name: () => "same" })).toThrow(
-			/Duplicate Neon tool id "same"/,
+			/Duplicate published tool name "same"/,
 		);
 	});
 

--- a/packages/tools/src/frameworks.test.ts
+++ b/packages/tools/src/frameworks.test.ts
@@ -72,6 +72,29 @@ describe("Mastra compatibility", () => {
 		expect(createProject.requireApproval).toBe(true);
 	});
 
+	test("publishes an adapter name as the Mastra id", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.list"] as const,
+		});
+		const configs = toMastraTools(tools, {
+			name: (tool) => `neon_${tool.id}`,
+		});
+		expect(Object.values(configs).map((tool) => tool.id)).toEqual([
+			"neon_list_projects",
+		]);
+	});
+
+	test("throws on duplicate Mastra adapter names", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.list", "projects.get"],
+		});
+		expect(() => toMastraTools(tools, { name: () => "same" })).toThrow(
+			/Duplicate Neon tool id "same"/,
+		);
+	});
+
 	test("forwards omitted path schemas from inject", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",

--- a/packages/tools/src/frameworks.test.ts
+++ b/packages/tools/src/frameworks.test.ts
@@ -95,6 +95,18 @@ describe("Mastra compatibility", () => {
 		);
 	});
 
+	test("throws when the adapter name callback does not return a string", () => {
+		const tools = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.list"] as const,
+		});
+		expect(() =>
+			toMastraTools(tools, {
+				name: () => undefined as unknown as string,
+			}),
+		).toThrow("Adapter tool name must be a string for projects.list");
+	});
+
 	test("forwards omitted path schemas from inject", () => {
 		const tools = createNeonTools({
 			apiKey: "test-key",

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -6,7 +6,12 @@ import {
 	createNeonTools,
 	publishedId,
 } from "./index.js";
-import { type NeonAdapterNameOptions, toMastraTools } from "./mastra.js";
+import {
+	type MastraTools,
+	type NamedMastraTools,
+	type NeonAdapterNameOptions,
+	toMastraTools,
+} from "./mastra.js";
 
 expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"list_projects">();
 expectTypeOf(
@@ -67,7 +72,9 @@ const renamedMastra = toMastraTools(tools, {
 expectTypeOf(renamedMastra.neon_list_projects.id).toEqualTypeOf<string>();
 
 declare const maybeName: NeonAdapterNameOptions;
-toMastraTools(tools, maybeName);
+expectTypeOf(toMastraTools(tools, maybeName)).toEqualTypeOf<
+	MastraTools<typeof tools> | NamedMastraTools<typeof tools>
+>();
 
 // @ts-expect-error Mastra configs preserve tool-specific request types
 mastraTools.list_projects.execute({ limit: "one" }, {});

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -6,7 +6,7 @@ import {
 	createNeonTools,
 	publishedId,
 } from "./index.js";
-import { toMastraTools } from "./mastra.js";
+import { type NeonAdapterNameOptions, toMastraTools } from "./mastra.js";
 
 expectTypeOf(publishedId("projects.list")).toEqualTypeOf<"list_projects">();
 expectTypeOf(
@@ -65,6 +65,9 @@ const renamedMastra = toMastraTools(tools, {
 	name: (tool) => `neon_${tool.id}`,
 });
 expectTypeOf(renamedMastra.neon_list_projects.id).toEqualTypeOf<string>();
+
+declare const maybeName: NeonAdapterNameOptions;
+toMastraTools(tools, maybeName);
 
 // @ts-expect-error Mastra configs preserve tool-specific request types
 mastraTools.list_projects.execute({ limit: "one" }, {});

--- a/packages/tools/src/index.test-d.ts
+++ b/packages/tools/src/index.test-d.ts
@@ -61,6 +61,11 @@ expectTypeOf(mastraTools).toHaveProperty("create_and_connect_projects");
 // @ts-expect-error unselected tools are absent from the Mastra tool record
 mastraTools.delete_projects;
 
+const renamedMastra = toMastraTools(tools, {
+	name: (tool) => `neon_${tool.id}`,
+});
+expectTypeOf(renamedMastra.neon_list_projects.id).toEqualTypeOf<string>();
+
 // @ts-expect-error Mastra configs preserve tool-specific request types
 mastraTools.list_projects.execute({ limit: "one" }, {});
 

--- a/packages/tools/src/lib/adapter-name.ts
+++ b/packages/tools/src/lib/adapter-name.ts
@@ -8,10 +8,18 @@ export const namedNeonTools = (
 	tools: Readonly<Record<string, NeonTool>>,
 	options?: NeonAdapterNameOptions,
 ): Array<{ tool: NeonTool; name: string }> => {
-	const named = Object.values(tools).map((tool) => ({
-		tool,
-		name: options?.name?.(tool) ?? tool.id,
-	}));
+	const named = Object.values(tools).map((tool) => {
+		if (options?.name === undefined) {
+			return { tool, name: tool.id };
+		}
+		const name = options.name(tool);
+		if (typeof name !== "string") {
+			throw new TypeError(
+				`Adapter tool name must be a string for ${tool.operationId}`,
+			);
+		}
+		return { tool, name };
+	});
 	const seen = new Map<string, string>();
 	for (const { tool, name } of named) {
 		const previous = seen.get(name);

--- a/packages/tools/src/lib/adapter-name.ts
+++ b/packages/tools/src/lib/adapter-name.ts
@@ -17,7 +17,7 @@ export const namedNeonTools = (
 		const previous = seen.get(name);
 		if (previous !== undefined) {
 			throw new Error(
-				`Duplicate Neon tool id "${name}" for ${previous}, ${tool.operationId}`,
+				`Duplicate published tool name "${name}" for ${previous}, ${tool.operationId}`,
 			);
 		}
 		seen.set(name, tool.operationId);

--- a/packages/tools/src/lib/adapter-name.ts
+++ b/packages/tools/src/lib/adapter-name.ts
@@ -1,0 +1,26 @@
+import type { NeonTool } from "./operation.js";
+
+export interface NeonAdapterNameOptions {
+	name?: (tool: NeonTool) => string;
+}
+
+export const namedNeonTools = (
+	tools: Readonly<Record<string, NeonTool>>,
+	options?: NeonAdapterNameOptions,
+): Array<{ tool: NeonTool; name: string }> => {
+	const named = Object.values(tools).map((tool) => ({
+		tool,
+		name: options?.name?.(tool) ?? tool.id,
+	}));
+	const seen = new Map<string, string>();
+	for (const { tool, name } of named) {
+		const previous = seen.get(name);
+		if (previous !== undefined) {
+			throw new Error(
+				`Duplicate Neon tool id "${name}" for ${previous}, ${tool.operationId}`,
+			);
+		}
+		seen.set(name, tool.operationId);
+	}
+	return named;
+};

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -1,3 +1,4 @@
+import { type NeonAdapterNameOptions, namedNeonTools } from "./adapter-name.js";
 import type { NeonTool } from "./operation.js";
 
 export interface McpToolResult {
@@ -102,14 +103,15 @@ export const registerNeonToolsWithSchema = (
 	server: McpToolServer,
 	tools: Readonly<Record<string, NeonTool>>,
 	inputSchema: (tool: NeonTool) => unknown,
+	options?: NeonAdapterNameOptions,
 ): void => {
 	if (typeof server.registerTool !== "function") {
 		throw new TypeError("Expected an MCP server with registerTool().");
 	}
 
-	for (const tool of Object.values(tools)) {
+	for (const { tool, name } of namedNeonTools(tools, options)) {
 		Reflect.apply(server.registerTool, server, [
-			tool.id,
+			name,
 			{
 				title: tool.title,
 				description: tool.description,

--- a/packages/tools/src/mastra.ts
+++ b/packages/tools/src/mastra.ts
@@ -30,6 +30,14 @@ export type MastraTools<Tools extends Readonly<Record<string, NeonTool>>> = {
 	[Tool in Tools[keyof Tools] as Tool["id"]]: MastraToolConfig<Tool>;
 };
 
+export type NamedMastraToolConfig<Tool extends NeonTool> = Omit<
+	MastraToolConfig<Tool>,
+	"id"
+> & { id: string };
+
+export type NamedMastraTools<Tools extends Readonly<Record<string, NeonTool>>> =
+	Record<string, NamedMastraToolConfig<Tools[keyof Tools]>>;
+
 type MastraToolSource = {
 	id: string;
 	description: string;
@@ -71,12 +79,21 @@ function assertMastraTools(
 	}
 }
 
-export const toMastraTools = <
+export function toMastraTools<
+	const Tools extends Readonly<Record<string, NeonTool>>,
+>(tools: Tools): MastraTools<Tools>;
+export function toMastraTools<
+	const Tools extends Readonly<Record<string, NeonTool>>,
+>(
+	tools: Tools,
+	options: { name: (tool: NeonTool) => string },
+): NamedMastraTools<Tools>;
+export function toMastraTools<
 	const Tools extends Readonly<Record<string, NeonTool>>,
 >(
 	tools: Tools,
 	options?: NeonAdapterNameOptions,
-): MastraTools<Tools> => {
+): MastraTools<Tools> | NamedMastraTools<Tools> {
 	const named = namedNeonTools(tools, options);
 	const adapted: unknown = Object.fromEntries(
 		named.map(({ tool, name }) => [
@@ -88,5 +105,8 @@ export const toMastraTools = <
 		adapted,
 		named.map(({ name }) => name),
 	);
-	return adapted as MastraTools<Tools>;
-};
+	if (options?.name === undefined) {
+		return adapted as MastraTools<Tools>;
+	}
+	return adapted as NamedMastraTools<Tools>;
+}

--- a/packages/tools/src/mastra.ts
+++ b/packages/tools/src/mastra.ts
@@ -92,6 +92,12 @@ export function toMastraTools<
 	const Tools extends Readonly<Record<string, NeonTool>>,
 >(
 	tools: Tools,
+	options: NeonAdapterNameOptions,
+): MastraTools<Tools> | NamedMastraTools<Tools>;
+export function toMastraTools<
+	const Tools extends Readonly<Record<string, NeonTool>>,
+>(
+	tools: Tools,
 	options?: NeonAdapterNameOptions,
 ): MastraTools<Tools> | NamedMastraTools<Tools> {
 	const named = namedNeonTools(tools, options);

--- a/packages/tools/src/mastra.ts
+++ b/packages/tools/src/mastra.ts
@@ -1,9 +1,15 @@
 import type * as z from "zod";
+import {
+	type NeonAdapterNameOptions,
+	namedNeonTools,
+} from "./lib/adapter-name.js";
 import type {
 	NeonTool,
 	NeonToolExecutionContext,
 	NeonToolResult,
 } from "./lib/operation.js";
+
+export type { NeonAdapterNameOptions } from "./lib/adapter-name.js";
 
 export interface MastraToolContext {
 	abortSignal?: AbortSignal;
@@ -51,16 +57,16 @@ export const toMastraTool = <const Tool extends MastraToolSource>(
 		>,
 });
 
-function assertMastraTools<Tools extends Readonly<Record<string, NeonTool>>>(
+function assertMastraTools(
 	value: unknown,
-	tools: Tools,
-): asserts value is MastraTools<Tools> {
+	names: readonly string[],
+): asserts value is Record<string, unknown> {
 	if (typeof value !== "object" || value === null) {
 		throw new TypeError("Expected Mastra tools to be an object.");
 	}
-	for (const tool of Object.values(tools)) {
-		if (!(tool.id in value)) {
-			throw new TypeError(`Missing Mastra tool "${tool.id}".`);
+	for (const name of names) {
+		if (!(name in value)) {
+			throw new TypeError(`Missing Mastra tool "${name}".`);
 		}
 	}
 }
@@ -69,10 +75,18 @@ export const toMastraTools = <
 	const Tools extends Readonly<Record<string, NeonTool>>,
 >(
 	tools: Tools,
+	options?: NeonAdapterNameOptions,
 ): MastraTools<Tools> => {
+	const named = namedNeonTools(tools, options);
 	const adapted: unknown = Object.fromEntries(
-		Object.values(tools).map((tool) => [tool.id, toMastraTool(tool)]),
+		named.map(({ tool, name }) => [
+			name,
+			{ ...toMastraTool(tool), id: name },
+		]),
 	);
-	assertMastraTools(adapted, tools);
-	return adapted;
+	assertMastraTools(
+		adapted,
+		named.map(({ name }) => name),
+	);
+	return adapted as MastraTools<Tools>;
 };

--- a/packages/tools/src/mcp-v1.ts
+++ b/packages/tools/src/mcp-v1.ts
@@ -1,3 +1,4 @@
+import type { NeonAdapterNameOptions } from "./lib/adapter-name.js";
 import {
 	type McpToolResult,
 	type McpToolServer,
@@ -5,11 +6,18 @@ import {
 } from "./lib/mcp-register.js";
 import type { NeonTool } from "./lib/operation.js";
 
+export type { NeonAdapterNameOptions } from "./lib/adapter-name.js";
 export type { McpToolResult, McpToolServer };
 
 export const registerNeonTools = (
 	server: McpToolServer,
 	tools: Readonly<Record<string, NeonTool>>,
+	options?: NeonAdapterNameOptions,
 ): void => {
-	registerNeonToolsWithSchema(server, tools, (tool) => tool.inputSchema);
+	registerNeonToolsWithSchema(
+		server,
+		tools,
+		(tool) => tool.inputSchema,
+		options,
+	);
 };

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -96,17 +96,20 @@ describe("MCP v2 compatibility", () => {
 	});
 
 	test("throws on duplicate adapter names before registerTool", () => {
-		const server = new McpServerV2({
-			name: "test-server",
-			version: "1.0.0",
-		});
+		let registered = 0;
+		const server = {
+			registerTool() {
+				registered += 1;
+			},
+		};
 		const catalog = createNeonTools({
 			apiKey: "test-key",
 			tools: ["projects.list", "projects.get"],
 		});
 		expect(() =>
 			registerNeonToolsV2(server, catalog, { name: () => "same" }),
-		).toThrow(/Duplicate Neon tool id "same"/);
+		).toThrow(/Duplicate published tool name "same"/);
+		expect(registered).toBe(0);
 	});
 
 	test("publishes compact JSON Schema without OpenAPI field essays", async () => {

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -72,6 +72,43 @@ describe("MCP v2 compatibility", () => {
 		expect(invalid.isError).toBe(true);
 	});
 
+	test("publishes an adapter name instead of tool.id", async () => {
+		const server = new McpServerV2({
+			name: "test-server",
+			version: "1.0.0",
+		});
+		registerNeonToolsV2(server, tools(), {
+			name: (tool) => `neon_${tool.id}`,
+		});
+		const client = new ClientV2({ name: "test-client", version: "1.0.0" });
+		const [clientTransport, serverTransport] =
+			InMemoryTransportV2.createLinkedPair();
+		await Promise.all([
+			server.connect(serverTransport),
+			client.connect(clientTransport),
+		]);
+		closeables.push(client, server);
+
+		const listed = await client.listTools();
+		expect(listed.tools.map((tool) => tool.name)).toEqual([
+			"neon_list_projects",
+		]);
+	});
+
+	test("throws on duplicate adapter names before registerTool", () => {
+		const server = new McpServerV2({
+			name: "test-server",
+			version: "1.0.0",
+		});
+		const catalog = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.list", "projects.get"],
+		});
+		expect(() =>
+			registerNeonToolsV2(server, catalog, { name: () => "same" }),
+		).toThrow(/Duplicate Neon tool id "same"/);
+	});
+
 	test("publishes compact JSON Schema without OpenAPI field essays", async () => {
 		const server = new McpServerV2({
 			name: "test-server",

--- a/packages/tools/src/mcp.ts
+++ b/packages/tools/src/mcp.ts
@@ -1,3 +1,4 @@
+import type { NeonAdapterNameOptions } from "./lib/adapter-name.js";
 import { compactJsonSchema, toMcpInputSchema } from "./lib/mcp-json-schema.js";
 import {
 	type McpToolResult,
@@ -6,6 +7,7 @@ import {
 } from "./lib/mcp-register.js";
 import type { NeonTool } from "./lib/operation.js";
 
+export type { NeonAdapterNameOptions } from "./lib/adapter-name.js";
 export type { McpStandardSchema } from "./lib/mcp-json-schema.js";
 export type { McpToolResult, McpToolServer };
 export { compactJsonSchema, toMcpInputSchema };
@@ -13,8 +15,12 @@ export { compactJsonSchema, toMcpInputSchema };
 export const registerNeonTools = (
 	server: McpToolServer,
 	tools: Readonly<Record<string, NeonTool>>,
+	options?: NeonAdapterNameOptions,
 ): void => {
-	registerNeonToolsWithSchema(server, tools, (tool) =>
-		toMcpInputSchema(tool.inputSchema),
+	registerNeonToolsWithSchema(
+		server,
+		tools,
+		(tool) => toMcpInputSchema(tool.inputSchema),
+		options,
 	);
 };


### PR DESCRIPTION
## Problem

`registerNeonTools` and `toMastraTools` iterate `Object.values(tools)` and publish `tool.id`. A host that remaps the catalog (`{ listProjects: tools.list_projects }`) still publishes `list_projects`. Renaming meant going back to `createNeonTools({ names })`. Two tools that collide on `id` failed inside the MCP SDK, not in Neon.

## Solution

Optional `{ name?: (tool) => string }` on both adapters. Duplicate published names throw before `registerTool`.

```ts
registerNeonTools(server, tools, { name: (tool) => `neon_${tool.id}` });

toMastraTools(tools, { name: (tool) => `neon_${tool.id}` });
```

Default is still `tool.id`. `toMastraTools(tools)` stays keyed by `Tool["id"]`. `toMastraTools(tools, { name })` returns `Record<string, { id: string; … }>`.

## Verification

- `pnpm --filter @neon/sdk build`
- `pnpm --filter @neon/tools tsc`
- `pnpm --filter @neon/tools exec vitest run`
- MCP listTools publishes `neon_list_projects` when `name` prefixes `tool.id`
- Duplicate `name()` results throw `Duplicate published tool name "same"` with zero `registerTool` calls
- Mastra `id` follows the same `name` function
- Type tests: default catalog has `list_projects`; `{ name }` types `neon_list_projects.id` as `string`

## Gaps

`createNeonTools({ names })` is unchanged. This option is only the adapter publish name.

A `name` function's return type is `string`, so TypeScript cannot prove a specific key like `"neon_list_projects"` is the only key.