### PR TITLE
Replace compactJsonSchema with toMcpJsonSchema

### DIFF
--- a/.changeset/tools-t11-mcp-schema.md
+++ b/.changeset/tools-t11-mcp-schema.md
@@ -1,0 +1,5 @@
+---
+"@neon/tools": major
+---
+
+`toMcpJsonSchema(schema)` takes a Zod schema and returns JSON Schema without `$schema`. `compactJsonSchema` is removed.

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -225,14 +225,11 @@ registerNeonTools(server, tools);
 Hosts that convert Zod themselves:
 
 ```ts
-import { compactJsonSchema } from "@neon/tools/mcp";
-import * as z from "zod";
+import { toMcpJsonSchema } from "@neon/tools/mcp";
 import { createNeonTool } from "@neon/tools";
 
 const tool = createNeonTool("projects.update", { apiKey });
-const inputSchema = compactJsonSchema(
-	z.toJSONSchema(tool.inputSchema, { io: "input" }),
-);
+const inputSchema = toMcpJsonSchema(tool.inputSchema);
 ```
 
 For a remote MCP server that already authenticated the client, omit `apiKey` at construction. `registerNeonTools` sends `authInfo.token` as the Bearer credential: MCP 2.x `http.authInfo.token`, MCP 1.x `authInfo.token`. The host must put a Neon API key or Neon OAuth access token there. A present `authInfo` with an empty token is an error, not a fall back to a constructor key.
@@ -252,7 +249,7 @@ Existing MCP 1.x servers can use the version-specific entry point:
 import { registerNeonTools } from "@neon/tools/mcp-v1";
 ```
 
-MCP 1.x still receives Zod input schemas, including handwritten `.describe()` copy. Generated Zod has no OpenAPI field essays. Use `compactJsonSchema` if you convert those schemas yourself and need `$schema` removed.
+MCP 1.x still receives Zod input schemas, including handwritten `.describe()` copy. Generated Zod has no OpenAPI field essays. Use `toMcpJsonSchema` if you convert those schemas yourself and need `$schema` removed.
 
 The adapter returns both text content and object-valued `structuredContent`. Execution failures use `isError: true` with structured error data.
 

--- a/packages/tools/src/lib/mcp-json-schema.test.ts
+++ b/packages/tools/src/lib/mcp-json-schema.test.ts
@@ -1,25 +1,17 @@
 import { describe, expect, test } from "vitest";
 import * as z from "zod";
-import { compactJsonSchema, toMcpInputSchema } from "./mcp-json-schema.js";
+import { toMcpInputSchema, toMcpJsonSchema } from "./mcp-json-schema.js";
 
-describe("compactJsonSchema", () => {
+describe("toMcpJsonSchema", () => {
 	test("drops root $schema and keeps field descriptions", () => {
-		const schema = {
-			$schema: "https://json-schema.org/draft/2020-12/schema",
-			type: "object",
-			description: "Create a record.",
-			properties: {
-				description: {
-					type: "string",
-					description: "Human-readable summary.",
-				},
-				name: { type: "string", description: "Display name." },
-			},
-			required: ["description"],
-			additionalProperties: false,
-		};
+		const schema = z
+			.strictObject({
+				description: z.string().describe("Human-readable summary."),
+				name: z.string().describe("Display name.").optional(),
+			})
+			.describe("Create a record.");
 
-		expect(compactJsonSchema(schema)).toEqual({
+		expect(toMcpJsonSchema(schema)).toEqual({
 			type: "object",
 			description: "Create a record.",
 			properties: {
@@ -32,6 +24,7 @@ describe("compactJsonSchema", () => {
 			required: ["description"],
 			additionalProperties: false,
 		});
+		expect(toMcpJsonSchema(schema)).not.toHaveProperty("$schema");
 	});
 });
 

--- a/packages/tools/src/lib/mcp-json-schema.ts
+++ b/packages/tools/src/lib/mcp-json-schema.ts
@@ -3,12 +3,14 @@ import * as z from "zod";
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 
-export const compactJsonSchema = (node: unknown): unknown => {
-	if (!isPlainObject(node)) {
-		return node;
+export const toMcpJsonSchema = (schema: z.ZodType): Record<string, unknown> => {
+	const json = z.toJSONSchema(schema, { io: "input" });
+	if (!isPlainObject(json)) {
+		throw new TypeError(
+			"MCP tool input schemas must be JSON Schema objects",
+		);
 	}
-	const rest = { ...node };
-	delete rest.$schema;
+	const { $schema: _, ...rest } = json;
 	return rest;
 };
 
@@ -29,13 +31,7 @@ export interface McpStandardSchema {
 }
 
 export const toMcpInputSchema = (schema: z.ZodType): McpStandardSchema => {
-	const json = compactJsonSchema(z.toJSONSchema(schema, { io: "input" }));
-	if (!isPlainObject(json)) {
-		throw new TypeError(
-			"MCP tool input schemas must be JSON Schema objects",
-		);
-	}
-
+	const json = toMcpJsonSchema(schema);
 	const standard =
 		"~standard" in schema && isPlainObject(schema["~standard"])
 			? schema["~standard"]

--- a/packages/tools/src/mcp.ts
+++ b/packages/tools/src/mcp.ts
@@ -1,4 +1,4 @@
-import { compactJsonSchema, toMcpInputSchema } from "./lib/mcp-json-schema.js";
+import { toMcpInputSchema, toMcpJsonSchema } from "./lib/mcp-json-schema.js";
 import {
 	type McpToolResult,
 	type McpToolServer,
@@ -8,7 +8,7 @@ import type { NeonTool } from "./lib/operation.js";
 
 export type { McpStandardSchema } from "./lib/mcp-json-schema.js";
 export type { McpToolResult, McpToolServer };
-export { compactJsonSchema, toMcpInputSchema };
+export { toMcpInputSchema, toMcpJsonSchema };
 
 export const registerNeonTools = (
 	server: McpToolServer,


### PR DESCRIPTION
## Problem

A host that converts a Neon tool's Zod schema into MCP JSON Schema on its own had two steps to get the shape `registerNeonTools` publishes: call `z.toJSONSchema(tool.inputSchema, { io: "input" })`, then pass the result through `compactJsonSchema` to drop `$schema`. The README documented both. `compactJsonSchema` took and returned `unknown`, so the host also had to narrow the result before handing it to an MCP server.

The conversion options and the `$schema` strip belong together. Splitting them across the host and this package means a host can pick different `toJSONSchema` options than `registerNeonTools` does and end up publishing a different schema for the same tool.

## Change

`@neon/tools/mcp` exports one typed helper that owns the whole conversion. `compactJsonSchema` is removed. This is a major release of `@neon/tools`.

```ts
import { toMcpJsonSchema } from "@neon/tools/mcp";
import { createNeonTool } from "@neon/tools";

