### PR TITLE
Add neon checkout --create for missing named branches

### DIFF
--- a/.changeset/checkout-create.md
+++ b/.changeset/checkout-create.md
@@ -1,0 +1,5 @@
+---
+"neon": minor
+---
+
+`neon checkout <name> --create` creates a missing named branch, then pins it.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -440,8 +440,8 @@ The branch argument is **optional**: run `neon checkout` with no branch in an in
 
 Branch **id vs name** is detected automatically (a `br-…` value is treated as an id):
 
-- **id** — matched strictly by id. A non-existent id is a hard "not found" error (ids are server-assigned, so checkout never creates one).
-- **name** — matched by name. If the name doesn't exist, in an interactive terminal `checkout` offers to **create** it (equivalent to `neon branch create --name <name>`: branched from the project's default branch with a read-write compute), then checks it out. In a non-interactive context a missing name is the usual "not found" error.
+- **id** — matched strictly by id. A non-existent id is a hard "not found" error (ids are server-assigned, so checkout never creates one, including with `--create`).
+- **name** — matched by name. If the name doesn't exist, pass `--create` to create it (equivalent to `neon branch create --name <name>`: branched from the project's default branch with a read-write compute, or from `neon.ts` when that file is present), then check it out. `--create` is a no-op when the name already exists. Without `--create`, an interactive terminal offers to create the branch; in CI or with no TTY the error names `--create`.
 
 The project is resolved through the standard neon chain, each entry winning over the next:
 
@@ -457,11 +457,15 @@ The resolved branch is then written (by name) to the same `.neon` file `link` us
 $ neon checkout main --project-id polished-snowflake-12345678
 INFO: Checked out branch br-main-branch-87654321 on project polished-snowflake-12345678. Updated /path/to/cwd/.neon.
 
