### PR TITLE
Include kind, status, and source on MCP tool errors

### DIFF
--- a/.changeset/tools-t10-mcp-errors.md
+++ b/.changeset/tools-t10-mcp-errors.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": patch
+---
+
+MCP tool failures include `name`, `kind`, and `status`/`code` when the thrown error has them.

--- a/.changeset/tools-t10-mcp-errors.md
+++ b/.changeset/tools-t10-mcp-errors.md
@@ -2,4 +2,4 @@
 "@neon/tools": patch
 ---
 
-MCP tool failures include `name`, `kind`, and `status`/`code` when the thrown error has them.
+MCP tool failures include `name`, `kind`, `status`/`code`, `source`, `timeoutMs`, `requestId`, `reason`, and `operationId` when the thrown error has them.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -273,7 +273,7 @@ import { registerNeonTools } from "@neon/tools/mcp-v1";
 
 MCP 1.x still receives Zod input schemas, including handwritten `.describe()` copy. Generated Zod has no OpenAPI field essays. Use `compactJsonSchema` if you convert those schemas yourself and need `$schema` removed.
 
-The adapter returns both text content and object-valued `structuredContent`. Execution failures use `isError: true` with structured error data.
+The adapter returns both text content and object-valued `structuredContent`. Execution failures use `isError: true` with `{ error: { message, name, kind, status, code } }` when those fields exist on the thrown error.
 
 MCP annotations are advisory; the protocol does not enforce approval. Tools expose `neon/requiresApproval` in MCP `_meta`. Hosts must read that value and enforce their own approval policy before execution.
 

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -273,7 +273,7 @@ import { registerNeonTools } from "@neon/tools/mcp-v1";
 
 MCP 1.x still receives Zod input schemas, including handwritten `.describe()` copy. Generated Zod has no OpenAPI field essays. Use `compactJsonSchema` if you convert those schemas yourself and need `$schema` removed.
 
