### PR TITLE
chore: release neon@4.14.2

### DIFF
--- a/.changeset/parent-command-help.md
+++ b/.changeset/parent-command-help.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-A top-level command that only has subcommands (`neon claim`, `neon env`, `neon logs`, …) prints that command's help when you run it with no subcommand, instead of an error that says to run `--help`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neon
 
+## 4.14.2
+
+### Patch Changes
+
+- fc95f62: A top-level command that only has subcommands (`neon claim`, `neon env`, `neon logs`, …) prints that command's help when you run it with no subcommand, instead of an error that says to run `--help`.
+
 ## 4.14.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.14.1",
+	"version": "4.14.2",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.14.2
+
+### Patch Changes
+
+- Updated dependencies [fc95f62]
+  - neon@4.14.2
+
 ## 4.14.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.14.1",
+  "version": "4.14.2",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
Bumps `neon` and `neonctl` 4.14.1 → 4.14.2 (Changesets fixed group).

Consumes `.changeset/parent-command-help.md` from #533. Bare parent CLI commands print group help instead of a demandCommand error.

No other unconsumed changesets were on `main`.