### PR TITLE
chore: release neon@4.16.0 neonctl@4.16.0 @neon/tools@1.3.1

### DIFF
--- a/.changeset/cli-triggers-credentials.md
+++ b/.changeset/cli-triggers-credentials.md
@@ -1,5 +1,0 @@
----
-"neon": minor
----
-
-Add `neon triggers` and `neon credentials` commands for scheduled function triggers and branch-scoped credentials.

--- a/.changeset/init-unified-flow.md
+++ b/.changeset/init-unified-flow.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-Let `neon init` set up an empty directory without a template, and honor the choice to skip neon.ts.

--- a/.changeset/tools-t10-mcp-errors.md
+++ b/.changeset/tools-t10-mcp-errors.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": patch
----
-
-MCP tool failures include `name`, `kind`, `status`/`code`, `source`, `timeoutMs`, `requestId`, `reason`, and `operationId` when the thrown error has them.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,15 @@
 # neon
 
+## 4.16.0
+
+### Minor Changes
+
+- 3d6be94: Add `neon triggers` and `neon credentials` commands for scheduled function triggers and branch-scoped credentials.
+
+### Patch Changes
+
+- e069f88: Let `neon init` set up an empty directory without a template, and honor the choice to skip neon.ts.
+
 ## 4.15.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.15.0",
+	"version": "4.16.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,13 @@
 # neonctl
 
+## 4.16.0
+
+### Patch Changes
+
+- Updated dependencies [3d6be94]
+- Updated dependencies [e069f88]
+  - neon@4.16.0
+
 ## 4.15.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.15.0",
+  "version": "4.16.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 1.3.1
+
+### Patch Changes
+
+- 1c632b8: MCP tool failures include `name`, `kind`, `status`/`code`, `source`, `timeoutMs`, `requestId`, `reason`, and `operationId` when the thrown error has them.
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Release bump

Prepare the merged CLI and tools changes for publication. This PR consumes three Changesets and updates package versions and changelogs only.

| Package | Previous | Next | Reason |
| --- | --- | --- | --- |
| `neon` | 4.15.0 | 4.16.0 | `neon triggers` and `neon credentials`; `neon init` on an empty directory and skip neon.ts |
| `neonctl` | 4.15.0 | 4.16.0 | Fixed-group bump with `neon` |
| `@neon/tools` | 1.3.0 | 1.3.1 | Changelog for MCP tool error fields that already shipped in 1.3.0 |

The CLI release adds:

```sh
neon triggers list|get|create|update|enable|disable|delete
neon credentials list|create|reveal|rotate|revoke
```

`neon init` can set up an empty directory without a template and honors skipping neon.ts.

## Also in here

`@neon/tools` 1.3.1 has no source change after the 1.3.0 publish. The pending changeset was leftover: #570 merged before the previous bump PR #594, and #594 did not consume it. 1.3.1 republishes the same code with the changelog line for MCP tool failures (`name`, `kind`, `status`/`code`, `source`, `timeoutMs`, `requestId`, `reason`, `operationId`).

## Verification

- `pnpm lint:ci` passed: 760 files checked.
- Diff is Changeset deletions, version bumps, and changelog entries only.

Build, tests, and live API flows were not rerun for this metadata-only PR.

## For your attention

- Merging lands the versions on `main`. Publication is a separate manual workflow after merge: `@neon/tools`, then `neon`, then `neonctl`.