-The adapter returns both text content and object-valued `structuredContent`. Execution failures use `isError: true` with `{ error: { message, name, kind, status, code } }` when those fields exist on the thrown error.
+The adapter returns both text content and object-valued `structuredContent`. Execution failures use `isError: true` with `{ error: { message, name, kind, status, code, source, timeoutMs, requestId, reason, operationId } }` when those fields exist on the thrown error. A wait timeout has `kind: "timeout"` and `source: "wait"`.
 
 MCP annotations are advisory; the protocol does not enforce approval. Tools expose `neon/requiresApproval` in MCP `_meta`. Hosts must read that value and enforce their own approval policy before execution.
 

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -1,4 +1,3 @@
-import { NeonError } from "@neon/sdk";
 import type { NeonTool } from "./operation.js";
 
 export interface McpToolResult {
@@ -21,11 +20,13 @@ const mcpErrorPayload = (error: unknown): Record<string, unknown> => {
 	const payload: Record<string, unknown> = {
 		message: errorMessage(error),
 	};
-	if (error instanceof NeonError) {
-		payload.name = error.name;
-		payload.kind = error.kind;
-	}
 	if (isRecord(error)) {
+		if (typeof error.name === "string") {
+			payload.name = error.name;
+		}
+		if (typeof error.kind === "string") {
+			payload.kind = error.kind;
+		}
 		if (
 			typeof error.status === "number" ||
 			typeof error.status === "string"

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -1,3 +1,4 @@
+import { NeonError } from "@neon/sdk";
 import type { NeonTool } from "./operation.js";
 
 export interface McpToolResult {
@@ -15,6 +16,28 @@ const errorMessage = (error: unknown): string =>
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null;
+
+const mcpErrorPayload = (error: unknown): Record<string, unknown> => {
+	const payload: Record<string, unknown> = {
+		message: errorMessage(error),
+	};
+	if (error instanceof NeonError) {
+		payload.name = error.name;
+		payload.kind = error.kind;
+	}
+	if (isRecord(error)) {
+		if (
+			typeof error.status === "number" ||
+			typeof error.status === "string"
+		) {
+			payload.status = error.status;
+		}
+		if (typeof error.code === "string") {
+			payload.code = error.code;
+		}
+	}
+	return payload;
+};
 
 const authInfoFrom = (context: unknown): unknown => {
 	if (!isRecord(context)) {
@@ -83,7 +106,7 @@ const createToolHandler =
 			};
 		} catch (error) {
 			const structuredContent = {
-				error: { message: errorMessage(error) },
+				error: mcpErrorPayload(error),
 			};
 			return {
 				content: [

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -36,6 +36,21 @@ const mcpErrorPayload = (error: unknown): Record<string, unknown> => {
 		if (typeof error.code === "string") {
 			payload.code = error.code;
 		}
+		if (typeof error.source === "string") {
+			payload.source = error.source;
+		}
+		if (typeof error.timeoutMs === "number") {
+			payload.timeoutMs = error.timeoutMs;
+		}
+		if (typeof error.requestId === "string") {
+			payload.requestId = error.requestId;
+		}
+		if (typeof error.reason === "string") {
+			payload.reason = error.reason;
+		}
+		if (typeof error.operationId === "string") {
+			payload.operationId = error.operationId;
+		}
 	}
 	return payload;
 };

--- a/packages/tools/src/lib/mcp-register.ts
+++ b/packages/tools/src/lib/mcp-register.ts
@@ -28,7 +28,8 @@ const mcpErrorPayload = (error: unknown): Record<string, unknown> => {
 			payload.kind = error.kind;
 		}
 		if (
-			typeof error.status === "number" ||
+			(typeof error.status === "number" &&
+				Number.isFinite(error.status)) ||
 			typeof error.status === "string"
 		) {
 			payload.status = error.status;
@@ -39,7 +40,10 @@ const mcpErrorPayload = (error: unknown): Record<string, unknown> => {
 		if (typeof error.source === "string") {
 			payload.source = error.source;
 		}
-		if (typeof error.timeoutMs === "number") {
+		if (
+			typeof error.timeoutMs === "number" &&
+			Number.isFinite(error.timeoutMs)
+		) {
 			payload.timeoutMs = error.timeoutMs;
 		}
 		if (typeof error.requestId === "string") {

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -287,6 +287,47 @@ describe("MCP request credentials", () => {
 		expect(result.structuredContent.error).not.toHaveProperty("kind");
 		expect(requests).toHaveLength(0);
 	});
+
+	test("copies name, kind, status, and code from a thrown non-NeonError", async () => {
+		const { server, handler } = captureHandler();
+		const catalog = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.list"] as const,
+			fetch: async () =>
+				new Response(JSON.stringify({ projects: [], pagination: {} }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		});
+		const thrown = Object.assign(new Error("branch limit"), {
+			name: "ConflictError",
+			kind: "conflict",
+			status: 409,
+			code: "branch_limit",
+		});
+		registerNeonToolsV2(server, {
+			"projects.list": {
+				...catalog["projects.list"],
+				execute: async () => {
+					throw thrown;
+				},
+			},
+		});
+
+		const result = await handler()({}, {});
+		expect(result).toMatchObject({
+			isError: true,
+			structuredContent: {
+				error: {
+					message: "branch limit",
+					name: "ConflictError",
+					kind: "conflict",
+					status: 409,
+					code: "branch_limit",
+				},
+			},
+		});
+	});
 });
 
 describe("MCP v1 compatibility", () => {

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -277,12 +277,14 @@ describe("MCP request credentials", () => {
 			isError: true,
 			structuredContent: {
 				error: {
+					name: "TypeError",
 					message: expect.stringContaining(
 						"A Neon API key or OAuth access token is required",
 					),
 				},
 			},
 		});
+		expect(result.structuredContent.error).not.toHaveProperty("kind");
 		expect(requests).toHaveLength(0);
 	});
 });

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -315,17 +315,24 @@ describe("MCP request credentials", () => {
 		});
 
 		const result = await handler()({}, {});
-		expect(result).toMatchObject({
-			isError: true,
-			structuredContent: {
-				error: {
-					message: "branch limit",
-					name: "ConflictError",
-					kind: "conflict",
-					status: 409,
-					code: "branch_limit",
-				},
+		const structuredContent = {
+			error: {
+				message: "branch limit",
+				name: "ConflictError",
+				kind: "conflict",
+				status: 409,
+				code: "branch_limit",
 			},
+		};
+		expect(result).toEqual({
+			isError: true,
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify(structuredContent),
+				},
+			],
+			structuredContent,
 		});
 	});
 });

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -169,6 +169,9 @@ describe("MCP v2 compatibility", () => {
 			structuredContent: {
 				error: {
 					message: expect.stringContaining("Authentication failed"),
+					name: "NeonAuthError",
+					kind: "auth",
+					status: 401,
 				},
 			},
 		});

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -402,6 +402,53 @@ describe("MCP request credentials", () => {
 		});
 		expect(result.structuredContent.error).not.toHaveProperty("operations");
 	});
+
+	test("omits non-finite timeoutMs and status from MCP errors", async () => {
+		const { server, handler } = captureHandler();
+		const catalog = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.list"] as const,
+			fetch: async () =>
+				new Response(JSON.stringify({ projects: [], pagination: {} }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		});
+		registerNeonToolsV2(server, {
+			"projects.list": {
+				...catalog["projects.list"],
+				execute: async () => {
+					throw Object.assign(new Error("Timed out"), {
+						name: "TimeoutError",
+						kind: "timeout",
+						timeoutMs: Number.NaN,
+						status: Number.POSITIVE_INFINITY,
+					});
+				},
+			},
+		});
+
+		const result = await handler()({}, {});
+		const structuredContent = {
+			error: {
+				message: "Timed out",
+				name: "TimeoutError",
+				kind: "timeout",
+			},
+		};
+		expect(result).toEqual({
+			isError: true,
+			content: [
+				{
+					type: "text",
+					text: JSON.stringify(structuredContent),
+				},
+			],
+			structuredContent,
+		});
+		expect(result.structuredContent.error).not.toHaveProperty("timeoutMs");
+		expect(result.structuredContent.error).not.toHaveProperty("status");
+	});
 });
 
 describe("MCP v1 compatibility", () => {

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -7,7 +7,12 @@ import { InMemoryTransport as InMemoryTransportV1 } from "@modelcontextprotocol/
 import { McpServer as McpServerV1 } from "@modelcontextprotocol/sdk-v1/server/mcp.js";
 import { McpServer as McpServerV2 } from "@modelcontextprotocol/server";
 import { afterEach, describe, expect, test } from "vitest";
-import { createNeonTools, publishedId, toolIds } from "./index.js";
+import {
+	createNeonTools,
+	NeonWaitTimeoutError,
+	publishedId,
+	toolIds,
+} from "./index.js";
 import {
 	type McpToolResult,
 	registerNeonTools as registerNeonToolsV2,
@@ -154,7 +159,10 @@ describe("MCP v2 compatibility", () => {
 					JSON.stringify({ message: "Authentication failed" }),
 					{
 						status: 401,
-						headers: { "content-type": "application/json" },
+						headers: {
+							"content-type": "application/json",
+							"x-request-id": "req-auth-1",
+						},
 					},
 				),
 		});
@@ -172,6 +180,7 @@ describe("MCP v2 compatibility", () => {
 					name: "NeonAuthError",
 					kind: "auth",
 					status: 401,
+					requestId: "req-auth-1",
 				},
 			},
 		});
