### PR TITLE
chore: release @neon/sdk@4.1.0 @neon/tools@1.3.0 neon@4.15.0

### DIFF
--- a/.changeset/calm-files-ignore.md
+++ b/.changeset/calm-files-ignore.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-Ignore `node_modules/` when the CLI installs the packages needed for a Neon config.

--- a/.changeset/checkout-create.md
+++ b/.changeset/checkout-create.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-`neon checkout <name> --create` creates a missing named branch, then pins it.

--- a/.changeset/sdk-spec-refresh-triggers-credentials.md
+++ b/.changeset/sdk-spec-refresh-triggers-credentials.md
@@ -1,6 +1,0 @@
----
-"@neon/sdk": minor
-"@neon/tools": minor
----
-
-Wrap Function triggers (`neon.triggers`) and credential reveal/rotate. Create input scopes stay `CredentialScope`; responses now type `GrantedCredentialScope[]`. Branch delete no longer accepts `hard_delete`. `@neon/tools/schemas` no longer exports `zDeleteProjectBranchQuery`.

--- a/.changeset/tools-sdk-4-errors.md
+++ b/.changeset/tools-sdk-4-errors.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": patch
----
-
-Object-list failures throw `NeonClientError`.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon-internals/env-core
 
+## 0.0.11
+
+### Patch Changes
+
+- @neon/config@1.3.3
+
 ## 0.0.10
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.10",
+	"version": "0.0.11",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # neon
 
+## 4.15.0
+
+### Minor Changes
+
+- 475686f: `neon checkout <name> --create` creates a missing named branch, then pins it.
+
+### Patch Changes
+
+- 1712d73: Ignore `node_modules/` when the CLI installs the packages needed for a Neon config.
+- Updated dependencies [0d4dd06]
+  - @neon/sdk@4.1.0
+  - @neon/config@1.3.3
+  - @neon/config-runtime@1.2.4
+
 ## 4.14.6
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.14.6",
+	"version": "4.15.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 1.2.4
+
+### Patch Changes
+
+- @neon/config@1.3.3
+
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 1.3.3
+
+### Patch Changes
+
+- Updated dependencies [0d4dd06]
+  - @neon/sdk@4.1.0
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.2.4
+
+### Patch Changes
+
+- @neon/config@1.3.3
+
 ## 1.2.3
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.2.3",
+	"version": "1.2.4",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.15.0
+
+### Patch Changes
+
+- Updated dependencies [1712d73]
+- Updated dependencies [475686f]
+  - neon@4.15.0
+
 ## 4.14.6
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.14.6",
+  "version": "4.15.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/sdk
 
+## 4.1.0
+
+### Minor Changes
+
+- 0d4dd06: Wrap Function triggers (`neon.triggers`) and credential reveal/rotate. Create input scopes stay `CredentialScope`; responses now type `GrantedCredentialScope[]`. Branch delete no longer accepts `hard_delete`. `@neon/tools/schemas` no longer exports `zDeleteProjectBranchQuery`.
+
 ## 4.0.0
 
 ### Major Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @neon/tools
 
+## 1.3.0
+
+### Minor Changes
+
+- 0d4dd06: Wrap Function triggers (`neon.triggers`) and credential reveal/rotate. Create input scopes stay `CredentialScope`; responses now type `GrantedCredentialScope[]`. Branch delete no longer accepts `hard_delete`. `@neon/tools/schemas` no longer exports `zDeleteProjectBranchQuery`.
+
+### Patch Changes
+
+- fb83cc4: Object-list failures throw `NeonClientError`.
+- Updated dependencies [0d4dd06]
+  - @neon/sdk@4.1.0
+
 ## 1.2.2
 
 ### Patch Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.2.2",
+	"version": "1.3.0",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Release bump

Prepare the merged SDK, tools and CLI changes for publication. This PR consumes four Changesets and updates package versions and changelogs only.

| Package | Previous | Next | Reason |
| --- | --- | --- | --- |
| `@neon/sdk` | 4.0.0 | 4.1.0 | Function triggers (`neon.triggers`) and credential reveal/rotate |
| `@neon/tools` | 1.2.2 | 1.3.0 | Matching tools; object-list failures throw `NeonClientError` |
| `neon` | 4.14.6 | 4.15.0 | `checkout --create`; ignore `node_modules/` during config dependency setup |
| `neonctl` | 4.14.6 | 4.15.0 | Fixed-group bump with `neon` |
| `@neon/config` | 1.3.2 | 1.3.3 | Dependency cascade |
| `@neon/config-runtime` | 1.2.3 | 1.2.4 | Dependency cascade |
| `@neon/env` | 1.2.3 | 1.2.4 | Dependency cascade |

The private `@neon-internals/env-core` also advances from 0.0.10 to 0.0.11 through the dependency cascade. It is bundled into consumers and is not published separately.

The CLI release includes creating a missing named branch and pinning it:

```sh
neon checkout feature-branch --create
```

## Verification

- `pnpm lint:ci` passed: 752 files checked.
- `git diff --check origin/main...HEAD` passed.
- Reviewed the diff at `8315c4c`: only Changeset deletions, version bumps and changelog entries.
- Build, tests and live API flows were not rerun for this metadata-only PR.

## For your attention

- The SDK/tools changelogs include compatibility changes: branch deletion drops `hard_delete`, `@neon/tools/schemas` drops `zDeleteProjectBranchQuery` and credential responses use `GrantedCredentialScope[]`. Credential creation inputs remain `CredentialScope`.
- Merging lands the versions on `main`. Publication requires a separate manual workflow after merge, with dependencies published before consumers and `neon` before `neonctl`.
