### PR TITLE
chore: release neon@4.17.0

### DIFF
--- a/.changeset/env-default-creds.md
+++ b/.changeset/env-default-creds.md
@@ -1,8 +1,0 @@
----
-"neon": minor
-"@neon/config": minor
-"@neon/config-runtime": minor
-"@neon/env": minor
----
-
-`env pull` / `fetchEnv` reveal the platform default AI Gateway and object-storage credentials instead of minting a combined branch credential. `neon.ts` functions can declare schedule triggers that apply after deploy.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neon-internals/env-core
 
+## 0.0.12
+
+### Patch Changes
+
+- Updated dependencies [e1e834a]
+  - @neon/config@1.4.0
+
 ## 0.0.11
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.11",
+	"version": "0.0.12",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # neon
 
+## 4.17.0
+
+### Minor Changes
+
+- e1e834a: `env pull` / `fetchEnv` reveal the platform default AI Gateway and object-storage credentials instead of minting a combined branch credential. `neon.ts` functions can declare schedule triggers that apply after deploy.
+
+### Patch Changes
+
+- Updated dependencies [e1e834a]
+  - @neon/config@1.4.0
+  - @neon/config-runtime@1.3.0
+
 ## 4.16.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.16.0",
+	"version": "4.17.0",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @neondatabase/config-runtime
 
+## 1.3.0
+
+### Minor Changes
+
+- e1e834a: `env pull` / `fetchEnv` reveal the platform default AI Gateway and object-storage credentials instead of minting a combined branch credential. `neon.ts` functions can declare schedule triggers that apply after deploy.
+
+### Patch Changes
+
+- Updated dependencies [e1e834a]
+  - @neon/config@1.4.0
+
 ## 1.2.4
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.2.4",
+	"version": "1.3.0",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config
 
+## 1.4.0
+
+### Minor Changes
+
+- e1e834a: `env pull` / `fetchEnv` reveal the platform default AI Gateway and object-storage credentials instead of minting a combined branch credential. `neon.ts` functions can declare schedule triggers that apply after deploy.
+
 ## 1.3.3
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.3.3",
+	"version": "1.4.0",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @neondatabase/env
 
+## 1.3.0
+
+### Minor Changes
+
+- e1e834a: `env pull` / `fetchEnv` reveal the platform default AI Gateway and object-storage credentials instead of minting a combined branch credential. `neon.ts` functions can declare schedule triggers that apply after deploy.
+
+### Patch Changes
+
+- Updated dependencies [e1e834a]
+  - @neon/config@1.4.0
+
 ## 1.2.4
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.2.4",
+	"version": "1.3.0",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.17.0
+
+### Patch Changes
+
+- Updated dependencies [e1e834a]
+  - neon@4.17.0
+
 ## 4.16.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Summary

Version bump + CHANGELOG only (`changeset version` of `.changeset/env-default-creds.md`).

| Package | npm | main |
|---|---|---|
| `neon` | 4.16.0 | 4.17.0 |
| `neonctl` | 4.16.0 | 4.17.0 (fixed group with `neon`) |
| `@neon/config` | 1.3.3 | 1.4.0 |
| `@neon/config-runtime` | 1.2.4 | 1.3.0 |
| `@neon/env` | 1.2.4 | 1.3.0 |
| `@neon-internals/env-core` | private | 0.0.11 → 0.0.12 (dependent cascade) |

`env pull` / `fetchEnv` reveal platform default AI Gateway and object-storage credentials instead of minting a combined branch credential. `neon.ts` functions can declare schedule triggers that apply after deploy.

Publish after merge, leaf first: `@neon/config` → `@neon/config-runtime` / `@neon/env` → `neon` → `neonctl`.

## Test plan

- [x] `pnpm lint:ci` on the bump
- [ ] PR CI green
- [ ] After merge: `workflow_dispatch` per package, then `npm view` + `npm i -g neon@latest` + `neon --version`