+$ neon checkout dev --create --project-id polished-snowflake-12345678
+INFO: Created branch dev (br-dev-branch-12345678).
+INFO: Checked out branch br-dev-branch-12345678 on project polished-snowflake-12345678. Updated /path/to/cwd/.neon.
+
 $ cat .neon
 {
   "orgId": "org-abc123",
   "projectId": "polished-snowflake-12345678",
-  "branch": "main"
+  "branch": "dev"
 }
 ```
 

--- a/packages/cli/e2e/branches.e2e.test.ts
+++ b/packages/cli/e2e/branches.e2e.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { apiRequest } from "@neon/e2e-harness";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import {
@@ -233,5 +236,76 @@ describe.sequential("e2e — neon CLI branch commands against the real API", () 
 			projectId,
 		]);
 		expect(databases.length).toBeGreaterThan(0);
+	});
+
+	it("checkout --create creates a missing branch, then is a no-op", async () => {
+		const contextFile = join(
+			mkdtempSync(join(tmpdir(), "neon-checkout-e2e-")),
+			".neon",
+		);
+
+		const missing = await runCli(
+			["checkout", "dev", "--project-id", projectId, "--no-env-pull"],
+			{ contextFile, json: false },
+		);
+		expect(missing.code).toBe(1);
+		expect(missing.stderr).toContain("Pass --create to create it");
+
+		const created = await runCli(
+			[
+				"checkout",
+				"dev",
+				"--create",
+				"--project-id",
+				projectId,
+				"--no-env-pull",
+			],
+			{ contextFile, json: false },
+		);
+		expect(created.code, created.stderr).toBe(0);
+		await waitForProjectReady(projectId);
+
+		expect(JSON.parse(readFileSync(contextFile, "utf8"))).toMatchObject({
+			projectId,
+			branch: "dev",
+		});
+
+		const listed = await runCliJson<{ id: string; name: string }[]>([
+			"branches",
+			"list",
+			"--project-id",
+			projectId,
+		]);
+		const dev = listed.find((branch) => branch.name === "dev");
+		expect(dev).toBeDefined();
+		const countAfterCreate = listed.length;
+
+		const again = await runCli(
+			[
+				"checkout",
+				"dev",
+				"--create",
+				"--project-id",
+				projectId,
+				"--no-env-pull",
+			],
+			{ contextFile, json: false },
+		);
+		expect(again.code, again.stderr).toBe(0);
+		expect(JSON.parse(readFileSync(contextFile, "utf8"))).toMatchObject({
+			projectId,
+			branch: "dev",
+		});
+
+		const listedAgain = await runCliJson<{ id: string; name: string }[]>([
+			"branches",
+			"list",
+			"--project-id",
+			projectId,
+		]);
+		expect(listedAgain.length).toBe(countAfterCreate);
+		expect(listedAgain.find((branch) => branch.name === "dev")?.id).toBe(
+			dev?.id,
+		);
 	});
 });

--- a/packages/cli/e2e/claim.e2e.test.ts
+++ b/packages/cli/e2e/claim.e2e.test.ts
@@ -106,6 +106,28 @@ describe.sequential("e2e — neon claim against live Claimable Neon", () => {
 				);
 				expect(fetched.id).toBe(created.project_id);
 
+				const checkout = await runCli(
+					[
+						"checkout",
+						created.branch_id,
+						"--create",
+						"--no-env-pull",
+					],
+					{
+						...anonymous,
+						configDir: createdIn.configDir,
+						contextFile: createdIn.contextFile,
+						cwd: createdIn.cwd,
+						json: false,
+					},
+				);
+				expect(checkout.code, checkout.stderr).toBe(0);
+				const afterCheckout = await runAnonymousJson<BareProject>(
+					["projects", "get", created.project_id],
+					createdIn,
+				);
+				expect(afterCheckout.id).toBe(created.project_id);
+
 				const liveStatus = await runAnonymousJson<ClaimStatus>(
 					["claim", "status", ...claimHostArgs()],
 					createdIn,

--- a/packages/cli/src/commands/__snapshots__/checkout.test.ts.snap
+++ b/packages/cli/src/commands/__snapshots__/checkout.test.ts.snap
@@ -1,8 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`checkout > --create on an existing name pins it and does not create 1`] = `""`;
+
 exports[`checkout > announces the branch currently pinned before switching to a new one 1`] = `""`;
 
 exports[`checkout > auto-detects the project when the API key maps to a single project 1`] = `""`;
+
+exports[`checkout > does not suggest --create when a branch id is missing 1`] = `""`;
+
+exports[`checkout > errors when --create is passed without a branch name 1`] = `""`;
 
 exports[`checkout > errors when a branch id is not found (ids are never auto-created) 1`] = `""`;
 

--- a/packages/cli/src/commands/checkout.test.ts
+++ b/packages/cli/src/commands/checkout.test.ts
@@ -237,7 +237,7 @@ describe("checkout", () => {
 			],
 			{
 				code: 1,
-				stderr: "ERROR: Branch does-not-exist not found. Available branches: main, test_branch, 123, test_branch_with_fixed_cu, test_branch_with_autoscaling, protected_branch",
+				stderr: "ERROR: Branch does-not-exist not found. Pass --create to create it. Available branches: main, test_branch, 123, test_branch_with_fixed_cu, test_branch_with_autoscaling, protected_branch",
 			},
 		);
 		removeFile(ctx);
@@ -254,7 +254,7 @@ describe("checkout", () => {
 		await testCliCommand(
 			[
 				"checkout",
-				"br-does-not-exist-123456",
+				"br-missing-branch-123456",
 				"--project-id",
 				"test",
 				"--context-file",
@@ -262,7 +262,7 @@ describe("checkout", () => {
 			],
 			{
 				code: 1,
-				stderr: "ERROR: Branch br-does-not-exist-123456 not found. Available branches: main, test_branch, 123, test_branch_with_fixed_cu, test_branch_with_autoscaling, protected_branch",
+				stderr: "ERROR: Branch br-missing-branch-123456 not found. Available branches: main, test_branch, 123, test_branch_with_fixed_cu, test_branch_with_autoscaling, protected_branch",
 			},
 		);
 		removeFile(ctx);
@@ -285,6 +285,67 @@ describe("checkout", () => {
 		);
 		removeFile(ctx);
 	});
+
+	test("errors when --create is passed without a branch name", async ({
+		testCliCommand,
+		removeFile,
+		tmpContext,
+	}) => {
+		const ctx = tmpContext("create_no_name");
+		await testCliCommand(["checkout", "--create", "--context-file", ctx], {
+			code: 1,
+			stderr: "ERROR: No branch specified. Pass a branch name with --create (e.g. `neon checkout dev --create`).",
+		});
+		removeFile(ctx);
+	});
+
+	test("does not suggest --create when a branch id is missing", async ({
+		testCliCommand,
+		removeFile,
+		tmpContext,
+	}) => {
+		const ctx = tmpContext("id_not_found_create");
+		await testCliCommand(
+			[
+				"checkout",
+				"br-missing-branch-123456",
+				"--create",
+				"--project-id",
+				"test",
+				"--context-file",
+				ctx,
+			],
+			{
+				code: 1,
+				stderr: "ERROR: Branch br-missing-branch-123456 not found. Available branches: main, test_branch, 123, test_branch_with_fixed_cu, test_branch_with_autoscaling, protected_branch",
+			},
+		);
+		removeFile(ctx);
+	});
+
+	test("--create on an existing name pins it and does not create", async ({
+		testCliCommand,
+		readFile,
+		tmpContext,
+	}) => {
+		const ctx = tmpContext("create_existing");
+		await testCliCommand([
+			"checkout",
+			"main",
+			"--create",
+			"--project-id",
+			"test",
+			"--no-env-pull",
+			"--env",
+			"/no/such-neon-checkout.env",
+			"--context-file",
+			ctx,
+		]);
+		expect(parseContext(readFile(ctx))).toEqual({
+			projectId: "test",
+			branch: "main",
+		});
+	});
 });
 
 describe("checkout --env", () => {
@@ -298,6 +359,21 @@ describe("checkout --env", () => {
 			},
 		);
 		expect(`${stdout}\n${stderr}`).toContain("Path to a .env file");
+	});
+
+	test("help describes --create and the create examples", async ({
+		testCliCommand,
+	}) => {
+		const { stdout, stderr } = await testCliCommand(
+			["checkout", "--help"],
+			{
+				snapshot: false,
+			},
+		);
+		const text = `${stdout}\n${stderr}`;
+		expect(text).toContain("--create");
+		expect(text).toContain("checkout dev --create");
+		expect(text).toContain("checkout feat --create --env .env.local");
 	});
 
 	test("checking out an existing branch does not load --env", async ({
@@ -333,6 +409,8 @@ describe("formatCheckoutPolicyFailure", () => {
 		expect(message).toContain(
 			"neon deploy --update-existing --env .env.local",
 		);
-		expect(message).toContain("neon checkout feat --env .env.local");
+		expect(message).toContain(
+			"neon checkout feat --create --env .env.local",
+		);
 	});
 });

--- a/packages/cli/src/commands/checkout.ts
+++ b/packages/cli/src/commands/checkout.ts
@@ -29,6 +29,7 @@ type CheckoutProps = CommonProps & {
 	id?: string;
 	envPull: boolean;
 	env?: string;
+	create?: boolean;
 	/** Global `--color` flag (default true); `--no-color` sets it false to force plain output. */
 	color?: boolean;
 };
@@ -50,7 +51,7 @@ export const formatCheckoutPolicyFailure = (opts: {
 	return [
 		`Branch ${opts.branchName} (${opts.branchId}) was created and checked out, but applying neon.ts to it failed: ${opts.failure}`,
 		`The branch is usable but does not match the policy, and \`${cli} checkout\` never reconciles a branch that already exists.`,