@@ -304,6 +313,11 @@ describe("MCP request credentials", () => {
 			kind: "conflict",
 			status: 409,
 			code: "branch_limit",
+			source: "wait",
+			timeoutMs: 30_000,
+			requestId: "req-1",
+			reason: "ECONNRESET",
+			operationId: "op-1",
 		});
 		registerNeonToolsV2(server, {
 			"projects.list": {
@@ -322,6 +336,11 @@ describe("MCP request credentials", () => {
 				kind: "conflict",
 				status: 409,
 				code: "branch_limit",
+				source: "wait",
+				timeoutMs: 30_000,
+				requestId: "req-1",
+				reason: "ECONNRESET",
+				operationId: "op-1",
 			},
 		};
 		expect(result).toEqual({
@@ -334,6 +353,54 @@ describe("MCP request credentials", () => {
 			],
 			structuredContent,
 		});
+	});
+
+	test("copies wait-timeout source without the operations list", async () => {
+		const { server, handler } = captureHandler();
+		const catalog = createNeonTools({
+			apiKey: "test-key",
+			tools: ["projects.list"] as const,
+			fetch: async () =>
+				new Response(JSON.stringify({ projects: [], pagination: {} }), {
+					status: 200,
+					headers: { "content-type": "application/json" },
+				}),
+		});
+		registerNeonToolsV2(server, {
+			"projects.list": {
+				...catalog["projects.list"],
+				execute: async () => {
+					throw new NeonWaitTimeoutError("Timed out waiting.", {
+						timeoutMs: 5_000,
+						operations: [
+							{
+								id: "op-1",
+								project_id: "project-id",
+								action: "create_branch",
+								status: "running",
+								failures_count: 0,
+								created_at: "2026-01-01T00:00:00Z",
+								updated_at: "2026-01-01T00:00:00Z",
+								total_duration_ms: 0,
+							},
+						],
+					});
+				},
+			},
+		});
+
+		const result = await handler()({}, {});
+		expect(result.isError).toBe(true);
+		expect(result.structuredContent).toEqual({
+			error: {
+				message: "Timed out waiting.",
+				name: "NeonWaitTimeoutError",
+				kind: "timeout",
+				source: "wait",
+				timeoutMs: 5_000,
+			},
+		});
+		expect(result.structuredContent.error).not.toHaveProperty("operations");
 	});
 });
 

