### PR TITLE
chore: release neon@4.14.4 @neon/sdk@4.0.0

### DIFF
--- a/.changeset/claimable-env-pull.md
+++ b/.changeset/claimable-env-pull.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-`neon env pull` works on unclaimed Claimable Neon projects. A `neon.ts` that only declares Postgres, Auth, and the Data API is honored; one that names AI Gateway, Functions, or Object Storage fails until the project is claimed. `neon claim create` writes the same vars as that pull.

--- a/.changeset/sdk-apikey-required.md
+++ b/.changeset/sdk-apikey-required.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": minor
----
-
-`createNeonClient` now throws a `"client"`-kind error when `apiKey` is missing or `""`, instead of sending an unauthenticated request and surfacing a 401 on the first call. A function that later returns empty is still accepted at construction.

--- a/.changeset/sdk-per-call-wait.md
+++ b/.changeset/sdk-per-call-wait.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": major
----
-
-`CallOptions` now accepts `wait: { pollIntervalMs?, timeoutMs? }`, so a single client can use a longer readiness budget on one `projects.create` without changing the rest. Client `wait` no longer accepts `signal`; pass `signal` on the call. `operations.waitFor` still takes top-level `pollIntervalMs`, `timeoutMs`, and `signal`.

--- a/.changeset/sdk-readme-cancellation.md
+++ b/.changeset/sdk-readme-cancellation.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": patch
----
-
-README Cancellation & deadlines examples now compile. Abort uses `list({}, { signal })`; a request timeout is `source === "request"`.

--- a/.changeset/sdk-readme-per-call-options.md
+++ b/.changeset/sdk-readme-per-call-options.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": patch
----
-
-Docs: `CallOptions` is `throwOnError`, `waitForReadiness`, `requestTimeoutMs`, `wait`, and `signal`. `retries`, `orgId`, `baseUrl`, and `fetch` are client-wide; per-request org selection uses method input (`org_id` / `fromOrgId`).

--- a/.changeset/sdk-retries-validation.md
+++ b/.changeset/sdk-retries-validation.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": patch
----
-
-`retries` is validated at `createNeonClient`. `NaN`, `Infinity`, fractions, and negatives throw a `"client"`-kind error instead of retrying forever (`NaN`/`Infinity`) or being accepted silently. `0` and the default `2` are unchanged.

--- a/.changeset/sdk-timeout-source.md
+++ b/.changeset/sdk-timeout-source.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": minor
----
-
-`NeonTimeoutError` is now the abstract base of `NeonRequestTimeoutError` (`source: "request"`) and `NeonWaitTimeoutError` (`source: "wait"`, plus `operations` for `neon.operations.waitFor`). `kind` remains `"timeout"`. Direct construction uses the subclasses.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon-internals/env-core
 
+## 0.0.10
+
+### Patch Changes
+
+- @neon/config@1.3.2
+
 ## 0.0.9
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # neon
 
+## 4.14.4
+
+### Patch Changes
+
+- 9434724: `neon env pull` works on unclaimed Claimable Neon projects. A `neon.ts` that only declares Postgres, Auth, and the Data API is honored; one that names AI Gateway, Functions, or Object Storage fails until the project is claimed. `neon claim create` writes the same vars as that pull.
+- Updated dependencies [bb909d2]
+- Updated dependencies [640adad]
+- Updated dependencies [86baf96]
+- Updated dependencies [fae6ba7]
+- Updated dependencies [df4dfc2]
+- Updated dependencies [780119e]
+  - @neon/sdk@4.0.0
+  - @neon/config@1.3.2
+  - @neon/config-runtime@1.2.3
+
 ## 4.14.3
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.14.3",
+	"version": "4.14.4",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 1.2.3
+
+### Patch Changes
+
+- @neon/config@1.3.2
+
 ## 1.2.2
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @neondatabase/config
 
+## 1.3.2
+
+### Patch Changes
+
+- Updated dependencies [bb909d2]
+- Updated dependencies [640adad]
+- Updated dependencies [86baf96]
+- Updated dependencies [fae6ba7]
+- Updated dependencies [df4dfc2]
+- Updated dependencies [780119e]
+  - @neon/sdk@4.0.0
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.2.3
+
+### Patch Changes
+
+- @neon/config@1.3.2
+
 ## 1.2.2
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.14.4
+
+### Patch Changes
+
+- Updated dependencies [9434724]
+  - neon@4.14.4
+
 ## 4.14.3
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.14.3",
+  "version": "4.14.4",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @neon/sdk
 
+## 4.0.0
+
+### Major Changes
+
+- 640adad: `CallOptions` now accepts `wait: { pollIntervalMs?, timeoutMs? }`, so a single client can use a longer readiness budget on one `projects.create` without changing the rest. Client `wait` no longer accepts `signal`; pass `signal` on the call. `operations.waitFor` still takes top-level `pollIntervalMs`, `timeoutMs`, and `signal`.
+
+### Minor Changes
+
+- bb909d2: `createNeonClient` now throws a `"client"`-kind error when `apiKey` is missing or `""`, instead of sending an unauthenticated request and surfacing a 401 on the first call. A function that later returns empty is still accepted at construction.
+- 780119e: `NeonTimeoutError` is now the abstract base of `NeonRequestTimeoutError` (`source: "request"`) and `NeonWaitTimeoutError` (`source: "wait"`, plus `operations` for `neon.operations.waitFor`). `kind` remains `"timeout"`. Direct construction uses the subclasses.
+
+### Patch Changes
+
+- 86baf96: README Cancellation & deadlines examples now compile. Abort uses `list({}, { signal })`; a request timeout is `source === "request"`.
+- fae6ba7: Docs: `CallOptions` is `throwOnError`, `waitForReadiness`, `requestTimeoutMs`, `wait`, and `signal`. `retries`, `orgId`, `baseUrl`, and `fetch` are client-wide; per-request org selection uses method input (`org_id` / `fromOrgId`).
+- df4dfc2: `retries` is validated at `createNeonClient`. `NaN`, `Infinity`, fractions, and negatives throw a `"client"`-kind error instead of retrying forever (`NaN`/`Infinity`) or being accepted silently. `0` and the default `2` are unchanged.
+
 ## 3.2.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "3.2.0",
+	"version": "4.0.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @neon/tools
 
+## 1.2.2
+
+### Patch Changes
+
+- Updated dependencies [bb909d2]
+- Updated dependencies [640adad]
+- Updated dependencies [86baf96]
+- Updated dependencies [fae6ba7]
+- Updated dependencies [df4dfc2]
+- Updated dependencies [780119e]
+  - @neon/sdk@4.0.0
+
 ## 1.2.1
 
 ### Patch Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Bumped

Direct:
- `neon` 4.14.3 → 4.14.4
- `neonctl` 4.14.3 → 4.14.4 (fixed group with `neon`)
- `@neon/sdk` 3.2.0 → 4.0.0

Cascade from `@neon/sdk@4.0.0`:
- `@neon/config` 1.3.1 → 1.3.2
- `@neon/config-runtime` 1.2.2 → 1.2.3
- `@neon/env` 1.2.2 → 1.2.3
- `@neon/tools` 1.2.1 → 1.2.2

## Publish after merge

Nothing publishes on merge. Dispatch `neon-pkgs.yml` in `databricks/secure-public-registry-releases-eng` once per package, leaf first:

1. `@neon/sdk`
2. `@neon/config`
3. `@neon/config-runtime`
4. `@neon/env`
5. `@neon/tools`
6. `neon`
7. `neonctl`