### PR TITLE
chore: release neon@4.17.1

### DIFF
--- a/.changeset/cli-help-flag-order.md
+++ b/.changeset/cli-help-flag-order.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-Subcommand `--help` lists that command's flags first and points at `neon --help` for globals.

--- a/.changeset/cli-help-stdout.md
+++ b/.changeset/cli-help-stdout.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-`neon --help` now prints on stdout, so pipes and `grep` see it. Piped help wraps on word boundaries instead of splitting words mid-line.

--- a/.changeset/cli-json-trailing-newline.md
+++ b/.changeset/cli-json-trailing-newline.md
@@ -1,5 +1,0 @@
----
-"neon": patch
----
-
-`--output json` now ends with a newline, like `--output yaml` and the table output already did. Piped and redirected JSON no longer runs into the next line.

--- a/.changeset/quiet-dingos-link.md
+++ b/.changeset/quiet-dingos-link.md
@@ -1,6 +1,0 @@
----
-"neon": patch
-"neonctl": patch
----
-
-Fix `neon init` to finish coding-agent setup before starting its built-in project linking flow.

--- a/.changeset/tools-t12-adapter-credential.md
+++ b/.changeset/tools-t12-adapter-credential.md
@@ -1,5 +1,0 @@
----
-"@neon/tools": patch
----
-
-Eve `abortSignal` is optional.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # neon
 
+## 4.17.1
+
+### Patch Changes
+
+- 9e553ab: Subcommand `--help` lists that command's flags first and points at `neon --help` for globals.
+- 26f29be: `neon --help` now prints on stdout, so pipes and `grep` see it. Piped help wraps on word boundaries instead of splitting words mid-line.
+- 0a19bdc: `--output json` now ends with a newline, like `--output yaml` and the table output already did. Piped and redirected JSON no longer runs into the next line.
+- c7432f9: Fix `neon init` to finish coding-agent setup before starting its built-in project linking flow.
+
 ## 4.17.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.17.0",
+	"version": "4.17.1",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,16 @@
 # neonctl
 
+## 4.17.1
+
+### Patch Changes
+
+- c7432f9: Fix `neon init` to finish coding-agent setup before starting its built-in project linking flow.
+- Updated dependencies [9e553ab]
+- Updated dependencies [26f29be]
+- Updated dependencies [0a19bdc]
+- Updated dependencies [c7432f9]
+  - neon@4.17.1
+
 ## 4.17.0
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.17.0",
+  "version": "4.17.1",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/tools
 
+## 1.3.2
+
+### Patch Changes
+
+- 54f8e9a: Eve `abortSignal` is optional.
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Release scope

Prepare patch releases for already-merged fixes that remain unpublished. This PR updates package versions and changelogs and consumes five changesets. It contains no source changes.

| Package | Current | Next |
| --- | --- | --- |
| `neon` | 4.17.0 | 4.17.1 |
| `neonctl` | 4.17.0 | 4.17.1 |
| `@neon/tools` | 1.3.1 | 1.3.2 |

`neonctl` stays versioned with `neon` through their Changesets fixed group.

## Included fixes

- Subcommand `--help` lists command-specific flags first and points to `neon --help` for global flags.
- `neon --help` writes to stdout so pipes and `grep` receive it. Piped help wraps at word boundaries.
- `--output json` ends with a newline, matching YAML and table output.
- `neon init` finishes coding-agent setup before starting project linking.
- `@neon/tools` makes Eve's `abortSignal` optional.

## Verification

- `pnpm lint:ci` passed.
- Diff checked against `origin/main`: only version fields, changelog entries and consumed changesets.
- PR CI has not run yet.

## Publishing

Merging prepares the versions on `main`. npm publishing requires a separate manual workflow after merge, in this order:

```text
@neon/tools@1.3.2 → neon@4.17.1 → neonctl@4.17.1
```

Confirm `neon@4.17.1` is available before publishing `neonctl`, which depends on that exact version.