### PR TITLE
chore: release neon@4.14.6

### DIFF
--- a/.changeset/drop-claimable-neon-marker.md
+++ b/.changeset/drop-claimable-neon-marker.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-`.neon` from `neon claim create` is the project id and branch only. Later commands use the identity assertion file, so `neon checkout` no longer drops Claimable auth.

--- a/.changeset/inspect-db-url-skip-auth.md
+++ b/.changeset/inspect-db-url-skip-auth.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-`neon inspect db --db-url` connects with the connection string and no longer opens a browser login.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neon
 
+## 4.14.6
+
+### Patch Changes
+
+- ae5d526: `.neon` from `neon claim create` is the project id and branch only. Later commands use the identity assertion file, so `neon checkout` no longer drops Claimable auth.
+- f991894: `neon inspect db --db-url` connects with the connection string and no longer opens a browser login.
+
 ## 4.14.5
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.14.5",
+	"version": "4.14.6",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.14.6
+
+### Patch Changes
+
+- Updated dependencies [ae5d526]
+- Updated dependencies [f991894]
+  - neon@4.14.6
+
 ## 4.14.5
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.14.5",
+  "version": "4.14.6",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Bumped

Direct:
- `neon` 4.14.5 → 4.14.6
- `neonctl` 4.14.5 → 4.14.6 (fixed group with `neon`)

4.14.6 includes:
- `.neon` from `neon claim create` is identifiers only; later commands use the identity assertion file
- `neon inspect db --db-url` connects with the connection string and no longer opens a browser login

## Publish after merge

Nothing publishes on merge. Dispatch `neon-pkgs.yml` in `databricks/secure-public-registry-releases-eng` once per package, leaf first:

1. `neon`
2. `neonctl`