### PR TITLE
Stop writing claimable traces into .neon

### DIFF
--- a/.changeset/drop-claimable-neon-marker.md
+++ b/.changeset/drop-claimable-neon-marker.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+`.neon` from `neon claim create` is the project id and branch only. Later commands use the identity assertion file, so `neon checkout` no longer drops Claimable auth.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -116,16 +116,16 @@ to skip the dotenv write.
 
 The command writes:
 
-- a `.neon` context that identifies the project and Claimable Neon service;
+- a `.neon` context with the project id and pinned branch;
 - an owner-only identity assertion under the CLI config directory;
 - `DATABASE_URL`, `DATABASE_URL_UNPOOLED`, `NEON_BRANCH`, and Auth / Data API variables
   when `neon.ts` declares them (or, with no `neon.ts`, when they are provisioned) to `.env`
   or `.env.local` (disable this with `--no-env-pull`). The write is the same `env pull` used
   after create.
 
-Subsequent project commands automatically exchange the assertion for a short-lived agent
-token and send API calls to Claimable Neon. The service decides which operations are
-allowed before claim.
+Subsequent project commands find that assertion by the linked project id, exchange it for a
+short-lived agent token, and send API calls to Claimable Neon. The service decides which
+operations are allowed before claim.
 
 ```bash
 neon claim status                 # lifecycle and transfer status

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -132,6 +132,7 @@ neon claim status                 # lifecycle and transfer status
 neon projects get <project-id>    # regular CLI command, same agent token
 neon psql --role-name neondb_owner -- -c "select now()"
 neon config plan
+neon checkout main
 neon env pull
 
 neon claim accept                 # create a claim code and open the transfer URL

--- a/packages/cli/e2e/claim.e2e.test.ts
+++ b/packages/cli/e2e/claim.e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect } from "vitest";
@@ -93,6 +93,12 @@ describe.sequential("e2e — neon claim against live Claimable Neon", () => {
 				);
 				projectId = created.project_id;
 				expect(created.state).toBe("unclaimed");
+				expect(
+					JSON.parse(readFileSync(createdIn.contextFile, "utf8")),
+				).toEqual({
+					projectId: created.project_id,
+					branch: created.branch_id,
+				});
 
 				const fetched = await runAnonymousJson<BareProject>(
 					["projects", "get", created.project_id],

--- a/packages/cli/src/claimable/state.test.ts
+++ b/packages/cli/src/claimable/state.test.ts
@@ -363,4 +363,41 @@ describe("claimable env target", () => {
 			}),
 		).toBe(true);
 	});
+
+	it("does not parse an unused assertion when account auth is already selected", () => {
+		const root = temporaryDirectory();
+		const configDir = join(root, "config");
+		const contextFile = join(root, ".neon");
+		writeClaimableCredentials(configDir, credentials);
+		writeFileSync(
+			claimableCredentialsPath(configDir, credentials.projectId),
+			"{",
+		);
+		writeFileSync(
+			contextFile,
+			JSON.stringify({ projectId: credentials.projectId }),
+		);
+		setAuthContext({ source: "api-key", configDir });
+		expect(
+			isClaimableEnvTarget({
+				apiHost: "https://console.neon.tech/api/v2",
+				contextFile,
+				configDir,
+			}),
+		).toBe(false);
+		expect(
+			shouldUseClaimableCredentials(
+				{
+					apiKeyFlag: "napi_test",
+					apiKeyEnv: "",
+					profileEnv: "",
+					profileFlag: "",
+					configDir,
+				},
+				undefined,
+				{ projectId: credentials.projectId },
+				configDir,
+			),
+		).toBe(false);
+	});
 });

--- a/packages/cli/src/claimable/state.test.ts
+++ b/packages/cli/src/claimable/state.test.ts
@@ -17,8 +17,8 @@ import {
 	isClaimableEnvTarget,
 	listClaimableCredentials,
 	readClaimableCredentials,
+	readLinkedClaimableCredentials,
 	removeClaimableCredentials,
-	resolveClaimableContext,
 	shouldUseClaimableCredentials,
 	writeClaimableCredentials,
 } from "./state.js";
@@ -154,26 +154,21 @@ describe("claimable credentials", () => {
 });
 
 describe("claimable context", () => {
-	it("resolves a versioned marker with a matching project", () => {
+	it("reads the assertion file for a linked project id", () => {
+		const configDir = temporaryDirectory();
+		writeClaimableCredentials(configDir, credentials);
+
 		expect(
-			resolveClaimableContext({
-				projectId: "project-test",
+			readLinkedClaimableCredentials(configDir, {
+				projectId: credentials.projectId,
 				branch: "br-test",
-				claimable: {
-					version: 1,
-					origin: "https://claimable.neon.tech",
-				},
 			}),
-		).toEqual({
-			projectId: "project-test",
-			branch: "br-test",
-			origin: "https://claimable.neon.tech",
-		});
+		).toEqual(credentials);
 	});
 
 	it("returns null for an ordinary Neon context", () => {
 		expect(
-			resolveClaimableContext({
+			readLinkedClaimableCredentials(temporaryDirectory(), {
 				orgId: "org-test",
 				projectId: "project-test",
 				branch: "main",
@@ -181,14 +176,96 @@ describe("claimable context", () => {
 		).toBeNull();
 	});
 
-	it("refuses a malformed marker rather than falling back to account auth", () => {
-		expect(() =>
-			resolveClaimableContext(
-				JSON.parse(
-					'{"projectId":"project-test","claimable":{"version":2,"origin":"https://claimable.neon.tech"}}',
-				),
+	it("returns null for a project id that could not have an assertion file", () => {
+		expect(
+			readLinkedClaimableCredentials(temporaryDirectory(), {
+				projectId: "new-project id",
+			}),
+		).toBeNull();
+	});
+
+	it("ignores leftover claimable fields in .neon and uses the credential file origin", () => {
+		const root = temporaryDirectory();
+		const configDir = join(root, "config");
+		const contextFile = join(root, ".neon");
+		writeClaimableCredentials(configDir, credentials);
+		const leftover = {
+			projectId: credentials.projectId,
+			branch: "br-test",
+			claimable: {
+				version: 2,
+				origin: "https://other.example",
+			},
+		};
+		writeFileSync(contextFile, JSON.stringify(leftover));
+		const before = readFileSync(contextFile, "utf8");
+
+		expect(
+			shouldUseClaimableCredentials(
+				{
+					apiKeyFlag: "",
+					apiKeyEnv: "",
+					profileEnv: "",
+					profileFlag: "",
+					configDir,
+				},
+				undefined,
+				{ projectId: credentials.projectId, branch: "br-test" },
+				configDir,
 			),
-		).toThrow("Unsupported Claimable Neon context version");
+		).toBe(true);
+		expect(
+			isClaimableEnvTarget({
+				apiHost: claimableApiHost(credentials.origin),
+				contextFile,
+				configDir,
+			}),
+		).toBe(true);
+		expect(
+			isClaimableEnvTarget({
+				apiHost: claimableApiHost("https://other.example"),
+				contextFile,
+				configDir,
+			}),
+		).toBe(false);
+		expect(readFileSync(contextFile, "utf8")).toBe(before);
+	});
+
+	it("does not select Claimable auth from a leftover marker without a credential file", () => {
+		const root = temporaryDirectory();
+		const configDir = join(root, "config");
+		const contextFile = join(root, ".neon");
+		writeFileSync(
+			contextFile,
+			JSON.stringify({
+				projectId: credentials.projectId,
+				claimable: { version: 1, origin: credentials.origin },
+			}),
+		);
+		const before = readFileSync(contextFile, "utf8");
+
+		expect(
+			shouldUseClaimableCredentials(
+				{
+					apiKeyFlag: "",
+					apiKeyEnv: "",
+					profileEnv: "",
+					profileFlag: "",
+					configDir,
+				},
+				undefined,
+				{ projectId: credentials.projectId },
+				configDir,
+			),
+		).toBe(false);
+		expect(
+			isClaimableEnvTarget({
+				apiHost: claimableApiHost(credentials.origin),
+				contextFile,
+				configDir,
+			}),
+		).toBe(false);
+		expect(readFileSync(contextFile, "utf8")).toBe(before);
 	});
 });
 
@@ -202,31 +279,30 @@ describe("claimable credential selection", () => {
 	};
 
 	it("uses the linked claimable project when no account credential was selected", () => {
+		const configDir = temporaryDirectory();
+		writeClaimableCredentials(configDir, credentials);
+
 		expect(
-			shouldUseClaimableCredentials(noInputs, undefined, {
-				projectId: "project-test",
-				claimable: {
-					version: 1,
-					origin: "https://claimable.neon.tech",
-				},
-			}),
+			shouldUseClaimableCredentials(
+				noInputs,
+				undefined,
+				{ projectId: credentials.projectId },
+				configDir,
+			),
 		).toBe(true);
 	});
 
-	it("lets every explicit or ambient account selection override the local marker", () => {
-		const context = {
-			projectId: "project-test",
-			claimable: {
-				version: 1,
-				origin: "https://claimable.neon.tech",
-			},
-		} as const;
+	it("lets every explicit or ambient account selection override the credential file", () => {
+		const configDir = temporaryDirectory();
+		writeClaimableCredentials(configDir, credentials);
+		const context = { projectId: credentials.projectId };
 
 		expect(
 			shouldUseClaimableCredentials(
 				{ ...noInputs, apiKeyFlag: "napi_explicit" },
 				undefined,
 				context,
+				configDir,
 			),
 		).toBe(false);
 		expect(
@@ -234,6 +310,7 @@ describe("claimable credential selection", () => {
 				{ ...noInputs, apiKeyEnv: "napi_ambient" },
 				undefined,
 				context,
+				configDir,
 			),
 		).toBe(false);
 		expect(
@@ -241,47 +318,48 @@ describe("claimable credential selection", () => {
 				{ ...noInputs, profileEnv: "work" },
 				undefined,
 				context,
+				configDir,
 			),
 		).toBe(false);
-		expect(shouldUseClaimableCredentials(noInputs, "work", context)).toBe(
-			false,
-		);
+		expect(
+			shouldUseClaimableCredentials(noInputs, "work", context, configDir),
+		).toBe(false);
 	});
 });
 
 describe("claimable env target", () => {
-	it("matches a claimable marker only when the API host is that origin's /v1", () => {
-		const contextFile = join(temporaryDirectory(), ".neon");
+	it("matches a credential file only when the API host is that origin's /v1", () => {
+		const root = temporaryDirectory();
+		const configDir = join(root, "config");
+		const contextFile = join(root, ".neon");
+		writeClaimableCredentials(configDir, credentials);
 		writeFileSync(
 			contextFile,
-			JSON.stringify({
-				projectId: "project-test",
-				claimable: {
-					version: 1,
-					origin: "https://claimable.neon.tech",
-				},
-			}),
+			JSON.stringify({ projectId: credentials.projectId }),
 		);
 		expect(
 			isClaimableEnvTarget({
-				apiHost: claimableApiHost("https://claimable.neon.tech"),
+				apiHost: claimableApiHost(credentials.origin),
 				contextFile,
+				configDir,
 			}),
 		).toBe(true);
 		expect(
 			isClaimableEnvTarget({
 				apiHost: "https://console.neon.tech/api/v2",
 				contextFile,
+				configDir,
 			}),
 		).toBe(false);
 	});
 
-	it("treats a claimable auth source as claimable even without a marker", () => {
+	it("treats a claimable auth source as claimable even without a credential file", () => {
 		setAuthContext({ source: "claimable", configDir: "/tmp" });
 		expect(
 			isClaimableEnvTarget({
 				apiHost: "https://console.neon.tech/api/v2",
 				contextFile: join(temporaryDirectory(), "missing.neon"),
+				configDir: "",
 			}),
 		).toBe(true);
 	});

--- a/packages/cli/src/claimable/state.ts
+++ b/packages/cli/src/claimable/state.ts
@@ -178,10 +178,6 @@ export const removeClaimableCredentials = (
 	}
 };
 
-/**
- * The linked directory is Claimable Neon when this project's assertion file
- * exists. `.neon` is identifiers only; leftover `claimable` keys are ignored.
- */
 export const readLinkedClaimableCredentials = (
 	configDir: string,
 	context: Context,
@@ -190,6 +186,14 @@ export const readLinkedClaimableCredentials = (
 	// A regular `.neon` project id that this regex would reject never had an assertion file.
 	if (!PROJECT_ID.test(context.projectId)) return null;
 	return readClaimableCredentials(configDir, context.projectId);
+};
+
+export const claimableCredentialsExist = (
+	configDir: string,
+	projectId: string,
+): boolean => {
+	if (!PROJECT_ID.test(projectId)) return false;
+	return existsSync(claimableCredentialsPath(configDir, projectId));
 };
 
 export const shouldUseClaimableCredentials = (
@@ -221,7 +225,9 @@ export const isClaimableEnvTarget = (props: {
 	contextFile: string;
 	configDir: string;
 }): boolean => {
-	if (getAuthContext()?.source === "claimable") return true;
+	const source = getAuthContext()?.source;
+	if (source === "claimable") return true;
+	if (source !== undefined) return false;
 	if (props.configDir.trim() === "") return false;
 	const stored = readLinkedClaimableCredentials(
 		props.configDir,

--- a/packages/cli/src/claimable/state.ts
+++ b/packages/cli/src/claimable/state.ts
@@ -27,12 +27,6 @@ export type StoredClaimableCredentials = {
 	assertionExpires?: number;
 };
 
-export type ResolvedClaimableContext = {
-	origin: string;
-	projectId: string;
-	branch?: string;
-};
-
 const isRecord = (value: unknown): value is Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value);
 
@@ -184,44 +178,31 @@ export const removeClaimableCredentials = (
 	}
 };
 
-export const resolveClaimableContext = (
+/**
+ * The linked directory is Claimable Neon when this project's assertion file
+ * exists. `.neon` is identifiers only; leftover `claimable` keys are ignored.
+ */
+export const readLinkedClaimableCredentials = (
+	configDir: string,
 	context: Context,
-): ResolvedClaimableContext | null => {
-	const marker: unknown = context.claimable;
-	if (marker === undefined) return null;
-	if (!isRecord(marker)) {
-		throw new Error(
-			'The linked .neon file has an invalid "claimable" marker. Delete the claimable field from .neon, or delete .neon.',
-		);
-	}
-	if (marker.version !== 1) {
-		throw new Error(
-			`Unsupported Claimable Neon context version in .neon. Update the Neon CLI before using this project.`,
-		);
-	}
-	if (!nonEmptyString(marker.origin) || !nonEmptyString(context.projectId)) {
-		throw new Error(
-			'The linked .neon file has an incomplete "claimable" marker. Delete the claimable field from .neon, or delete .neon.',
-		);
-	}
-	assertProjectId(context.projectId);
-	return {
-		origin: marker.origin,
-		projectId: context.projectId,
-		...(nonEmptyString(context.branch) ? { branch: context.branch } : {}),
-	};
+): StoredClaimableCredentials | null => {
+	if (!nonEmptyString(context.projectId)) return null;
+	// A regular `.neon` project id that this regex would reject never had an assertion file.
+	if (!PROJECT_ID.test(context.projectId)) return null;
+	return readClaimableCredentials(configDir, context.projectId);
 };
 
 export const shouldUseClaimableCredentials = (
 	inputs: CredentialInputs,
 	profileFlag: string | undefined,
 	context: Context,
+	configDir: string,
 ): boolean =>
 	inputs.apiKeyFlag.trim() === "" &&
 	inputs.apiKeyEnv.trim() === "" &&
 	inputs.profileEnv.trim() === "" &&
 	(profileFlag === undefined || profileFlag.trim() === "") &&
-	resolveClaimableContext(context) !== null;
+	readLinkedClaimableCredentials(configDir, context) !== null;
 
 /** Management API base URL the CLI uses for a Claimable Neon origin. */
 export const claimableApiHost = (origin: string): string =>
@@ -231,19 +212,24 @@ export const claimableApiHost = (origin: string): string =>
  * Whether this invocation is talking to Claimable Neon, so env resolve must not
  * mint credentials or pull services that require claim.
  *
- * Auth source wins so a same-process checkout that rewrote `.neon` without the
- * marker still skips minting. A `.neon` marker plus a production API host is an
- * account override and is not claimable.
+ * Auth source wins so a same-process checkout that rewrote `.neon` still skips
+ * minting. A credential file plus a production API host is an account override
+ * and is not claimable.
  */
 export const isClaimableEnvTarget = (props: {
 	apiHost: string;
 	contextFile: string;
+	configDir: string;
 }): boolean => {
 	if (getAuthContext()?.source === "claimable") return true;
-	const linked = resolveClaimableContext(readContextFile(props.contextFile));
-	if (linked === null) return false;
+	if (props.configDir.trim() === "") return false;
+	const stored = readLinkedClaimableCredentials(
+		props.configDir,
+		readContextFile(props.contextFile),
+	);
+	if (stored === null) return false;
 	return (
 		props.apiHost.trim().replace(/\/+$/, "") ===
-		claimableApiHost(linked.origin)
+		claimableApiHost(stored.origin)
 	);
 };

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -31,6 +31,7 @@ import {
 import type { NeonApiClient } from "../api.js";
 import * as authModule from "../auth";
 import { AuthRefreshError, refreshToken } from "../auth";
+import { claimableCredentialsPath } from "../claimable/state.js";
 import * as credentialIo from "../credential_io.js";
 import { log } from "../log.js";
 import { test } from "../test_utils/fixtures";
@@ -770,6 +771,50 @@ describe("ensureAuth", () => {
 		const props = setupTestProps(server);
 		await expect(ensureAuth(props)).rejects.toThrow(/not valid JSON/);
 		expect(authSpy).not.toHaveBeenCalled();
+	});
+
+	test("does not parse a leftover Claimable assertion when --api-key is set", async ({
+		runMockServer,
+	}) => {
+		const server = await runMockServer("main");
+		const contextFile = join(configDir, ".neon");
+		const projectId = "patient-art-12345";
+		writeFileSync(
+			contextFile,
+			JSON.stringify({ projectId, branch: "main" }),
+		);
+		writeFileSync(claimableCredentialsPath(configDir, projectId), "{", {
+			mode: 0o600,
+		});
+		recordCredentialInputs({
+			apiKeyFlag: "napi_test",
+			apiKeyEnv: "",
+			profileEnv: "",
+			profileFlag: "",
+			configDir,
+		});
+		try {
+			const props = {
+				...setupTestProps(server),
+				apiKey: "napi_test",
+				contextFile,
+			};
+			await ensureAuth(props);
+			expect(props.apiKey).toBe("napi_test");
+			expect(authSpy).not.toHaveBeenCalled();
+		} finally {
+			recordCredentialInputs({
+				apiKeyFlag: "",
+				apiKeyEnv: "",
+				profileEnv: "",
+				profileFlag: "",
+				configDir,
+			});
+			rmSync(contextFile, { force: true });
+			rmSync(claimableCredentialsPath(configDir, projectId), {
+				force: true,
+			});
+		}
 	});
 
 	test("should try refresh when token is missing access_token but has refresh_token", async ({

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -44,6 +44,7 @@ import { setAuthContext } from "../auth_context.js";
 import { ClaimableClient, ClaimableServiceError } from "../claimable/api.js";
 import {
 	assertionHasExpired,
+	claimableCredentialsExist,
 	claimableCredentialsPath,
 	readLinkedClaimableCredentials,
 	shouldUseClaimableCredentials,
@@ -704,7 +705,8 @@ export const ensureAuth = async (
 	}
 
 	if (
-		readLinkedClaimableCredentials(props.configDir, localContext) !== null
+		localContext.projectId !== undefined &&
+		claimableCredentialsExist(props.configDir, localContext.projectId)
 	) {
 		log.warning(
 			"This directory is linked to a claimable project, but NEON_API_KEY or NEON_PROFILE is set. This command will use that account credential instead of the unclaimed project. Unset them to keep using the unclaimed project.",

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -45,8 +45,7 @@ import { ClaimableClient, ClaimableServiceError } from "../claimable/api.js";
 import {
 	assertionHasExpired,
 	claimableCredentialsPath,
-	readClaimableCredentials,
-	resolveClaimableContext,
+	readLinkedClaimableCredentials,
 	shouldUseClaimableCredentials,
 } from "../claimable/state.js";
 import {
@@ -646,37 +645,33 @@ export const ensureAuth = async (
 			? props.contextFile()
 			: (props.contextFile ?? currentContextFile());
 	const localContext = readContextFile(contextFile);
-	if (shouldUseClaimableCredentials(inputs, props.profile, localContext)) {
-		const linked = resolveClaimableContext(localContext);
-		if (linked === null) {
+	if (
+		shouldUseClaimableCredentials(
+			inputs,
+			props.profile,
+			localContext,
+			props.configDir,
+		)
+	) {
+		const stored = readLinkedClaimableCredentials(
+			props.configDir,
+			localContext,
+		);
+		if (stored === null || localContext.projectId === undefined) {
 			throw new Error(
-				"The linked Claimable Neon context could not be resolved.",
+				"The linked Claimable Neon identity assertion could not be read.",
 			);
 		}
-		const stored = readClaimableCredentials(
-			props.configDir,
-			linked.projectId,
-		);
 		const path = claimableCredentialsPath(
 			props.configDir,
-			linked.projectId,
+			localContext.projectId,
 		);
-		if (stored === null) {
-			throw new Error(
-				`The linked project is claimable, but its identity assertion is missing from ${path}. Run \`neon claim create\` in a new directory, or \`neon link\` after claiming the project.`,
-			);
-		}
 		if (assertionHasExpired(stored)) {
 			throw new Error(
-				`The identity assertion for ${linked.projectId} has expired. Run \`neon claim delete ${linked.projectId} --yes\` to drop the local record.`,
+				`The identity assertion for ${localContext.projectId} has expired. Run \`neon claim delete ${localContext.projectId} --yes\` to drop the local record.`,
 			);
 		}
 		const client = new ClaimableClient(stored.origin);
