### PR TITLE
fix(neon): ignore node_modules during config setup

### DIFF
--- a/.changeset/calm-files-ignore.md
+++ b/.changeset/calm-files-ignore.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+Ignore `node_modules/` when the CLI installs the packages needed for a Neon config.

--- a/packages/cli/src/commands/config.init.test.ts
+++ b/packages/cli/src/commands/config.init.test.ts
@@ -65,6 +65,35 @@ describe("config init", () => {
 			expect.arrayContaining(["@neon/config", "@neon/env"]),
 		);
 		expect(calls[0].cwd).toBe(workspace);
+		expect(readFileSync(join(workspace, ".gitignore"), "utf8")).toBe(
+			"node_modules/\n",
+		);
+	});
+
+	test("appends node_modules/ to an existing .gitignore before installing", async () => {
+		writeFileSync(join(workspace, ".gitignore"), "dist\n");
+
+		await initCmd({
+			cwd: workspace,
+			run: () => Promise.resolve(true),
+		});
+
+		expect(readFileSync(join(workspace, ".gitignore"), "utf8")).toBe(
+			"dist\nnode_modules/\n",
+		);
+	});
+
+	test("does not duplicate an existing node_modules gitignore entry", async () => {
+		writeFileSync(join(workspace, ".gitignore"), "node_modules\ndist\n");
+
+		await initCmd({
+			cwd: workspace,
+			run: () => Promise.resolve(true),
+		});
+
+		expect(readFileSync(join(workspace, ".gitignore"), "utf8")).toBe(
+			"node_modules\ndist\n",
+		);
 	});
 
 	test("installs with the package manager the project uses, not the one that invoked us", async () => {
@@ -147,6 +176,7 @@ describe("config init", () => {
 
 		expect(calls).toHaveLength(0);
 		expect(existsSync(join(workspace, "neon.ts"))).toBe(true);
+		expect(existsSync(join(workspace, ".gitignore"))).toBe(false);
 	});
 
 	test("--services declares the selected services and scaffolds the function source", async () => {

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -40,7 +40,11 @@ import {
 	renderNeonConfigFromView,
 } from "../config_template.js";
 
-import { contextBranch, readContextFile } from "../context.js";
+import {
+	contextBranch,
+	ensureDirectoryGitignored,
+	readContextFile,
+} from "../context.js";
 import { isCi } from "../env.js";
 import { loadEnvFileIntoProcess } from "../env_file.js";
 import { log } from "../log.js";
@@ -438,6 +442,7 @@ export const initCmd = async (props: ConfigInitProps): Promise<void> => {
 				formatInstallCommand(pm, missing),
 			);
 		} else {
+			ensureDirectoryGitignored(join(cwd, "node_modules"));
 			log.info("Installing %s with %s…", missing.join(", "), pm);
 			const ok = await run(pm, args, cwd);
 			if (!ok) {

--- a/packages/cli/src/context.ts
+++ b/packages/cli/src/context.ts
@@ -340,10 +340,24 @@ export const setContext = (file: string, context: ResolvedContext) => {
  * must not be blocked by a `.gitignore` write error.
  */
 export const ensureGitignored = (file: string): void => {
+	ensureGitignoreEntry(file, basenameOf(file));
+};
+
+/**
+ * Make sure a directory is ignored by the `.gitignore` in its parent. The written entry keeps
+ * the conventional trailing slash, while coverage checks also recognize an existing entry
+ * without one.
+ */
+export const ensureDirectoryGitignored = (directory: string): void => {
+	const normalized = directory.replace(/[\\/]+$/, "");
+	ensureGitignoreEntry(directory, `${basenameOf(normalized)}/`);
+};
+
+const ensureGitignoreEntry = (path: string, entry: string): void => {
 	try {
-		const dir = dirname(file);
-		const entry = basenameOf(file);
+		const dir = dirname(path);
 		const gitignorePath = resolve(dir, GITIGNORE_FILE);
+		const coveredEntry = entry.replace(/\/$/, "");
 
 		if (!existsSync(gitignorePath)) {
 			writeFileSync(gitignorePath, `${entry}\n`);
@@ -351,7 +365,7 @@ export const ensureGitignored = (file: string): void => {
 		}
 
 		const current = readFileSync(gitignorePath, "utf-8");
-		if (hasGitignoreEntry(current, entry)) {
+		if (hasGitignoreEntry(current, coveredEntry)) {
 			return;
 		}
 
@@ -361,7 +375,7 @@ export const ensureGitignored = (file: string): void => {
 		writeFileSync(gitignorePath, current + addition);
 	} catch (err) {
 		const message = err instanceof Error ? err.message : String(err);
-		log.debug("Failed to update .gitignore next to %s: %s", file, message);
+		log.debug("Failed to update .gitignore next to %s: %s", path, message);
 	}
 };
 


### PR DESCRIPTION
## Summary

- add `node_modules/` to `.gitignore` before automatically installing Neon config packages
- preserve existing `.gitignore` content and avoid duplicate entries
- leave `.gitignore` unchanged when installation is disabled
- add a patch changeset for `neon`

## Tests

- `pnpm --filter neon exec vitest run src/commands/config.init.test.ts -t 'installs the missing|appends node_modules|does not duplicate|--no-install'`
- `pnpm --filter neon exec vitest run src/context.test.ts`
- `pnpm exec biome check packages/cli/src/context.ts packages/cli/src/commands/config.ts packages/cli/src/commands/config.init.test.ts`
