### PR TITLE
Skip OAuth for neon inspect db --db-url

### DIFF
--- a/.changeset/inspect-db-url-skip-auth.md
+++ b/.changeset/inspect-db-url-skip-auth.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+`neon inspect db --db-url` connects with the connection string and no longer opens a browser login.

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -824,6 +824,105 @@ describe("ensureAuth", () => {
 		expect(props.apiKey).toBe("valid-token");
 	});
 
+	test("should skip global auth for inspect db --db-url", async ({
+		runMockServer,
+	}) => {
+		const server = await runMockServer("main");
+		const originalArgv = process.argv;
+		const credentialsPath = join(configDir, "credentials.json");
+		if (existsSync(credentialsPath)) {
+			rmSync(credentialsPath);
+		}
+
+		process.argv = [
+			"node",
+			"neon",
+			"inspect",
+			"db",
+			"table-sizes",
+			"--db-url",
+			"postgresql://127.0.0.1:1/postgres",
+		];
+		try {
+			await ensureAuth({
+				...setupTestProps(server),
+				_: ["inspect", "db", "table-sizes"],
+			});
+		} finally {
+			process.argv = originalArgv;
+		}
+
+		expect(authSpy).not.toHaveBeenCalled();
+		expect(refreshTokenSpy).not.toHaveBeenCalled();
+	});
+
+	test("inspect db --db-url does not refresh or refuse broken stored credentials", async ({
+		runMockServer,
+	}) => {
+		const server = await runMockServer("main");
+		const originalArgv = process.argv;
+		writeFileSync(join(configDir, "credentials.json"), "invalid json", {
+			mode: 0o700,
+		});
+
+		process.argv = [
+			"node",
+			"neon",
+			"inspect",
+			"db",
+			"locks",
+			"--db-url=postgresql://127.0.0.1:1/postgres",
+		];
+		try {
+			await ensureAuth({
+				...setupTestProps(server),
+				_: ["inspect", "db", "locks"],
+			});
+		} finally {
+			process.argv = originalArgv;
+		}
+
+		expect(authSpy).not.toHaveBeenCalled();
+		expect(refreshTokenSpy).not.toHaveBeenCalled();
+	});
+
+	test("inspect db --db-url does not refresh an expired stored token", async ({
+		runMockServer,
+	}) => {
+		const server = await runMockServer("main");
+		const originalArgv = process.argv;
+		writeFileSync(
+			join(configDir, "credentials.json"),
+			JSON.stringify({
+				access_token: "expired-token",
+				refresh_token: "refresh-token",
+				expires_at: Date.now() - 3600 * 1000,
+			}),
+			{ mode: 0o700 },
+		);
+
+		process.argv = [
+			"node",
+			"neon",
+			"inspect",
+			"db",
+			"table-sizes",
+			"--db-url",
+			"postgresql://127.0.0.1:1/postgres",
+		];
+		try {
+			await ensureAuth({
+				...setupTestProps(server),
+				_: ["inspect", "db", "table-sizes"],
+			});
+		} finally {
+			process.argv = originalArgv;
+		}
+
+		expect(authSpy).not.toHaveBeenCalled();
+		expect(refreshTokenSpy).not.toHaveBeenCalled();
+	});
+
 	test("should skip global auth for ask command", async ({
 		runMockServer,
 	}) => {

--- a/packages/cli/src/commands/auth.test.ts
+++ b/packages/cli/src/commands/auth.test.ts
@@ -828,29 +828,16 @@ describe("ensureAuth", () => {
 		runMockServer,
 	}) => {
 		const server = await runMockServer("main");
-		const originalArgv = process.argv;
 		const credentialsPath = join(configDir, "credentials.json");
 		if (existsSync(credentialsPath)) {
 			rmSync(credentialsPath);
 		}
 
-		process.argv = [
-			"node",
-			"neon",
-			"inspect",
-			"db",
-			"table-sizes",
-			"--db-url",
-			"postgresql://127.0.0.1:1/postgres",
-		];
-		try {
-			await ensureAuth({
-				...setupTestProps(server),
-				_: ["inspect", "db", "table-sizes"],
-			});
-		} finally {
-			process.argv = originalArgv;
-		}
+		await ensureAuth({
+			...setupTestProps(server),
+			_: ["inspect", "db", "table-sizes"],
+			dbUrl: "postgresql://127.0.0.1:1/postgres",
+		});
 
 		expect(authSpy).not.toHaveBeenCalled();
 		expect(refreshTokenSpy).not.toHaveBeenCalled();
@@ -860,27 +847,15 @@ describe("ensureAuth", () => {
 		runMockServer,
 	}) => {
 		const server = await runMockServer("main");
-		const originalArgv = process.argv;
 		writeFileSync(join(configDir, "credentials.json"), "invalid json", {
 			mode: 0o700,
 		});
 
-		process.argv = [
-			"node",
-			"neon",
-			"inspect",
-			"db",
-			"locks",
-			"--db-url=postgresql://127.0.0.1:1/postgres",
-		];
-		try {
-			await ensureAuth({
-				...setupTestProps(server),
-				_: ["inspect", "db", "locks"],
-			});
-		} finally {
-			process.argv = originalArgv;
-		}
+		await ensureAuth({
+			...setupTestProps(server),
+			_: ["inspect", "db", "locks"],
+			dbUrl: "postgresql://127.0.0.1:1/postgres",
+		});
 
 		expect(authSpy).not.toHaveBeenCalled();
 		expect(refreshTokenSpy).not.toHaveBeenCalled();
@@ -890,7 +865,6 @@ describe("ensureAuth", () => {
 		runMockServer,
 	}) => {
 		const server = await runMockServer("main");
-		const originalArgv = process.argv;
 		writeFileSync(
 			join(configDir, "credentials.json"),
 			JSON.stringify({
@@ -901,23 +875,11 @@ describe("ensureAuth", () => {
 			{ mode: 0o700 },
 		);
 
-		process.argv = [
-			"node",
-			"neon",
-			"inspect",
-			"db",
-			"table-sizes",
-			"--db-url",
-			"postgresql://127.0.0.1:1/postgres",
-		];
-		try {
-			await ensureAuth({
-				...setupTestProps(server),
-				_: ["inspect", "db", "table-sizes"],
-			});
-		} finally {
-			process.argv = originalArgv;
-		}
+		await ensureAuth({
+			...setupTestProps(server),
+			_: ["inspect", "db", "table-sizes"],
+			dbUrl: "postgresql://127.0.0.1:1/postgres",
+		});
 
 		expect(authSpy).not.toHaveBeenCalled();
 		expect(refreshTokenSpy).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -87,6 +87,7 @@ type AuthProps = {
 	profile?: string;
 	keyring?: boolean;
 	contextFile?: string | ((cwd?: string) => string);
+	dbUrl?: string;
 };
 
 export const locationForAuth = (

--- a/packages/cli/src/commands/auth.ts
+++ b/packages/cli/src/commands/auth.ts
@@ -55,6 +55,7 @@ import {
 	isClaimCommand,
 	isConfigInit,
 	isCurrentBranchProbe,
+	isInspectDbUrl,
 	isMcpCommand,
 	isMcpOauth,
 	isPluginsCommand,
@@ -582,6 +583,11 @@ export const ensureAuth = async (
 	}
 
 	if (isMcpOauth(props)) {
+		return;
+	}
+
+	// `--db-url` is a Postgres URI; project/branch resolution is skipped.
+	if (isInspectDbUrl(props)) {
 		return;
 	}
 

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -83,6 +83,49 @@ describe("inspect db", () => {
 		expect(stderr).not.toMatch(/Cannot run interactive auth in CI/);
 	});
 
+	test("empty --db-url still requires Neon credentials", async ({
+		testCliCommand,
+	}) => {
+		const { stderr } = await testCliCommand(
+			["inspect", "db", "table-sizes", "--db-url="],
+			{
+				apiKey: false,
+				code: 1,
+				snapshot: false,
+				env: { CI: "true" },
+				stderr: expect.stringMatching(
+					/Cannot run interactive auth in CI/,
+				),
+			},
+		);
+		expect(stderr).not.toMatch(/Cannot read properties of null/);
+	});
+
+	test("-- after options does not treat a later --db-url as the flag", async ({
+		testCliCommand,
+	}) => {
+		const { stderr } = await testCliCommand(
+			[
+				"inspect",
+				"db",
+				"table-sizes",
+				"--",
+				"--db-url",
+				UNREACHABLE_DB_URL,
+			],
+			{
+				apiKey: false,
+				code: 1,
+				snapshot: false,
+				env: { CI: "true" },
+				stderr: expect.stringMatching(
+					/Cannot run interactive auth in CI/,
+				),
+			},
+		);
+		expect(stderr).not.toMatch(/Cannot read properties of null/);
+	});
+
 	test("locks --db-url bypasses the API and reports a Postgres connection error", async ({
 		testCliCommand,
 	}) => {

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -65,6 +65,24 @@ describe("inspect db", () => {
 		);
 	});
 
+	test("table-sizes --db-url does not require Neon credentials", async ({
+		testCliCommand,
+	}) => {
+		const { stderr } = await testCliCommand(
+			["inspect", "db", "table-sizes", "--db-url", UNREACHABLE_DB_URL],
+			{
+				apiKey: false,
+				code: 1,
+				snapshot: false,
+				env: { CI: "true" },
+				stderr: expect.stringMatching(
+					/Could not connect to Postgres at 127\.0\.0\.1:1/,
+				),
+			},
+		);
+		expect(stderr).not.toMatch(/Cannot run interactive auth in CI/);
+	});
+
 	test("locks --db-url bypasses the API and reports a Postgres connection error", async ({
 		testCliCommand,
 	}) => {

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -107,50 +107,37 @@ describe("isAskCommand", () => {
 });
 
 describe("isInspectDbUrl", () => {
-	const originalArgv = process.argv;
-
-	afterEach(() => {
-		process.argv = originalArgv;
+	test("is true for inspect and inspection with a nonempty --db-url", () => {
+		expect(
+			isInspectDbUrl({
+				_: ["inspect", "db", "table-sizes"],
+				dbUrl: "postgresql://localhost/postgres",
+			}),
+		).toBe(true);
+		expect(
+			isInspectDbUrl({
+				_: ["inspection", "db", "locks"],
+				dbUrl: "postgresql://localhost/postgres",
+			}),
+		).toBe(true);
 	});
 
-	test("is true for inspect and inspection with --db-url", () => {
-		process.argv = [
-			"node",
-			"neon",
-			"inspect",
-			"db",
-			"table-sizes",
-			"--db-url",
-			"postgresql://localhost/postgres",
-		];
-		expect(isInspectDbUrl({ _: ["inspect", "db", "table-sizes"] })).toBe(
-			true,
-		);
-		process.argv = [
-			"node",
-			"neon",
-			"inspection",
-			"db",
-			"locks",
-			"--db-url=postgresql://localhost/postgres",
-		];
-		expect(isInspectDbUrl({ _: ["inspection", "db", "locks"] })).toBe(true);
-	});
-
-	test("is false without --db-url or on another command", () => {
-		process.argv = ["node", "neon", "inspect", "db", "table-sizes"];
+	test("is false without a nonempty --db-url or on another command", () => {
 		expect(isInspectDbUrl({ _: ["inspect", "db", "table-sizes"] })).toBe(
 			false,
 		);
-		process.argv = [
-			"node",
-			"neon",
-			"projects",
-			"list",
-			"--db-url",
-			"postgresql://localhost/postgres",
-		];
-		expect(isInspectDbUrl({ _: ["projects", "list"] })).toBe(false);
+		expect(
+			isInspectDbUrl({
+				_: ["inspect", "db", "table-sizes"],
+				dbUrl: "",
+			}),
+		).toBe(false);
+		expect(
+			isInspectDbUrl({
+				_: ["projects", "list"],
+				dbUrl: "postgresql://localhost/postgres",
+			}),
+		).toBe(false);
 	});
 });
 

--- a/packages/cli/src/context.test.ts
+++ b/packages/cli/src/context.test.ts
@@ -15,6 +15,7 @@ import {
 	ensureGitignored,
 	isAskCommand,
 	isCurrentBranchProbe,
+	isInspectDbUrl,
 	isMcpOauth,
 	isPluginsCommand,
 	isSkillsCommand,
@@ -102,6 +103,54 @@ describe("isAskCommand", () => {
 		expect(isAskCommand({ _: ["skills"] })).toBe(false);
 		expect(isAskCommand({ _: ["mcp"] })).toBe(false);
 		expect(isAskCommand({ _: ["init"] })).toBe(false);
+	});
+});
+
+describe("isInspectDbUrl", () => {
+	const originalArgv = process.argv;
+
+	afterEach(() => {
+		process.argv = originalArgv;
+	});
+
+	test("is true for inspect and inspection with --db-url", () => {
+		process.argv = [
+			"node",
+			"neon",
+			"inspect",
+			"db",
+			"table-sizes",
+			"--db-url",
+			"postgresql://localhost/postgres",
+		];
+		expect(isInspectDbUrl({ _: ["inspect", "db", "table-sizes"] })).toBe(
+			true,
+		);
+		process.argv = [
+			"node",
+			"neon",
+			"inspection",
+			"db",
+			"locks",
+			"--db-url=postgresql://localhost/postgres",
+		];
+		expect(isInspectDbUrl({ _: ["inspection", "db", "locks"] })).toBe(true);
+	});
+
+	test("is false without --db-url or on another command", () => {
+		process.argv = ["node", "neon", "inspect", "db", "table-sizes"];
+		expect(isInspectDbUrl({ _: ["inspect", "db", "table-sizes"] })).toBe(
+			false,
+		);
+		process.argv = [
+			"node",
+			"neon",
+			"projects",
+			"list",
+			"--db-url",
+			"postgresql://localhost/postgres",
+		];
+		expect(isInspectDbUrl({ _: ["projects", "list"] })).toBe(false);
 	});
 });
 

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -112,6 +112,20 @@ export const isPluginsCommand = (args: { _: (string | number)[] }): boolean =>
 export const isAskCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "ask";
 
+/**
+ * `inspect db --db-url` talks to Postgres with the connection string. Auth
+ * middleware runs before inspect flags are parsed, so this reads raw argv.
+ */
+export const isInspectDbUrl = (args: { _: (string | number)[] }): boolean =>
+	(args._[0] === "inspect" || args._[0] === "inspection") &&
+	argvHasDbUrl(process.argv);
+
+function argvHasDbUrl(argv: readonly string[]): boolean {
+	return argv.some(
+		(arg) => arg === "--db-url" || arg.startsWith("--db-url="),
+	);
+}
+
 /** Raw argv is required because auth middleware runs before MCP flags are parsed. */
 export const isMcpOauth = (args: { _: (string | number)[] }): boolean =>
 	isMcpCommand(args) && argvEnablesMcpOauth(process.argv);

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -113,18 +113,17 @@ export const isAskCommand = (args: { _: (string | number)[] }): boolean =>
 	args._[0] === "ask";
 
 /**
- * `inspect db --db-url` talks to Postgres with the connection string. Auth
- * middleware runs before inspect flags are parsed, so this reads raw argv.
+ * `inspect db --db-url` talks to Postgres with that URI. Skip only when the
+ * parsed value is nonempty: empty `--db-url` still goes through project
+ * resolution and needs an API client.
  */
-export const isInspectDbUrl = (args: { _: (string | number)[] }): boolean =>
+export const isInspectDbUrl = (args: {
+	_: (string | number)[];
+	dbUrl?: string;
+}): boolean =>
 	(args._[0] === "inspect" || args._[0] === "inspection") &&
-	argvHasDbUrl(process.argv);
-
-function argvHasDbUrl(argv: readonly string[]): boolean {
-	return argv.some(
-		(arg) => arg === "--db-url" || arg.startsWith("--db-url="),
-	);
-}
+	typeof args.dbUrl === "string" &&
+	args.dbUrl.length > 0;
 
 /** Raw argv is required because auth middleware runs before MCP flags are parsed. */
 export const isMcpOauth = (args: { _: (string | number)[] }): boolean =>


### PR DESCRIPTION
## Problem

`neon inspect db <subcommand> --db-url <postgres-uri>` is documented as inspecting any Postgres from a connection string and skipping Neon API project/branch resolution. With no `NEON_API_KEY` and no stored profile, it still starts the browser login.

Reproduced against neon@4.14.5 (`0152006`), empty `--config-dir`, `CI=true`:

```text
node dist/index.js --config-dir $empty --no-analytics inspect db table-sizes \
  --db-url 'postgresql://user:pass@127.0.0.1:1/postgres'
# ERROR: Cannot run interactive auth in CI
```

The URI already names the host. The next step is a Postgres connect, which in this case should be `Could not connect to Postgres at 127.0.0.1:1`.

Without `--db-url`, that CI error is correct: inspect still lists endpoints, roles, and passwords through the Neon API.

## Diagnosis

`--db-url` already skips `fillSingleProject` and `resolveInspectTargets` returns the URI as-is. `ensureAuth` is global middleware and runs first. Inspect is not in its skip list (`open`, `ask`, `profile`, `mcp --oauth`, …), so a missing credential falls through to `authFlow`.

`--db-url` is a command option. Global `ensureAuth` sees the parsed `dbUrl`. Skip only when that value is a nonempty string, matching `fillSingleProjectUnlessDbUrl` and `resolveInspectTargets`. Empty `--db-url` and `-- --db-url …` still authenticate, so project resolution has an API client.

Existing `--db-url` tests always pass `--api-key test-key`, so they never hit the unauthenticated path.

## Interface

Same invocation. With `--db-url`, no Neon login:

```text
neon inspect db table-sizes --db-url 'postgresql://user:pass@127.0.0.1:1/postgres'
# ERROR: Could not connect to Postgres at 127.0.0.1:1: connect ECONNREFUSED 127.0.0.1:1
```

```text
neon inspect db table-sizes
# ERROR: Cannot run interactive auth in CI
# (unchanged when no API key / profile)
```

`inspection` is the same as `inspect`. `--db-url=` and `-- --db-url …` still authenticate. Other commands with a `dbUrl` still authenticate.

## Also in here

Patch changeset for `neon`.

## Verification

- `pnpm --filter neon exec vitest run src/context.test.ts src/commands/auth.test.ts` — 67 passed
- `pnpm --filter neon build && pnpm --filter neon exec vitest run src/commands/inspect.test.ts` — 23 passed
- `pnpm --filter neon typecheck`
- Built CLI, empty config, `CI=true`: `--db-url` to `127.0.0.1:1` prints the Postgres refused error; the same command without `--db-url` still prints `Cannot run interactive auth in CI`

Tests added:

- `inspect` / `inspection` skip auth only with a nonempty parsed `--db-url`; empty `--db-url` and another command with `dbUrl` do not
- `ensureAuth` with `--db-url` does not open OAuth, refresh, or refuse a broken credentials file or an expired token
- CLI `table-sizes --db-url` with `apiKey: false` and `CI=true` reports the Postgres connection error, not the CI auth error
- empty `--db-url=` and `-- --db-url …` with no API key still print `Cannot run interactive auth in CI`, not a null `apiClient` crash

Not run: live `pnpm test:e2e:live`, and a successful inspect against a real Postgres URI (the suite uses an unreachable port for `--db-url`).

## For your attention

- Auth is skipped only when the command is `inspect`/`inspection` and the parsed `--db-url` is nonempty. A linked `.neon` plus `neon inspect db table-sizes` still logs in.
- This does not read `DATABASE_URL`. Pass `--db-url`.