-		`Fix the cause above, then run \`${cli} deploy --update-existing${envArg}\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`${cli} branches delete ${opts.branchName}\` then \`${cli} checkout ${opts.branchName}${envArg}\`.`,
+		`Fix the cause above, then run \`${cli} deploy --update-existing${envArg}\` to apply the policy to it — or, if your policy only configures new branches (keyed on \`!branch.exists\`), delete the branch and check it out again: \`${cli} branches delete ${opts.branchName}\` then \`${cli} checkout ${opts.branchName} --create${envArg}\`.`,
 	].join("\n");
 };
 
@@ -75,6 +76,12 @@ export const builder = (argv: yargs.Argv) =>
 				type: "boolean",
 				default: true,
 			},
+			create: {
+				describe:
+					"Create the named branch if it does not exist, then check it out",
+				type: "boolean",
+				default: false,
+			},
 			...envFlag,
 			env: {
 				...envFlag.env,
@@ -93,7 +100,11 @@ export const builder = (argv: yargs.Argv) =>
 				'Pin the branch named "main" in the closest .neon file',
 			],
 			[
-				"$0 checkout feat --env .env.local",
+				"$0 checkout dev --create",
+				"Create and pin a missing branch named dev",
+			],
+			[
+				"$0 checkout feat --create --env .env.local",
 				"Create feat from neon.ts, loading Function env from .env.local first",
 			],
 			[
@@ -112,6 +123,12 @@ export const handler = async (props: CheckoutProps) => {
 			"%s Currently on branch %s",
 			chalk.dim("→"),
 			chalk.cyan.bold(previousBranch),
+		);
+	}
+
+	if (props.create && !props.id?.trim()) {
+		throw new Error(
+			`No branch specified. Pass a branch name with --create (e.g. \`${getCliName()} checkout dev --create\`).`,
 		);
 	}
 
