### PR TITLE
chore: release @neon/sdk@3.2.0

### DIFF
--- a/.changeset/paginated-throw-on-error.md
+++ b/.changeset/paginated-throw-on-error.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": minor
----
-
-`Paginated.page()` and `Paginated.all()` now honour `throwOnError` (client-wide and per call), matching every other method. With `throwOnError: true` they resolve to the bare page / item array and reject on failure instead of always returning `{ data, error }`. `Paginated<T>` gained a second type parameter `Throw` (default `false`), and `Consumption` is now generic over the client's `throwOnError` like the other resources. Default (`throwOnError: false`) clients are unaffected; the async iterator still throws on a page error.

--- a/.changeset/sdk-error-kind-narrowing.md
+++ b/.changeset/sdk-error-kind-narrowing.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": minor
----
-
-`error.kind` now narrows. `NeonResult` and `RawResult` type `error` as `NeonErrorUnion`, and every error class carries a literal `kind`, so `if (error?.kind === "not_found") error.status` compiles without `instanceof`. New `NeonClientError` (`kind: "client"`) replaces the bare `NeonError` the SDK used for SDK-side failures. `isNeonError` is the type guard for `catch` after `throwOnError`. `instanceof NeonError` still matches; `instanceof NeonApiError` still matches 404/401/429 subclasses.

--- a/.changeset/sdk-neon-client-default-type.md
+++ b/.changeset/sdk-neon-client-default-type.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": patch
----
-
-`NeonClient` now defaults its type parameter to `false`, so `NeonClient` can be used without a type argument to describe the client returned by `createNeonClient({ apiKey })`. `NeonClient<true>` continues to describe a `throwOnError: true` client.

--- a/.changeset/wait-for-readiness-client-false.md
+++ b/.changeset/wait-for-readiness-client-false.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": patch
----
-
-`createNeonClient({ waitForReadiness: false })` now turns off readiness polling on `projects.create`, `projects.createAndConnect`, `branches.create`, and `branches.createAndConnect`. Those methods still default polling on when the client option is unset. Per-call `{ waitForReadiness }` still wins.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon-internals/env-core
 
+## 0.0.9
+
+### Patch Changes
+
+- @neon/config@1.3.1
+
 ## 0.0.8
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.8",
+	"version": "0.0.9",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # neon
 
+## 4.14.3
+
+### Patch Changes
+
+- Updated dependencies [9ac65e5]
+- Updated dependencies [ed53d40]
+- Updated dependencies [0474691]
+- Updated dependencies [79494fe]
+  - @neon/sdk@3.2.0
+  - @neon/config@1.3.1
+  - @neon/config-runtime@1.2.2
+
 ## 4.14.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.14.2",
+	"version": "4.14.3",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 1.2.2
+
+### Patch Changes
+
+- @neon/config@1.3.1
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @neondatabase/config
 
+## 1.3.1
+
+### Patch Changes
+
+- Updated dependencies [9ac65e5]
+- Updated dependencies [ed53d40]
+- Updated dependencies [0474691]
+- Updated dependencies [79494fe]
+  - @neon/sdk@3.2.0
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.2.2
+
+### Patch Changes
+
+- @neon/config@1.3.1
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 4.14.3
+
+### Patch Changes
+
+- neon@4.14.3
+
 ## 4.14.2
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.14.2",
+  "version": "4.14.3",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @neon/sdk
 
+## 3.2.0
+
+### Minor Changes
+
+- 9ac65e5: `Paginated.page()` and `Paginated.all()` now honour `throwOnError` (client-wide and per call), matching every other method. With `throwOnError: true` they resolve to the bare page / item array and reject on failure instead of always returning `{ data, error }`. `Paginated<T>` gained a second type parameter `Throw` (default `false`), and `Consumption` is now generic over the client's `throwOnError` like the other resources. Default (`throwOnError: false`) clients are unaffected; the async iterator still throws on a page error.
+- ed53d40: `error.kind` now narrows. `NeonResult` and `RawResult` type `error` as `NeonErrorUnion`, and every error class carries a literal `kind`, so `if (error?.kind === "not_found") error.status` compiles without `instanceof`. New `NeonClientError` (`kind: "client"`) replaces the bare `NeonError` the SDK used for SDK-side failures. `isNeonError` is the type guard for `catch` after `throwOnError`. `instanceof NeonError` still matches; `instanceof NeonApiError` still matches 404/401/429 subclasses.
+
+### Patch Changes
+
+- 0474691: `NeonClient` now defaults its type parameter to `false`, so `NeonClient` can be used without a type argument to describe the client returned by `createNeonClient({ apiKey })`. `NeonClient<true>` continues to describe a `throwOnError: true` client.
+- 79494fe: `createNeonClient({ waitForReadiness: false })` now turns off readiness polling on `projects.create`, `projects.createAndConnect`, `branches.create`, and `branches.createAndConnect`. Those methods still default polling on when the client option is unset. Per-call `{ waitForReadiness }` still wins.
+
 ## 3.1.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "3.1.0",
+	"version": "3.2.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @neon/tools
 
+## 1.2.1
+
+### Patch Changes
+
+- `collectPages` now consumes the bare page / item array that a throwing SDK client returns from `Paginated.page()` and `.all()`, instead of unwrapping a `{ data, error }` envelope.
+- Updated dependencies [9ac65e5]
+- Updated dependencies [ed53d40]
+- Updated dependencies [0474691]
+- Updated dependencies [79494fe]
+  - @neon/sdk@3.2.0
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
Version bump for S1–S4 on `@neon/sdk`, plus the `@neon/tools` `collectPages` follow-up from S2. Dependents are patch-cascaded.

| Package | From | To |
| --- | --- | --- |
| `@neon/sdk` | 3.1.0 | **3.2.0** |
| `@neon/tools` | 1.2.0 | 1.2.1 |
| `@neon/config` | 1.3.0 | 1.3.1 |
| `@neon/config-runtime` | 1.2.1 | 1.2.2 |
| `@neon/env` | 1.2.1 | 1.2.2 |
| `neon` / `neonctl` | 4.14.2 | 4.14.3 |

`@neon-internals/env-core` 0.0.8 → 0.0.9 (private, not published).

Publish after merge, leaf-first: `@neon/sdk` → `@neon/config` → `@neon/config-runtime` / `@neon/env` / `@neon/tools` → `neon` → `neonctl`.