### PR TITLE
Keep an absolute --file path off the working directory

### DIFF
--- a/.changeset/env-file-absolute-path.md
+++ b/.changeset/env-file-absolute-path.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+`neon claim create --file` and `neon env pull --file` keep an absolute path instead of joining it onto the working directory.

--- a/packages/cli/src/env_file.test.ts
+++ b/packages/cli/src/env_file.test.ts
@@ -165,6 +165,11 @@ describe("resolveEnvFilePath", () => {
 		);
 	});
 
+	it("keeps an absolute --file instead of joining it onto cwd", () => {
+		const absolute = join(tmpdir(), "neonctl-elsewhere", ".env.prod");
+		expect(resolveEnvFilePath(cwd, absolute)).toBe(absolute);
+	});
+
 	it("defaults to .env.local when no .env exists", () => {
 		expect(resolveEnvFilePath(cwd)).toBe(join(cwd, ".env.local"));
 	});

--- a/packages/cli/src/env_file.ts
+++ b/packages/cli/src/env_file.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 /**
  * Default dotenv file `env pull` writes to: `.env` when one already exists in the working
@@ -7,7 +7,9 @@ import { join } from "node:path";
  * `vercel env pull` convention. An explicit `--file` always wins over this.
  */
 export const resolveEnvFilePath = (cwd: string, file?: string): string => {
-	if (file) return join(cwd, file);
+	// path.join concatenates a later absolute segment onto cwd, so `--file /abs/path`
+	// would write under the working directory. resolve() keeps an absolute path as-is.
+	if (file) return resolve(cwd, file);
 	if (existsSync(join(cwd, ".env"))) return join(cwd, ".env");
 	return join(cwd, ".env.local");
 };


### PR DESCRIPTION
## Problem

`neon claim create --file /abs/path/.env.local` and `neon env pull --file /abs/path` open a path under the current working directory:

```text
ENOENT: no such file or directory, open '/cwd/Users/you/abs/path/.env.local'
```

`--file .env.local` (relative) works. Both commands share `resolveEnvFilePath`, which used `path.join(cwd, file)`. On current Node, `path.join` concatenates a later absolute segment onto `cwd` instead of replacing it.

## Solution

Resolve `--file` with `path.resolve(cwd, file)`. An absolute path stays absolute; a relative path is still joined onto `cwd`. Defaults (`.env` / `.env.local`) are unchanged.

## User-facing API

```bash
neon claim create --file /abs/path/.env.local
neon env pull --file /abs/path/.env.preview
neon claim create --file .env.local
```

Same flags. Absolute `--file` now writes that file.

## Verification

Unit test: `resolveEnvFilePath(cwd, "/tmp/elsewhere/.env.prod")` equals the absolute path. Relative `--file`, default `.env.local`, and existing `.env` tests still pass. `env.test.ts` and `claim.test.ts` still pass.

## Flag

Ships with the next `neon` / `neonctl` patch via the changeset. Not on 4.14.3 until that release.