@@ -210,9 +227,9 @@ const applyPolicyOrDescribeFailure = async (
  *
  * - Branch **id** (`br-…`): looked up by id. A non-existent id is a hard "not
  *   found" error — we never offer to create one, since ids are server-assigned.
- * - Branch **name**: looked up by name. If it doesn't exist, in an interactive
- *   terminal we offer to create it (like `neonctl branch create --name <name>`);
- *   in a non-interactive context it's the usual "not found" error.
+ * - Branch **name**: looked up by name. If it doesn't exist, `--create` creates
+ *   it (like `neon branch create --name <name>`). Without the flag, a TTY offers
+ *   to create it; CI / non-TTY exits with a not-found error that names `--create`.
  * - **Omitted**: open an interactive picker listing the project's branches plus a
  *   "create a new branch" option (TTY only); in a non-interactive context a missing
  *   branch is a hard error.
@@ -292,12 +309,17 @@ const resolveBranchId = async (
 		};
 	}
 
-	// Name not found: offer to create it interactively, mirroring `branch create`.
-	if (isCi() || !process.stdout.isTTY) {
-		throw new Error(notFoundMessage(ref, branches));
+	if (props.create) {
+		return createCheckoutBranch(props, projectId, ref, branches);
 	}
 
-	log.error(notFoundMessage(ref, branches));
+	const missingName = notFoundMessage(ref, branches, { suggestCreate: true });
+	// Name not found: offer to create it interactively, mirroring `branch create`.
+	if (isCi() || !process.stdout.isTTY) {
+		throw new Error(missingName);
+	}
+
+	log.error(missingName);
 	const { create } = await prompts({
 		type: "confirm",
 		name: "create",
@@ -357,8 +379,12 @@ const createCheckoutBranch = async (
 	};
 };
 
-const notFoundMessage = (ref: string, branches: Branch[]): string =>
-	`Branch ${ref} not found.\nAvailable branches: ${branches
+const notFoundMessage = (
+	ref: string,
+	branches: Branch[],
+	opts?: { suggestCreate: boolean },
+): string =>
+	`Branch ${ref} not found.${opts?.suggestCreate ? " Pass --create to create it." : ""}\nAvailable branches: ${branches
 		.map((b: Branch) => b.name)
 		.join(", ")}`;
 


### PR DESCRIPTION
## Problem

Agents and CI can't create a missing branch through `neon checkout <name>`. Creation requires an interactive confirmation, so non-TTY runs exit before reaching the existing create-and-pin flow.

## Interface

Adds `--create`, defaulting to `false`:

```bash
# Create dev if missing, then pin it in .neon
neon checkout dev --create --project-id <project-id>

# In an already-linked directory
neon checkout dev --create

# Load Function env before creating from neon.ts
neon checkout feat --create --env .env.local

# Pin without pulling environment variables
neon checkout dev --create --no-env-pull
```

| Input | Behavior |
| --- | --- |
| Missing name with `--create` | Creates and checks out the branch without a confirmation prompt |
| Existing name with `--create` | Checks out the existing branch |
| Missing name without `--create`, interactive terminal | Keeps the existing create prompt |
| Missing name without `--create`, CI or no TTY | Exits 1 with `Pass --create to create it.` and the available branches |
| Missing `br-…` id, with or without `--create` | Exits 1 with a not-found error; ids are server-assigned |
| `neon checkout --create` | Exits 1 and asks for a branch name |

The flag uses the existing creation flow: `neon.ts` controls the new branch when present; otherwise it branches from the project's default branch with a read-write compute.

Project resolution, `.neon` pinning and automatic env pull keep their existing behavior. Successful checkout logs the branch id, project id and updated context path. Plain `neon checkout` still opens the branch picker in an interactive terminal.

## Also included

- README and help examples for `--create`.
- Policy-failure recovery instructions include `--create` when recreating a deleted branch.
- A minor changeset for `neon`.

## Verification

Checkout fixture tests passed locally (18). Added coverage for:

- Missing-name guidance, missing ids with and without `--create`, missing positional input and help examples.
- Checking out an existing name with `--create`, including ignoring a nonexistent `--env` file.
- Live API creation, persisted `.neon` state and a second checkout that preserves the branch id and branch count.
- Checking out an existing Claimable Neon branch with `--create` and continuing to access the project.
- Policy-failure recovery commands retaining both `--create` and `--env`.

Live e2e was not run locally (no API key in the worktree). The added live checks use `--no-env-pull`; they don't exercise automatic env pull, policy-driven creation or the interactive prompt.

## For your attention

`--create` only creates a missing branch. Existing branches aren't reconciled against `neon.ts`. If policy application fails after creation, checkout exits nonzero with the branch still created and pinned; recovery remains `neon deploy --update-existing` or deletion followed by a new checkout with `--create`.