--- a/packages/tools/src/mcp.test.ts
+++ b/packages/tools/src/mcp.test.ts
@@ -6,13 +6,9 @@ import { Client as ClientV1 } from "@modelcontextprotocol/sdk-v1/client/index.js
 import { InMemoryTransport as InMemoryTransportV1 } from "@modelcontextprotocol/sdk-v1/inMemory.js";
 import { McpServer as McpServerV1 } from "@modelcontextprotocol/sdk-v1/server/mcp.js";
 import { McpServer as McpServerV2 } from "@modelcontextprotocol/server";
+import { NeonWaitTimeoutError } from "@neon/sdk";
 import { afterEach, describe, expect, test } from "vitest";
-import {
-	createNeonTools,
-	NeonWaitTimeoutError,
-	publishedId,
-	toolIds,
-} from "./index.js";
+import { createNeonTools, publishedId, toolIds } from "./index.js";
 import {
 	type McpToolResult,
 	registerNeonTools as registerNeonToolsV2,


### PR DESCRIPTION
## Problem

`registerNeonTools` reduces execution failures to `{ error: { message } }`. MCP hosts lose the fields SDK callers use after `isNeonError`, so distinguishing authentication failures, timeouts and operation failures requires parsing the message.

## Error payload

Both `@neon/tools/mcp` and `@neon/tools/mcp-v1` copy supported scalar fields from the thrown error into `structuredContent`. The same payload is JSON-encoded in text content, with `isError: true`.

Payload shape, matching the README:

```js
{
  error: {
    message, name, kind, status, code, source,
    timeoutMs, requestId, reason, operationId
  }
}
```

`message` is always present. Other fields are included when present with the supported type: strings, a string or finite number for `status`, and a finite number for `timeoutMs`. Non-finite numeric values are omitted. Fields are copied from ordinary errors too; the adapter does not require a Neon error class.

For example, a wait timeout produces:

```json
{
  "error": {
    "message": "Timed out waiting.",
    "name": "NeonWaitTimeoutError",
    "kind": "timeout",
    "source": "wait",
    "timeoutMs": 5000
  }
}
```

A host can branch on `error.kind === "timeout"` and `error.source === "wait"`. The `operations` list is not copied.

Registration calls, successful `{ data }` results and `error.message` remain unchanged. The README documents the payload and a patch changeset covers `@neon/tools`.

## Verification

Ran at `7c1ef34`:

```bash
pnpm --filter @neon/tools exec vitest run src/mcp.test.ts
```

All 16 tests passed. Coverage includes MCP v1/v2 registration and successful calls, authentication error fields, ordinary-error scalar fields, wait timeouts, omission of non-finite numbers and matching text/structured error payloads.

The suite uses in-memory MCP transports and supplied fetch responses. Live Neon requests were not exercised by this run.

Lands on `main` after [#591](https://github.com/neondatabase/neon-pkgs/pull/591).