const tool = createNeonTool("projects.update", { apiKey });
const inputSchema = toMcpJsonSchema(tool.inputSchema);
```

Signature:

```ts
toMcpJsonSchema(schema: z.ZodType): Record<string, unknown>
```

It runs `z.toJSONSchema(schema, { io: "input" })`, throws `TypeError("MCP tool input schemas must be JSON Schema objects")` if the result is not a plain object and returns the object without the root `$schema` key. Nothing else in the output is touched.

`toMcpInputSchema` calls it, so MCP 2 `registerNeonTools` publishes the same JSON Schema as before, without `$schema`. Hosts that only call `registerNeonTools` see no change.

Migration for hosts that called `compactJsonSchema`:

```ts
// before
const inputSchema = compactJsonSchema(
	z.toJSONSchema(tool.inputSchema, { io: "input" }),
);

// after
const inputSchema = toMcpJsonSchema(tool.inputSchema);
```

### Why `$schema` is dropped

MCP 2 `inputSchema` allows `$schema?: string`, so keeping it would be valid protocol output. Dropping it matches what this package already publishes through `registerNeonTools` and what the README's two-step conversion already produced. The helper exists so a host gets that same output; it is not enforcing a protocol requirement.

### What the helper does not do

- It does not inline `$ref` or `$defs`. Generated Neon tool schemas are root objects, Zod 4.4.3 inlines reused schemas and the current generated catalog contains no `$ref` or `$defs`. A recursive schema can emit `$ref: "#"`; `$defs` was not observed on those cases.
- It strips only the root `$schema` key. A nested `$schema` passes through.
- It keeps `additionalProperties: false`. That is the input shape of a Zod strict object; dropping it would make the published schema accept extra keys the tool then rejects at validation.

## Also in here

- `packages/tools/README.md` shows the one-call form in the MCP 2 section and names `toMcpJsonSchema` in the MCP 1.x note.
- The `compactJsonSchema` unit test now feeds a Zod strict object into `toMcpJsonSchema` and asserts the emitted JSON Schema has no `$schema`, keeps field and root descriptions, `required` and `additionalProperties: false`.
- Changeset: major bump for `@neon/tools`.

## Verification

Against base `67821e0`:

```
pnpm --filter @neon/sdk build
pnpm --filter @neon/tools tsc
pnpm --filter @neon/tools exec vitest run
```

`vitest run`: 11 files, 140 tests passed. Covered behaviours:

- a Zod strict object converts to JSON Schema with `type`, `properties`, `required` and `additionalProperties: false`, and no root `$schema`
- root and field `.describe()` copy survives the conversion
- `toMcpInputSchema` publishes that JSON Schema through `~standard.jsonSchema.input()` and still validates good and bad input through `validate`

Not verified: the `TypeError` path. `z.toJSONSchema` on a Zod root object returns a plain object, and no Neon tool schema produces anything else, so there is no test that reaches the throw.

## For your attention

- Any host importing `compactJsonSchema` from `@neon/tools/mcp` breaks on upgrade. The migration is the one-line swap above.
- The helper is fixed to `{ io: "input" }`. A host that needs output-shaped JSON Schema or other `toJSONSchema` options still calls `z.toJSONSchema` itself and gets `$schema` in the result.
