### PR TITLE
Document that in-repo-only code belongs in internals/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,13 @@ repo imported it. See below.
 
 ### `internals/` — private packages bundled into their consumers
 
+Code whose only consumers are other packages in this repo, and that Neon users are not
+meant to import, is not part of a published package. Put it in `internals/` as a
+`@neon-internals/*` workspace package and bundle it into the consumers. Re-exporting it
+from `@neon/config/v1`, `@neon/env`, or any other public entry so a sibling can reach it
+is how implementor-only code becomes someone else's API (`@neon/env/runtime`,
+`@neon/config/paths`).
+
 Credential reading, profile resolution and config paths are shared by `neon` and `@neon/env`
 from `@neon-internals/cli-core` — the two that read a credential off disk; `@neon/config` takes
 an explicit key and reads nothing. `@neon-internals/env-core` is the second one, holding

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,11 @@ pnpm --filter @neon/env test:ci
 | `internals/` | `@neon-internals/*` — private, never published, bundled into the packages that use them. Currently the credential and env-resolution code shared by the `neon` CLI and `@neon/env`; each has its own README |
 | `tests/` | Test-only workspace packages, currently the live e2e harness |
 
-See [`AGENTS.md`](./AGENTS.md) for the deeper architecture and per-package notes (especially the
-CLI package, which keeps its own toolchain).
+If the only consumers of a helper are other packages in this repo, and a Neon user should not
+import it, it does not go on a published export. Share it through `internals/`
+(`@neon-internals/*`), not by adding it to `@neon/config/v1` (or any other public surface) so a
+sibling can reach it. [`AGENTS.md`](./AGENTS.md) has the packaging rules, plus the deeper
+architecture and per-package notes (especially the CLI package, which keeps its own toolchain).
 
 Some packages add their own contributing notes for rules that only apply there. Read the
 package's file before changing it:


### PR DESCRIPTION
## Problem

Sharing a helper across packages by exporting it from `@neon/config/v1` (or any other published entry) makes that helper a Neon user API. The consumers were other packages in this repo. `@neon/env/runtime` and `@neon/config/paths` were the same shape.

## Rule

Code whose only consumers are other packages here, and that a Neon user is not meant to import, stays off published exports. Share it through `internals/` (`@neon-internals/*`) and bundle it into the consumers.

`CONTRIBUTING.md` states the rule next to the directory map. `AGENTS.md` states it at the start of the `internals/` section, ahead of the existing packaging mechanics.

## Verification

Read the two added paragraphs against the `internals/` layout (`cli-core`, `env-core`). No runtime change; no changeset.

## For your attention

This does not move any existing export. Packages that already re-export implementor-only names keep them until a follow-up.