-		if (client.origin !== new ClaimableClient(linked.origin).origin) {
-			throw new Error(
-				`The linked .neon file and ${path} name different Claimable Neon services. Delete .neon or the assertion file and run \`neon claim create\` in a new directory.`,
-			);
-		}
 		let token;
 		try {
 			token = await client.exchange(stored.identityAssertion);
@@ -708,7 +703,9 @@ export const ensureAuth = async (
 		return;
 	}
 
-	if (localContext.claimable !== undefined) {
+	if (
+		readLinkedClaimableCredentials(props.configDir, localContext) !== null
+	) {
 		log.warning(
 			"This directory is linked to a claimable project, but NEON_API_KEY or NEON_PROFILE is set. This command will use that account credential instead of the unclaimed project. Unset them to keep using the unclaimed project.",
 		);

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -9,6 +9,7 @@ import { join } from "node:path";
 import strip from "strip-ansi";
 import { afterEach, beforeAll, describe, expect, test } from "vitest";
 import {
+	claimableCredentialsPath,
 	readClaimableCredentials,
 	writeClaimableCredentials,
 } from "../claimable/state.js";
@@ -246,6 +247,44 @@ describe("claim status and delete after the assertion expires", () => {
 		expect(code).toBe(1);
 		expect(stderr).toContain("not linked to a claimable project");
 		expect(stderr).not.toContain("identity assertion is missing");
+		expect(reachedClaimableService(stderr)).toBe(false);
+	});
+
+	test("status of an explicit project does not parse a leftover linked assertion", async () => {
+		const linkedProjectId = "patient-art-12345";
+		const { code, stdout, stderr } = await runCli(
+			[
+				"claim",
+				"status",
+				expiredCredentials.projectId,
+				"--output",
+				"json",
+			],
+			{},
+			({ configDir, contextFile }) => {
+				writeFileSync(
+					contextFile,
+					JSON.stringify({
+						projectId: linkedProjectId,
+						branch: "main",
+					}),
+				);
+				writeFileSync(
+					claimableCredentialsPath(configDir, linkedProjectId),
+					"{",
+					{ mode: 0o600 },
+				);
+				writeClaimableCredentials(configDir, expiredCredentials);
+			},
+		);
+
+		expect(code).toBe(0);
+		expect(stderr).toBe("");
+		expect(JSON.parse(stdout)).toMatchObject({
+			project_id: expiredCredentials.projectId,
+			state: "expired",
+			reconciled: false,
+		});
 		expect(reachedClaimableService(stderr)).toBe(false);
 	});
 

--- a/packages/cli/src/commands/claim.cli.test.ts
+++ b/packages/cli/src/commands/claim.cli.test.ts
@@ -204,6 +204,51 @@ describe("claim status and delete after the assertion expires", () => {
 		).toBeNull();
 	});
 
+	test("status with a regular .neon and no assertion is not a missing identity", async () => {
+		const { code, stderr } = await runCli(
+			["claim", "status"],
+			{},
+			({ contextFile }) => {
+				writeFileSync(
+					contextFile,
+					JSON.stringify({
+						projectId: "patient-art-12345",
+						branch: "main",
+					}),
+				);
+			},
+		);
+
+		expect(code).toBe(1);
+		expect(stderr).toContain("not linked to a claimable project");
+		expect(stderr).not.toContain("identity assertion is missing");
+		expect(reachedClaimableService(stderr)).toBe(false);
+	});
+
+	test("status with a leftover claimable field and no assertion is not a missing identity", async () => {
+		const { code, stderr } = await runCli(
+			["claim", "status"],
+			{},
+			({ contextFile }) => {
+				writeFileSync(
+					contextFile,
+					JSON.stringify({
+						projectId: "patient-art-12345",
+						claimable: {
+							version: 1,
+							origin: "https://claimable.neon.tech",
+						},
+					}),
+				);
+			},
+		);
+
+		expect(code).toBe(1);
+		expect(stderr).toContain("not linked to a claimable project");
+		expect(stderr).not.toContain("identity assertion is missing");
+		expect(reachedClaimableService(stderr)).toBe(false);
+	});
+
 	test("accept refuses an expired assertion without contacting the service", async () => {
 		const { code, stderr } = await runCli(
 			["claim", "accept", expiredCredentials.projectId, "--no-open"],

--- a/packages/cli/src/commands/claim.create.env.test.ts
+++ b/packages/cli/src/commands/claim.create.env.test.ts
@@ -2,6 +2,7 @@ import {
 	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readFileSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
@@ -366,7 +367,7 @@ describe("claim create env pull", () => {
 	it("writes DATABASE_URL, DATABASE_URL_UNPOOLED, and NEON_BRANCH", async () => {
 		const service = await startService();
 		const api = new FakeNeonApi();
-		const { cwd } = await runCreate(service.origin, api);
+		const { cwd, contextFile } = await runCreate(service.origin, api);
 
 		const env = readEnvFile(join(cwd, ".env.local"));
 		expect(env.DATABASE_URL).toContain("-pooler.fake.neon.tech");
@@ -374,6 +375,10 @@ describe("claim create env pull", () => {
 			`${BRANCH_ID}.fake.neon.tech`,
 		);
 		expect(env.NEON_BRANCH).toBe(BRANCH_NAME);
+		expect(JSON.parse(readFileSync(contextFile, "utf8"))).toEqual({
+			projectId: PROJECT_ID,
+			branch: BRANCH_ID,
+		});
 		expect(api.credentialCreateCalls).toBe(0);
 		expect(
 			service.seen.some((entry) => entry.includes("/credentials")),
@@ -410,6 +415,10 @@ describe("claim create env pull", () => {
 
 		expect(existsSync(join(cwd, ".env.local"))).toBe(false);
 		expect(existsSync(contextFile)).toBe(true);
+		expect(JSON.parse(readFileSync(contextFile, "utf8"))).toEqual({
+			projectId: PROJECT_ID,
+			branch: BRANCH_ID,
+		});
 		expect(readClaimableCredentials(configDir, PROJECT_ID)).not.toBeNull();
 		expect(
 			service.seen.some((entry) => entry.includes("/oauth2/token")),

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -365,23 +365,35 @@ const resolveTarget = (
 	rejectExplicitAccountCredential(props);
 	const requested = props.projectId?.trim();
 	const context = readContextFile(props.contextFile);
+	if (requested) {
+		const credentials = readClaimableCredentials(
+			props.configDir,
+			requested,
+		);
+		if (credentials === null) {
+			throw new Error(
+				`The identity assertion for ${requested} is missing. The project cannot be managed from this machine; claim it through its existing verification URL or run \`neon link\` after it is claimed.`,
+			);
+		}
+		return {
+			projectId: requested,
+			credentials,
+			client: new ClaimableClient(credentials.origin),
+			contextMatches: context.projectId === requested,
+		};
+	}
 	const linked = readLinkedClaimableCredentials(props.configDir, context);
-	const projectId =
-		requested || (linked !== null ? context.projectId : undefined);
-	if (projectId === undefined) {
+	if (linked === null) {
 		throw new Error(
 			"This directory is not linked to a claimable project. Pass a project id from `neon claim list`, or run `neon claim create` first.",
 		);
 	}
-	const credentials = readClaimableCredentials(props.configDir, projectId);
-	if (credentials === null) {
-		throw new Error(
-			`The identity assertion for ${projectId} is missing. The project cannot be managed from this machine; claim it through its existing verification URL or run \`neon link\` after it is claimed.`,
-		);
-	}
-	const client = new ClaimableClient(credentials.origin);
-	const contextMatches = context.projectId === projectId;
-	return { projectId, credentials, client, contextMatches };
+	return {
+		projectId: linked.projectId,
+		credentials: linked,
+		client: new ClaimableClient(linked.origin),
+		contextMatches: true,
+	};
 };
 
 const requireLiveIdentity = (credentials: StoredClaimableCredentials): void => {

--- a/packages/cli/src/commands/claim.ts
+++ b/packages/cli/src/commands/claim.ts
@@ -18,8 +18,8 @@ import {
 	assertionHasExpired,
 	listClaimableCredentials,
 	readClaimableCredentials,
+	readLinkedClaimableCredentials,
 	removeClaimableCredentials,
-	resolveClaimableContext,
 	type StoredClaimableCredentials,
 	writeClaimableCredentials,
 } from "../claimable/state.js";
@@ -365,8 +365,9 @@ const resolveTarget = (
 	rejectExplicitAccountCredential(props);
 	const requested = props.projectId?.trim();
 	const context = readContextFile(props.contextFile);
-	const linked = resolveClaimableContext(context);
-	const projectId = requested || linked?.projectId;
+	const linked = readLinkedClaimableCredentials(props.configDir, context);
+	const projectId =
+		requested || (linked !== null ? context.projectId : undefined);
 	if (projectId === undefined) {
 		throw new Error(
 			"This directory is not linked to a claimable project. Pass a project id from `neon claim list`, or run `neon claim create` first.",
@@ -379,16 +380,7 @@ const resolveTarget = (
 		);
 	}
 	const client = new ClaimableClient(credentials.origin);
-	const contextMatches = linked?.projectId === projectId;
-	if (
-		contextMatches &&
-		linked !== null &&
-		client.origin !== new ClaimableClient(linked.origin).origin
-	) {
-		throw new Error(
-			"The .neon context and saved identity assertion name different Claimable Neon services. Delete .neon or the assertion file and run `neon claim create` in a new directory.",
-		);
-	}
+	const contextMatches = context.projectId === projectId;
 	return { projectId, credentials, client, contextMatches };
 };
 
@@ -420,7 +412,7 @@ const clearLocalRecord = (
 export const create = async (props: CreateProps): Promise<void> => {
 	rejectExplicitAccountCredential(props);
 	const existing = readContextFile(props.contextFile);
-	if (existing.projectId || existing.orgId || existing.claimable) {
+	if (existing.projectId || existing.orgId) {
 		throw new Error(
 			`${props.contextFile} already links this directory to a Neon project. Run \`neon claim create\` from an unlinked directory.`,
 		);
@@ -461,7 +453,6 @@ export const create = async (props: CreateProps): Promise<void> => {
 		applyContext(props.contextFile, {
 			projectId: registration.project.id,
 			branch: registration.project.branchId,
-			claimable: { version: 1, origin: client.origin },
 		});
 		contextWritten = true;
 
@@ -481,6 +472,7 @@ export const create = async (props: CreateProps): Promise<void> => {
 				apiClient,
 				apiKey: token.accessToken,
 				apiHost,
+				configDir: props.configDir,
 				contextFile: props.contextFile,
 				output: props.output,
 				projectId: registration.project.id,

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -45,6 +45,7 @@ type DevProps = CommonProps & {
 	projectId?: string;
 	branch?: string;
 	id?: string;
+	configDir?: string;
 };
 
 export const command = "dev";
@@ -116,7 +117,7 @@ export const builder = (argv: yargs.Argv) =>
  *   reason; `dev` was the one that didn't.
  */
 export const devEnvContext = (
-	props: Pick<DevProps, "projectId" | "apiKey" | "apiHost"> & {
+	props: Pick<DevProps, "projectId" | "apiKey" | "apiHost" | "configDir"> & {
 		contextFile?: string;
 	},
 	branchId: string | undefined,
@@ -137,6 +138,7 @@ export const devEnvContext = (
 		...(isClaimableEnvTarget({
 			apiHost: props.apiHost,
 			contextFile: props.contextFile ?? "",
+			configDir: props.configDir ?? "",
 		})
 			? { claimable: true }
 			: {}),

--- a/packages/cli/src/commands/env.test.ts
+++ b/packages/cli/src/commands/env.test.ts
@@ -1,5 +1,6 @@
 import {
 	existsSync,
+	mkdirSync,
 	mkdtempSync,
 	readFileSync,
 	rmSync,
@@ -30,6 +31,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import yargs from "yargs/yargs";
 
 import { clearAuthContext, setAuthContext } from "../auth_context.js";
+import { writeClaimableCredentials } from "../claimable/state.js";
 import { readEnvFile } from "../env_file.js";
 import {
 	autoPullEnvAfterPin,
@@ -1363,24 +1365,40 @@ describe("env pull with the AI Gateway implied (no neon.ts)", () => {
 const CLAIMABLE_ORIGIN = "https://claimable.neon.tech";
 const CLAIMABLE_API_HOST = `${CLAIMABLE_ORIGIN}/v1`;
 
-const writeClaimableContext = (cwd: string): string => {
+const writeClaimableLink = (
+	cwd: string,
+): { contextFile: string; configDir: string } => {
 	const contextFile = join(cwd, ".neon");
+	const configDir = join(cwd, "config");
+	mkdirSync(configDir, { recursive: true });
 	writeFileSync(
 		contextFile,
 		JSON.stringify({
 			projectId: PROJECT_ID,
 			branch: BRANCH_NAME,
-			claimable: { version: 1, origin: CLAIMABLE_ORIGIN },
 		}),
 	);
-	return contextFile;
+	writeClaimableCredentials(configDir, {
+		version: 1,
+		origin: CLAIMABLE_ORIGIN,
+		registrationId: "reg_test",
+		projectId: PROJECT_ID,
+		branchId: BRANCH_ID,
+		identityAssertion: "signed-identity-assertion",
+		expiresAt: "2027-01-01T00:00:00.000Z",
+	});
+	return { contextFile, configDir };
 };
 
-const claimableProps = (api: FakeNeonApi, cwd: string): EnvPullProps => ({
-	...baseProps(api, cwd),
-	contextFile: writeClaimableContext(cwd),
-	apiHost: CLAIMABLE_API_HOST,
-});
+const claimableProps = (api: FakeNeonApi, cwd: string): EnvPullProps => {
+	const { contextFile, configDir } = writeClaimableLink(cwd);
+	return {
+		...baseProps(api, cwd),
+		contextFile,
+		configDir,
+		apiHost: CLAIMABLE_API_HOST,
+	};
+};
 
 describe("env pull on a claimable project", () => {
 	let cwd: string;
@@ -1431,13 +1449,14 @@ describe("env pull on a claimable project", () => {
 		expect(api.credentialCreateCalls).toBe(0);
 	});
 
-	it("still implies the AI Gateway when a claimable marker is overridden by the Neon API host", async () => {
+	it("still implies the AI Gateway when a credential file is overridden by the Neon API host", async () => {
 		const api = new FakeNeonApi();
-		writeClaimableContext(cwd);
+		const { contextFile, configDir } = writeClaimableLink(cwd);
 		await pull(
 			{
 				...baseProps(api, cwd),
-				contextFile: join(cwd, ".neon"),
+				contextFile,
+				configDir,
 			},
 			{ implyAiGateway: true },
 		);
@@ -1448,7 +1467,30 @@ describe("env pull on a claimable project", () => {
 		);
 	});
 
-	it("still skips minting when checkout dropped the marker but auth is claimable", async () => {
+	it("still skips minting after checkout rewrote .neon without a claimable field", async () => {
+		const api = new FakeNeonApi();
+		const { contextFile, configDir } = writeClaimableLink(cwd);
+		writeFileSync(
+			contextFile,
+			JSON.stringify({ projectId: PROJECT_ID, branch: BRANCH_NAME }),
+		);
+		await pull(
+			{
+				...baseProps(api, cwd),
+				contextFile,
+				configDir,
+				apiHost: CLAIMABLE_API_HOST,
+			},
+			{ implyAiGateway: true },
+		);
+
+		expect(api.credentialCreateCalls).toBe(0);
+		expect(readFileSync(join(cwd, ".env.local"), "utf8")).not.toContain(
+			"NEON_AI_GATEWAY",
+		);
+	});
+
+	it("still skips minting when auth is claimable even without a credential file", async () => {
 		const api = new FakeNeonApi();
 		setAuthContext({ source: "claimable", configDir: cwd });
 		await pull(baseProps(api, cwd), { implyAiGateway: true });

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -58,6 +58,11 @@ export type EnvPullProps = BranchScopeProps & {
 	 * by walking cwd.
 	 */
 	config?: string;
+	/**
+	 * CLI config directory. Claimable env resolve looks up the assertion file
+	 * here; `.neon` is identifiers only.
+	 */
+	configDir?: string;
 };
 
 export const command = "env";
@@ -256,7 +261,11 @@ export const pull = async (
 	opts: { announce?: boolean; implyAiGateway?: boolean } = {},
 ): Promise<PullOutcome> => {
 	const cwd = props.cwd ?? process.cwd();
-	const claimable = isClaimableEnvTarget(props);
+	const claimable = isClaimableEnvTarget({
+		apiHost: props.apiHost,
+		contextFile: props.contextFile,
+		configDir: props.configDir ?? "",
+	});
 	const dropped =
 		claimable &&
 		(props.services !== undefined || props.envKeys !== undefined)

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -5,12 +5,6 @@ import type yargs from "yargs";
 
 import { log } from "./log.js";
 
-export type ClaimableContext = {
-	version: 1;
-	/** Omits the `/v1` API prefix. */
-	origin: string;
-};
-
 export type Context = {
 	orgId?: string;
 	projectId?: string;
@@ -26,7 +20,6 @@ export type Context = {
 	 * dropped the next time the context is written.
 	 */
 	branchId?: string;
-	claimable?: ClaimableContext;
 };
 
 /**


### PR DESCRIPTION
## Problem

`neon claim create` writes a Claimable project into `.neon`. Later commands are supposed to keep using that unclaimed project.

They don't, after `neon checkout`. `applyContext` replaces the whole file. Checkout writes project id and branch, and the next process has no Claimable selector, so it falls through to account OAuth.

```json
{
  "projectId": "spring-fog-53223520",
  "branch": "br-bitter-shape-aeqvnrl8",
  "claimable": { "version": 1, "origin": "https://claimable.neon.tech" }
}
```

The identity assertion already lives in `claimable-credential.<projectId>.json` and already stores `origin`. The object in `.neon` is a second copy that checkout deletes.

## Diagnosis

Auth keyed off `.neon.claimable`, not the assertion file.

`shouldUseClaimableCredentials` was true only when that field parsed. Same-process `env pull` still worked because auth source was already `claimable`. A new process after checkout did not.

The origin in `.neon` was only compared to the origin in the assertion file.

## Interface

`.neon` is identifiers:

```json
{
  "projectId": "spring-fog-53223520",
  "branch": "br-bitter-shape-aeqvnrl8"
}
```

```bash
neon claim create
neon env pull
neon checkout main
neon env pull
neon claim status
neon claim delete --yes
```

No account flag, no `NEON_API_KEY`: if that project id has an assertion file, the CLI exchanges it and talks to Claimable Neon.

`--api-key`, `NEON_API_KEY`, `--profile`, and `NEON_PROFILE` still override. The warning fires when the assertion file exists, not when `.neon` had a `claimable` field.

`neon claim status` with no project id in a regular linked directory (project id, no assertion file) still errors with "not linked to a claimable project". It does not say the identity assertion is missing.

`neon claim status|accept|delete <id>` reads only that project's assertion. A leftover file for the directory's project is not consulted.

Leftover `"claimable": { ... }` keys in an old `.neon` are ignored. They are not migrated. The next write of `.neon` drops them.

`neon claim create --config` still uses that file for registration and the bundled pull. Create forwards `configDir` into that pull.

## Also in here

- README claim section: `.neon` is project id and branch; later commands look up the assertion file, including `neon checkout`.
- Patch changeset on `neon`.
- A project id that could not have an assertion file (the `set-context` tests use `"new-project id"`) does not throw during auth routing.
- A leftover assertion that is not valid JSON still fails Claimable auth, and does not block `--api-key` / `NEON_API_KEY`.

## Verification

Against live Claimable Neon, source CLI, isolated `--config-dir`, `NEON_API_KEY` unset:

```text
neon claim create
# .neon is projectId + branch, no claimable key
# new process: neon env pull  → DATABASE_URL, DATABASE_URL_UNPOOLED, NEON_BRANCH
# new process: neon claim status → unclaimed
neon checkout br-bitter-shape-aeqvnrl8
# .neon branch becomes main; new process env pull still Claimable
neon claim delete --yes
```

`pnpm --filter neon test:ci` on the identifiers-only change: 4507 passed, 6 skipped.

Added coverage:

- identifiers-only `.neon` plus assertion file selects Claimable auth
- leftover `claimable` field with a file still uses the file's origin
- leftover field without a file does not select Claimable auth; `claim status` says not linked
- checkout-shaped `.neon` without a `claimable` field still skips minting
- create writes no `claimable` key, including `--no-env-pull`
- `claim status` in a regular linked directory is not "identity assertion is missing"
- `"new-project id"` does not throw on routing
- leftover assertion that is not valid JSON fails Claimable auth and does not block `--api-key`
- `claim status <id>` does not parse a leftover linked assertion

Not verified: `neon dev` on an unclaimed project after this change. Live e2e `claim.e2e.test.ts` now asserts `.neon` shape; that job runs in CI.

## For your attention

- An assertion file for a project id selects Claimable auth in every directory whose `.neon` names that id, until `claim delete` / claimed status removes the file.
- `claim create` still stores the branch **id**. `checkout` then rewrites it to the branch **name**. Unchanged.
