### PR TITLE
fix(cli): handle disabled LFC in inspect

### DIFF
--- a/.changeset/inspect-disabled-lfc.md
+++ b/.changeset/inspect-disabled-lfc.md
@@ -1,0 +1,5 @@
+---
+"neon": patch
+---
+
+`neon inspect db lfc-hit-rate` and `working-set` now explain that the cache is served from `shared_buffers` when the Local File Cache is disabled.

--- a/packages/cli/src/commands/inspect.test.ts
+++ b/packages/cli/src/commands/inspect.test.ts
@@ -4,6 +4,7 @@ import { describe, expect } from "vitest";
 import { test } from "../test_utils/fixtures";
 import { INSPECT_QUERIES } from "../utils/inspect_queries.js";
 import { writer } from "../writer.js";
+import { visibleInspectFields } from "./inspect.js";
 
 // `inspect db` opens a real Postgres connection with the embedded wire client,
 // so these tests drive the hermetic `--db-url` path: point at a port nothing is
@@ -181,6 +182,57 @@ describe("inspect db", () => {
 				"Local File Cache hit rate (compute-wide",
 			),
 		});
+	});
+
+	test("cache checks keep disabled-LFC notes separate from metric values", () => {
+		const hitRate = INSPECT_QUERIES["lfc-hit-rate"];
+		const workingSet = INSPECT_QUERIES["working-set"];
+
+		expect(
+			visibleInspectFields(
+				hitRate,
+				[{ name: "lfc hit rate", ratio: 0.9, note: null }],
+				false,
+			),
+		).toEqual(["name", "ratio"]);
+		expect(
+			visibleInspectFields(
+				hitRate,
+				[{ name: "lfc hit rate", ratio: null, note: "LFC disabled" }],
+				false,
+			),
+		).toEqual(["name", "note"]);
+		expect(
+			visibleInspectFields(
+				workingSet,
+				[
+					{
+						window: null,
+						working_set: null,
+						lfc_size: null,
+						exceeds_lfc: null,
+						note: "LFC disabled",
+					},
+				],
+				false,
+			),
+		).toEqual(["note"]);
+	});
+
+	test.each([
+		"lfc-hit-rate",
+		"working-set",
+	] as const)("%s guards Neon metrics when LFC is disabled", (name) => {
+		const sql = INSPECT_QUERIES[name].sql;
+
+		expect(sql).toContain(
+			"current_setting('neon.file_cache_size_limit', true)",
+		);
+		expect(sql).toContain("WHEN settings.lfc_bytes > 0 THEN");
+		expect(sql).toContain(
+			"LFC disabled; cache is served from shared_buffers",
+		);
+		expect(sql).toContain("Compute cache hit rate metric");
 	});
 
 	test("stalled-queries is compute-wide and preserves its diagnostic fields", () => {

--- a/packages/cli/src/commands/inspect.ts
+++ b/packages/cli/src/commands/inspect.ts
@@ -37,6 +37,21 @@ const fillSingleProjectUnlessDbUrl = async (
 	return fillSingleProject(props);
 };
 
+export const visibleInspectFields = (
+	query: InspectQuery,
+	rows: readonly Record<string, unknown>[],
+	includeDatabaseColumn: boolean,
+): string[] => {
+	const fields = includeDatabaseColumn
+		? ["database", ...query.fields]
+		: [...query.fields];
+	return fields.filter(
+		(field) =>
+			!query.optionalFields?.includes(field) ||
+			rows.some((row) => row[field] != null),
+	);
+};
+
 const runSubcommand = async (name: InspectSubcommand, props: InspectProps) => {
 	const query: InspectQuery = INSPECT_QUERIES[name];
 	const { targets, includeDatabaseColumn, branchDatabaseCount } =
@@ -77,9 +92,7 @@ const runSubcommand = async (name: InspectSubcommand, props: InspectProps) => {
 		}
 	}
 
-	const fields = includeDatabaseColumn
-		? ["database", ...query.fields]
-		: query.fields;
+	const fields = visibleInspectFields(query, rows, includeDatabaseColumn);
 	writer(props).end(rows, {
 		fields: fields as readonly (keyof (typeof rows)[number])[],
 		emptyMessage: includeDatabaseColumn

--- a/packages/cli/src/utils/inspect_queries.ts
+++ b/packages/cli/src/utils/inspect_queries.ts
@@ -16,6 +16,8 @@ export type InspectQuery = {
 	sql: string;
 	/** Output columns, in display order (also the object keys after mapping). */
 	fields: readonly string[];
+	/** Fields hidden from table output when every row has a null value. */
+	optionalFields?: readonly string[];
 	/** Friendly message when the result set is empty (table output only). */
 	emptyMessage?: string;
 	emptyMessageAll?: string;
@@ -267,7 +269,8 @@ export const INSPECT_QUERIES = {
 		describe:
 			"Local File Cache hit rate (compute-wide, needs neon extension)",
 		scope: "compute",
-		fields: ["name", "ratio"],
+		fields: ["name", "ratio", "note"],
+		optionalFields: ["ratio", "note"],
 		emptyMessage: "No LFC stats available.",
 		requiresExtension: "neon",
 		// Read the hit/miss counters from neon_get_lfc_stats() rather than the
@@ -275,47 +278,93 @@ export const INSPECT_QUERIES = {
 		// cloud_admin and are not always readable by end-user roles, whereas the
 		// function is EXECUTE-able by the default role.
 		sql: /* sql */ `
-			WITH lfc AS (
-				SELECT lfc_key AS k, lfc_value AS v
-				FROM neon_get_lfc_stats() t(lfc_key text, lfc_value bigint)
+			WITH settings AS (
+				SELECT
+					COALESCE(
+						pg_size_bytes(current_setting('neon.file_cache_size_limit', true)),
+						0
+					) AS lfc_bytes,
+					current_setting('shared_buffers') AS shared_buffers
 			)
 			SELECT
 				'lfc hit rate' AS name,
-				max(v) FILTER (WHERE k = 'file_cache_hits')::float
-					/ nullif(
-						max(v) FILTER (WHERE k = 'file_cache_hits')
-						+ max(v) FILTER (WHERE k = 'file_cache_misses'),
-						0
-					) AS ratio
-			FROM lfc;
+				CASE
+					WHEN settings.lfc_bytes > 0 THEN
+						(
+							SELECT
+								max(v) FILTER (WHERE k = 'file_cache_hits')::float
+									/ nullif(
+										max(v) FILTER (WHERE k = 'file_cache_hits')
+										+ max(v) FILTER (WHERE k = 'file_cache_misses'),
+										0
+									)
+							FROM neon_get_lfc_stats() t(k text, v bigint)
+						)
+				END AS ratio,
+				CASE
+					WHEN settings.lfc_bytes = 0 THEN
+						'LFC disabled; cache is served from shared_buffers ('
+						|| settings.shared_buffers
+						|| '). Use SHOW shared_buffers and the Compute cache hit rate metric.'
+				END AS note
+			FROM settings;
 		`,
 	},
 	"working-set": {
 		describe:
 			"Estimated working set vs LFC size (compute-wide, needs neon extension)",
 		scope: "compute",
-		fields: ["window", "working_set", "lfc_size", "exceeds_lfc"],
+		fields: ["window", "working_set", "lfc_size", "exceeds_lfc", "note"],
+		optionalFields: [
+			"window",
+			"working_set",
+			"lfc_size",
+			"exceeds_lfc",
+			"note",
+		],
 		emptyMessage: "No working-set estimate available.",
 		requiresExtension: "neon",
 		sql: /* sql */ `
+			WITH settings AS (
+				SELECT
+					COALESCE(
+						pg_size_bytes(current_setting('neon.file_cache_size_limit', true)),
+						0
+					) AS lfc_bytes,
+					current_setting('shared_buffers') AS shared_buffers
+			)
 			SELECT
-				w.window,
-				pg_size_pretty(w.working_set_bytes) AS working_set,
-				pg_size_pretty(pg_size_bytes(current_setting('neon.file_cache_size_limit'))) AS lfc_size,
+				working_set.window,
+				pg_size_pretty(working_set.working_set_bytes) AS working_set,
 				CASE
-					WHEN w.working_set_bytes
-						> pg_size_bytes(current_setting('neon.file_cache_size_limit'))
-					THEN 'yes' ELSE 'no'
-				END AS exceeds_lfc
-			FROM (
+					WHEN settings.lfc_bytes > 0 THEN
+						pg_size_pretty(settings.lfc_bytes)
+				END AS lfc_size,
+				CASE
+					WHEN settings.lfc_bytes = 0 THEN NULL
+					WHEN working_set.working_set_bytes > settings.lfc_bytes THEN 'yes'
+					ELSE 'no'
+				END AS exceeds_lfc,
+				CASE
+					WHEN settings.lfc_bytes = 0 THEN
+						'LFC disabled; cache is served from shared_buffers ('
+						|| settings.shared_buffers
+						|| '). Use SHOW shared_buffers and the Compute cache hit rate metric.'
+				END AS note
+			FROM settings
+			LEFT JOIN LATERAL (
 				SELECT
 					x AS window,
-					approximate_working_set_size_seconds(
-						extract('epoch' from x::interval)::int
-					)::bigint * 8192 AS working_set_bytes
+					CASE
+						WHEN settings.lfc_bytes > 0 THEN
+							approximate_working_set_size_seconds(
+								extract('epoch' from x::interval)::int
+							)::bigint * 8192
+					END AS working_set_bytes
 				FROM (VALUES ('1m'), ('5m'), ('15m'), ('1h')) AS t(x)
-			) w
-			ORDER BY working_set_bytes;
+				WHERE settings.lfc_bytes > 0
+			) working_set ON true
+			ORDER BY working_set.working_set_bytes;
 		`,
 	},
 	"vacuum-stats": {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #589
- [ ] That issue was marked as `status: accepting prs` (the issue is assigned directly)
- [x] Steps in [CONTRIBUTING.md](https://github.com/neondatabase/neon-pkgs/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Detects when `neon.file_cache_size_limit` is absent or zero. In that case, `lfc-hit-rate` and `working-set` return their existing metric fields as `null`, add a separate `note`, show the active `shared_buffers` size, and direct users to the Compute cache hit rate metric. Null-only optional columns are hidden from table output, while JSON and YAML remain structured. Existing LFC-backed behavior is unchanged.

The disabled path short-circuits both Neon metric functions, so it does not attempt to read LFC statistics or calculate an LFC working set.

## Testing

- `pnpm --filter neon... build`
- `pnpm --filter neon exec vitest run src/commands/inspect.test.ts src/list_tables.test.ts` (57 passed)
- Biome check on changed TypeScript files
- Both SQL paths exercised against local Postgres; disabled-mode stubs throw if either Neon metric function is called