### PR TITLE
feat(sdk)!: use named parameter objects for resource methods

### DIFF
--- a/.changeset/sdk-named-parameters.md
+++ b/.changeset/sdk-named-parameters.md
@@ -1,0 +1,6 @@
+---
+"@neon/sdk": major
+"@neon/tools": patch
+---
+
+Change ergonomic SDK resource methods to accept one flat named parameter object followed by optional call options. Update tools to bind the new method shapes while preserving their published input schemas.

--- a/packages/sdk/MIGRATION.md
+++ b/packages/sdk/MIGRATION.md
@@ -1,0 +1,327 @@
+# Migrating to named parameters
+
+The next major release of `@neon/sdk` changes ergonomic resource methods that took
+positional identifiers or other scalar values. Those values now belong in one flat,
+named parameter object. `CallOptions` remains a separate final argument.
+
+```ts
+// Before
+await neon.branches.update(projectId, branchId, { name: "preview" }, {
+  throwOnError: true,
+});
+
+// Next major
+await neon.branches.update(
+  { projectId, branchId, name: "preview" },
+  { throwOnError: true },
+);
+```
+
+This is a direct breaking change: positional overloads are removed. Return values,
+`{ data, error }` behavior, `throwOnError`, readiness polling, retries, cancellation,
+and API requests keep their existing meanings.
+
+## Migration rules
+
+- Put resource locators and request or query fields together in the first object.
+- Keep `CallOptions` second: `{ throwOnError?, waitForReadiness?, requestTimeoutMs?,
+  wait?, signal? }`.
+- Use `projectId` and `branchId` for project and branch identifiers.
+- Use `databaseName` to locate an existing database. On `databases.update`, `name`
+  remains the optional new name.
+- Use `roleName` to locate an existing Postgres role. The `name` field on
+  `roles.create` is unchanged.
+- Keep existing payload spelling. OpenAPI payload and query fields such as `org_id`,
+  `parent_id`, `expires_at`, `owner_name`, `content_type`, and `principal_type` stay
+  snake_case.
+
+`…input` and `…query` below mean the same fields accepted by the old input or query
+object, now flattened into the named parameter object.
+
+Common replacements:
+
+```ts
+// One identifier, then multiple identifiers
+await neon.projects.get({ projectId });
+await neon.branches.get({ projectId, branchId });
+
+// Create and update payloads are flat
+await neon.branches.create({ projectId, name: "preview", parent_id: branchId });
+await neon.branches.update({ projectId, branchId, name: "renamed" });
+
+// List filters share the first object with the locator
+const branches = await neon.branches
+  .list({ projectId, search: "preview", include_deleted: false })
+  .all();
+
+// A method with an optional old payload still receives the required locators
+await neon.branches.resetFromParent({ projectId, branchId });
+
+// Locate the database with databaseName; name remains the rename value
+await neon.postgres.databases.update({
+  projectId,
+  branchId,
+  databaseName: "app",
+  name: "app_v2",
+});
+
+await neon.snapshots.setSchedule({
+  projectId,
+  branchId,
+  schedule: [{ frequency: "daily", retention_seconds: 7 * 24 * 60 * 60 }],
+});
+
+await neon.operations.waitFor(
+  { operations },
+  { pollIntervalMs: 1_000, timeoutMs: 120_000 },
+);
+```
+
+## Changed methods
+
+### Projects, permissions, and members
+
+| Method | Before | Next major |
+| --- | --- | --- |
+| `projects.get` | `get(id)` | `get({ projectId })` |
+| `projects.createAndConnect` | `createAndConnect(input?, { pooled?, …options }?)` | `createAndConnect({ …input, pooled? }, options?)` |
+| `projects.update` | `update(id, input)` | `update({ projectId, …input })` |
+| `projects.delete` | `delete(id)` | `delete({ projectId })` |
+| `projects.recover` | `recover(id)` | `recover({ projectId })` |
+| `projects.permissions.list` | `list(projectId)` | `list({ projectId })` |
+| `projects.permissions.grant` | `grant(projectId, email)` | `grant({ projectId, email })` |
+| `projects.permissions.revoke` | `revoke(projectId, permissionId)` | `revoke({ projectId, permissionId })` |
+| `projects.members.list` | `list(projectId, query?)` | `list({ projectId, …query })` |
+| `projects.members.setRole` | `setRole(projectId, memberId, role, { confirmSelfDemotion?, …options }?)` | `setRole({ projectId, memberId, role, confirmSelfDemotion? }, options?)` |
+| `projects.members.removeRole` | `removeRole(projectId, memberId, { confirmSelfLockout?, …options }?)` | `removeRole({ projectId, memberId, confirmSelfLockout? }, options?)` |
+
+### Branches
+
+| Method | Before | Next major |
+| --- | --- | --- |
+| `branches.list` | `list(projectId, query?)` | `list({ projectId, …query })` |
+| `branches.get` | `get(projectId, branchId)` | `get({ projectId, branchId })` |
+| `branches.create` | `create(projectId, input?)` | `create({ projectId, …input })` |
+| `branches.update` | `update(projectId, branchId, input)` | `update({ projectId, branchId, …input })` |
+| `branches.delete` | `delete(projectId, branchId)` | `delete({ projectId, branchId })` |
+| `branches.createAndConnect` | `createAndConnect(projectId, input?, { pooled?, …options }?)` | `createAndConnect({ projectId, …input, pooled? }, options?)` |
+| `branches.getDefault` | `getDefault(projectId)` | `getDefault({ projectId })` |
+| `branches.setDefault` | `setDefault(projectId, branchId)` | `setDefault({ projectId, branchId })` |
+| `branches.resetFromParent` | `resetFromParent(projectId, branchId, input?)` | `resetFromParent({ projectId, branchId, …input })` |
+| `branches.compareSchema` | `compareSchema(projectId, branchId, input)` | `compareSchema({ projectId, branchId, …input })` |
+| `branches.finalizeRestore` | `finalizeRestore(projectId, branchId, input?)` | `finalizeRestore({ projectId, branchId, …input })` |
+
+### Postgres
+
+| Method | Before | Next major |
+| --- | --- | --- |
+| `postgres.endpoints.list` | `list(projectId)` | `list({ projectId })` |
+| `postgres.endpoints.listByBranch` | `listByBranch(projectId, branchId)` | `listByBranch({ projectId, branchId })` |
+| `postgres.endpoints.get` | `get(projectId, endpointId)` | `get({ projectId, endpointId })` |
+| `postgres.endpoints.create` | `create(projectId, input)` | `create({ projectId, …input })` |
+| `postgres.endpoints.update` | `update(projectId, endpointId, input)` | `update({ projectId, endpointId, …input })` |
+| `postgres.endpoints.delete` | `delete(projectId, endpointId)` | `delete({ projectId, endpointId })` |
+| `postgres.endpoints.start` | `start(projectId, endpointId)` | `start({ projectId, endpointId })` |
+| `postgres.endpoints.suspend` | `suspend(projectId, endpointId)` | `suspend({ projectId, endpointId })` |
+| `postgres.endpoints.restart` | `restart(projectId, endpointId)` | `restart({ projectId, endpointId })` |
+| `postgres.roles.list` | `list(projectId, branchId)` | `list({ projectId, branchId })` |
+| `postgres.roles.get` | `get(projectId, branchId, name)` | `get({ projectId, branchId, roleName })` |
+| `postgres.roles.create` | `create(projectId, branchId, input)` | `create({ projectId, branchId, …input })` |
+| `postgres.roles.delete` | `delete(projectId, branchId, name)` | `delete({ projectId, branchId, roleName })` |
+| `postgres.roles.password` | `password(projectId, branchId, name)` | `password({ projectId, branchId, roleName })` |
+| `postgres.roles.resetPassword` | `resetPassword(projectId, branchId, name)` | `resetPassword({ projectId, branchId, roleName })` |
+| `postgres.databases.list` | `list(projectId, branchId)` | `list({ projectId, branchId })` |
+| `postgres.databases.get` | `get(projectId, branchId, name)` | `get({ projectId, branchId, databaseName })` |
+| `postgres.databases.create` | `create(projectId, branchId, input)` | `create({ projectId, branchId, …input })` |
+| `postgres.databases.update` | `update(projectId, branchId, name, input)` | `update({ projectId, branchId, databaseName, …input })` |
+| `postgres.databases.delete` | `delete(projectId, branchId, name)` | `delete({ projectId, branchId, databaseName })` |
+| `postgres.dataApi.get` | `get(projectId, branchId, databaseName)` | `get({ projectId, branchId, databaseName })` |
+| `postgres.dataApi.create` | `create(projectId, branchId, databaseName, input?)` | `create({ projectId, branchId, databaseName, …input })` |
+| `postgres.dataApi.update` | `update(projectId, branchId, databaseName, input?)` | `update({ projectId, branchId, databaseName, …input })` |
+| `postgres.dataApi.delete` | `delete(projectId, branchId, databaseName)` | `delete({ projectId, branchId, databaseName })` |
+
+### Storage and functions
+
+| Method | Before | Next major |
+| --- | --- | --- |
+| `storage.get` | `get(projectId, branchId)` | `get({ projectId, branchId })` |
+| `storage.buckets.list` | `list(projectId, branchId)` | `list({ projectId, branchId })` |
+| `storage.buckets.create` | `create(projectId, branchId, input)` | `create({ projectId, branchId, …input })` |
+| `storage.buckets.delete` | `delete(projectId, branchId, bucketName)` | `delete({ projectId, branchId, bucketName })` |
+| `storage.objects.list` | `list(projectId, branchId, bucketName, query?)` | `list({ projectId, branchId, bucketName, …query })` |
+| `storage.objects.get` | `get(projectId, branchId, bucketName, objectKey)` | `get({ projectId, branchId, bucketName, objectKey })` |
+| `storage.objects.delete` | `delete(projectId, branchId, bucketName, objectKey)` | `delete({ projectId, branchId, bucketName, objectKey })` |
+| `storage.objects.deleteByPrefix` | `deleteByPrefix(projectId, branchId, bucketName, prefix)` | `deleteByPrefix({ projectId, branchId, bucketName, prefix })` |
+| `storage.objects.presign` | `presign(projectId, branchId, bucketName, objectKey, input)` | `presign({ projectId, branchId, bucketName, objectKey, …input })` |
+| `functions.list` | `list(projectId, branchId, query?)` | `list({ projectId, branchId, …query })` |
+| `functions.get` | `get(projectId, branchId, slug)` | `get({ projectId, branchId, slug })` |
+| `functions.update` | `update(projectId, branchId, slug, input)` | `update({ projectId, branchId, slug, …input })` |
+| `functions.delete` | `delete(projectId, branchId, slug)` | `delete({ projectId, branchId, slug })` |
+| `functions.deploy` | `deploy(projectId, branchId, slug, input?)` | `deploy({ projectId, branchId, slug, …input })` |
+| `functions.customDomains.list` | `list(projectId, branchId, query?)` | `list({ projectId, branchId, …query })` |
+| `functions.customDomains.register` | `register(projectId, branchId, input)` | `register({ projectId, branchId, …input })` |
+| `functions.customDomains.delete` | `delete(projectId, branchId, domain)` | `delete({ projectId, branchId, domain })` |
+
+### Triggers, credentials, gateway, and logs
+
+| Method | Before | Next major |
+| --- | --- | --- |
+| `triggers.list` | `list(projectId, branchId)` | `list({ projectId, branchId })` |
+| `triggers.create` | `create(projectId, branchId, input)` | `create({ projectId, branchId, …input })` |
+| `triggers.get` | `get(projectId, branchId, triggerId)` | `get({ projectId, branchId, triggerId })` |
+| `triggers.update` | `update(projectId, branchId, triggerId, input)` | `update({ projectId, branchId, triggerId, …input })` |
+| `triggers.delete` | `delete(projectId, branchId, triggerId)` | `delete({ projectId, branchId, triggerId })` |
+| `credentials.list` | `list(projectId, branchId)` | `list({ projectId, branchId })` |
+| `credentials.create` | `create(projectId, branchId, input)` | `create({ projectId, branchId, …input })` |
+| `credentials.revoke` | `revoke(projectId, branchId, tokenId)` | `revoke({ projectId, branchId, tokenId })` |
+| `credentials.reveal` | `reveal(projectId, branchId, tokenId)` | `reveal({ projectId, branchId, tokenId })` |
+| `credentials.rotate` | `rotate(projectId, branchId, tokenId)` | `rotate({ projectId, branchId, tokenId })` |
+| `aiGateway.get` | `get(projectId, branchId)` | `get({ projectId, branchId })` |
+| `logs.query` | `query(projectId, branchId, input?)` | `query({ projectId, branchId, …input })` |
+| `logs.fields` | `fields(projectId, branchId)` | `fields({ projectId, branchId })` |
+| `logs.fieldValues` | `fieldValues(projectId, branchId, fieldName, query?)` | `fieldValues({ projectId, branchId, fieldName, …query })` |
+
+### Snapshots and operations
+
+| Method | Before | Next major |
+| --- | --- | --- |
+| `snapshots.list` | `list(projectId)` | `list({ projectId })` |
+| `snapshots.create` | `create(projectId, branchId, input?)` | `create({ projectId, branchId, …input })` |
+| `snapshots.update` | `update(projectId, snapshotId, input)` | `update({ projectId, snapshotId, …input })` |
+| `snapshots.delete` | `delete(projectId, snapshotId)` | `delete({ projectId, snapshotId })` |
+| `snapshots.restore` | `restore(projectId, snapshotId, input?)` | `restore({ projectId, snapshotId, …input })` |
+| `snapshots.getSchedule` | `getSchedule(projectId, branchId)` | `getSchedule({ projectId, branchId })` |
+| `snapshots.setSchedule` | `setSchedule(projectId, branchId, schedule)` | `setSchedule({ projectId, branchId, schedule })` |
+| `operations.list` | `list(projectId)` | `list({ projectId })` |
+| `operations.get` | `get(projectId, operationId)` | `get({ projectId, operationId })` |
+| `operations.waitFor` | `waitFor(operations, options?)` | `waitFor({ operations }, options?)` |
+
+`operations.waitFor` still accepts `pollIntervalMs`, `timeoutMs`, `signal`, and
+`throwOnError` in its second argument. As before, its execution options exclude
+`requestTimeoutMs`, `waitForReadiness`, and `wait` because the operation poller owns its
+own timeout and interval.
+
+### API keys and Neon Auth
+
+| Method | Before | Next major |
+| --- | --- | --- |
+| `apiKeys.create` | `create(keyName)` | `create({ keyName })` |
+| `apiKeys.revoke` | `revoke(keyId)` | `revoke({ keyId })` |
+| `auth.get` | `get(projectId, branchId)` | `get({ projectId, branchId })` |
+| `auth.create` | `create(projectId, branchId, input)` | `create({ projectId, branchId, …input })` |
+| `auth.disable` | `disable(projectId, branchId, input?)` | `disable({ projectId, branchId, …input })` |
+| `auth.updateConfig` | `updateConfig(projectId, branchId, input)` | `updateConfig({ projectId, branchId, …input })` |
+| `auth.oauthProviders.list` | `list(projectId, branchId)` | `list({ projectId, branchId })` |
+| `auth.oauthProviders.add` | `add(projectId, branchId, input)` | `add({ projectId, branchId, …input })` |
+| `auth.oauthProviders.update` | `update(projectId, branchId, providerId, input)` | `update({ projectId, branchId, providerId, …input })` |
+| `auth.oauthProviders.delete` | `delete(projectId, branchId, providerId)` | `delete({ projectId, branchId, providerId })` |
+| `auth.trustedDomains.list` | `list(projectId, branchId)` | `list({ projectId, branchId })` |
+| `auth.trustedDomains.add` | `add(projectId, branchId, input)` | `add({ projectId, branchId, …input })` |
+| `auth.trustedDomains.delete` | `delete(projectId, branchId, input)` | `delete({ projectId, branchId, …input })` |
+| `auth.users.create` | `create(projectId, branchId, input)` | `create({ projectId, branchId, …input })` |
+| `auth.users.delete` | `delete(projectId, branchId, authUserId)` | `delete({ projectId, branchId, authUserId })` |
+| `auth.users.updateRole` | `updateRole(projectId, branchId, authUserId, roles)` | `updateRole({ projectId, branchId, authUserId, roles })` |
+
+## Fields that moved from options
+
+Three workflow or safety fields are method input, not execution policy, so they move to
+the first object:
+
+```ts
+await neon.projects.createAndConnect(
+  { name: "app", pooled: false },
+  { wait: { timeoutMs: 600_000 } },
+);
+
+await neon.branches.createAndConnect(
+  { projectId, name: "preview", pooled: false },
+  { signal },
+);
+
+await neon.projects.members.setRole(
+  { projectId, memberId, role: "viewer", confirmSelfDemotion: true },
+  { throwOnError: true },
+);
+
+await neon.projects.members.removeRole(
+  { projectId, memberId, confirmSelfLockout: true },
+  { throwOnError: true },
+);
+```
+
+`SetRoleOptions` and `RemoveRoleOptions` remain exported as aliases of `CallOptions`.
+They no longer contain the confirmation fields.
+
+## Parameter types
+
+Every changed method exports a resource-qualified `*Params` type next to its resource.
+Examples include `ProjectGetParams`, `BranchUpdateParams`, `DatabasesUpdateParams`,
+`BucketObjectsPresignParams`, `AuthUsersUpdateRoleParams`, and
+`OperationsWaitForParams`:
+
+```ts
+import type { BranchCreateParams, CallOptions } from "@neon/sdk";
+
+const params: BranchCreateParams = {
+  projectId,
+  name: "preview",
+  parent_id: parentBranchId,
+};
+const options: CallOptions = { signal };
+
+await neon.branches.create(params, options);
+```
+
+The types preserve the existing generated request fields and aliases. They do not rename
+snake_case payload properties.
+
+## Unchanged calls
+
+Methods that were already object-only keep their call shape: `projects.list`,
+`projects.create`, `projects.transfer`, `projects.transferFromUser`,
+`postgres.connectionString`, and the three `consumption` methods. Zero-input methods
+also stay unchanged: `apiKeys.list`, `regions.list`, `user.me`, and
+`user.organizations`.
+
+The raw API is unchanged. Raw methods still take the generated `{ client, path, query,
+body, … }` object. Pagination is also unchanged after construction: `.page(cursor)`,
+`.all()`, and async iteration keep the same signatures and return behavior. Callback
+signatures are unchanged; for example, the `snapshots.restore` preview callback still
+receives `(branch, { signal })`.
+
+## JavaScript callers and invalid legacy input
+
+TypeScript reports positional calls at compile time. JavaScript callers that pass a
+legacy scalar where a named parameter object is required receive a typed
+`NeonClientError` through the usual result or throw channel:
+
+```js
+import { createNeonClient, NeonClientError } from "@neon/sdk";
+
+const neon = createNeonClient({ apiKey });
+const result = await neon.projects.get("project-id");
+result.error instanceof NeonClientError; // true
+result.error.kind; // "client"
+
+const throwing = createNeonClient({ apiKey, throwOnError: true });
+await throwing.projects.get("project-id"); // throws NeonClientError
+```
+
+Paginated methods remain lazy, so validation surfaces when the pagination object is
+consumed:
+
+```js
+const branches = neon.branches.list("project-id");
+
+const page = await branches.page(); // { data: undefined, error: NeonClientError }
+const all = await branches.all();   // { data: undefined, error: NeonClientError }
+
+for await (const branch of branches) {
+  // async iteration always throws on an error, including NeonClientError
+}
+```
+
+For the fields that moved from options, JavaScript does not get a positional-object
+validation error because both arguments are objects. Move `pooled`,
+`confirmSelfDemotion`, and `confirmSelfLockout` into the first object so the requested
+behavior is applied.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -7,6 +7,9 @@ Two layers, one package:
 - **`createNeonClient`** — an ergonomic client (auth once, `{ data, error }` results, typed errors, retries, readiness polling, auto-pagination, workflows), organized into resource namespaces.
 - **`raw`** — the full generated 1:1 surface: every endpoint as a standalone, tree-shakeable function. Also at the `@neon/sdk/raw` subpath.
 
+The next major release changes ergonomic resource methods to named parameter objects. If
+you are upgrading existing code, start with [Migrating to named parameters](./MIGRATION.md).
+
 ---
 
 ## Install
@@ -25,7 +28,10 @@ import { createNeonClient } from "@neon/sdk";
 const neon = createNeonClient({ apiKey: process.env.NEON_API_KEY! });
 
 // create a project and get a ready-to-use connection string
-const { data, error } = await neon.projects.createAndConnect({ name: "my-app" });
+const { data, error } = await neon.projects.createAndConnect({
+  name: "my-app",
+  pooled: true,
+});
 if (error) throw error;
 const { project, connectionString } = data;
 ```
@@ -48,14 +54,14 @@ const { project, connectionString } = data;
 | `baseUrl` | `string` | `https://console.neon.tech/api/v2` | Override the API base URL. |
 | `fetch` | `typeof fetch` | global `fetch` | Custom fetch implementation (proxies, tests, non-global runtimes). |
 
-`CallOptions` — `{ throwOnError?, waitForReadiness?, requestTimeoutMs?, wait?, signal? }` — is accepted **per call** as the last `options` argument, overriding the client default where one exists (`signal` is call-only). `retries`, `orgId`, `baseUrl`, and `fetch` are client-wide. Paginated methods take `CallOptions` after their query.
+`CallOptions` — `{ throwOnError?, waitForReadiness?, requestTimeoutMs?, wait?, signal? }` — is accepted **per call** as the last `options` argument, overriding the client default where one exists (`signal` is call-only). `retries`, `orgId`, `baseUrl`, and `fetch` are client-wide. Resource identifiers and request fields live together in the first named parameter object; paginated methods still take `CallOptions` second.
 
 ## The result model
 
 By default every method resolves to a discriminated `{ data, error }` envelope — no `try/catch` needed:
 
 ```ts
-const { data, error } = await neon.projects.get("late-frost-12345");
+const { data, error } = await neon.projects.get({ projectId: "late-frost-12345" });
 if (error) {
   // error is NeonErrorUnion — discriminate on error.kind
   return;
@@ -67,8 +73,11 @@ Set `throwOnError` (on the client or per call) to get the bare resource and thro
 
 ```ts
 const neon = createNeonClient({ apiKey, throwOnError: true });
-const project = await neon.projects.get("…");                 // Project (throws on error)
-const res     = await neon.projects.get("…", { throwOnError: false }); // { data, error }
+const project = await neon.projects.get({ projectId: "…" }); // Project (throws on error)
+const res = await neon.projects.get(
+  { projectId: "…" },
+  { throwOnError: false },
+); // { data, error }
 ```
 
 ## Errors
@@ -93,7 +102,7 @@ The `error` channel carries a typed hierarchy (all `Error` subclasses with a `ki
 The error channel is typed as `NeonErrorUnion`, the union of every row below the base.
 
 ```ts
-const { error } = await neon.branches.get(pid, "nope");
+const { error } = await neon.branches.get({ projectId: pid, branchId: "nope" });
 if (error?.kind === "not_found") {
   error.status;    // 404
   error.requestId; // string | undefined
@@ -118,7 +127,7 @@ With `throwOnError`, the thrown value is a `NeonErrorUnion` member at runtime, b
 import { isNeonError } from "@neon/sdk";
 
 try {
-  await neon.projects.get(pid, { throwOnError: true });
+  await neon.projects.get({ projectId: pid }, { throwOnError: true });
 } catch (e: unknown) {
   if (!isNeonError(e)) throw e;
   if (e.kind === "not_found") e.status;   // number
@@ -134,7 +143,7 @@ error trackers instead of collapsing onto one string:
 ```ts
 import { NeonNetworkError } from "@neon/sdk";
 
-const { error } = await neon.projects.get(id);
+const { error } = await neon.projects.get({ projectId: id });
 if (error instanceof NeonNetworkError) {
   error.reason; // "ECONNRESET"
   error.message; // 'Network error: no response received from the Neon API (ECONNRESET).'
@@ -157,20 +166,27 @@ const controller = new AbortController();
 const { error } = await neon.projects.list({}, { signal: controller.signal }).all();
 if (error?.kind === "aborted") { /* the caller stopped it */ }
 
-const result = await neon.projects.get(id, { signal: controller.signal });
+const result = await neon.projects.get(
+  { projectId: id },
+  { signal: controller.signal },
+);
 if (result.error?.kind === "aborted") { /* the caller stopped it */ }
 ```
 
 ```ts
 const bounded = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
-const slow = await bounded.projects.get(id, { requestTimeoutMs: 5_000 });
+const slow = await bounded.projects.get(
+  { projectId: id },
+  { requestTimeoutMs: 5_000 },
+);
 if (slow.error?.kind === "timeout" && slow.error.source === "request") {
   /* the request deadline was exceeded */
 }
 
-await bounded.storage.objects.get(projectId, branchId, "bucket", "big.tar", {
-  requestTimeoutMs: Number.POSITIVE_INFINITY,
-});
+await bounded.storage.objects.get(
+  { projectId, branchId, bucketName: "bucket", objectKey: "big.tar" },
+  { requestTimeoutMs: Number.POSITIVE_INFINITY },
+);
 ```
 
 `"aborted"` and `"timeout"` are deliberately distinct: a timeout is worth retrying, a
@@ -185,7 +201,7 @@ const { data, error } = await neon.projects.create(
 if (error?.kind === "timeout" && error.source === "wait") {
   // The project exists and is still provisioning. Poll again with a fresh budget
   // instead of calling create a second time.
-  const resumed = await neon.operations.waitFor(error.operations, {
+  const resumed = await neon.operations.waitFor({ operations: error.operations }, {
     timeoutMs: 120_000,
   });
   if (resumed.error) throw resumed.error;
@@ -244,19 +260,19 @@ consuming it twice gets a fresh deadline each time.
 
 Neon mutations are asynchronous (they return `operations`). `waitForReadiness` blocks until they settle.
 
-Omit the client option to use per-method defaults: `projects.create`, `projects.createAndConnect`, `branches.create`, and `branches.createAndConnect` poll; other mutations (for example `projects.update`) do not. `createNeonClient({ waitForReadiness: false })` disables polling on those four. `createNeonClient({ waitForReadiness: true })` enables it on every mutation that returns operations. Per-call `{ waitForReadiness }` still wins. The connect workflows also hand back a connection string. Per-call `wait` overrides the client's poll interval and timeout for that call, field by field: `{ wait: { timeoutMs: 600_000 } }` keeps the client's `pollIntervalMs`. The primitive is `neon.operations.waitFor(operations)`.
+Omit the client option to use per-method defaults: `projects.create`, `projects.createAndConnect`, `branches.create`, and `branches.createAndConnect` poll; other mutations (for example `projects.update`) do not. `createNeonClient({ waitForReadiness: false })` disables polling on those four. `createNeonClient({ waitForReadiness: true })` enables it on every mutation that returns operations. Per-call `{ waitForReadiness }` still wins. The connect workflows also hand back a connection string. Per-call `wait` overrides the client's poll interval and timeout for that call, field by field: `{ wait: { timeoutMs: 600_000 } }` keeps the client's `pollIntervalMs`. The primitive is `neon.operations.waitFor({ operations })`.
 
 ```ts
 const neon = createNeonClient({ apiKey });
 await neon.projects.create({ name: "app" }); // polls (method default)
-await neon.projects.update(id, { name: "renamed" }); // does not poll
+await neon.projects.update({ projectId: id, name: "renamed" }); // does not poll
 
 const skipWait = createNeonClient({ apiKey, waitForReadiness: false });
 await skipWait.projects.create({ name: "app" }); // returns before operations finish
 await skipWait.projects.create({ name: "app" }, { waitForReadiness: true }); // polls anyway
 
 const alwaysWait = createNeonClient({ apiKey, waitForReadiness: true });
-await alwaysWait.projects.update(id, { name: "renamed" }); // polls
+await alwaysWait.projects.update({ projectId: id, name: "renamed" }); // polls
 
 await neon.projects.create(
   { name: "app" },
@@ -268,26 +284,26 @@ await neon.projects.create(
 
 ## API reference
 
-Legend: **[P]** returns `Paginated<T>` — `page()`/`all()` resolve to the resource (or `{ data, error }`) per `throwOnError` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take an optional trailing `options` arg and resolve to the resource (or `{ data, error }`).
+Legend: **[P]** returns `Paginated<T>` — `page()`/`all()` resolve to the resource (or `{ data, error }`) per `throwOnError` · **[W]** workflow (multi-step) · **→void** resolves to `void`. Unless noted, methods take one named parameter object followed by an optional `CallOptions` argument and resolve to the resource (or `{ data, error }`). Zero-input methods remain zero-input.
 
 ### `neon.projects`
 
 | Method | Returns | Notes |
 | --- | --- | --- |
 | `list(query?)` | **[P]** `ProjectListItem` | `query`: `{ search?, org_id?, limit? }` (cursor managed for you) |
-| `get(id)` | `Project` | |
+| `get({ projectId })` | `Project` | |
 | `create(input?)` | `Project` | API always provisions default-branch compute. No connection string. Readiness polling on by default. `input`: `{ name?, region_id?, pg_version?, org_id?, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, settings? }` |
-| `createAndConnect(input?, { pooled? })` | **[W]** `{ project, connectionString }` | one call + readiness; `pooled` default `true` |
-| `update(id, input)` | `Project` | `input`: `{ name?, settings? }` |
-| `delete(id)` | `Project` | |
+| `createAndConnect({ …input, pooled? }, options?)` | **[W]** `{ project, connectionString }` | one call + readiness; `pooled` default `true` |
+| `update({ projectId, name?, settings? })` | `Project` | `name` is the new project name |
+| `delete({ projectId })` | `Project` | |
+| `recover({ projectId })` | `Project` | beta — recover a soft-deleted project |
 | `transfer({ fromOrgId?, toOrgId, projectIds })` | **→void** | `fromOrgId` defaults to client `orgId` |
 | `transferFromUser({ toOrgId, projectIds })` | **→void** | personal account → org |
 
 ```ts
 // Provision a project and get a pooled connection string in one call
 const { data } = await neon.projects.createAndConnect(
-  { name: "tenant-42", region_id: "aws-us-east-1" },
-  { pooled: true },
+  { name: "tenant-42", region_id: "aws-us-east-1", pooled: true },
 );
 // data: { project, connectionString }
 
@@ -303,17 +319,17 @@ await neon.projects.transfer({
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, query?)` | **[P]** `Branch` | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }` |
-| `get(projectId, branchId)` | `Branch` | |
-| `create(projectId, input?)` | `Branch` | RW compute on by default. `noCompute: true` skips the endpoint. No connection string. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
-| `update(projectId, branchId, input)` | `Branch` | `input`: `{ name?, protected?, expires_at? }` |
-| `delete(projectId, branchId)` | **→void** | |
-| `createAndConnect(projectId, input?, { pooled? })` | **[W]** `{ branch, endpoint, connectionString }` | `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }` |
-| `getDefault(projectId)` | `Branch` | resolves the default branch by the `default` flag |
-| `setDefault(projectId, branchId)` | `Branch` | |
-| `resetFromParent(projectId, branchId, { preserveUnderName? }?)` | `Branch` | parent HEAD only; discards writes since the branch diverged. `preserveUnderName` is required when the branch has children. Pass `{ waitForReadiness: true }` before using the branch |
-| `compareSchema(projectId, branchId, input)` | `{ diff? }` | `input`: `{ databaseName, baseBranchId?, lsn?, timestamp?, baseLsn?, baseTimestamp? }`. Omitting `baseBranchId` compares against the parent |
-| `finalizeRestore(projectId, branchId, { name? }?)` | **→void** | commits a restore previewed with `snapshots.restore({ finalize: false })` |
+| `list({ projectId, …query })` | **[P]** `Branch` | `query`: `{ search?, sort_by?, sort_order?, include_deleted? }` |
+| `get({ projectId, branchId })` | `Branch` | |
+| `create({ projectId, …input })` | `Branch` | RW compute on by default. `noCompute: true` skips the endpoint. No connection string. Readiness polling on by default. `input`: `{ name?, parent_id?, parent_lsn?, parent_timestamp?, protected?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? }, noCompute? }` |
+| `update({ projectId, branchId, …input })` | `Branch` | `input`: `{ name?, protected?, expires_at? }` |
+| `delete({ projectId, branchId })` | **→void** | |
+| `createAndConnect({ projectId, …input, pooled? }, options?)` | **[W]** `{ branch, endpoint, connectionString }` | `input`: `{ name?, parentId?, compute?: { minCu?, maxCu?, suspendTimeoutSeconds? } }`; `pooled` default `true` |
+| `getDefault({ projectId })` | `Branch` | resolves the default branch by the `default` flag |
+| `setDefault({ projectId, branchId })` | `Branch` | |
+| `resetFromParent({ projectId, branchId, preserveUnderName? }, options?)` | `Branch` | parent HEAD only; discards writes since the branch diverged. `preserveUnderName` is required when the branch has children. Pass `{ waitForReadiness: true }` before using the branch |
+| `compareSchema({ projectId, branchId, …input })` | `{ diff? }` | `input`: `{ databaseName, baseBranchId?, lsn?, timestamp?, baseLsn?, baseTimestamp? }`. Omitting `baseBranchId` compares against the parent |
+| `finalizeRestore({ projectId, branchId, name? })` | **→void** | commits a restore previewed with `snapshots.restore({ finalize: false })` |
 
 **There is no `recover`.** Neon stopped publishing `POST /projects/{project_id}/branches/{branch_id}/recover` in its OpenAPI spec, so the wrapper is gone until it returns. The endpoint still answers, so a soft-deleted branch can still be recovered through the low-level client — note that this envelope carries the API's own error body rather than a `NeonError`:
 
@@ -331,21 +347,24 @@ const branch = data?.branch;
 
 ```ts
 // Resolve the project's default ("production") branch
-const { data: prod } = await neon.branches.getDefault(projectId);
+const { data: prod } = await neon.branches.getDefault({ projectId });
 
-await neon.branches.create(projectId, {
+await neon.branches.create({
+  projectId,
   name: "preview/pr-123",
   parent_id: prod?.id,
 });
 
-await neon.branches.create(projectId, {
+await neon.branches.create({
+  projectId,
   name: "schema-only",
   parent_id: prod?.id,
   noCompute: true,
 });
 
 // Branch off it with its own compute — returns a ready connection string
-const { data } = await neon.branches.createAndConnect(projectId, {
+const { data } = await neon.branches.createAndConnect({
+  projectId,
   name: "preview/pr-123",
   parentId: prod?.id,
   compute: { minCu: 0.25, maxCu: 2 },
@@ -353,14 +372,13 @@ const { data } = await neon.branches.createAndConnect(projectId, {
 // data: { branch, endpoint, connectionString }
 
 const { data: schema } = await neon.branches.compareSchema(
-  projectId,
-  data!.branch.id,
-  { databaseName: "neondb" },
+  { projectId, branchId: data!.branch.id, databaseName: "neondb" },
 );
 
-await neon.branches.resetFromParent(projectId, data!.branch.id, undefined, {
-  waitForReadiness: true,
-});
+await neon.branches.resetFromParent(
+  { projectId, branchId: data!.branch.id },
+  { waitForReadiness: true },
+);
 ```
 
 ### `neon.postgres`
@@ -378,28 +396,30 @@ const { data: uri } = await neon.postgres.connectionString({
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId)` | `Endpoint[]` |
-| `get(projectId, endpointId)` | `Endpoint` |
-| `create(projectId, input)` | `Endpoint` — `input`: `{ branch_id, type, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, suspend_timeout_seconds?, provisioner? }` |
-| `update(projectId, endpointId, input)` | `Endpoint` |
-| `delete(projectId, endpointId)` | **→void** |
-| `start` / `suspend` / `restart(projectId, endpointId)` | `Endpoint` |
+| `list({ projectId })` | `Endpoint[]` |
+| `listByBranch({ projectId, branchId })` | `Endpoint[]` |
+| `get({ projectId, endpointId })` | `Endpoint` |
+| `create({ projectId, …input })` | `Endpoint` — `input`: `{ branch_id, type, autoscaling_limit_min_cu?, autoscaling_limit_max_cu?, suspend_timeout_seconds?, provisioner? }` |
+| `update({ projectId, endpointId, …input })` | `Endpoint` |
+| `delete({ projectId, endpointId })` | **→void** |
+| `start` / `suspend` / `restart({ projectId, endpointId })` | `Endpoint` |
 
 #### `neon.postgres.roles`
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId, branchId)` | `Role[]` |
-| `get(projectId, branchId, name)` | `Role` |
-| `create(projectId, branchId, { name, no_login? })` | `Role` |
-| `delete(projectId, branchId, name)` | **→void** |
-| `password(projectId, branchId, name)` | `string` (reveals the password) |
-| `resetPassword(projectId, branchId, name)` | `Role` (carries the new password) |
+| `list({ projectId, branchId })` | `Role[]` |
+| `get({ projectId, branchId, roleName })` | `Role` |
+| `create({ projectId, branchId, name, no_login? })` | `Role` |
+| `delete({ projectId, branchId, roleName })` | **→void** |
+| `password({ projectId, branchId, roleName })` | `string` (reveals the password) |
+| `resetPassword({ projectId, branchId, roleName })` | `Role` (carries the new password) |
 
 ```ts
 // Reveal a role's password, or rotate it
-const { data: password } = await neon.postgres.roles.password(projectId, branchId, "neondb_owner");
-const { data: role } = await neon.postgres.roles.resetPassword(projectId, branchId, "neondb_owner");
+const roleParams = { projectId, branchId, roleName: "neondb_owner" };
+const { data: password } = await neon.postgres.roles.password(roleParams);
+const { data: role } = await neon.postgres.roles.resetPassword(roleParams);
 // role.password holds the new secret
 ```
 
@@ -407,20 +427,20 @@ const { data: role } = await neon.postgres.roles.resetPassword(projectId, branch
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId, branchId)` | `Database[]` |
-| `get(projectId, branchId, name)` | `Database` |
-| `create(projectId, branchId, { name, owner_name })` | `Database` |
-| `update(projectId, branchId, name, { name?, owner_name? })` | `Database` |
-| `delete(projectId, branchId, name)` | **→void** |
+| `list({ projectId, branchId })` | `Database[]` |
+| `get({ projectId, branchId, databaseName })` | `Database` |
+| `create({ projectId, branchId, name, owner_name })` | `Database` |
+| `update({ projectId, branchId, databaseName, name?, owner_name? })` | `Database` |
+| `delete({ projectId, branchId, databaseName })` | **→void** |
 
 #### `neon.postgres.dataApi`
 
 | Method | Returns |
 | --- | --- |
-| `get(projectId, branchId, databaseName)` | `DataApiReponse` |
-| `create(projectId, branchId, databaseName, input?)` | `DataApiCreateResponse` |
-| `update(projectId, branchId, databaseName, input?)` | **→void** |
-| `delete(projectId, branchId, databaseName)` | **→void** |
+| `get({ projectId, branchId, databaseName })` | `DataApiReponse` |
+| `create({ projectId, branchId, databaseName, …input })` | `DataApiCreateResponse` |
+| `update({ projectId, branchId, databaseName, …input })` | **→void** |
+| `delete({ projectId, branchId, databaseName })` | **→void** |
 
 ### `neon.storage`
 
@@ -431,31 +451,37 @@ enabled and the branch S3 endpoint metadata; buckets and objects are nested unde
 
 | Method | Returns |
 | --- | --- |
-| `get(projectId, branchId)` | `BranchStorage` |
+| `get({ projectId, branchId })` | `BranchStorage` |
 
 #### `neon.storage.buckets`
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId, branchId)` | `Bucket[]` |
-| `create(projectId, branchId, { name, access_level? })` | `Bucket` — `access_level`: `"private"` \| `"public_read"` |
-| `delete(projectId, branchId, bucketName)` | **→void** |
+| `list({ projectId, branchId })` | `Bucket[]` |
+| `create({ projectId, branchId, name, access_level? })` | `Bucket` — `access_level`: `"private"` \| `"public_read"` |
+| `delete({ projectId, branchId, bucketName })` | **→void** |
 
 #### `neon.storage.objects`
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, branchId, bucketName, query?)` | `BucketObjectsListResponse` | `query`: `{ prefix?, delimiter?, cursor?, limit? }` — one page (`folders`, `objects`, `next_cursor`) |
-| `get(projectId, branchId, bucketName, objectKey)` | `Blob` | raw object bytes |
-| `delete(projectId, branchId, bucketName, objectKey)` | **→void** | |
-| `deleteByPrefix(projectId, branchId, bucketName, prefix)` | `{ deleted: number }` | `prefix` must end with `/` |
-| `presign(projectId, branchId, bucketName, objectKey, input)` | `PresignResponse` | `input`: `{ operation: "upload" \| "download", content_type?, expires_in_seconds? }` |
+| `list({ projectId, branchId, bucketName, …query })` | `BucketObjectsListResponse` | `query`: `{ prefix?, delimiter?, cursor?, limit? }` — one page (`folders`, `objects`, `next_cursor`) |
+| `get({ projectId, branchId, bucketName, objectKey })` | `Blob` | raw object bytes |
+| `delete({ projectId, branchId, bucketName, objectKey })` | **→void** | |
+| `deleteByPrefix({ projectId, branchId, bucketName, prefix })` | `{ deleted: number }` | `prefix` must end with `/` |
+| `presign({ projectId, branchId, bucketName, objectKey, …input })` | `PresignResponse` | `input`: `{ operation: "upload" \| "download", content_type?, expires_in_seconds? }` |
 
 ```ts
 // Upload via presigned PUT (same flow as neon bucket object put)
 const { data: presign } = await neon.storage.objects.presign(
-  projectId, branchId, "avatars", "user-1.png",
-  { operation: "upload", content_type: "image/png" },
+  {
+    projectId,
+    branchId,
+    bucketName: "avatars",
+    objectKey: "user-1.png",
+    operation: "upload",
+    content_type: "image/png",
+  },
 );
 if (!presign) throw new Error("presign failed");
 
@@ -472,16 +498,19 @@ Branch-scoped Neon Functions (beta).
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, branchId, query?)` | **[P]** `NeonFunction` | `query`: `{ limit? }` |
-| `get(projectId, branchId, slug)` | `NeonFunction` | |
-| `update(projectId, branchId, slug, input)` | `NeonFunction` | `input`: `{ name? }` |
-| `delete(projectId, branchId, slug)` | **→void** | |
-| `deploy(projectId, branchId, slug, input?)` | `NeonFunctionDeployment` | multipart — `input`: `{ zip?: Blob \| File, runtime?: "nodejs24", environment?: string }` (`environment` is a JSON-encoded `Record<string, string>`) |
+| `list({ projectId, branchId, …query })` | **[P]** `NeonFunction` | `query`: `{ limit? }` |
+| `get({ projectId, branchId, slug })` | `NeonFunction` | |
+| `update({ projectId, branchId, slug, …input })` | `NeonFunction` | `input`: `{ name? }` |
+| `delete({ projectId, branchId, slug })` | **→void** | |
+| `deploy({ projectId, branchId, slug, …input })` | `NeonFunctionDeployment` | multipart — `input`: `{ zip?: Blob \| File, runtime?: "nodejs24", environment?: string }` (`environment` is a JSON-encoded `Record<string, string>`) |
 
 ```ts
 // Deploy a bundled index.mjs inside a zip (first deploy must include zip)
 const zip = await Bun.file("bundle.zip").arrayBuffer();
-const { data: deployment } = await neon.functions.deploy(projectId, branchId, "api", {
+const { data: deployment } = await neon.functions.deploy({
+  projectId,
+  branchId,
+  slug: "api",
   zip: new File([zip], "bundle.zip", { type: "application/zip" }),
   runtime: "nodejs24",
 });
@@ -500,15 +529,19 @@ resolves and a certificate is issued on the first request.
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, branchId, query?)` | **[P]** `CustomDomain` | `query`: `{ limit? }` |
-| `register(projectId, branchId, input)` | `CustomDomain` | `input`: `{ domain, entity_type, entity_id }` |
-| `delete(projectId, branchId, domain)` | **→void** | |
+| `list({ projectId, branchId, …query })` | **[P]** `CustomDomain` | `query`: `{ limit? }` |
+| `register({ projectId, branchId, …input })` | `CustomDomain` | `input`: `{ domain, entity_type, entity_id }` |
+| `delete({ projectId, branchId, domain })` | **→void** | |
 
 ```ts
 const { data: registered } = await neon.functions.customDomains.register(
-  projectId,
-  branchId,
-  { domain: "docs.example.com", entity_type: "function", entity_id: "api" },
+  {
+    projectId,
+    branchId,
+    domain: "docs.example.com",
+    entity_type: "function",
+    entity_id: "api",
+  },
 );
 // Point a CNAME for docs.example.com at registered.cname_target
 ```
@@ -519,15 +552,17 @@ Branch-scoped triggers (beta). v1 only supports `type: "schedule"`, which invoke
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, branchId)` | `Trigger[]` | |
-| `create(projectId, branchId, input)` | `Trigger` | `input`: `{ type: "schedule", function_slug, name, schedule: { cron }, function_path?, enabled? }` |
-| `get(projectId, branchId, triggerId)` | `Trigger` | |
-| `update(projectId, branchId, triggerId, input)` | `Trigger` | `input` must include `type: "schedule"`; other fields optional |
-| `delete(projectId, branchId, triggerId)` | **→void** | |
+| `list({ projectId, branchId })` | `Trigger[]` | |
+| `create({ projectId, branchId, …input })` | `Trigger` | `input`: `{ type: "schedule", function_slug, name, schedule: { cron }, function_path?, enabled? }` |
+| `get({ projectId, branchId, triggerId })` | `Trigger` | |
+| `update({ projectId, branchId, triggerId, …input })` | `Trigger` | `input` must include `type: "schedule"`; other fields optional |
+| `delete({ projectId, branchId, triggerId })` | **→void** | |
 
 ```ts
 const { data: trigger, error: createError } =
-  await neon.triggers.create(projectId, branchId, {
+  await neon.triggers.create({
+    projectId,
+    branchId,
     type: "schedule",
     function_slug: "worker",
     name: "daily-refresh",
@@ -536,11 +571,14 @@ const { data: trigger, error: createError } =
   });
 if (createError) throw createError;
 
-await neon.triggers.update(projectId, branchId, trigger.trigger_id, {
+await neon.triggers.update({
+  projectId,
+  branchId,
+  triggerId: trigger.trigger_id,
   type: "schedule",
   enabled: true,
 });
-await neon.triggers.delete(projectId, branchId, trigger.trigger_id);
+await neon.triggers.delete({ projectId, branchId, triggerId: trigger.trigger_id });
 ```
 
 ### `neon.credentials`
@@ -560,17 +598,17 @@ scopes.
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, branchId)` | `CredentialMeta[]` | |
-| `create(projectId, branchId, input)` | `CreateCredentialResponse` | `input`: `{ name?, scopes, principal_type: "user" }` |
-| `revoke(projectId, branchId, tokenId)` | **→void** | |
-| `reveal(projectId, branchId, tokenId)` | `CredentialSecret` | `{ token_id, api_token, s3_secret_access_key }` — no `branch_id`. 404 if revoked, expired, or wrong project. 409 if issued before secret retrieval; rotate to obtain one |
-| `rotate(projectId, branchId, tokenId)` | `RotateCredentialResponse` | Not idempotent. A lost 200 already committed; create a replacement and revoke this one. After rotate, a replica may briefly accept the old secret |
+| `list({ projectId, branchId })` | `CredentialMeta[]` | |
+| `create({ projectId, branchId, …input })` | `CreateCredentialResponse` | `input`: `{ name?, scopes, principal_type: "user" }` |
+| `revoke({ projectId, branchId, tokenId })` | **→void** | |
+| `reveal({ projectId, branchId, tokenId })` | `CredentialSecret` | `{ token_id, api_token, s3_secret_access_key }` — no `branch_id`. 404 if revoked, expired, or wrong project. 409 if issued before secret retrieval; rotate to obtain one |
+| `rotate({ projectId, branchId, tokenId })` | `RotateCredentialResponse` | Not idempotent. A lost 200 already committed; create a replacement and revoke this one. After rotate, a replica may briefly accept the old secret |
 
 ```ts
 const { data: created, error: createError } = await neon.credentials.create(
-  projectId,
-  branchId,
   {
+    projectId,
+    branchId,
     scopes: ["storage:read"],
     principal_type: "user",
   },
@@ -578,16 +616,12 @@ const { data: created, error: createError } = await neon.credentials.create(
 if (createError) throw createError;
 
 const { data: revealed, error: revealError } = await neon.credentials.reveal(
-  projectId,
-  branchId,
-  created.token_id,
+  { projectId, branchId, tokenId: created.token_id },
 );
 if (revealError) throw revealError;
 
 const { data: rotated, error: rotateError } = await neon.credentials.rotate(
-  projectId,
-  branchId,
-  created.token_id,
+  { projectId, branchId, tokenId: created.token_id },
 );
 if (rotateError) throw rotateError;
 ```
@@ -598,7 +632,7 @@ Branch-scoped AI Gateway endpoint metadata (beta).
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `get(projectId, branchId)` | `BranchAiGateway` | 404 when AI Gateway is not enabled on the branch |
+| `get({ projectId, branchId })` | `BranchAiGateway` | 404 when AI Gateway is not enabled on the branch |
 
 ### `neon.logs`
 
@@ -632,7 +666,7 @@ function logsUnavailableReason(error: unknown): string | undefined {
   return typeof body.reason === "string" ? body.reason : undefined;
 }
 
-const { error } = await neon.logs.fields(projectId, branchId);
+const { error } = await neon.logs.fields({ projectId, branchId });
 if (error) {
   if (logsUnavailableReason(error) === "telemetry_not_enabled") {
     // no logs on this branch, ever — carry on
@@ -649,9 +683,9 @@ produced a `pg_endpoint` record. And `minimum_severity` can be rejected outright
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `query(projectId, branchId, input?)` | **[P]** `ProjectBranchLogRecord` | `input`: `{ since?, start_time?, end_time?, limit?, sort_order?, source?, service_name?, scope_name?, minimum_severity?, severity_text?, body_contains?, trace_id?, logql? }` — filters combine with `AND` |
-| `fields(projectId, branchId)` | `string[]` | field names this branch has emitted, usable as `fieldName` below |
-| `fieldValues(projectId, branchId, fieldName, query?)` | `ProjectBranchLogFieldValuesResponse` | `query`: `{ since?, start_time?, end_time?, source?, limit? }` — check `is_truncated` |
+| `query({ projectId, branchId, …input })` | **[P]** `ProjectBranchLogRecord` | `input`: `{ since?, start_time?, end_time?, limit?, sort_order?, source?, service_name?, scope_name?, minimum_severity?, severity_text?, body_contains?, trace_id?, logql? }` — filters combine with `AND` |
+| `fields({ projectId, branchId })` | `string[]` | field names this branch has emitted, usable as `fieldName` below |
+| `fieldValues({ projectId, branchId, fieldName, …query })` | `ProjectBranchLogFieldValuesResponse` | `query`: `{ since?, start_time?, end_time?, source?, limit? }` — check `is_truncated` |
 
 Give the window as **either** `since` (`"30m"`, `"6h"`, `"7d"`) **or** `start_time`;
 supplying both is rejected with `conflicting_time_range`. `logql` replaces the seven
@@ -669,7 +703,9 @@ were complete.
 ```ts
 // Errors from a function over the last 6 hours, newest first
 const { data: errors } = await neon.logs
-  .query(projectId, branchId, {
+  .query({
+    projectId,
+    branchId,
     since: "6h",
     source: "function",
     // some branches' log backends reject minimum_severity; severity_text always works
@@ -678,16 +714,16 @@ const { data: errors } = await neon.logs
   .all();
 
 // Paging replays the filters for you — the endpoint returns wrong results otherwise
-for await (const line of neon.logs.query(projectId, branchId, { since: "1h" })) {
+for await (const line of neon.logs.query({ projectId, branchId, since: "1h" })) {
   console.log(line.timestamp, line.message);
 }
 
 // Discover what you can enumerate, then read one field's values
-const { data: fields } = await neon.logs.fields(projectId, branchId);
+const { data: fields } = await neon.logs.fields({ projectId, branchId });
 // e.g. ["service_name", "severity_text", "scope_name", "entity_type"]
 
 const { data: services } = await neon.logs.fieldValues(
-  projectId, branchId, "service_name", { since: "24h" },
+  { projectId, branchId, fieldName: "service_name", since: "24h" },
 );
 console.log(services?.values);
 if (services?.is_truncated) {
@@ -697,7 +733,7 @@ if (services?.is_truncated) {
 
 **`fieldName` must be a name `fields` returned.** The enumerable set and the filterable
 set overlap rather than nest: `source` is a filter — on `query` and on `fieldValues`' own
-query — but is not enumerable, so `fieldValues(…, "source")` answers `400` with
+query — but is not enumerable, so `fieldValues({ …, fieldName: "source" })` answers `400` with
 `reason: "unknown_field"`; `entity_type` is enumerable but is not a filter on `query`.
 
 `fields` returns a bare `string[]` because its response carries nothing else.
@@ -708,17 +744,19 @@ the values can be trusted and unwrapping would hide it.
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId)` | `Snapshot[]` | |
-| `create(projectId, branchId, input?)` | `Snapshot` | `input`: `{ name?, timestamp?, lsn?, expiresAt? }` (point-in-time) |
-| `update(projectId, snapshotId, input)` | `Snapshot` | `input`: `{ name?, expiresAt? }` — pass `expiresAt: null` to clear the expiration |
-| `delete(projectId, snapshotId)` | **→void** | |
-| `restore(projectId, snapshotId, input?)` | `Branch` | see below |
-| `getSchedule(projectId, branchId)` | `BackupSchedule` | `frequency` stays a wide `string`: a branch can still hold a schedule created when the API accepted other values |
-| `setSchedule(projectId, branchId, schedule)` | **→void** | `schedule.schedule[].frequency` is narrowed to `SnapshotFrequency` (`"daily" \| "weekly" \| "monthly"`) |
+| `list({ projectId })` | `Snapshot[]` | |
+| `create({ projectId, branchId, …input })` | `Snapshot` | `input`: `{ name?, timestamp?, lsn?, expiresAt? }` (point-in-time) |
+| `update({ projectId, snapshotId, …input })` | `Snapshot` | `input`: `{ name?, expiresAt? }` — pass `expiresAt: null` to clear the expiration |
+| `delete({ projectId, snapshotId })` | **→void** | |
+| `restore({ projectId, snapshotId, …input })` | `Branch` | see below |
+| `getSchedule({ projectId, branchId })` | `BackupSchedule` | `frequency` stays a wide `string`: a branch can still hold a schedule created when the API accepted other values |
+| `setSchedule({ projectId, branchId, schedule })` | **→void** | `schedule[].frequency` is narrowed to `SnapshotFrequency` (`"daily" \| "weekly" \| "monthly"`) |
 
 ```ts
 // Snapshot a branch at a point in time (or an `lsn`), with a name + TTL
-const { data: snapshot } = await neon.snapshots.create(projectId, branchId, {
+const { data: snapshot } = await neon.snapshots.create({
+  projectId,
+  branchId,
   name: "pre-migration",
   timestamp: "2026-06-01T00:00:00Z",
   expiresAt: "2026-07-01T00:00:00Z",
@@ -731,7 +769,9 @@ const { data: snapshot } = await neon.snapshots.create(projectId, branchId, {
 - **Transaction-style** with `preview`: it restores un-finalized, runs your callback against the restored branch, then **finalizes (commit)** if it returns `true` or **deletes the preview branch (abort)** if `false` (unless `keepOnAbort`):
 
 ```ts
-await neon.snapshots.restore(projectId, snapshotId, {
+await neon.snapshots.restore({
+  projectId,
+  snapshotId,
   targetBranchId,
   // second argument carries the call's signal; the SDK cannot interrupt your callback
   preview: async (branch, { signal }) =>
@@ -743,9 +783,9 @@ await neon.snapshots.restore(projectId, snapshotId, {
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId)` | **[P]** `Operation` | |
-| `get(projectId, operationId)` | `Operation` | |
-| `waitFor(operations, options?)` | **→void** | `options`: `{ pollIntervalMs?, timeoutMs?, signal? }` — the readiness primitive. A wait timeout's `error.operations` is the still-outstanding subset; pass it here to resume. |
+| `list({ projectId })` | **[P]** `Operation` | |
+| `get({ projectId, operationId })` | `Operation` | |
+| `waitFor({ operations }, options?)` | **→void** | `options`: `{ pollIntervalMs?, timeoutMs?, signal?, throwOnError? }` — the readiness primitive. `requestTimeoutMs`, `waitForReadiness`, and `wait` are excluded. A wait timeout's `error.operations` is the still-outstanding subset; pass it here to resume. |
 
 ```ts
 // Wait on operations from a raw call (or when waitForReadiness is off)
@@ -754,7 +794,10 @@ const { data } = await raw.createProjectBranch({
   path: { project_id: projectId },
   body: { branch: { name: "wip" } },
 });
-const { error } = await neon.operations.waitFor(data!.operations, { timeoutMs: 120_000 });
+const { error } = await neon.operations.waitFor(
+  { operations: data!.operations },
+  { timeoutMs: 120_000 },
+);
 ```
 
 ### `neon.consumption`
@@ -784,8 +827,8 @@ for await (const project of neon.consumption.perProject({
 | Method | Returns | Notes |
 | --- | --- | --- |
 | `list()` | `ApiKeysListResponseItem[]` | |
-| `create(keyName)` | `ApiKeyCreateResponse` | the `key` token is shown **once** |
-| `revoke(keyId)` | `ApiKeyRevokeResponse` | |
+| `create({ keyName })` | `ApiKeyCreateResponse` | the `key` token is shown **once** |
+| `revoke({ keyId })` | `ApiKeyRevokeResponse` | |
 
 ### `neon.regions` / `neon.user`
 
@@ -801,21 +844,28 @@ Branch-scoped Neon Auth (the legacy project-scoped endpoints are deprecated and 
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `get(projectId, branchId)` | `NeonAuthIntegration` | |
-| `create(projectId, branchId, input)` | `NeonAuthCreateIntegrationResponse` | enable the integration |
-| `disable(projectId, branchId, { deleteData? }?)` | **→void** | |
-| `updateConfig(projectId, branchId, input)` | `NeonAuthConfigResponse` | |
-| `oauthProviders.list / add / update / delete` | `NeonAuthOauthProvider`(`[]`) / **→void** | |
-| `trustedDomains.list / add / delete` | `NeonAuthRedirectUriWhitelistDomain[]` / **→void** | redirect-URI whitelist |
-| `users.create / delete / updateRole` | `NeonAuthCreateNewUserResponse` / **→void** / role | |
+| `get({ projectId, branchId })` | `NeonAuthIntegration` | |
+| `create({ projectId, branchId, …input })` | `NeonAuthCreateIntegrationResponse` | enable the integration |
+| `disable({ projectId, branchId, deleteData? })` | **→void** | |
+| `updateConfig({ projectId, branchId, …input })` | `NeonAuthConfigResponse` | |
+| `oauthProviders.list({ projectId, branchId })` | `NeonAuthOauthProvider[]` | |
+| `oauthProviders.add({ projectId, branchId, …input })` | `NeonAuthOauthProvider` | |
+| `oauthProviders.update({ projectId, branchId, providerId, …input })` | `NeonAuthOauthProvider` | |
+| `oauthProviders.delete({ projectId, branchId, providerId })` | **→void** | |
+| `trustedDomains.list({ projectId, branchId })` | `NeonAuthRedirectUriWhitelistDomain[]` | redirect-URI whitelist |
+| `trustedDomains.add({ projectId, branchId, domain, auth_provider })` | **→void** | redirect-URI whitelist |
+| `trustedDomains.delete({ projectId, branchId, auth_provider, domains })` | **→void** | redirect-URI whitelist |
+| `users.create({ projectId, branchId, …input })` | `NeonAuthCreateNewUserResponse` | |
+| `users.delete({ projectId, branchId, authUserId })` | **→void** | |
+| `users.updateRole({ projectId, branchId, authUserId, roles })` | role | |
 
 ### `neon.projects.permissions`
 
 | Method | Returns |
 | --- | --- |
-| `list(projectId)` | `ProjectPermission[]` |
-| `grant(projectId, email)` | `ProjectPermission` |
-| `revoke(projectId, permissionId)` | `ProjectPermission` |
+| `list({ projectId })` | `ProjectPermission[]` |
+| `grant({ projectId, email })` | `ProjectPermission` |
+| `revoke({ projectId, permissionId })` | `ProjectPermission` |
 
 For an **org-owned** project, roles for existing organization members live on
 `neon.projects.members` below instead.
@@ -830,9 +880,9 @@ only — a personal project answers 404.
 
 | Method | Returns | Notes |
 | --- | --- | --- |
-| `list(projectId, query?)` | **[P]** `ProjectMember` | `query`: `{ limit? }` |
-| `setRole(projectId, memberId, role, { confirmSelfDemotion? }?)` | `ProjectMemberRoleResponse` | `role`: `"viewer" \| "editor" \| "admin"`; idempotent |
-| `removeRole(projectId, memberId, { confirmSelfLockout? }?)` | `ProjectMemberRoleResponse` | clears the explicit grant; idempotent |
+| `list({ projectId, …query })` | **[P]** `ProjectMember` | `query`: `{ limit? }` |
+| `setRole({ projectId, memberId, role, confirmSelfDemotion? }, options?)` | `ProjectMemberRoleResponse` | `role`: `"viewer" \| "editor" \| "admin"`; idempotent |
+| `removeRole({ projectId, memberId, confirmSelfLockout? }, options?)` | `ProjectMemberRoleResponse` | clears the explicit grant; idempotent |
 
 A `ProjectMember` carries several role-ish fields, and they are not interchangeable.
 **Read `effective_project_permission`** for "what can this member actually do" — `VIEWER`
@@ -853,15 +903,12 @@ access (`confirmSelfLockout`); without it the API rejects the call.
 
 ```ts
 const { data: grant } = await neon.projects.members.setRole(
-  projectId, memberId, "editor",
+  { projectId, memberId, role: "editor" },
 );
 // A downgrade can leave credentials the member still holds
 if (grant?.credential_rotation_recommended) { /* rotate database credentials */ }
 if (grant?.org_api_key_rotation_recommended) { /* rotate project-scoped org keys */ }
 ```
-
-Also on `neon.projects`: `recover(id)` (beta — recover a soft-deleted project), and on
-`neon.postgres.endpoints`: `listByBranch(projectId, branchId)` → `Endpoint[]`.
 
 ---
 

--- a/packages/sdk/e2e/errors.e2e.test.ts
+++ b/packages/sdk/e2e/errors.e2e.test.ts
@@ -18,7 +18,9 @@ describe.sequential("e2e — @neon/sdk error mapping against the real API", () =
 	it("maps a missing project to NeonNotFoundError with the real status", async () => {
 		const neon = makeClient();
 
-		const { data, error } = await neon.projects.get(MISSING_PROJECT_ID);
+		const { data, error } = await neon.projects.get({
+			projectId: MISSING_PROJECT_ID,
+		});
 
 		expect(data).toBeUndefined();
 		expect(error).toBeInstanceOf(NeonNotFoundError);
@@ -46,7 +48,7 @@ describe.sequential("e2e — @neon/sdk error mapping against the real API", () =
 		const neon = makeThrowingClient();
 
 		await expect(
-			neon.projects.get(MISSING_PROJECT_ID),
+			neon.projects.get({ projectId: MISSING_PROJECT_ID }),
 		).rejects.toBeInstanceOf(NeonNotFoundError);
 	});
 

--- a/packages/sdk/e2e/resources.e2e.test.ts
+++ b/packages/sdk/e2e/resources.e2e.test.ts
@@ -29,7 +29,7 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 	beforeAll(async () => {
 		neon = makeClient();
 		projectId = await createProject({ name: uniqueProjectName("sdk-res") });
-		const main = expectOk(await neon.branches.getDefault(projectId));
+		const main = expectOk(await neon.branches.getDefault({ projectId }));
 		defaultBranchId = main.id;
 	});
 
@@ -39,7 +39,8 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 	it("round-trips a branch through create, get, update and delete", async () => {
 		const created = expectOk(
-			await neon.branches.create(projectId, {
+			await neon.branches.create({
+				projectId,
 				name: "crud",
 				parent_id: defaultBranchId,
 				noCompute: true,
@@ -48,46 +49,53 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		expect(created.name).toBe("crud");
 
 		const fetched = expectOk(
-			await neon.branches.get(projectId, created.id),
+			await neon.branches.get({ projectId, branchId: created.id }),
 		);
 		expect(fetched.id).toBe(created.id);
 
 		const renamed = expectOk(
 			await neon.branches.update(
-				projectId,
-				created.id,
-				{ name: "crud-renamed" },
+				{ projectId, branchId: created.id, name: "crud-renamed" },
 				{ waitForReadiness: true },
 			),
 		);
 		expect(renamed.name).toBe("crud-renamed");
 
 		expectOk(
-			await neon.branches.delete(projectId, created.id, {
-				waitForReadiness: true,
-			}),
+			await neon.branches.delete(
+				{ projectId, branchId: created.id },
+				{
+					waitForReadiness: true,
+				},
+			),
 		);
 
-		const { error } = await neon.branches.get(projectId, created.id);
+		const { error } = await neon.branches.get({
+			projectId,
+			branchId: created.id,
+		});
 		expect(error).toBeInstanceOf(NeonNotFoundError);
 	});
 
 	it("compares schemas and resets a child back to its parent", async () => {
 		const child = expectOk(
-			await neon.branches.createAndConnect(projectId, {
+			await neon.branches.createAndConnect({
+				projectId,
 				name: "reset-child",
 				parentId: defaultBranchId,
 			}),
 		);
 		const branchId = child.branch.id;
 		const roles = expectOk(
-			await neon.postgres.roles.list(projectId, branchId),
+			await neon.postgres.roles.list({ projectId, branchId }),
 		);
 		const owner = roles[0];
 		if (!owner) throw new Error("child branch has no role");
 
 		const matching = expectOk(
-			await neon.branches.compareSchema(projectId, branchId, {
+			await neon.branches.compareSchema({
+				projectId,
+				branchId,
 				databaseName: "neondb",
 				baseBranchId: defaultBranchId,
 			}),
@@ -96,31 +104,34 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 		expectOk(
 			await neon.postgres.databases.create(
-				projectId,
-				branchId,
-				{ name: "child_only", owner_name: owner.name },
+				{
+					projectId,
+					branchId,
+					name: "child_only",
+					owner_name: owner.name,
+				},
 				{ waitForReadiness: true },
 			),
 		);
 
 		expectOk(
 			await neon.branches.resetFromParent(
-				projectId,
-				branchId,
-				undefined,
+				{ projectId, branchId },
 				{
 					waitForReadiness: true,
 				},
 			),
 		);
 		const after = expectOk(
-			await neon.postgres.databases.list(projectId, branchId),
+			await neon.postgres.databases.list({ projectId, branchId }),
 		);
 		expect(after.map((database) => database.name)).not.toContain(
 			"child_only",
 		);
 		const matchingAgain = expectOk(
-			await neon.branches.compareSchema(projectId, branchId, {
+			await neon.branches.compareSchema({
+				projectId,
+				branchId,
 				databaseName: "neondb",
 				baseBranchId: defaultBranchId,
 			}),
@@ -128,15 +139,19 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		expect(matchingAgain.diff ?? "").toBe("");
 
 		expectOk(
-			await neon.branches.delete(projectId, branchId, {
-				waitForReadiness: true,
-			}),
+			await neon.branches.delete(
+				{ projectId, branchId },
+				{
+					waitForReadiness: true,
+				},
+			),
 		);
 	});
 
 	it("creates a branch with its compute and a connection string in one call", async () => {
 		const created = expectOk(
-			await neon.branches.createAndConnect(projectId, {
+			await neon.branches.createAndConnect({
+				projectId,
 				name: "with-compute",
 				parentId: defaultBranchId,
 			}),
@@ -148,74 +163,89 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 		// The endpoint the workflow reports must be the one the API actually attached.
 		const endpoints = expectOk(
-			await neon.postgres.endpoints.listByBranch(
+			await neon.postgres.endpoints.listByBranch({
 				projectId,
-				created.branch.id,
-			),
+				branchId: created.branch.id,
+			}),
 		);
 		expect(endpoints.map((endpoint) => endpoint.id)).toContain(
 			created.endpoint.id,
 		);
 
 		expectOk(
-			await neon.branches.delete(projectId, created.branch.id, {
-				waitForReadiness: true,
-			}),
+			await neon.branches.delete(
+				{ projectId, branchId: created.branch.id },
+				{
+					waitForReadiness: true,
+				},
+			),
 		);
 	});
 
 	it("attaches a read-write endpoint unless noCompute is true", async () => {
 		const withCompute = expectOk(
-			await neon.branches.create(projectId, {
+			await neon.branches.create({
+				projectId,
 				name: "with-endpoint",
 				parent_id: defaultBranchId,
 			}),
 		);
 		const attached = expectOk(
-			await neon.postgres.endpoints.listByBranch(
+			await neon.postgres.endpoints.listByBranch({
 				projectId,
-				withCompute.id,
-			),
+				branchId: withCompute.id,
+			}),
 		);
 		expect(
 			attached.filter((endpoint) => endpoint.type === "read_write"),
 		).toHaveLength(1);
 
 		const bare = expectOk(
-			await neon.branches.create(projectId, {
+			await neon.branches.create({
+				projectId,
 				name: "bare",
 				parent_id: defaultBranchId,
 				noCompute: true,
 			}),
 		);
 		const none = expectOk(
-			await neon.postgres.endpoints.listByBranch(projectId, bare.id),
+			await neon.postgres.endpoints.listByBranch({
+				projectId,
+				branchId: bare.id,
+			}),
 		);
 		expect(none).toEqual([]);
 
 		expectOk(
-			await neon.branches.delete(projectId, withCompute.id, {
-				waitForReadiness: true,
-			}),
+			await neon.branches.delete(
+				{ projectId, branchId: withCompute.id },
+				{
+					waitForReadiness: true,
+				},
+			),
 		);
 		expectOk(
-			await neon.branches.delete(projectId, bare.id, {
-				waitForReadiness: true,
-			}),
+			await neon.branches.delete(
+				{ projectId, branchId: bare.id },
+				{
+					waitForReadiness: true,
+				},
+			),
 		);
 	});
 
 	it("manages roles, including the two different password shapes", async () => {
 		const before = expectOk(
-			await neon.postgres.roles.list(projectId, defaultBranchId),
+			await neon.postgres.roles.list({
+				projectId,
+				branchId: defaultBranchId,
+			}),
 		);
 		expect(before.length).toBeGreaterThan(0);
 
 		const created = expectOk(
 			await neon.postgres.roles.create(
-				projectId,
-				defaultBranchId,
-				{ name: "e2e_role" },
+				{ projectId, branchId: defaultBranchId, name: "e2e_role" },
 				{ waitForReadiness: true },
 			),
 		);
@@ -224,20 +254,18 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		// `password` unwraps to a bare string, `resetPassword` returns the whole Role —
 		// an asymmetry that's easy to break when the response mapping is touched.
 		const password = expectOk(
-			await neon.postgres.roles.password(
+			await neon.postgres.roles.password({
 				projectId,
-				defaultBranchId,
-				"e2e_role",
-			),
+				branchId: defaultBranchId,
+				roleName: "e2e_role",
+			}),
 		);
 		expect(typeof password).toBe("string");
 		expect(password.length).toBeGreaterThan(0);
 
 		const reset = expectOk(
 			await neon.postgres.roles.resetPassword(
-				projectId,
-				defaultBranchId,
-				"e2e_role",
+				{ projectId, branchId: defaultBranchId, roleName: "e2e_role" },
 				{ waitForReadiness: true },
 			),
 		);
@@ -246,65 +274,77 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 		expectOk(
 			await neon.postgres.roles.delete(
-				projectId,
-				defaultBranchId,
-				"e2e_role",
+				{ projectId, branchId: defaultBranchId, roleName: "e2e_role" },
 				{ waitForReadiness: true },
 			),
 		);
 		const after = expectOk(
-			await neon.postgres.roles.list(projectId, defaultBranchId),
+			await neon.postgres.roles.list({
+				projectId,
+				branchId: defaultBranchId,
+			}),
 		);
 		expect(after.map((role) => role.name)).not.toContain("e2e_role");
 	});
 
 	it("round-trips a database", async () => {
 		const roles = expectOk(
-			await neon.postgres.roles.list(projectId, defaultBranchId),
+			await neon.postgres.roles.list({
+				projectId,
+				branchId: defaultBranchId,
+			}),
 		);
 		const owner = roles[0];
 		if (!owner) throw new Error("project has no role to own a database");
 
 		const created = expectOk(
 			await neon.postgres.databases.create(
-				projectId,
-				defaultBranchId,
-				{ name: "e2e_db", owner_name: owner.name },
+				{
+					projectId,
+					branchId: defaultBranchId,
+					name: "e2e_db",
+					owner_name: owner.name,
+				},
 				{ waitForReadiness: true },
 			),
 		);
 		expect(created.name).toBe("e2e_db");
 
 		const fetched = expectOk(
-			await neon.postgres.databases.get(
+			await neon.postgres.databases.get({
 				projectId,
-				defaultBranchId,
-				"e2e_db",
-			),
+				branchId: defaultBranchId,
+				databaseName: "e2e_db",
+			}),
 		);
 		expect(fetched.owner_name).toBe(owner.name);
 
 		expectOk(
 			await neon.postgres.databases.delete(
-				projectId,
-				defaultBranchId,
-				"e2e_db",
+				{
+					projectId,
+					branchId: defaultBranchId,
+					databaseName: "e2e_db",
+				},
 				{ waitForReadiness: true },
 			),
 		);
 		const after = expectOk(
-			await neon.postgres.databases.list(projectId, defaultBranchId),
+			await neon.postgres.databases.list({
+				projectId,
+				branchId: defaultBranchId,
+			}),
 		);
 		expect(after.map((db) => db.name)).not.toContain("e2e_db");
 	});
 
 	it("lists and fetches the default branch's endpoint", async () => {
-		const all = expectOk(await neon.postgres.endpoints.list(projectId));
+		const all = expectOk(await neon.postgres.endpoints.list({ projectId }));
 		const byBranch = expectOk(
-			await neon.postgres.endpoints.listByBranch(
+			await neon.postgres.endpoints.listByBranch({
 				projectId,
-				defaultBranchId,
-			),
+				branchId: defaultBranchId,
+			}),
 		);
 		expect(byBranch.length).toBeGreaterThan(0);
 		expect(all.map((endpoint) => endpoint.id)).toEqual(
@@ -314,7 +354,10 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		const first = byBranch[0];
 		if (!first) throw new Error("default branch has no endpoint");
 		const fetched = expectOk(
-			await neon.postgres.endpoints.get(projectId, first.id),
+			await neon.postgres.endpoints.get({
+				projectId,
+				endpointId: first.id,
+			}),
 		);
 		expect(fetched.id).toBe(first.id);
 		expect(fetched.branch_id).toBe(defaultBranchId);
@@ -322,26 +365,30 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 
 	it("waitFor resolves against operations the project has already run", async () => {
 		const operations = expectOk(
-			await neon.operations.list(projectId).all(),
+			await neon.operations.list({ projectId }).all(),
 		);
 		expect(operations.length).toBeGreaterThan(0);
 
 		// Everything this project has done is finished by now, so waitFor must recognise
 		// the terminal states and return rather than poll until the timeout.
-		expectOk(await neon.operations.waitFor(operations.slice(0, 5)));
+		expectOk(
+			await neon.operations.waitFor({
+				operations: operations.slice(0, 5),
+			}),
+		);
 
 		const single = operations[0];
 		if (!single) throw new Error("unreachable");
 		const fetched = expectOk(
-			await neon.operations.get(projectId, single.id),
+			await neon.operations.get({ projectId, operationId: single.id }),
 		);
 		expect(fetched.id).toBe(single.id);
 	});
 
 	it("a wait timeout carries outstanding operations so waitFor can resume", async () => {
 		const { data, error } = await neon.branches.create(
-			projectId,
 			{
+				projectId,
 				name: "wait-timeout-resume",
 				parent_id: defaultBranchId,
 				noCompute: true,
@@ -370,18 +417,23 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			branchId =
 				error.operations.find((op) => op.branch_id)?.branch_id ??
 				branchId;
-			expectOk(await neon.operations.waitFor(error.operations));
+			expectOk(
+				await neon.operations.waitFor({ operations: error.operations }),
+			);
 			if (branchId) {
 				const branch = expectOk(
-					await neon.branches.get(projectId, branchId),
+					await neon.branches.get({ projectId, branchId }),
 				);
 				expect(branch.id).toBe(branchId);
 			}
 		} finally {
 			if (branchId) {
-				await neon.branches.delete(projectId, branchId, {
-					waitForReadiness: true,
-				});
+				await neon.branches.delete(
+					{ projectId, branchId },
+					{
+						waitForReadiness: true,
+					},
+				);
 			}
 		}
 	});
@@ -390,7 +442,9 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 		let tokenId: string | undefined;
 		try {
 			const created = expectOk(
-				await neon.credentials.create(projectId, defaultBranchId, {
+				await neon.credentials.create({
+					projectId,
+					branchId: defaultBranchId,
 					name: "sdk-e2e",
 					scopes: ["storage:read"],
 					principal_type: "user",
@@ -401,48 +455,48 @@ describe.sequential("e2e — @neon/sdk resources against the real API", () => {
 			expect(created.s3_secret_access_key.length).toBeGreaterThan(0);
 
 			const revealed = expectOk(
-				await neon.credentials.reveal(
+				await neon.credentials.reveal({
 					projectId,
-					defaultBranchId,
-					created.token_id,
-				),
+					branchId: defaultBranchId,
+					tokenId: created.token_id,
+				}),
 			);
 			expect(revealed.token_id).toBe(created.token_id);
 			expect(revealed.api_token).toBe(created.api_token);
 			expect(revealed).not.toHaveProperty("branch_id");
 
 			const rotated = expectOk(
-				await neon.credentials.rotate(
+				await neon.credentials.rotate({
 					projectId,
-					defaultBranchId,
-					created.token_id,
-				),
+					branchId: defaultBranchId,
+					tokenId: created.token_id,
+				}),
 			);
 			expect(rotated.token_id).toBe(created.token_id);
 			expect(rotated.api_token).not.toBe(created.api_token);
 
 			expectOk(
-				await neon.credentials.revoke(
+				await neon.credentials.revoke({
 					projectId,
-					defaultBranchId,
-					created.token_id,
-				),
+					branchId: defaultBranchId,
+					tokenId: created.token_id,
+				}),
 			);
 			tokenId = undefined;
 
-			const { error } = await neon.credentials.reveal(
+			const { error } = await neon.credentials.reveal({
 				projectId,
-				defaultBranchId,
-				created.token_id,
-			);
+				branchId: defaultBranchId,
+				tokenId: created.token_id,
+			});
 			expect(error).toBeInstanceOf(NeonNotFoundError);
 		} finally {
 			if (tokenId) {
-				await neon.credentials.revoke(
+				await neon.credentials.revoke({
 					projectId,
-					defaultBranchId,
+					branchId: defaultBranchId,
 					tokenId,
-				);
+				});
 			}
 		}
 	});

--- a/packages/sdk/e2e/workflows.e2e.test.ts
+++ b/packages/sdk/e2e/workflows.e2e.test.ts
@@ -36,7 +36,7 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 
 			// Readiness polling is the point: the project must be usable, not merely created.
 			const project = expectOk(
-				await neon.projects.get(created.project.id),
+				await neon.projects.get({ projectId: created.project.id }),
 			);
 			expect(project.id).toBe(created.project.id);
 		},
@@ -80,9 +80,12 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			);
 			track(project.id);
 
-			const main = expectOk(await neon.branches.getDefault(project.id));
+			const main = expectOk(
+				await neon.branches.getDefault({ projectId: project.id }),
+			);
 			expectOk(
-				await neon.branches.create(project.id, {
+				await neon.branches.create({
+					projectId: project.id,
 					name: "dev",
 					parent_id: main.id,
 					noCompute: true,
@@ -94,7 +97,9 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			// `pagination.next` while projects use `pagination.cursor`, and a stubbed
 			// response can only ever confirm whichever one the stub was written with.
 			const all = expectOk(
-				await neon.branches.list(project.id, { limit: 1 }).all(),
+				await neon.branches
+					.list({ projectId: project.id, limit: 1 })
+					.all(),
 			);
 			expect(all.map((branch) => branch.name).sort()).toStrictEqual([
 				"dev",
@@ -102,7 +107,8 @@ describe.sequential("e2e — @neon/sdk workflows against the real API", () => {
 			]);
 
 			const streamed: string[] = [];
-			for await (const branch of neon.branches.list(project.id, {
+			for await (const branch of neon.branches.list({
+				projectId: project.id,
 				limit: 1,
 			})) {
 				streamed.push(branch.name);

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -42,6 +42,7 @@
 	},
 	"files": [
 		"README.md",
+		"MIGRATION.md",
 		"dist/",
 		"package.json"
 	],

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -43,24 +43,143 @@ export {
 	NeonWaitTimeoutError,
 } from "./neon/errors.js";
 export type { Page, Paginated } from "./neon/paginate.js";
+// Named operation parameter types.
 export type {
+	ApiKeysCreateParams,
+	ApiKeysRevokeParams,
+} from "./neon/resources/account.js";
+export type { AiGatewayGetParams } from "./neon/resources/ai-gateway.js";
+export type {
+	AuthCreateParams,
+	AuthDisableParams,
+	AuthGetParams,
+	AuthOauthProvidersAddParams,
+	AuthOauthProvidersDeleteParams,
+	AuthOauthProvidersListParams,
+	AuthOauthProvidersUpdateParams,
+	AuthTrustedDomainsAddParams,
+	AuthTrustedDomainsDeleteParams,
+	AuthTrustedDomainsListParams,
+	AuthUpdateConfigParams,
+	AuthUsersCreateParams,
+	AuthUsersDeleteParams,
+	AuthUsersUpdateRoleParams,
+} from "./neon/resources/auth.js";
+export type {
+	BranchCompareSchemaParams,
 	BranchConnection,
+	BranchCreateAndConnectParams,
+	BranchCreateParams,
+	BranchDeleteParams,
+	BranchFinalizeRestoreParams,
+	BranchGetDefaultParams,
+	BranchGetParams,
+	BranchListParams,
+	BranchResetFromParentParams,
+	BranchSetDefaultParams,
+	BranchUpdateParams,
 	CompareSchemaInput,
 	ComputeSettings,
 	CreateAndConnectInput,
 	ResetFromParentInput,
 } from "./neon/resources/branches.js";
 export type {
+	BucketObjectsDeleteByPrefixParams,
+	BucketObjectsDeleteParams,
+	BucketObjectsGetParams,
+	BucketObjectsListParams,
+	BucketObjectsPresignParams,
+} from "./neon/resources/bucket-objects.js";
+export type {
+	BucketsCreateParams,
+	BucketsDeleteParams,
+	BucketsListParams,
+} from "./neon/resources/buckets.js";
+export type {
+	CredentialsCreateParams,
+	CredentialsListParams,
+	CredentialsRevealParams,
+	CredentialsRevokeParams,
+	CredentialsRotateParams,
+} from "./neon/resources/credentials.js";
+export type {
+	CustomDomainsDeleteParams,
+	CustomDomainsListParams,
+	CustomDomainsRegisterParams,
+} from "./neon/resources/custom-domains.js";
+export type {
+	DataApiCreateParams,
+	DataApiDeleteParams,
+	DataApiGetParams,
+	DataApiUpdateParams,
+} from "./neon/resources/dataapi.js";
+export type {
+	DatabasesCreateParams,
+	DatabasesDeleteParams,
+	DatabasesGetParams,
+	DatabasesListParams,
+	DatabasesUpdateParams,
+} from "./neon/resources/databases.js";
+export type {
+	EndpointsCreateParams,
+	EndpointsDeleteParams,
+	EndpointsGetParams,
+	EndpointsListByBranchParams,
+	EndpointsListParams,
+	EndpointsRestartParams,
+	EndpointsStartParams,
+	EndpointsSuspendParams,
+	EndpointsUpdateParams,
+} from "./neon/resources/endpoints.js";
+export type {
+	FunctionsDeleteParams,
+	FunctionsDeployParams,
+	FunctionsGetParams,
+	FunctionsListParams,
+	FunctionsUpdateParams,
+} from "./neon/resources/functions.js";
+export type {
 	LogFieldValuesQuery,
 	LogQueryInput,
+	LogsFieldsParams,
+	LogsFieldValuesParams,
+	LogsQueryParams,
 } from "./neon/resources/logs.js";
+export type {
+	OperationsGetParams,
+	OperationsListParams,
+	OperationsWaitForParams,
+} from "./neon/resources/operations.js";
 export type { ConnectionStringParams } from "./neon/resources/postgres.js";
 export type {
 	ProjectConnection,
+	ProjectCreateAndConnectParams,
+	ProjectCreateParams,
+	ProjectDeleteParams,
+	ProjectGetParams,
+	ProjectListParams,
+	ProjectMemberListParams,
+	ProjectMemberRemoveRoleParams,
+	ProjectMemberSetRoleParams,
+	ProjectPermissionGrantParams,
+	ProjectPermissionListParams,
+	ProjectPermissionRevokeParams,
+	ProjectRecoverParams,
+	ProjectTransferFromUserParams,
+	ProjectTransferParams,
+	ProjectUpdateParams,
 	RemoveRoleOptions,
 	SetRoleOptions,
 	TransferProjectsInput,
 } from "./neon/resources/projects.js";
+export type {
+	RolesCreateParams,
+	RolesDeleteParams,
+	RolesGetParams,
+	RolesListParams,
+	RolesPasswordParams,
+	RolesResetPasswordParams,
+} from "./neon/resources/roles.js";
 export type {
 	BackupScheduleItemInput,
 	CreateSnapshotInput,
@@ -68,8 +187,23 @@ export type {
 	RestoreSnapshotInput,
 	SetScheduleInput,
 	SnapshotFrequency,
+	SnapshotsCreateParams,
+	SnapshotsDeleteParams,
+	SnapshotsGetScheduleParams,
+	SnapshotsListParams,
+	SnapshotsRestoreParams,
+	SnapshotsSetScheduleParams,
+	SnapshotsUpdateParams,
 	UpdateSnapshotInput,
 } from "./neon/resources/snapshots.js";
+export type { StorageGetParams } from "./neon/resources/storage.js";
+export type {
+	TriggersCreateParams,
+	TriggersDeleteParams,
+	TriggersGetParams,
+	TriggersListParams,
+	TriggersUpdateParams,
+} from "./neon/resources/triggers.js";
 export type { NeonResult, Outcome } from "./neon/result.js";
 export type { WaitBudget, WaitForOptions } from "./neon/wait.js";
 export type * from "./raw.js";

--- a/packages/sdk/src/neon/cancellation.server.test.ts
+++ b/packages/sdk/src/neon/cancellation.server.test.ts
@@ -155,7 +155,7 @@ describe("against a real socket that never responds", () => {
 			requestTimeoutMs: 60,
 		});
 
-		const { error } = await neon.projects.get("p-1");
+		const { error } = await neon.projects.get({ projectId: "p-1" });
 		behaviour.hang = false;
 		expect(error?.kind).toBe("timeout");
 	});
@@ -166,9 +166,12 @@ describe("against a real socket that never responds", () => {
 		const controller = new AbortController();
 		setTimeout(() => controller.abort(), 40);
 
-		const { error } = await neon.projects.get("p-1", {
-			signal: controller.signal,
-		});
+		const { error } = await neon.projects.get(
+			{ projectId: "p-1" },
+			{
+				signal: controller.signal,
+			},
+		);
 		behaviour.hang = false;
 		expect(error?.kind).toBe("aborted");
 	});
@@ -202,7 +205,7 @@ describe("work that happens before fetch is reached", () => {
 		});
 
 		const startedAt = Date.now();
-		const { error } = await neon.projects.get("p-1");
+		const { error } = await neon.projects.get({ projectId: "p-1" });
 		expect(error?.kind).toBe("timeout");
 		expect(Date.now() - startedAt).toBeLessThan(1_000);
 	});
@@ -350,7 +353,9 @@ describe("readiness polling", () => {
 			throw new Error("expected wait timeout");
 		}
 		resetBehaviour({ operationRunning: false, hangOperations: false });
-		const resumed = await neon.operations.waitFor(error.operations);
+		const resumed = await neon.operations.waitFor({
+			operations: error.operations,
+		});
 		expect(resumed.error).toBeUndefined();
 	});
 
@@ -362,18 +367,20 @@ describe("readiness polling", () => {
 			retries: 0,
 		});
 		const { error } = await neon.operations.waitFor(
-			[
-				{
-					id: "op-1",
-					project_id: "p-1",
-					action: "create_timeline",
-					status: "running",
-					failures_count: 0,
-					created_at: "2026-01-01T00:00:00Z",
-					updated_at: "2026-01-01T00:00:00Z",
-					total_duration_ms: 0,
-				},
-			],
+			{
+				operations: [
+					{
+						id: "op-1",
+						project_id: "p-1",
+						action: "create_timeline",
+						status: "running",
+						failures_count: 0,
+						created_at: "2026-01-01T00:00:00Z",
+						updated_at: "2026-01-01T00:00:00Z",
+						total_duration_ms: 0,
+					},
+				],
+			},
 			{ pollIntervalMs: 5, timeoutMs: 80 },
 		);
 		if (error?.kind !== "timeout" || error.source !== "wait") {
@@ -423,13 +430,19 @@ describe("per-call timeout validation", () => {
 		// Not validating per-call left NaN silently meaning "unbounded" and a value past
 		// setTimeout's range silently meaning 1ms.
 		await expect(
-			neon.projects.get("p-1", { requestTimeoutMs: Number.NaN }),
+			neon.projects.get(
+				{ projectId: "p-1" },
+				{ requestTimeoutMs: Number.NaN },
+			),
 		).rejects.toMatchObject({ kind: "client" });
 		await expect(
-			neon.projects.get("p-1", { requestTimeoutMs: 2 ** 31 }),
+			neon.projects.get(
+				{ projectId: "p-1" },
+				{ requestTimeoutMs: 2 ** 31 },
+			),
 		).rejects.toMatchObject({ kind: "client" });
 		await expect(
-			neon.projects.get("p-1", { requestTimeoutMs: -1 }),
+			neon.projects.get({ projectId: "p-1" }, { requestTimeoutMs: -1 }),
 		).rejects.toMatchObject({ kind: "client" });
 	});
 
@@ -441,9 +454,12 @@ describe("per-call timeout validation", () => {
 			requestTimeoutMs: 50,
 		});
 
-		const { error } = await neon.projects.get("p-1", {
-			requestTimeoutMs: Number.POSITIVE_INFINITY,
-		});
+		const { error } = await neon.projects.get(
+			{ projectId: "p-1" },
+			{
+				requestTimeoutMs: Number.POSITIVE_INFINITY,
+			},
+		);
 		expect(error).toBeUndefined();
 	});
 });

--- a/packages/sdk/src/neon/cancellation.test.ts
+++ b/packages/sdk/src/neon/cancellation.test.ts
@@ -48,9 +48,12 @@ describe("a caller's signal reaches the request", () => {
 		setTimeout(() => controller.abort(), 20);
 
 		const startedAt = Date.now();
-		const { data, error } = await neon.projects.get("p", {
-			signal: controller.signal,
-		});
+		const { data, error } = await neon.projects.get(
+			{ projectId: "p" },
+			{
+				signal: controller.signal,
+			},
+		);
 
 		expect(Date.now() - startedAt).toBeLessThan(1_000);
 		expect(data).toBeUndefined();
@@ -67,7 +70,7 @@ describe("a caller's signal reaches the request", () => {
 		setTimeout(() => controller.abort(), 20);
 
 		const result = await neon.projects
-			.get("p", { signal: controller.signal })
+			.get({ projectId: "p" }, { signal: controller.signal })
 			.catch((thrown) => ({ thrown }));
 
 		expect(result).not.toHaveProperty("thrown");
@@ -87,7 +90,10 @@ describe("a caller's signal reaches the request", () => {
 		setTimeout(() => controller.abort(), 20);
 
 		await expect(
-			neon.projects.get("p", { signal: controller.signal }),
+			neon.projects.get(
+				{ projectId: "p" },
+				{ signal: controller.signal },
+			),
 		).rejects.toBeInstanceOf(NeonAbortError);
 	});
 
@@ -133,7 +139,7 @@ describe("requestTimeoutMs bounds a call", () => {
 		});
 
 		const startedAt = Date.now();
-		const { error } = await neon.projects.get("p");
+		const { error } = await neon.projects.get({ projectId: "p" });
 
 		expect(Date.now() - startedAt).toBeLessThan(1_000);
 		expect(error?.kind).toBe("timeout");
@@ -159,7 +165,7 @@ describe("requestTimeoutMs bounds a call", () => {
 		});
 
 		const startedAt = Date.now();
-		const { error } = await neon.projects.get("p");
+		const { error } = await neon.projects.get({ projectId: "p" });
 
 		expect(error?.kind).toBe("timeout");
 		expect(Date.now() - startedAt).toBeLessThan(1_000);
@@ -204,7 +210,7 @@ describe("requestTimeoutMs bounds a call", () => {
 			},
 		});
 
-		const { data, error } = await neon.projects.get("p");
+		const { data, error } = await neon.projects.get({ projectId: "p" });
 		expect(error).toBeUndefined();
 		expect(data?.id).toBe("p");
 	});
@@ -223,9 +229,12 @@ describe("requestTimeoutMs bounds a call", () => {
 			},
 		});
 
-		const { error } = await neon.projects.get("p", {
-			requestTimeoutMs: Number.POSITIVE_INFINITY,
-		});
+		const { error } = await neon.projects.get(
+			{ projectId: "p" },
+			{
+				requestTimeoutMs: Number.POSITIVE_INFINITY,
+			},
+		);
 		expect(error).toBeUndefined();
 	});
 
@@ -256,7 +265,7 @@ describe("retry scheduling", () => {
 		setTimeout(() => controller.abort(), 20);
 
 		const result = await neon.projects
-			.get("p", { signal: controller.signal })
+			.get({ projectId: "p" }, { signal: controller.signal })
 			.catch((thrown) => ({ thrown }));
 
 		expect(result).not.toHaveProperty("thrown");
@@ -275,7 +284,10 @@ describe("retry scheduling", () => {
 		setTimeout(() => controller.abort(), 20);
 
 		await expect(
-			neon.projects.get("p", { signal: controller.signal }),
+			neon.projects.get(
+				{ projectId: "p" },
+				{ signal: controller.signal },
+			),
 		).rejects.toBeInstanceOf(NeonAbortError);
 	});
 
@@ -292,7 +304,7 @@ describe("retry scheduling", () => {
 		});
 
 		const startedAt = Date.now();
-		const { error } = await neon.projects.get("p");
+		const { error } = await neon.projects.get({ projectId: "p" });
 
 		// The real 429 is surfaced instead of being hidden behind a long sleep or a
 		// timeout, and the header is never shortened into an early retry.
@@ -313,7 +325,7 @@ describe("retry scheduling", () => {
 			fetch: rateLimited.fetch,
 		});
 
-		await neon.projects.get("p");
+		await neon.projects.get({ projectId: "p" });
 		expect(rateLimited.calls()).toBe(3);
 	});
 });

--- a/packages/sdk/src/neon/client.test-d.ts
+++ b/packages/sdk/src/neon/client.test-d.ts
@@ -27,7 +27,7 @@ import type { NeonResult } from "./result.js";
 
 it("default client returns the { data, error } envelope", () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	expectTypeOf(neon.projects.get("p")).resolves.toEqualTypeOf<
+	expectTypeOf(neon.projects.get({ projectId: "p" })).resolves.toEqualTypeOf<
 		NeonResult<Project>
 	>();
 	expectTypeOf(neon.projects.create()).resolves.toEqualTypeOf<
@@ -37,43 +37,48 @@ it("default client returns the { data, error } envelope", () => {
 
 it("throwOnError on the client narrows methods to the bare resource", () => {
 	const neon = createNeonClient({ apiKey: "x", throwOnError: true });
-	expectTypeOf(neon.projects.get("p")).resolves.toEqualTypeOf<Project>();
+	expectTypeOf(
+		neon.projects.get({ projectId: "p" }),
+	).resolves.toEqualTypeOf<Project>();
 });
 
 it("per-call throwOnError overrides the client default and narrows", () => {
 	const neon = createNeonClient({ apiKey: "x" });
 	expectTypeOf(
-		neon.projects.get("p", { throwOnError: true }),
+		neon.projects.get({ projectId: "p" }, { throwOnError: true }),
 	).resolves.toEqualTypeOf<Project>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
-		throwing.projects.get("p", { throwOnError: false }),
+		throwing.projects.get({ projectId: "p" }, { throwOnError: false }),
 	).resolves.toEqualTypeOf<NeonResult<Project>>();
 });
 
 it("branches + workflows carry the envelope and narrow under throwOnError", () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	expectTypeOf(neon.branches.list("p")).toEqualTypeOf<Paginated<Branch>>();
-	expectTypeOf(neon.branches.get("p", "br")).resolves.toEqualTypeOf<
-		NeonResult<Branch>
+	expectTypeOf(neon.branches.list({ projectId: "p" })).toEqualTypeOf<
+		Paginated<Branch>
 	>();
 	expectTypeOf(
-		neon.branches.create("p", { name: "x" }),
+		neon.branches.get({ projectId: "p", branchId: "br" }),
 	).resolves.toEqualTypeOf<NeonResult<Branch>>();
 	expectTypeOf(
-		neon.branches.create("p", { name: "x", noCompute: true }),
+		neon.branches.create({ projectId: "p", name: "x" }),
 	).resolves.toEqualTypeOf<NeonResult<Branch>>();
-	neon.branches.create("p", {
+	expectTypeOf(
+		neon.branches.create({ projectId: "p", name: "x", noCompute: true }),
+	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	// @ts-expect-error compute is invalid when noCompute is true
+	neon.branches.create({
+		projectId: "p",
 		noCompute: true,
-		// @ts-expect-error compute is invalid when noCompute is true
 		compute: { minCu: 1 },
 	});
-	expectTypeOf(neon.branches.createAndConnect("p")).resolves.toEqualTypeOf<
-		NeonResult<BranchConnection>
-	>();
 	expectTypeOf(
-		neon.branches.createAndConnect("p", { name: "x" }),
+		neon.branches.createAndConnect({ projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<BranchConnection>>();
+	expectTypeOf(
+		neon.branches.createAndConnect({ projectId: "p", name: "x" }),
 	).resolves.toEqualTypeOf<NeonResult<BranchConnection>>();
 	expectTypeOf(
 		neon.projects.createAndConnect({ name: "x" }),
@@ -81,24 +86,26 @@ it("branches + workflows carry the envelope and narrow under throwOnError", () =
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
-		throwing.branches.createAndConnect("p", { name: "x" }),
+		throwing.branches.createAndConnect({ projectId: "p", name: "x" }),
 	).resolves.toEqualTypeOf<BranchConnection>();
 	expectTypeOf(
-		throwing.branches.delete("p", "br"),
+		throwing.branches.delete({ projectId: "p", branchId: "br" }),
 	).resolves.toEqualTypeOf<void>();
 	expectTypeOf(
-		neon.branches.resetFromParent("p", "br"),
+		neon.branches.resetFromParent({ projectId: "p", branchId: "br" }),
 	).resolves.toEqualTypeOf<NeonResult<Branch>>();
 	expectTypeOf(
 		neon.branches.resetFromParent(
-			"p",
-			"br",
-			{ preserveUnderName: "old" },
+			{ projectId: "p", branchId: "br", preserveUnderName: "old" },
 			{ throwOnError: true },
 		),
 	).resolves.toEqualTypeOf<Branch>();
 	expectTypeOf(
-		neon.branches.compareSchema("p", "br", { databaseName: "neondb" }),
+		neon.branches.compareSchema({
+			projectId: "p",
+			branchId: "br",
+			databaseName: "neondb",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<{ diff?: string }>>();
 });
 
@@ -107,30 +114,36 @@ it("cancellation and deadline options are accepted on the client and per call", 
 	const controller = new AbortController();
 
 	expectTypeOf(
-		neon.projects.get("p", {
-			signal: controller.signal,
-			requestTimeoutMs: 5_000,
-		}),
+		neon.projects.get(
+			{ projectId: "p" },
+			{
+				signal: controller.signal,
+				requestTimeoutMs: 5_000,
+			},
+		),
 	).resolves.toEqualTypeOf<NeonResult<Project>>();
 
-	// Paginated lists take the same per-call options as every other method, after their
-	// query, and still erase the response-body type.
+	// Paginated lists take the same per-call options after their parameter object
+	// as every other method, and still erase the response-body type.
 	expectTypeOf(
 		neon.projects.list({ search: "x" }, { signal: controller.signal }),
 	).toEqualTypeOf<Paginated<ProjectListItem>>();
-	expectTypeOf(neon.branches.list("p", undefined, {})).toEqualTypeOf<
+	expectTypeOf(neon.branches.list({ projectId: "p" }, {})).toEqualTypeOf<
 		Paginated<Branch>
 	>();
 	expectTypeOf(
-		neon.operations.list("p", { requestTimeoutMs: 1_000 }),
+		neon.operations.list({ projectId: "p" }, { requestTimeoutMs: 1_000 }),
 	).toEqualTypeOf<Paginated<Operation>>();
 
 	// A per-call throwOnError still narrows when other options ride along.
 	expectTypeOf(
-		neon.projects.get("p", {
-			throwOnError: true,
-			signal: controller.signal,
-		}),
+		neon.projects.get(
+			{ projectId: "p" },
+			{
+				throwOnError: true,
+				signal: controller.signal,
+			},
+		),
 	).resolves.toEqualTypeOf<Project>();
 
 	createNeonClient({
@@ -165,62 +178,80 @@ it("cancellation and deadline options are accepted on the client and per call", 
 			},
 		},
 	);
-	neon.operations.waitFor([], {
-		timeoutMs: 120_000,
-		signal: controller.signal,
-	});
-	neon.operations.waitFor([], {
-		// @ts-expect-error — waitFor takes top-level timeoutMs, not nested wait
-		wait: { timeoutMs: 120_000 },
-	});
+	neon.operations.waitFor(
+		{ operations: [] },
+		{
+			timeoutMs: 120_000,
+			signal: controller.signal,
+		},
+	);
+	neon.operations.waitFor(
+		{ operations: [] },
+		{
+			// @ts-expect-error — waitFor takes top-level timeoutMs, not nested wait
+			wait: { timeoutMs: 120_000 },
+		},
+	);
 });
 
 it("postgres namespace + tier-2/3 resources are reachable and typed", () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	expectTypeOf(neon.postgres.endpoints.list("p")).resolves.toEqualTypeOf<
-		NeonResult<Endpoint[]>
-	>();
 	expectTypeOf(
-		neon.postgres.roles.password("p", "br", "neondb_owner"),
+		neon.postgres.endpoints.list({ projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<Endpoint[]>>();
+	expectTypeOf(
+		neon.postgres.roles.password({
+			projectId: "p",
+			branchId: "br",
+			roleName: "neondb_owner",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
 	expectTypeOf(
 		neon.postgres.connectionString({ projectId: "p" }),
 	).resolves.toEqualTypeOf<NeonResult<string>>();
-	expectTypeOf(neon.snapshots.list("p")).resolves.toEqualTypeOf<
-		NeonResult<Snapshot[]>
-	>();
+	expectTypeOf(
+		neon.snapshots.list({ projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<Snapshot[]>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
 		throwing.postgres.connectionString({ projectId: "p" }),
 	).resolves.toEqualTypeOf<string>();
 	expectTypeOf(
-		throwing.postgres.dataApi.delete("p", "br", "neondb"),
+		throwing.postgres.dataApi.delete({
+			projectId: "p",
+			branchId: "br",
+			databaseName: "neondb",
+		}),
 	).resolves.toEqualTypeOf<void>();
 });
 
 it("agent-platform helpers (default org, default branch, transfer, finalize) are typed", () => {
 	const neon = createNeonClient({ apiKey: "x", orgId: "org-123" });
-	expectTypeOf(neon.branches.getDefault("p")).resolves.toEqualTypeOf<
-		NeonResult<Branch>
-	>();
-	expectTypeOf(neon.branches.setDefault("p", "br")).resolves.toEqualTypeOf<
-		NeonResult<Branch>
-	>();
 	expectTypeOf(
-		neon.branches.finalizeRestore("p", "br"),
+		neon.branches.getDefault({ projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	expectTypeOf(
+		neon.branches.setDefault({ projectId: "p", branchId: "br" }),
+	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	expectTypeOf(
+		neon.branches.finalizeRestore({ projectId: "p", branchId: "br" }),
 	).resolves.toEqualTypeOf<NeonResult<void>>();
 	expectTypeOf(
 		neon.projects.transfer({ toOrgId: "org-paid", projectIds: ["p"] }),
 	).resolves.toEqualTypeOf<NeonResult<void>>();
 	expectTypeOf(
-		neon.snapshots.create("p", "br", {
+		neon.snapshots.create({
+			projectId: "p",
+			branchId: "br",
 			name: "baseline",
 			timestamp: "2026-01-01T00:00:00Z",
 		}),
 	).resolves.toEqualTypeOf<NeonResult<Snapshot>>();
 	expectTypeOf(
-		neon.snapshots.restore("p", "snap", {
+		neon.snapshots.restore({
+			projectId: "p",
+			snapshotId: "snap",
 			targetBranchId: "br",
 			preview: (restored) => {
 				expectTypeOf(restored).toEqualTypeOf<Branch>();
@@ -231,11 +262,15 @@ it("agent-platform helpers (default org, default branch, transfer, finalize) are
 
 	// setSchedule narrows `frequency` to the API-accepted values.
 	expectTypeOf(
-		neon.snapshots.setSchedule("p", "br", {
+		neon.snapshots.setSchedule({
+			projectId: "p",
+			branchId: "br",
 			schedule: [{ frequency: "daily", hour: 3 }],
 		}),
 	).resolves.toEqualTypeOf<NeonResult<void>>();
-	neon.snapshots.setSchedule("p", "br", {
+	neon.snapshots.setSchedule({
+		projectId: "p",
+		branchId: "br",
 		// @ts-expect-error — "hourly" is not an accepted SnapshotFrequency
 		schedule: [{ frequency: "hourly" }],
 	});
@@ -243,75 +278,100 @@ it("agent-platform helpers (default org, default branch, transfer, finalize) are
 
 it("phase-1 namespaces (auth, permissions, recover, branch endpoints) are typed", () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	expectTypeOf(neon.auth.get("p", "br")).resolves.toEqualTypeOf<
-		NeonResult<NeonAuthIntegration>
-	>();
 	expectTypeOf(
-		neon.auth.oauthProviders.list("p", "br"),
+		neon.auth.get({ projectId: "p", branchId: "br" }),
+	).resolves.toEqualTypeOf<NeonResult<NeonAuthIntegration>>();
+	expectTypeOf(
+		neon.auth.oauthProviders.list({ projectId: "p", branchId: "br" }),
 	).resolves.toEqualTypeOf<NeonResult<NeonAuthOauthProvider[]>>();
 	expectTypeOf(
-		neon.auth.oauthProviders.add("p", "br", { id: "google" }),
+		neon.auth.oauthProviders.add({
+			projectId: "p",
+			branchId: "br",
+			id: "google",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<NeonAuthOauthProvider>>();
-	expectTypeOf(neon.projects.permissions.list("p")).resolves.toEqualTypeOf<
-		NeonResult<ProjectPermission[]>
-	>();
 	expectTypeOf(
-		neon.projects.permissions.grant("p", "user@example.com"),
+		neon.projects.permissions.list({ projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<ProjectPermission[]>>();
+	expectTypeOf(
+		neon.projects.permissions.grant({
+			projectId: "p",
+			email: "user@example.com",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<ProjectPermission>>();
-	expectTypeOf(neon.projects.recover("p")).resolves.toEqualTypeOf<
-		NeonResult<Project>
-	>();
 	expectTypeOf(
-		neon.postgres.endpoints.listByBranch("p", "br"),
+		neon.projects.recover({ projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<Project>>();
+	expectTypeOf(
+		neon.postgres.endpoints.listByBranch({
+			projectId: "p",
+			branchId: "br",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<Endpoint[]>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
-		throwing.auth.get("p", "br"),
+		throwing.auth.get({ projectId: "p", branchId: "br" }),
 	).resolves.toEqualTypeOf<NeonAuthIntegration>();
 	expectTypeOf(
-		throwing.auth.oauthProviders.delete("p", "br", "google"),
+		throwing.auth.oauthProviders.delete({
+			projectId: "p",
+			branchId: "br",
+			providerId: "google",
+		}),
 	).resolves.toEqualTypeOf<void>();
 	expectTypeOf(
-		throwing.projects.permissions.list("p"),
+		throwing.projects.permissions.list({ projectId: "p" }),
 	).resolves.toEqualTypeOf<ProjectPermission[]>();
 });
 
 it("triggers is typed", () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	expectTypeOf(neon.triggers.list("p", "br")).resolves.toEqualTypeOf<
-		NeonResult<Trigger[]>
-	>();
-	expectTypeOf(neon.triggers.list("p", "br")).not.toEqualTypeOf<
-		Paginated<Trigger>
-	>();
 	expectTypeOf(
-		neon.triggers.create("p", "br", {
+		neon.triggers.list({ projectId: "p", branchId: "br" }),
+	).resolves.toEqualTypeOf<NeonResult<Trigger[]>>();
+	expectTypeOf(
+		neon.triggers.list({ projectId: "p", branchId: "br" }),
+	).not.toEqualTypeOf<Paginated<Trigger>>();
+	expectTypeOf(
+		neon.triggers.create({
+			projectId: "p",
+			branchId: "br",
 			type: "schedule",
 			function_slug: "worker",
 			name: "daily-refresh",
 			schedule: { cron: "0 9 * * *" },
 		}),
 	).resolves.toEqualTypeOf<NeonResult<Trigger>>();
-	expectTypeOf(neon.triggers.get("p", "br", "trg")).resolves.toEqualTypeOf<
-		NeonResult<Trigger>
-	>();
 	expectTypeOf(
-		neon.triggers.update("p", "br", "trg", {
+		neon.triggers.get({ projectId: "p", branchId: "br", triggerId: "trg" }),
+	).resolves.toEqualTypeOf<NeonResult<Trigger>>();
+	expectTypeOf(
+		neon.triggers.update({
+			projectId: "p",
+			branchId: "br",
+			triggerId: "trg",
 			type: "schedule",
 			enabled: true,
 		}),
 	).resolves.toEqualTypeOf<NeonResult<Trigger>>();
-	expectTypeOf(neon.triggers.delete("p", "br", "trg")).resolves.toEqualTypeOf<
-		NeonResult<void>
-	>();
+	expectTypeOf(
+		neon.triggers.delete({
+			projectId: "p",
+			branchId: "br",
+			triggerId: "trg",
+		}),
+	).resolves.toEqualTypeOf<NeonResult<void>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
-	expectTypeOf(throwing.triggers.list("p", "br")).resolves.toEqualTypeOf<
-		Trigger[]
-	>();
 	expectTypeOf(
-		throwing.triggers.create("p", "br", {
+		throwing.triggers.list({ projectId: "p", branchId: "br" }),
+	).resolves.toEqualTypeOf<Trigger[]>();
+	expectTypeOf(
+		throwing.triggers.create({
+			projectId: "p",
+			branchId: "br",
 			type: "schedule",
 			function_slug: "worker",
 			name: "daily-refresh",
@@ -319,58 +379,59 @@ it("triggers is typed", () => {
 		}),
 	).resolves.toEqualTypeOf<Trigger>();
 
-	neon.triggers.create("p", "br", {
+	neon.triggers.create({
+		projectId: "p",
+		branchId: "br",
 		// @ts-expect-error v1 only accepts type: "schedule"
 		type: "webhook",
 		function_slug: "worker",
 		name: "daily-refresh",
 		schedule: { cron: "0 9 * * *" },
 	});
-	neon.triggers.create(
-		"p",
-		"br",
-		// @ts-expect-error function_slug is required
-		{
-			type: "schedule",
-			name: "daily-refresh",
-			schedule: { cron: "0 9 * * *" },
-		},
-	);
-	neon.triggers.create(
-		"p",
-		"br",
-		// @ts-expect-error name is required
-		{
-			type: "schedule",
-			function_slug: "worker",
-			schedule: { cron: "0 9 * * *" },
-		},
-	);
-	neon.triggers.create(
-		"p",
-		"br",
-		// @ts-expect-error schedule is required
-		{
-			type: "schedule",
-			function_slug: "worker",
-			name: "daily-refresh",
-		},
-	);
-	neon.triggers.create("p", "br", {
+	// @ts-expect-error function_slug is required
+	neon.triggers.create({
+		projectId: "p",
+		branchId: "br",
+		type: "schedule",
+		name: "daily-refresh",
+		schedule: { cron: "0 9 * * *" },
+	});
+	// @ts-expect-error name is required
+	neon.triggers.create({
+		projectId: "p",
+		branchId: "br",
+		type: "schedule",
+		function_slug: "worker",
+		schedule: { cron: "0 9 * * *" },
+	});
+	// @ts-expect-error schedule is required
+	neon.triggers.create({
+		projectId: "p",
+		branchId: "br",
+		type: "schedule",
+		function_slug: "worker",
+		name: "daily-refresh",
+	});
+	neon.triggers.create({
+		projectId: "p",
+		branchId: "br",
 		type: "schedule",
 		function_slug: "worker",
 		name: "daily-refresh",
 		// @ts-expect-error cron is required
 		schedule: {},
 	});
-	neon.triggers.update(
-		"p",
-		"br",
-		"trg",
-		// @ts-expect-error update keeps the type discriminant
-		{ enabled: true },
-	);
-	neon.triggers.update("p", "br", "trg", {
+	// @ts-expect-error update keeps the type discriminant
+	neon.triggers.update({
+		projectId: "p",
+		branchId: "br",
+		triggerId: "trg",
+		enabled: true,
+	});
+	neon.triggers.update({
+		projectId: "p",
+		branchId: "br",
+		triggerId: "trg",
 		// @ts-expect-error v1 only accepts type: "schedule"
 		type: "webhook",
 		enabled: true,
@@ -380,18 +441,34 @@ it("triggers is typed", () => {
 it("credentials reveal and rotate are typed", () => {
 	const neon = createNeonClient({ apiKey: "x" });
 	expectTypeOf(
-		neon.credentials.reveal("p", "br", "tok"),
+		neon.credentials.reveal({
+			projectId: "p",
+			branchId: "br",
+			tokenId: "tok",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<CredentialSecret>>();
 	expectTypeOf(
-		neon.credentials.rotate("p", "br", "tok"),
+		neon.credentials.rotate({
+			projectId: "p",
+			branchId: "br",
+			tokenId: "tok",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<RotateCredentialResponse>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
-		throwing.credentials.reveal("p", "br", "tok"),
+		throwing.credentials.reveal({
+			projectId: "p",
+			branchId: "br",
+			tokenId: "tok",
+		}),
 	).resolves.toEqualTypeOf<CredentialSecret>();
 	expectTypeOf(
-		throwing.credentials.rotate("p", "br", "tok"),
+		throwing.credentials.rotate({
+			projectId: "p",
+			branchId: "br",
+			tokenId: "tok",
+		}),
 	).resolves.toEqualTypeOf<RotateCredentialResponse>();
 });
 
@@ -403,7 +480,9 @@ it("credential create input stays requestable scopes", () => {
 		"ai_gateway:invoke",
 		"functions:invoke",
 	];
-	expectTypeOf(neon.credentials.create).toBeCallableWith("p", "br", {
+	expectTypeOf(neon.credentials.create).toBeCallableWith({
+		projectId: "p",
+		branchId: "br",
 		scopes: requestable,
 		principal_type: "user",
 	});
@@ -415,42 +494,58 @@ it("credential create input stays requestable scopes", () => {
 		principal_type: "user" as const,
 	};
 	// @ts-expect-error GrantedCredentialScope is not assignable to CredentialScope
-	neon.credentials.create("p", "br", echoed);
+	neon.credentials.create({ projectId: "p", branchId: "br", ...echoed });
 	const telemetry: Array<"telemetry:write"> = ["telemetry:write"];
 	const telemetryInput = {
 		scopes: telemetry,
 		principal_type: "user" as const,
 	};
 	// @ts-expect-error telemetry:write is granted-only
-	neon.credentials.create("p", "br", telemetryInput);
+	neon.credentials.create({
+		projectId: "p",
+		branchId: "br",
+		...telemetryInput,
+	});
 });
 
 it("functions.customDomains is typed", () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	expectTypeOf(neon.functions.customDomains.list("p", "br")).toEqualTypeOf<
-		Paginated<CustomDomain>
-	>();
 	expectTypeOf(
-		neon.functions.customDomains.register("p", "br", {
+		neon.functions.customDomains.list({ projectId: "p", branchId: "br" }),
+	).toEqualTypeOf<Paginated<CustomDomain>>();
+	expectTypeOf(
+		neon.functions.customDomains.register({
+			projectId: "p",
+			branchId: "br",
 			domain: "docs.example.com",
 			entity_type: "function",
 			entity_id: "api",
 		}),
 	).resolves.toEqualTypeOf<NeonResult<CustomDomain>>();
 	expectTypeOf(
-		neon.functions.customDomains.delete("p", "br", "docs.example.com"),
+		neon.functions.customDomains.delete({
+			projectId: "p",
+			branchId: "br",
+			domain: "docs.example.com",
+		}),
 	).resolves.toEqualTypeOf<NeonResult<void>>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
 	expectTypeOf(
-		throwing.functions.customDomains.register("p", "br", {
+		throwing.functions.customDomains.register({
+			projectId: "p",
+			branchId: "br",
 			domain: "docs.example.com",
 			entity_type: "function",
 			entity_id: "api",
 		}),
 	).resolves.toEqualTypeOf<CustomDomain>();
 	expectTypeOf(
-		throwing.functions.customDomains.delete("p", "br", "docs.example.com"),
+		throwing.functions.customDomains.delete({
+			projectId: "p",
+			branchId: "br",
+			domain: "docs.example.com",
+		}),
 	).resolves.toEqualTypeOf<void>();
 });
 
@@ -469,13 +564,19 @@ it("README cancellation snippets typecheck", async () => {
 		expectTypeOf(error.kind).toEqualTypeOf<"aborted">();
 	}
 
-	const result = await neon.projects.get(id, { signal: controller.signal });
+	const result = await neon.projects.get(
+		{ projectId: id },
+		{ signal: controller.signal },
+	);
 	if (result.error?.kind === "aborted") {
 		expectTypeOf(result.error.kind).toEqualTypeOf<"aborted">();
 	}
 
 	const bounded = createNeonClient({ apiKey, requestTimeoutMs: 30_000 });
-	const slow = await bounded.projects.get(id, { requestTimeoutMs: 5_000 });
+	const slow = await bounded.projects.get(
+		{ projectId: id },
+		{ requestTimeoutMs: 5_000 },
+	);
 	if (slow.error?.kind === "timeout" && slow.error.source === "request") {
 		expectTypeOf(slow.error.source).toEqualTypeOf<"request">();
 		// @ts-expect-error operations is a wait-timeout field
@@ -483,10 +584,7 @@ it("README cancellation snippets typecheck", async () => {
 	}
 
 	await bounded.storage.objects.get(
-		projectId,
-		branchId,
-		"bucket",
-		"big.tar",
+		{ projectId, branchId, bucketName: "bucket", objectKey: "big.tar" },
 		{
 			requestTimeoutMs: Number.POSITIVE_INFINITY,
 		},
@@ -501,7 +599,7 @@ it("README cancellation snippets typecheck", async () => {
 			readonly Operation[]
 		>();
 		const resumed = await neon.operations.waitFor(
-			created.error.operations,
+			{ operations: created.error.operations },
 			{ timeoutMs: 120_000 },
 		);
 		if (resumed.error) throw resumed.error;
@@ -510,7 +608,7 @@ it("README cancellation snippets typecheck", async () => {
 
 it("NeonClient without a type argument is the non-throwing client", () => {
 	function seed(neon: NeonClient) {
-		return neon.projects.get("p");
+		return neon.projects.get({ projectId: "p" });
 	}
 	expectTypeOf(seed).returns.toEqualTypeOf<Promise<NeonResult<Project>>>();
 	const neon: NeonClient = createNeonClient({ apiKey: "x" });
@@ -522,7 +620,9 @@ it("NeonClient<true> still returns the bare resource", () => {
 		apiKey: "x",
 		throwOnError: true,
 	});
-	expectTypeOf(throwing.projects.get("p")).resolves.toEqualTypeOf<Project>();
+	expectTypeOf(
+		throwing.projects.get({ projectId: "p" }),
+	).resolves.toEqualTypeOf<Project>();
 });
 
 it("paginated lists honour throwOnError on page() and all()", async () => {
@@ -550,29 +650,31 @@ it("paginated lists honour throwOnError on page() and all()", async () => {
 	>();
 
 	const throwing = createNeonClient({ apiKey: "x", throwOnError: true });
-	expectTypeOf(throwing.branches.list("p")).toEqualTypeOf<
+	expectTypeOf(throwing.branches.list({ projectId: "p" })).toEqualTypeOf<
 		Paginated<Branch, true>
 	>();
-	expectTypeOf(throwing.branches.list("p").all()).resolves.toEqualTypeOf<
-		Branch[]
-	>();
-	expectTypeOf(throwing.branches.list("p").page()).resolves.toEqualTypeOf<
-		Page<Branch>
-	>();
 	expectTypeOf(
-		throwing.branches.list("p", undefined, { throwOnError: false }).all(),
+		throwing.branches.list({ projectId: "p" }).all(),
+	).resolves.toEqualTypeOf<Branch[]>();
+	expectTypeOf(
+		throwing.branches.list({ projectId: "p" }).page(),
+	).resolves.toEqualTypeOf<Page<Branch>>();
+	expectTypeOf(
+		throwing.branches
+			.list({ projectId: "p" }, { throwOnError: false })
+			.all(),
 	).resolves.toEqualTypeOf<NeonResult<Branch[]>>();
-	expectTypeOf(throwing.operations.list("p")).toEqualTypeOf<
+	expectTypeOf(throwing.operations.list({ projectId: "p" })).toEqualTypeOf<
 		Paginated<Operation, true>
 	>();
-	expectTypeOf(throwing.logs.query("p", "br")).toEqualTypeOf<
-		Paginated<ProjectBranchLogRecord, true>
-	>();
+	expectTypeOf(
+		throwing.logs.query({ projectId: "p", branchId: "br" }),
+	).toEqualTypeOf<Paginated<ProjectBranchLogRecord, true>>();
 	expectTypeOf(
 		throwing.consumption.perProject(consumptionQuery),
 	).toEqualTypeOf<Paginated<ConsumptionHistoryPerProject, true>>();
 
-	for await (const branch of throwing.branches.list("p")) {
+	for await (const branch of throwing.branches.list({ projectId: "p" })) {
 		expectTypeOf(branch).toEqualTypeOf<Branch>();
 		break;
 	}

--- a/packages/sdk/src/neon/errors.test-d.ts
+++ b/packages/sdk/src/neon/errors.test-d.ts
@@ -49,7 +49,9 @@ it("NeonTimeoutError is abstract; subclasses take the matching init", () => {
 
 it("kind narrows NeonResult.error to the matching subclass", async () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	const { error }: NeonResult<Project> = await neon.projects.get("p");
+	const { error }: NeonResult<Project> = await neon.projects.get({
+		projectId: "p",
+	});
 
 	if (error?.kind === "not_found") {
 		expectTypeOf(error).toEqualTypeOf<NeonNotFoundError>();
@@ -119,7 +121,9 @@ it("kind narrows NeonResult.error to the matching subclass", async () => {
 
 it("a switch over kind is exhaustive", async () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	const { error }: NeonResult<Project> = await neon.projects.get("p");
+	const { error }: NeonResult<Project> = await neon.projects.get({
+		projectId: "p",
+	});
 	if (!error) return;
 
 	switch (error.kind) {
@@ -141,7 +145,9 @@ it("a switch over kind is exhaustive", async () => {
 
 it("instanceof NeonApiError exposes status on the union", async () => {
 	const neon = createNeonClient({ apiKey: "x" });
-	const { error }: NeonResult<Project> = await neon.projects.get("p");
+	const { error }: NeonResult<Project> = await neon.projects.get({
+		projectId: "p",
+	});
 	if (error instanceof NeonApiError) {
 		expectTypeOf(error.status).toEqualTypeOf<number>();
 		expectTypeOf(error.kind).toEqualTypeOf<NeonApiErrorKind>();

--- a/packages/sdk/src/neon/named-params.test-d.ts
+++ b/packages/sdk/src/neon/named-params.test-d.ts
@@ -1,0 +1,84 @@
+import { expectTypeOf, it } from "vitest";
+import {
+	type Branch,
+	createNeonClient,
+	type NeonResult,
+	type Paginated,
+	type RemoveRoleOptions,
+	type SetRoleOptions,
+} from "../index.js";
+
+it("named inputs preserve resource and pagination inference", () => {
+	const client = createNeonClient({ apiKey: "unused" });
+	expectTypeOf(
+		client.branches.get({ branchId: "b", projectId: "p" }),
+	).resolves.toEqualTypeOf<NeonResult<Branch>>();
+	expectTypeOf(
+		client.branches.get(
+			{ projectId: "p", branchId: "b" },
+			{ throwOnError: true },
+		),
+	).resolves.toEqualTypeOf<Branch>();
+	expectTypeOf(
+		client.branches.list(
+			{ projectId: "p", limit: 2 },
+			{ throwOnError: true },
+		),
+	).toEqualTypeOf<Paginated<Branch, true>>();
+	expectTypeOf(
+		client.branches.delete(
+			{ projectId: "p", branchId: "b" },
+			{ throwOnError: true },
+		),
+	).resolves.toEqualTypeOf<void>();
+	expectTypeOf(
+		client.operations.waitFor(
+			{ operations: [] },
+			{ timeoutMs: 100, throwOnError: true },
+		),
+	).resolves.toEqualTypeOf<void>();
+
+	// @ts-expect-error positional resource identifiers were removed
+	client.branches.get("p", "b");
+	// @ts-expect-error a branch selector is required
+	client.branches.get({ projectId: "p" });
+	// @ts-expect-error numeric API key ids retain their type
+	client.apiKeys.revoke({ keyId: "1" });
+	// @ts-expect-error compute settings and noCompute remain mutually exclusive
+	client.branches.create({
+		projectId: "p",
+		noCompute: true,
+		compute: { minCu: 1 },
+	});
+	// @ts-expect-error operation arrays now belong to a named object
+	client.operations.waitFor([]);
+	// @ts-expect-error waitFor does not support requestTimeoutMs
+	client.operations.waitFor({ operations: [] }, { requestTimeoutMs: 100 });
+});
+
+it("workflow fields belong to operation inputs, not execution options", () => {
+	const client = createNeonClient({ apiKey: "unused" });
+	client.projects.createAndConnect({ name: "app", pooled: false });
+	client.branches.createAndConnect({ projectId: "p", pooled: false });
+	client.projects.members.setRole({
+		projectId: "p",
+		memberId: "m",
+		role: "viewer",
+		confirmSelfDemotion: true,
+	});
+	client.projects.members.removeRole({
+		projectId: "p",
+		memberId: "m",
+		confirmSelfLockout: true,
+	});
+	// @ts-expect-error pooled moved into the first argument
+	client.projects.createAndConnect({}, { pooled: false });
+	// @ts-expect-error pooled moved into the first argument
+	client.branches.createAndConnect({ projectId: "p" }, { pooled: false });
+	// @ts-expect-error confirmation moved into the operation input
+	const setOptions: SetRoleOptions = { confirmSelfDemotion: true };
+	// @ts-expect-error confirmation moved into the operation input
+	const removeOptions: RemoveRoleOptions = { confirmSelfLockout: true };
+	void setOptions;
+	void removeOptions;
+});

--- a/packages/sdk/src/neon/named-params.test.ts
+++ b/packages/sdk/src/neon/named-params.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from "vitest";
+import { createNeonClient } from "./client.js";
+import { NeonClientError } from "./errors.js";
+
+const unchanged = new Set([
+	"user.me",
+	"user.organizations",
+	"regions.list",
+	"apiKeys.list",
+	"projects.list",
+	"projects.create",
+	"projects.createAndConnect",
+	"projects.transfer",
+	"projects.transferFromUser",
+	"postgres.connectionString",
+]);
+
+/** Exercise the public resource methods, including nested namespaces. */
+function operations(client: object) {
+	const found: Array<{
+		name: string;
+		invoke: (input: unknown, opts?: unknown) => unknown;
+	}> = [];
+	function visit(resource: object, prefix: string) {
+		const proto = Object.getPrototypeOf(resource);
+		if (proto && proto !== Object.prototype) {
+			for (const key of Object.getOwnPropertyNames(proto)) {
+				if (key === "constructor") continue;
+				const name = `${prefix}.${key}`;
+				const method = (resource as Record<string, unknown>)[key];
+				if (
+					typeof method === "function" &&
+					!unchanged.has(name) &&
+					!name.startsWith("consumption.")
+				) {
+					found.push({
+						name,
+						invoke: (input, opts) =>
+							method.call(resource, input, opts),
+					});
+				}
+			}
+		}
+		for (const [key, value] of Object.entries(resource)) {
+			if (
+				key !== "client" &&
+				value !== null &&
+				typeof value === "object"
+			) {
+				visit(value, prefix ? `${prefix}.${key}` : key);
+			}
+		}
+	}
+	visit(client, "");
+	return found;
+}
+
+function consume(value: unknown): Promise<unknown> {
+	if (
+		value !== null &&
+		typeof value === "object" &&
+		"all" in value &&
+		typeof value.all === "function"
+	) {
+		return value.all();
+	}
+	return Promise.resolve(value);
+}
+
+function requestAt(requests: Request[], index: number): Request {
+	const request = requests[index];
+	if (!request) throw new Error(`Missing request ${index}`);
+	return request;
+}
+
+describe("named operation inputs", () => {
+	const names = operations(createNeonClient({ apiKey: "unused" })).map(
+		({ name }) => name,
+	);
+	for (const name of names) {
+		it(`${name} rejects legacy and missing-selector inputs before fetching`, async () => {
+			const fetch = vi.fn(async () => new Response("{}"));
+			const client = createNeonClient({
+				apiKey: "unused",
+				fetch,
+				retries: 0,
+			});
+			const operation = operations(client).find(
+				(entry) => entry.name === name,
+			);
+			if (!operation) throw new Error(`Missing public operation ${name}`);
+			for (const input of ["old-id", 42, null, undefined, [], {}]) {
+				const result = await consume(operation.invoke(input));
+				expect(result).toMatchObject({ error: { kind: "client" } });
+				await expect(
+					consume(operation.invoke(input, { throwOnError: true })),
+				).rejects.toBeInstanceOf(NeonClientError);
+			}
+			expect(fetch).not.toHaveBeenCalled();
+		});
+	}
+
+	it("invalid list inputs remain lazy and obey every consumption mode", async () => {
+		const fetch = vi.fn(async () => new Response("{}"));
+		const client = createNeonClient({ apiKey: "unused", fetch });
+		// @ts-expect-error JavaScript caller using the removed positional signature
+		const list = client.branches.list("old-project");
+		expect(fetch).not.toHaveBeenCalled();
+		await expect(list.page()).resolves.toMatchObject({
+			error: { kind: "client" },
+		});
+		await expect(list.all()).resolves.toMatchObject({
+			error: { kind: "client" },
+		});
+		await expect(
+			list[Symbol.asyncIterator]().next(),
+		).rejects.toBeInstanceOf(NeonClientError);
+		expect(fetch).not.toHaveBeenCalled();
+	});
+
+	it("separates an encoded database locator from its new name and body", async () => {
+		const requests: Request[] = [];
+		const client = createNeonClient({
+			apiKey: "unused",
+			fetch: async (input, init) => {
+				requests.push(
+					input instanceof Request ? input : new Request(input, init),
+				);
+				return Response.json({ database: { name: "renamed" } });
+			},
+		});
+		const result = await client.postgres.databases.update({
+			projectId: "project one",
+			branchId: "branch/two",
+			databaseName: "old name",
+			name: "renamed",
+		});
+		expect(result.error).toBeUndefined();
+		expect(requests).toHaveLength(1);
+		expect(requests[0]?.method).toBe("PATCH");
+		expect(new URL(requestAt(requests, 0).url).pathname).toBe(
+			"/api/v2/projects/project%20one/branches/branch%2Ftwo/databases/old%20name",
+		);
+		expect(await requestAt(requests, 0).json()).toEqual({
+			database: { name: "renamed" },
+		});
+	});
+
+	it("keeps named log selectors and filters stable across lazy pages", async () => {
+		const requests: Request[] = [];
+		const client = createNeonClient({
+			apiKey: "unused",
+			fetch: async (input, init) => {
+				requests.push(
+					input instanceof Request ? input : new Request(input, init),
+				);
+				return Response.json({
+					logs: [{ message: `page ${requests.length}` }],
+					is_truncated: requests.length === 1,
+					next_cursor: requests.length === 1 ? "next" : "",
+				});
+			},
+		});
+		const params = { projectId: "p", branchId: "b", since: "1h", limit: 2 };
+		const list = client.logs.query(params);
+		params.projectId = "different";
+		params.since = "2h";
+		expect(requests).toHaveLength(0);
+		const result = await list.all();
+		expect(result.error).toBeUndefined();
+		expect(requests).toHaveLength(2);
+		for (const request of requests) {
+			expect(new URL(request.url).pathname).toBe(
+				"/api/v2/projects/p/branches/b/logs/query",
+			);
+		}
+		expect(await requestAt(requests, 0).json()).toEqual({
+			since: "1h",
+			limit: 2,
+		});
+		expect(await requestAt(requests, 1).json()).toEqual({
+			since: "1h",
+			limit: 2,
+			cursor: "next",
+		});
+	});
+
+	it("routes confirmation flags from the operation input to the query only", async () => {
+		const requests: Request[] = [];
+		const client = createNeonClient({
+			apiKey: "unused",
+			fetch: async (input, init) => {
+				requests.push(
+					input instanceof Request ? input : new Request(input, init),
+				);
+				return Response.json({});
+			},
+		});
+		await client.projects.members.setRole({
+			projectId: "p",
+			memberId: "m",
+			role: "viewer",
+			confirmSelfDemotion: true,
+		});
+		await client.projects.members.removeRole({
+			projectId: "p",
+			memberId: "m",
+			confirmSelfLockout: true,
+		});
+		expect(
+			new URL(requestAt(requests, 0).url).searchParams.get(
+				"confirm_self_demotion",
+			),
+		).toBe("true");
+		expect(await requestAt(requests, 0).json()).toEqual({ role: "viewer" });
+		expect(
+			new URL(requestAt(requests, 1).url).searchParams.get(
+				"confirm_self_lockout",
+			),
+		).toBe("true");
+		expect(await requestAt(requests, 1).text()).toBe("");
+	});
+});

--- a/packages/sdk/src/neon/paginate.ts
+++ b/packages/sdk/src/neon/paginate.ts
@@ -67,7 +67,12 @@ class PaginatedList<T, D> implements Paginated<T, boolean> {
 				this.#fetchPage(cursor, deadline.signal),
 			);
 		} catch (error) {
-			return err(cancelled(deadline) ?? toNeonError(error, undefined));
+			return err(
+				cancelled(deadline) ??
+					(isNeonError(error)
+						? error
+						: toNeonError(error, undefined)),
+			);
 		}
 		const cancellation = cancelled(deadline);
 		if (cancellation) return err(cancellation);

--- a/packages/sdk/src/neon/params.ts
+++ b/packages/sdk/src/neon/params.ts
@@ -1,0 +1,36 @@
+import { NeonClientError } from "./errors.js";
+import { err, finalize, type NeonResult } from "./result.js";
+
+/** Validate only the operation-object boundary and its required selectors. */
+export function validateParams(
+	value: unknown,
+	method: string,
+	required: Record<string, "string" | "number" | "array"> = {},
+): NeonClientError | undefined {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return new NeonClientError(
+			`${method} expects a named parameter object. See the SDK migration guide.`,
+		);
+	}
+	const params = value as Record<string, unknown>;
+	for (const [name, type] of Object.entries(required)) {
+		const valid =
+			type === "array"
+				? Array.isArray(params[name])
+				: typeof params[name] === type;
+		if (!valid) {
+			return new NeonClientError(
+				`${method} requires ${name} in its parameter object (${type}).`,
+			);
+		}
+	}
+	return undefined;
+}
+
+/** Keep invalid JavaScript inputs on the same async result/throw contract. */
+export async function invalidParamsResult<T>(
+	error: NeonClientError,
+	shouldThrow: boolean,
+): Promise<T | NeonResult<T>> {
+	return finalize(err<T>(error), shouldThrow);
+}

--- a/packages/sdk/src/neon/resources/account.ts
+++ b/packages/sdk/src/neon/resources/account.ts
@@ -15,7 +15,16 @@ import type {
 	RegionResponse,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
+
+export type ApiKeysCreateParams = {
+	keyName: string;
+};
+
+export type ApiKeysRevokeParams = {
+	keyId: number;
+};
 
 /** Current user / account resource. */
 export class User<DThrow extends boolean> {
@@ -118,15 +127,27 @@ export class ApiKeys<DThrow extends boolean> {
 	 *
 	 * @apiCall POST /api_keys
 	 */
-	create(keyName: string): Promise<Outcome<ApiKeyCreateResponse, DThrow>>;
+	create(
+		params: ApiKeysCreateParams,
+	): Promise<Outcome<ApiKeyCreateResponse, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		keyName: string,
+		params: ApiKeysCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<ApiKeyCreateResponse, Throw>>;
 	create(
-		keyName: string,
+		params: ApiKeysCreateParams,
 		opts?: CallOptions,
 	): Promise<ApiKeyCreateResponse | NeonResult<ApiKeyCreateResponse>> {
+		const invalid = validateParams(params, "apiKeys.create", {
+			keyName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<ApiKeyCreateResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { keyName } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -141,15 +162,27 @@ export class ApiKeys<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /api_keys/{key_id} */
-	revoke(keyId: number): Promise<Outcome<ApiKeyRevokeResponse, DThrow>>;
+	revoke(
+		params: ApiKeysRevokeParams,
+	): Promise<Outcome<ApiKeyRevokeResponse, DThrow>>;
 	revoke<Throw extends boolean = DThrow>(
-		keyId: number,
+		params: ApiKeysRevokeParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<ApiKeyRevokeResponse, Throw>>;
 	revoke(
-		keyId: number,
+		params: ApiKeysRevokeParams,
 		opts?: CallOptions,
 	): Promise<ApiKeyRevokeResponse | NeonResult<ApiKeyRevokeResponse>> {
+		const invalid = validateParams(params, "apiKeys.revoke", {
+			keyId: "number",
+		});
+		if (invalid) {
+			return invalidParamsResult<ApiKeyRevokeResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { keyId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/ai-gateway.ts
+++ b/packages/sdk/src/neon/resources/ai-gateway.ts
@@ -1,7 +1,13 @@
 import { getProjectBranchAiGateway } from "../../client/sdk.gen.js";
 import type { BranchAiGateway } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
+
+export type AiGatewayGetParams = {
+	projectId: string;
+	branchId: string;
+};
 
 /** Branch-scoped AI Gateway endpoint metadata. */
 export class AiGateway<DThrow extends boolean> {
@@ -12,20 +18,26 @@ export class AiGateway<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/ai_gateway */
-	get(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<BranchAiGateway, DThrow>>;
+	get(params: AiGatewayGetParams): Promise<Outcome<BranchAiGateway, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: AiGatewayGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<BranchAiGateway, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
+		params: AiGatewayGetParams,
 		opts?: CallOptions,
 	): Promise<BranchAiGateway | NeonResult<BranchAiGateway>> {
+		const invalid = validateParams(params, "aiGateway.get", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<BranchAiGateway>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/auth.ts
+++ b/packages/sdk/src/neon/resources/auth.ts
@@ -32,7 +32,39 @@ import type {
 	UpdateNeonAuthUserRoleResponse,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
+
+type BranchParams = { projectId: string; branchId: string };
+
+export type AuthOauthProvidersListParams = BranchParams;
+export type AuthOauthProvidersAddParams = BranchParams &
+	NeonAuthAddOAuthProviderRequest;
+export type AuthOauthProvidersUpdateParams = BranchParams & {
+	providerId: NeonAuthOauthProviderId;
+} & NeonAuthUpdateOAuthProviderRequest;
+export type AuthOauthProvidersDeleteParams = BranchParams & {
+	providerId: NeonAuthOauthProviderId;
+};
+
+export type AuthTrustedDomainsListParams = BranchParams;
+export type AuthTrustedDomainsAddParams = BranchParams &
+	NeonAuthAddDomainToRedirectUriWhitelistRequest;
+export type AuthTrustedDomainsDeleteParams = BranchParams &
+	NeonAuthDeleteDomainFromRedirectUriWhitelistRequest;
+
+export type AuthUsersCreateParams = BranchParams &
+	CreateBranchNeonAuthNewUserRequest;
+export type AuthUsersDeleteParams = BranchParams & { authUserId: string };
+export type AuthUsersUpdateRoleParams = BranchParams & {
+	authUserId: string;
+	roles: string[];
+};
+
+export type AuthGetParams = BranchParams;
+export type AuthCreateParams = BranchParams & EnableNeonAuthIntegrationRequest;
+export type AuthDisableParams = BranchParams & { deleteData?: boolean };
+export type AuthUpdateConfigParams = BranchParams & NeonAuthConfigUpdate;
 
 /** Branch-scoped Neon Auth OAuth providers (Google, GitHub, …). */
 export class AuthOauthProviders<DThrow extends boolean> {
@@ -44,19 +76,27 @@ export class AuthOauthProviders<DThrow extends boolean> {
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/auth/oauth_providers */
 	list(
-		projectId: string,
-		branchId: string,
+		params: AuthOauthProvidersListParams,
 	): Promise<Outcome<NeonAuthOauthProvider[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: AuthOauthProvidersListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthOauthProvider[], Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
+		params: AuthOauthProvidersListParams,
 		opts?: CallOptions,
 	): Promise<NeonAuthOauthProvider[] | NeonResult<NeonAuthOauthProvider[]>> {
+		const invalid = validateParams(params, "auth.oauthProviders.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthOauthProvider[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -72,22 +112,27 @@ export class AuthOauthProviders<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/auth/oauth_providers */
 	add(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthAddOAuthProviderRequest,
+		params: AuthOauthProvidersAddParams,
 	): Promise<Outcome<NeonAuthOauthProvider, DThrow>>;
 	add<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthAddOAuthProviderRequest,
+		params: AuthOauthProvidersAddParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthOauthProvider, Throw>>;
 	add(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthAddOAuthProviderRequest,
+		params: AuthOauthProvidersAddParams,
 		opts?: CallOptions,
 	): Promise<NeonAuthOauthProvider | NeonResult<NeonAuthOauthProvider>> {
+		const invalid = validateParams(params, "auth.oauthProviders.add", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthOauthProvider>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -104,25 +149,28 @@ export class AuthOauthProviders<DThrow extends boolean> {
 
 	/** @apiCall PATCH …/auth/oauth_providers/{oauth_provider_id} */
 	update(
-		projectId: string,
-		branchId: string,
-		providerId: NeonAuthOauthProviderId,
-		input: NeonAuthUpdateOAuthProviderRequest,
+		params: AuthOauthProvidersUpdateParams,
 	): Promise<Outcome<NeonAuthOauthProvider, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		providerId: NeonAuthOauthProviderId,
-		input: NeonAuthUpdateOAuthProviderRequest,
+		params: AuthOauthProvidersUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthOauthProvider, Throw>>;
 	update(
-		projectId: string,
-		branchId: string,
-		providerId: NeonAuthOauthProviderId,
-		input: NeonAuthUpdateOAuthProviderRequest,
+		params: AuthOauthProvidersUpdateParams,
 		opts?: CallOptions,
 	): Promise<NeonAuthOauthProvider | NeonResult<NeonAuthOauthProvider>> {
+		const invalid = validateParams(params, "auth.oauthProviders.update", {
+			projectId: "string",
+			branchId: "string",
+			providerId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthOauthProvider>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, providerId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -143,22 +191,28 @@ export class AuthOauthProviders<DThrow extends boolean> {
 
 	/** @apiCall DELETE …/auth/oauth_providers/{oauth_provider_id} */
 	delete(
-		projectId: string,
-		branchId: string,
-		providerId: NeonAuthOauthProviderId,
+		params: AuthOauthProvidersDeleteParams,
 	): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		providerId: NeonAuthOauthProviderId,
+		params: AuthOauthProvidersDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		providerId: NeonAuthOauthProviderId,
+		params: AuthOauthProvidersDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "auth.oauthProviders.delete", {
+			projectId: "string",
+			branchId: "string",
+			providerId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, providerId } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteBranchNeonAuthOauthProvider({
 				client,
@@ -184,22 +238,30 @@ export class AuthTrustedDomains<DThrow extends boolean> {
 
 	/** @apiCall GET …/auth/trusted_domains */
 	list(
-		projectId: string,
-		branchId: string,
+		params: AuthTrustedDomainsListParams,
 	): Promise<Outcome<NeonAuthRedirectUriWhitelistDomain[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: AuthTrustedDomainsListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthRedirectUriWhitelistDomain[], Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
+		params: AuthTrustedDomainsListParams,
 		opts?: CallOptions,
 	): Promise<
 		| NeonAuthRedirectUriWhitelistDomain[]
 		| NeonResult<NeonAuthRedirectUriWhitelistDomain[]>
 	> {
+		const invalid = validateParams(params, "auth.trustedDomains.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthRedirectUriWhitelistDomain[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -214,23 +276,26 @@ export class AuthTrustedDomains<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST …/auth/trusted_domains */
-	add(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthAddDomainToRedirectUriWhitelistRequest,
-	): Promise<Outcome<void, DThrow>>;
+	add(params: AuthTrustedDomainsAddParams): Promise<Outcome<void, DThrow>>;
 	add<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthAddDomainToRedirectUriWhitelistRequest,
+		params: AuthTrustedDomainsAddParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	add(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthAddDomainToRedirectUriWhitelistRequest,
+		params: AuthTrustedDomainsAddParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "auth.trustedDomains.add", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			addBranchNeonAuthTrustedDomain({
 				client,
@@ -244,22 +309,27 @@ export class AuthTrustedDomains<DThrow extends boolean> {
 
 	/** @apiCall DELETE …/auth/trusted_domains */
 	delete(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthDeleteDomainFromRedirectUriWhitelistRequest,
+		params: AuthTrustedDomainsDeleteParams,
 	): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthDeleteDomainFromRedirectUriWhitelistRequest,
+		params: AuthTrustedDomainsDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthDeleteDomainFromRedirectUriWhitelistRequest,
+		params: AuthTrustedDomainsDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "auth.trustedDomains.delete", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteBranchNeonAuthTrustedDomain({
 				client,
@@ -282,25 +352,30 @@ export class AuthUsers<DThrow extends boolean> {
 
 	/** @apiCall POST …/auth/users */
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateBranchNeonAuthNewUserRequest,
+		params: AuthUsersCreateParams,
 	): Promise<Outcome<NeonAuthCreateNewUserResponse, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CreateBranchNeonAuthNewUserRequest,
+		params: AuthUsersCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthCreateNewUserResponse, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateBranchNeonAuthNewUserRequest,
+		params: AuthUsersCreateParams,
 		opts?: CallOptions,
 	): Promise<
 		| NeonAuthCreateNewUserResponse
 		| NeonResult<NeonAuthCreateNewUserResponse>
 	> {
+		const invalid = validateParams(params, "auth.users.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthCreateNewUserResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -316,23 +391,27 @@ export class AuthUsers<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE …/auth/users/{auth_user_id} */
-	delete(
-		projectId: string,
-		branchId: string,
-		authUserId: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: AuthUsersDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		authUserId: string,
+		params: AuthUsersDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		authUserId: string,
+		params: AuthUsersDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "auth.users.delete", {
+			projectId: "string",
+			branchId: "string",
+			authUserId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, authUserId } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteBranchNeonAuthUser({
 				client,
@@ -349,28 +428,32 @@ export class AuthUsers<DThrow extends boolean> {
 
 	/** @apiCall PATCH …/auth/users/{auth_user_id}/role */
 	updateRole(
-		projectId: string,
-		branchId: string,
-		authUserId: string,
-		roles: string[],
+		params: AuthUsersUpdateRoleParams,
 	): Promise<Outcome<UpdateNeonAuthUserRoleResponse, DThrow>>;
 	updateRole<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		authUserId: string,
-		roles: string[],
+		params: AuthUsersUpdateRoleParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<UpdateNeonAuthUserRoleResponse, Throw>>;
 	updateRole(
-		projectId: string,
-		branchId: string,
-		authUserId: string,
-		roles: string[],
+		params: AuthUsersUpdateRoleParams,
 		opts?: CallOptions,
 	): Promise<
 		| UpdateNeonAuthUserRoleResponse
 		| NeonResult<UpdateNeonAuthUserRoleResponse>
 	> {
+		const invalid = validateParams(params, "auth.users.updateRole", {
+			projectId: "string",
+			branchId: "string",
+			authUserId: "string",
+			roles: "array",
+		});
+		if (invalid) {
+			return invalidParamsResult<UpdateNeonAuthUserRoleResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, authUserId, roles } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -409,20 +492,26 @@ export class Auth<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/auth */
-	get(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<NeonAuthIntegration, DThrow>>;
+	get(params: AuthGetParams): Promise<Outcome<NeonAuthIntegration, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: AuthGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthIntegration, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
+		params: AuthGetParams,
 		opts?: CallOptions,
 	): Promise<NeonAuthIntegration | NeonResult<NeonAuthIntegration>> {
+		const invalid = validateParams(params, "auth.get", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthIntegration>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -438,25 +527,30 @@ export class Auth<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/auth */
 	create(
-		projectId: string,
-		branchId: string,
-		input: EnableNeonAuthIntegrationRequest,
+		params: AuthCreateParams,
 	): Promise<Outcome<NeonAuthCreateIntegrationResponse, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: EnableNeonAuthIntegrationRequest,
+		params: AuthCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthCreateIntegrationResponse, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input: EnableNeonAuthIntegrationRequest,
+		params: AuthCreateParams,
 		opts?: CallOptions,
 	): Promise<
 		| NeonAuthCreateIntegrationResponse
 		| NeonResult<NeonAuthCreateIntegrationResponse>
 	> {
+		const invalid = validateParams(params, "auth.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthCreateIntegrationResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -472,28 +566,31 @@ export class Auth<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/auth */
-	disable(
-		projectId: string,
-		branchId: string,
-		input?: { deleteData?: boolean },
-	): Promise<Outcome<void, DThrow>>;
+	disable(params: AuthDisableParams): Promise<Outcome<void, DThrow>>;
 	disable<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: { deleteData?: boolean } | undefined,
+		params: AuthDisableParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	disable(
-		projectId: string,
-		branchId: string,
-		input?: { deleteData?: boolean },
+		params: AuthDisableParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "auth.disable", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, deleteData } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			disableNeonAuth({
 				client,
 				path: { project_id: projectId, branch_id: branchId },
-				body: { delete_data: input?.deleteData },
+				body: { delete_data: deleteData },
 				throwOnError: false,
 				signal,
 			}),
@@ -502,22 +599,27 @@ export class Auth<DThrow extends boolean> {
 
 	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id}/auth/config */
 	updateConfig(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthConfigUpdate,
+		params: AuthUpdateConfigParams,
 	): Promise<Outcome<NeonAuthConfigResponse, DThrow>>;
 	updateConfig<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthConfigUpdate,
+		params: AuthUpdateConfigParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonAuthConfigResponse, Throw>>;
 	updateConfig(
-		projectId: string,
-		branchId: string,
-		input: NeonAuthConfigUpdate,
+		params: AuthUpdateConfigParams,
 		opts?: CallOptions,
 	): Promise<NeonAuthConfigResponse | NeonResult<NeonAuthConfigResponse>> {
+		const invalid = validateParams(params, "auth.updateConfig", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonAuthConfigResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/branches.test.ts
+++ b/packages/sdk/src/neon/resources/branches.test.ts
@@ -50,7 +50,8 @@ describe("branches.create", () => {
 			},
 		}));
 
-		const { data, error } = await neon.branches.create("p-1", {
+		const { data, error } = await neon.branches.create({
+			projectId: "p-1",
 			name: "feature",
 			parent_id: "br-parent",
 			compute: { minCu: 0.5, maxCu: 2, suspendTimeoutSeconds: 300 },
@@ -78,7 +79,7 @@ describe("branches.create", () => {
 			body: { branch: { id: "br-1", name: "feature" } },
 		}));
 
-		await neon.branches.create("p-1", { name: "feature" });
+		await neon.branches.create({ projectId: "p-1", name: "feature" });
 
 		expect(calls[0]?.body).toEqual({
 			branch: { name: "feature" },
@@ -92,7 +93,8 @@ describe("branches.create", () => {
 			body: { branch: { id: "br-1", name: "bare" } },
 		}));
 
-		const { data, error } = await neon.branches.create("p-1", {
+		const { data, error } = await neon.branches.create({
+			projectId: "p-1",
 			name: "bare",
 			noCompute: true,
 		});
@@ -108,9 +110,10 @@ describe("branches.create", () => {
 			body: { message: "should not be called" },
 		}));
 
-		const { data, error } = await neon.branches.create("p-1", {
+		// @ts-expect-error runtime guard for JS callers
+		const { data, error } = await neon.branches.create({
+			projectId: "p-1",
 			noCompute: true,
-			// @ts-expect-error runtime guard for JS callers
 			compute: { minCu: 1 },
 		});
 
@@ -131,9 +134,10 @@ describe("branches.create", () => {
 			},
 		});
 		await expect(
-			throwing.branches.create("p-1", {
+			// @ts-expect-error runtime guard for JS callers
+			throwing.branches.create({
+				projectId: "p-1",
 				noCompute: true,
-				// @ts-expect-error runtime guard for JS callers
 				compute: { minCu: 1 },
 			}),
 		).rejects.toMatchObject({
@@ -162,7 +166,8 @@ describe("branches.createAndConnect", () => {
 			},
 		}));
 
-		const { data, error } = await neon.branches.createAndConnect("p-1", {
+		const { data, error } = await neon.branches.createAndConnect({
+			projectId: "p-1",
 			name: "feature",
 			parentId: "br-parent",
 		});
@@ -198,11 +203,11 @@ describe("branches.resetFromParent", () => {
 			};
 		});
 
-		const { data, error } = await neon.branches.resetFromParent(
-			"p-1",
-			"br-child",
-			{ preserveUnderName: "feature-old" },
-		);
+		const { data, error } = await neon.branches.resetFromParent({
+			projectId: "p-1",
+			branchId: "br-child",
+			preserveUnderName: "feature-old",
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual({ id: "br-child", name: "feature" });
@@ -222,10 +227,10 @@ describe("branches.resetFromParent", () => {
 			body: { branch: { id: "br-root" } },
 		}));
 
-		const { data, error } = await neon.branches.resetFromParent(
-			"p-1",
-			"br-root",
-		);
+		const { data, error } = await neon.branches.resetFromParent({
+			projectId: "p-1",
+			branchId: "br-root",
+		});
 
 		expect(data).toBeUndefined();
 		expect(error?.kind).toBe("client");
@@ -244,16 +249,14 @@ describe("branches.compareSchema", () => {
 			body: { diff: "--- a\n+++ b\n" },
 		}));
 
-		const { data, error } = await neon.branches.compareSchema(
-			"p-1",
-			"br-child",
-			{
-				databaseName: "neondb",
-				baseBranchId: "br-parent",
-				lsn: "0/1",
-				baseLsn: "0/2",
-			},
-		);
+		const { data, error } = await neon.branches.compareSchema({
+			projectId: "p-1",
+			branchId: "br-child",
+			databaseName: "neondb",
+			baseBranchId: "br-parent",
+			lsn: "0/1",
+			baseLsn: "0/2",
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual({ diff: "--- a\n+++ b\n" });

--- a/packages/sdk/src/neon/resources/branches.ts
+++ b/packages/sdk/src/neon/resources/branches.ts
@@ -21,16 +21,12 @@ import { withConnectionString } from "../connection.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { NeonClientError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 type ListQuery = Omit<NonNullable<ListProjectBranchesData["query"]>, "cursor">;
 type BranchFields = NonNullable<BranchCreateRequest["branch"]>;
 type UpdateInput = BranchUpdateRequest["branch"];
-
-interface WorkflowOptions<Throw extends boolean> extends CallOptions<Throw> {
-	/** Return a pooled connection string (default `true`). */
-	pooled?: boolean;
-}
 
 export interface ComputeSettings {
 	minCu?: number;
@@ -83,6 +79,46 @@ export interface CompareSchemaInput {
 	baseTimestamp?: string;
 }
 
+export type BranchListParams = ListQuery & { projectId: string };
+export interface BranchGetParams {
+	projectId: string;
+	branchId: string;
+}
+export type BranchCreateParams = CreateInput & { projectId: string };
+export type BranchUpdateParams = UpdateInput & {
+	projectId: string;
+	branchId: string;
+};
+export interface BranchDeleteParams {
+	projectId: string;
+	branchId: string;
+}
+export type BranchCreateAndConnectParams = CreateAndConnectInput & {
+	projectId: string;
+	/** Return a pooled connection string (default `true`). */
+	pooled?: boolean;
+};
+export interface BranchGetDefaultParams {
+	projectId: string;
+}
+export interface BranchSetDefaultParams {
+	projectId: string;
+	branchId: string;
+}
+export type BranchResetFromParentParams = ResetFromParentInput & {
+	projectId: string;
+	branchId: string;
+};
+export type BranchCompareSchemaParams = CompareSchemaInput & {
+	projectId: string;
+	branchId: string;
+};
+export interface BranchFinalizeRestoreParams {
+	projectId: string;
+	branchId: string;
+	name?: string;
+}
+
 export class Branches<DThrow extends boolean> {
 	readonly #ctx: RequestContext;
 
@@ -91,26 +127,32 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches (cursor-paginated) */
-	list(projectId: string, query?: ListQuery): Paginated<Branch, DThrow>;
+	list(params: BranchListParams): Paginated<Branch, DThrow>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		query: ListQuery | undefined,
+		params: BranchListParams,
 		opts: CallOptions<Throw>,
 	): Paginated<Branch, Throw>;
 	list(
-		projectId: string,
-		query?: ListQuery,
+		params: BranchListParams,
 		opts?: CallOptions,
 	): Paginated<Branch, boolean> {
+		const error = validateParams(params, "branches.list", {
+			projectId: "string",
+		});
+		const { projectId, ...query } = error
+			? ({} as BranchListParams)
+			: params;
 		return paginate(
-			(cursor, signal) =>
-				listProjectBranches({
+			async (cursor, signal) => {
+				if (error) throw error;
+				return listProjectBranches({
 					client: this.#ctx.client,
 					path: { project_id: projectId },
 					query: { ...query, cursor },
 					throwOnError: false,
 					signal,
-				}),
+				});
+			},
 			(data) => ({
 				items: data?.branches ?? [],
 				cursor: data?.pagination?.next,
@@ -121,17 +163,25 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id} */
-	get(projectId: string, branchId: string): Promise<Outcome<Branch, DThrow>>;
+	get(params: BranchGetParams): Promise<Outcome<Branch, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: BranchGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
+		params: BranchGetParams,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const error = validateParams(params, "branches.get", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Branch>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -153,20 +203,24 @@ export class Branches<DThrow extends boolean> {
 	 * Readiness polling stays on for `noCompute` branches because a
 	 * compute-less branch still has provisioning operations.
 	 */
-	create(
-		projectId: string,
-		input?: CreateInput,
-	): Promise<Outcome<Branch, DThrow>>;
+	create(params: BranchCreateParams): Promise<Outcome<Branch, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		input: CreateInput | undefined,
+		params: BranchCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
 	async create(
-		projectId: string,
-		input?: CreateInput,
+		params: BranchCreateParams,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const paramsError = validateParams(params, "branches.create", {
+			projectId: "string",
+		});
+		if (paramsError)
+			return invalidParamsResult<Branch>(
+				paramsError,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, ...input } = params;
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const parsed = parseCreateInput(input);
@@ -200,23 +254,25 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id} */
-	update(
-		projectId: string,
-		branchId: string,
-		input: UpdateInput,
-	): Promise<Outcome<Branch, DThrow>>;
+	update(params: BranchUpdateParams): Promise<Outcome<Branch, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: UpdateInput,
+		params: BranchUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
 	update(
-		projectId: string,
-		branchId: string,
-		input: UpdateInput,
+		params: BranchUpdateParams,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const error = validateParams(params, "branches.update", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Branch>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -232,17 +288,25 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id} */
-	delete(projectId: string, branchId: string): Promise<Outcome<void, DThrow>>;
+	delete(params: BranchDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: BranchDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
+		params: BranchDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const error = validateParams(params, "branches.delete", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (error)
+			return invalidParamsResult<void>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, branchId } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranch({
 				client,
@@ -254,19 +318,25 @@ export class Branches<DThrow extends boolean> {
 	}
 
 	createAndConnect(
-		projectId: string,
-		input?: CreateAndConnectInput,
+		params: BranchCreateAndConnectParams,
 	): Promise<Outcome<BranchConnection, DThrow>>;
 	createAndConnect<Throw extends boolean = DThrow>(
-		projectId: string,
-		input: CreateAndConnectInput | undefined,
-		opts: WorkflowOptions<Throw>,
+		params: BranchCreateAndConnectParams,
+		opts: CallOptions<Throw>,
 	): Promise<Outcome<BranchConnection, Throw>>;
 	async createAndConnect(
-		projectId: string,
-		input?: CreateAndConnectInput,
-		opts?: WorkflowOptions<boolean>,
+		params: BranchCreateAndConnectParams,
+		opts?: CallOptions<boolean>,
 	): Promise<BranchConnection | NeonResult<BranchConnection>> {
+		const error = validateParams(params, "branches.createAndConnect", {
+			projectId: "string",
+		});
+		if (error)
+			return invalidParamsResult<BranchConnection>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, pooled = true, name, parentId, compute } = params;
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
@@ -277,10 +347,10 @@ export class Branches<DThrow extends boolean> {
 					path: { project_id: projectId },
 					body: {
 						branch: {
-							name: input?.name,
-							parent_id: input?.parentId,
+							name,
+							parent_id: parentId,
 						},
-						endpoints: [readWriteEndpoint(input?.compute)],
+						endpoints: [readWriteEndpoint(compute)],
 					},
 					throwOnError: false,
 					signal,
@@ -295,7 +365,7 @@ export class Branches<DThrow extends boolean> {
 				endpoint: data.endpoints[0],
 				connectionString,
 			}),
-			opts?.pooled ?? true,
+			pooled,
 		);
 		return finalize(out, shouldThrow);
 	}
@@ -304,15 +374,26 @@ export class Branches<DThrow extends boolean> {
 	 * Resolve the project's default branch (by the `default` flag — not by name).
 	 * Returns a {@link NeonClientError} when no default branch is found.
 	 */
-	getDefault(projectId: string): Promise<Outcome<Branch, DThrow>>;
+	getDefault(
+		params: BranchGetDefaultParams,
+	): Promise<Outcome<Branch, DThrow>>;
 	getDefault<Throw extends boolean = DThrow>(
-		projectId: string,
+		params: BranchGetDefaultParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
 	async getDefault(
-		projectId: string,
+		params: BranchGetDefaultParams,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const error = validateParams(params, "branches.getDefault", {
+			projectId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Branch>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId } = params;
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
@@ -344,19 +425,26 @@ export class Branches<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/set_as_default */
 	setDefault(
-		projectId: string,
-		branchId: string,
+		params: BranchSetDefaultParams,
 	): Promise<Outcome<Branch, DThrow>>;
 	setDefault<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: BranchSetDefaultParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
 	setDefault(
-		projectId: string,
-		branchId: string,
+		params: BranchSetDefaultParams,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const error = validateParams(params, "branches.setDefault", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Branch>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -377,22 +465,26 @@ export class Branches<DThrow extends boolean> {
 	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/restore
 	 */
 	resetFromParent(
-		projectId: string,
-		branchId: string,
-		input?: ResetFromParentInput,
+		params: BranchResetFromParentParams,
 	): Promise<Outcome<Branch, DThrow>>;
 	resetFromParent<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: ResetFromParentInput | undefined,
+		params: BranchResetFromParentParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
 	async resetFromParent(
-		projectId: string,
-		branchId: string,
-		input?: ResetFromParentInput,
+		params: BranchResetFromParentParams,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const error = validateParams(params, "branches.resetFromParent", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Branch>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, branchId, preserveUnderName } = params;
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const current = await this.#ctx.execute(
@@ -428,9 +520,9 @@ export class Branches<DThrow extends boolean> {
 					path: { project_id: projectId, branch_id: branchId },
 					body: {
 						source_branch_id: parentId,
-						...(input?.preserveUnderName === undefined
+						...(preserveUnderName === undefined
 							? {}
-							: { preserve_under_name: input.preserveUnderName }),
+							: { preserve_under_name: preserveUnderName }),
 					},
 					throwOnError: false,
 					signal,
@@ -445,24 +537,38 @@ export class Branches<DThrow extends boolean> {
 	 * @apiCall GET /projects/{project_id}/branches/{branch_id}/compare_schema
 	 */
 	compareSchema(
-		projectId: string,
-		branchId: string,
-		input: CompareSchemaInput,
+		params: BranchCompareSchemaParams,
 	): Promise<Outcome<BranchSchemaCompareResponse, DThrow>>;
 	compareSchema<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CompareSchemaInput,
+		params: BranchCompareSchemaParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<BranchSchemaCompareResponse, Throw>>;
 	compareSchema(
-		projectId: string,
-		branchId: string,
-		input: CompareSchemaInput,
+		params: BranchCompareSchemaParams,
 		opts?: CallOptions,
 	): Promise<
 		BranchSchemaCompareResponse | NeonResult<BranchSchemaCompareResponse>
 	> {
+		const error = validateParams(params, "branches.compareSchema", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (error)
+			return invalidParamsResult<BranchSchemaCompareResponse>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const {
+			projectId,
+			branchId,
+			databaseName,
+			baseBranchId,
+			lsn,
+			timestamp,
+			baseLsn,
+			baseTimestamp,
+		} = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -470,20 +576,16 @@ export class Branches<DThrow extends boolean> {
 					client,
 					path: { project_id: projectId, branch_id: branchId },
 					query: {
-						db_name: input.databaseName,
-						...(input.baseBranchId === undefined
+						db_name: databaseName,
+						...(baseBranchId === undefined
 							? {}
-							: { base_branch_id: input.baseBranchId }),
-						...(input.lsn === undefined ? {} : { lsn: input.lsn }),
-						...(input.timestamp === undefined
+							: { base_branch_id: baseBranchId }),
+						...(lsn === undefined ? {} : { lsn }),
+						...(timestamp === undefined ? {} : { timestamp }),
+						...(baseLsn === undefined ? {} : { base_lsn: baseLsn }),
+						...(baseTimestamp === undefined
 							? {}
-							: { timestamp: input.timestamp }),
-						...(input.baseLsn === undefined
-							? {}
-							: { base_lsn: input.baseLsn }),
-						...(input.baseTimestamp === undefined
-							? {}
-							: { base_timestamp: input.baseTimestamp }),
+							: { base_timestamp: baseTimestamp }),
 					},
 					throwOnError: false,
 					signal,
@@ -500,29 +602,33 @@ export class Branches<DThrow extends boolean> {
 	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/restore/finalize
 	 */
 	finalizeRestore(
-		projectId: string,
-		branchId: string,
-		input?: { name?: string },
+		params: BranchFinalizeRestoreParams,
 	): Promise<Outcome<void, DThrow>>;
 	finalizeRestore<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: { name?: string } | undefined,
+		params: BranchFinalizeRestoreParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	finalizeRestore(
-		projectId: string,
-		branchId: string,
-		input?: { name?: string },
+		params: BranchFinalizeRestoreParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const error = validateParams(params, "branches.finalizeRestore", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (error)
+			return invalidParamsResult<void>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, branchId, name } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				finalizeRestoreBranch({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					body: { name: input?.name },
+					body: { name },
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/sdk/src/neon/resources/bucket-objects.ts
+++ b/packages/sdk/src/neon/resources/bucket-objects.ts
@@ -13,12 +13,34 @@ import type {
 	PresignResponse,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type ListQuery = Omit<
 	NonNullable<ListProjectBranchBucketObjectsData["query"]>,
 	"cursor"
 >;
+
+export type BucketObjectsListParams = {
+	projectId: string;
+	branchId: string;
+	bucketName: string;
+} & ListQuery & { cursor?: string };
+export type BucketObjectsGetParams = {
+	projectId: string;
+	branchId: string;
+	bucketName: string;
+	objectKey: string;
+};
+export type BucketObjectsDeleteParams = BucketObjectsGetParams;
+export type BucketObjectsDeleteByPrefixParams = {
+	projectId: string;
+	branchId: string;
+	bucketName: string;
+	prefix: string;
+};
+export type BucketObjectsPresignParams = BucketObjectsGetParams &
+	PresignRequest;
 
 /** Objects inside a branch bucket. */
 export class BucketObjects<DThrow extends boolean> {
@@ -30,27 +52,30 @@ export class BucketObjects<DThrow extends boolean> {
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/buckets/{bucket_name}/objects */
 	list(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		query?: ListQuery & { cursor?: string },
+		params: BucketObjectsListParams,
 	): Promise<Outcome<BucketObjectsListResponse, DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		query: (ListQuery & { cursor?: string }) | undefined,
+		params: BucketObjectsListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<BucketObjectsListResponse, Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		query?: ListQuery & { cursor?: string },
+		params: BucketObjectsListParams,
 		opts?: CallOptions,
 	): Promise<
 		BucketObjectsListResponse | NeonResult<BucketObjectsListResponse>
 	> {
+		const invalid = validateParams(params, "storage.objects.list", {
+			projectId: "string",
+			branchId: "string",
+			bucketName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<BucketObjectsListResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, bucketName, ...query } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -70,26 +95,28 @@ export class BucketObjects<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/buckets/{bucket_name}/objects/{object_key}/download */
-	get(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
-	): Promise<Outcome<Blob, DThrow>>;
+	get(params: BucketObjectsGetParams): Promise<Outcome<Blob, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
+		params: BucketObjectsGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Blob, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
+		params: BucketObjectsGetParams,
 		opts?: CallOptions,
 	): Promise<Blob | NeonResult<Blob>> {
+		const invalid = validateParams(params, "storage.objects.get", {
+			projectId: "string",
+			branchId: "string",
+			bucketName: "string",
+			objectKey: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Blob>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, bucketName, objectKey } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -109,26 +136,28 @@ export class BucketObjects<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/buckets/{bucket_name}/objects/{object_key} */
-	delete(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: BucketObjectsDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
+		params: BucketObjectsDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
+		params: BucketObjectsDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "storage.objects.delete", {
+			projectId: "string",
+			branchId: "string",
+			bucketName: "string",
+			objectKey: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, bucketName, objectKey } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchBucketObject({
 				client,
@@ -146,28 +175,36 @@ export class BucketObjects<DThrow extends boolean> {
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/buckets/{bucket_name}/objects-by-prefix */
 	deleteByPrefix(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		prefix: string,
+		params: BucketObjectsDeleteByPrefixParams,
 	): Promise<Outcome<BucketObjectsDeletePrefixResponse, DThrow>>;
 	deleteByPrefix<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		prefix: string,
+		params: BucketObjectsDeleteByPrefixParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<BucketObjectsDeletePrefixResponse, Throw>>;
 	deleteByPrefix(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		prefix: string,
+		params: BucketObjectsDeleteByPrefixParams,
 		opts?: CallOptions,
 	): Promise<
 		| BucketObjectsDeletePrefixResponse
 		| NeonResult<BucketObjectsDeletePrefixResponse>
 	> {
+		const invalid = validateParams(
+			params,
+			"storage.objects.deleteByPrefix",
+			{
+				projectId: "string",
+				branchId: "string",
+				bucketName: "string",
+				prefix: "string",
+			},
+		);
+		if (invalid) {
+			return invalidParamsResult<BucketObjectsDeletePrefixResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, bucketName, prefix } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -188,28 +225,29 @@ export class BucketObjects<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/buckets/{bucket_name}/objects/{object_key}/presign */
 	presign(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
-		input: PresignRequest,
+		params: BucketObjectsPresignParams,
 	): Promise<Outcome<PresignResponse, DThrow>>;
 	presign<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
-		input: PresignRequest,
+		params: BucketObjectsPresignParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<PresignResponse, Throw>>;
 	presign(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-		objectKey: string,
-		input: PresignRequest,
+		params: BucketObjectsPresignParams,
 		opts?: CallOptions,
 	): Promise<PresignResponse | NeonResult<PresignResponse>> {
+		const invalid = validateParams(params, "storage.objects.presign", {
+			projectId: "string",
+			branchId: "string",
+			bucketName: "string",
+			objectKey: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<PresignResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, bucketName, objectKey, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/buckets.ts
+++ b/packages/sdk/src/neon/resources/buckets.ts
@@ -9,9 +9,21 @@ import type {
 	BucketCreateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = BucketCreateRequest;
+
+export type BucketsListParams = { projectId: string; branchId: string };
+export type BucketsCreateParams = {
+	projectId: string;
+	branchId: string;
+} & CreateInput;
+export type BucketsDeleteParams = {
+	projectId: string;
+	branchId: string;
+	bucketName: string;
+};
 
 /** Branch-scoped object-storage buckets. */
 export class Buckets<DThrow extends boolean> {
@@ -22,20 +34,26 @@ export class Buckets<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/buckets */
-	list(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<Bucket[], DThrow>>;
+	list(params: BucketsListParams): Promise<Outcome<Bucket[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: BucketsListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Bucket[], Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
+		params: BucketsListParams,
 		opts?: CallOptions,
 	): Promise<Bucket[] | NeonResult<Bucket[]>> {
+		const invalid = validateParams(params, "storage.buckets.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Bucket[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -50,23 +68,26 @@ export class Buckets<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/buckets */
-	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
-	): Promise<Outcome<Bucket, DThrow>>;
+	create(params: BucketsCreateParams): Promise<Outcome<Bucket, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: BucketsCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Bucket, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: BucketsCreateParams,
 		opts?: CallOptions,
 	): Promise<Bucket | NeonResult<Bucket>> {
+		const invalid = validateParams(params, "storage.buckets.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Bucket>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -82,23 +103,27 @@ export class Buckets<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/buckets/{bucket_name} */
-	delete(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: BucketsDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
+		params: BucketsDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		bucketName: string,
+		params: BucketsDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "storage.buckets.delete", {
+			projectId: "string",
+			branchId: "string",
+			bucketName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, bucketName } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchBucket({
 				client,

--- a/packages/sdk/src/neon/resources/credentials.test.ts
+++ b/packages/sdk/src/neon/resources/credentials.test.ts
@@ -66,7 +66,10 @@ describe("credentials", () => {
 			body: { credentials: [meta] },
 		}));
 
-		const { data, error } = await neon.credentials.list("p-1", "br-1");
+		const { data, error } = await neon.credentials.list({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 		expect(error).toBeUndefined();
 		expect(data).toEqual([meta]);
 		expect(calls[0].method).toBe("GET");
@@ -86,11 +89,11 @@ describe("credentials", () => {
 			scopes: ["storage:read" as const],
 			principal_type: "user" as const,
 		};
-		const { data, error } = await neon.credentials.create(
-			"p-1",
-			"br-1",
-			input,
-		);
+		const { data, error } = await neon.credentials.create({
+			projectId: "p-1",
+			branchId: "br-1",
+			...input,
+		});
 		expect(error).toBeUndefined();
 		expect(data).toEqual(created);
 		expect(calls[0].method).toBe("POST");
@@ -99,11 +102,11 @@ describe("credentials", () => {
 
 	it("revokes with a 204", async () => {
 		const { neon, calls } = neonRouting(() => ({ status: 204 }));
-		const { error } = await neon.credentials.revoke(
-			"p-1",
-			"br-1",
-			meta.token_id,
-		);
+		const { error } = await neon.credentials.revoke({
+			projectId: "p-1",
+			branchId: "br-1",
+			tokenId: meta.token_id,
+		});
 		expect(error).toBeUndefined();
 		expect(calls[0].method).toBe("DELETE");
 		expect(calls[0].url).toContain(
@@ -122,11 +125,11 @@ describe("credentials", () => {
 			body: secret,
 		}));
 
-		const { data, error } = await neon.credentials.reveal(
-			"p-1",
-			"br-1",
-			meta.token_id,
-		);
+		const { data, error } = await neon.credentials.reveal({
+			projectId: "p-1",
+			branchId: "br-1",
+			tokenId: meta.token_id,
+		});
 		expect(error).toBeUndefined();
 		expect(data).toEqual(secret);
 		expect(data).not.toHaveProperty("branch_id");
@@ -142,11 +145,11 @@ describe("credentials", () => {
 			status: 404,
 			body: { message: "not found" },
 		}));
-		const { error } = await neon.credentials.reveal(
-			"p-1",
-			"br-1",
-			"missing",
-		);
+		const { error } = await neon.credentials.reveal({
+			projectId: "p-1",
+			branchId: "br-1",
+			tokenId: "missing",
+		});
 		expect(error).toBeInstanceOf(NeonNotFoundError);
 	});
 
@@ -155,11 +158,11 @@ describe("credentials", () => {
 			status: 409,
 			body: { message: "no recoverable secret" },
 		}));
-		const { error } = await neon.credentials.reveal(
-			"p-1",
-			"br-1",
-			meta.token_id,
-		);
+		const { error } = await neon.credentials.reveal({
+			projectId: "p-1",
+			branchId: "br-1",
+			tokenId: meta.token_id,
+		});
 		expect(error).toBeInstanceOf(NeonApiError);
 		expect(error).toMatchObject({ status: 409 });
 		expect(calls).toHaveLength(1);
@@ -177,11 +180,11 @@ describe("credentials", () => {
 			body: rotated,
 		}));
 
-		const { data, error } = await neon.credentials.rotate(
-			"p-1",
-			"br-1",
-			meta.token_id,
-		);
+		const { data, error } = await neon.credentials.rotate({
+			projectId: "p-1",
+			branchId: "br-1",
+			tokenId: meta.token_id,
+		});
 		expect(error).toBeUndefined();
 		expect(data).toEqual(rotated);
 		expect(data?.token_id).toBe(meta.token_id);
@@ -200,11 +203,11 @@ describe("credentials", () => {
 			{ retries: 2 },
 		);
 
-		const { error } = await neon.credentials.rotate(
-			"p-1",
-			"br-1",
-			meta.token_id,
-		);
+		const { error } = await neon.credentials.rotate({
+			projectId: "p-1",
+			branchId: "br-1",
+			tokenId: meta.token_id,
+		});
 		expect(error).toBeInstanceOf(NeonApiError);
 		expect(error).toMatchObject({ status: 500 });
 		expect(calls).toHaveLength(1);

--- a/packages/sdk/src/neon/resources/credentials.ts
+++ b/packages/sdk/src/neon/resources/credentials.ts
@@ -13,9 +13,23 @@ import type {
 	RotateCredentialResponse,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = CreateCredentialRequest;
+
+export type CredentialsListParams = { projectId: string; branchId: string };
+export type CredentialsCreateParams = {
+	projectId: string;
+	branchId: string;
+} & CreateInput;
+export type CredentialsRevokeParams = {
+	projectId: string;
+	branchId: string;
+	tokenId: string;
+};
+export type CredentialsRevealParams = CredentialsRevokeParams;
+export type CredentialsRotateParams = CredentialsRevokeParams;
 
 /** Branch-scoped scoped credentials. */
 export class Credentials<DThrow extends boolean> {
@@ -27,19 +41,27 @@ export class Credentials<DThrow extends boolean> {
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/credentials */
 	list(
-		projectId: string,
-		branchId: string,
+		params: CredentialsListParams,
 	): Promise<Outcome<CredentialMeta[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: CredentialsListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<CredentialMeta[], Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
+		params: CredentialsListParams,
 		opts?: CallOptions,
 	): Promise<CredentialMeta[] | NeonResult<CredentialMeta[]>> {
+		const invalid = validateParams(params, "credentials.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<CredentialMeta[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -55,24 +77,29 @@ export class Credentials<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/credentials */
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: CredentialsCreateParams,
 	): Promise<Outcome<CreateCredentialResponse, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: CredentialsCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<CreateCredentialResponse, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: CredentialsCreateParams,
 		opts?: CallOptions,
 	): Promise<
 		CreateCredentialResponse | NeonResult<CreateCredentialResponse>
 	> {
+		const invalid = validateParams(params, "credentials.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<CreateCredentialResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -88,23 +115,27 @@ export class Credentials<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/credentials/{token_id} */
-	revoke(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
-	): Promise<Outcome<void, DThrow>>;
+	revoke(params: CredentialsRevokeParams): Promise<Outcome<void, DThrow>>;
 	revoke<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRevokeParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	revoke(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRevokeParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "credentials.revoke", {
+			projectId: "string",
+			branchId: "string",
+			tokenId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, tokenId } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			revokeCredential({
 				client,
@@ -121,22 +152,28 @@ export class Credentials<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/credentials/{token_id}/reveal */
 	reveal(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRevealParams,
 	): Promise<Outcome<CredentialSecret, DThrow>>;
 	reveal<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRevealParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<CredentialSecret, Throw>>;
 	reveal(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRevealParams,
 		opts?: CallOptions,
 	): Promise<CredentialSecret | NeonResult<CredentialSecret>> {
+		const invalid = validateParams(params, "credentials.reveal", {
+			projectId: "string",
+			branchId: "string",
+			tokenId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<CredentialSecret>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, tokenId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -156,24 +193,30 @@ export class Credentials<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/credentials/{token_id}/rotate */
 	rotate(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRotateParams,
 	): Promise<Outcome<RotateCredentialResponse, DThrow>>;
 	rotate<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRotateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<RotateCredentialResponse, Throw>>;
 	rotate(
-		projectId: string,
-		branchId: string,
-		tokenId: string,
+		params: CredentialsRotateParams,
 		opts?: CallOptions,
 	): Promise<
 		RotateCredentialResponse | NeonResult<RotateCredentialResponse>
 	> {
+		const invalid = validateParams(params, "credentials.rotate", {
+			projectId: "string",
+			branchId: "string",
+			tokenId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<RotateCredentialResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, tokenId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/custom-domains.test.ts
+++ b/packages/sdk/src/neon/resources/custom-domains.test.ts
@@ -76,7 +76,7 @@ describe("functions.customDomains", () => {
 		});
 
 		const { data, error } = await neon.functions.customDomains
-			.list("p-1", "br-1")
+			.list({ projectId: "p-1", branchId: "br-1" })
 			.all();
 
 		expect(error).toBeUndefined();
@@ -98,15 +98,13 @@ describe("functions.customDomains", () => {
 			body: domain,
 		}));
 
-		const { data, error } = await neon.functions.customDomains.register(
-			"p-1",
-			"br-1",
-			{
-				domain: "docs.example.com",
-				entity_type: "function",
-				entity_id: "api",
-			},
-		);
+		const { data, error } = await neon.functions.customDomains.register({
+			projectId: "p-1",
+			branchId: "br-1",
+			domain: "docs.example.com",
+			entity_type: "function",
+			entity_id: "api",
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual(domain);
@@ -132,15 +130,13 @@ describe("functions.customDomains", () => {
 			body: withStatus,
 		}));
 
-		const { data, error } = await neon.functions.customDomains.register(
-			"p-1",
-			"br-1",
-			{
-				domain: "docs.example.com",
-				entity_type: "function",
-				entity_id: "api",
-			},
-		);
+		const { data, error } = await neon.functions.customDomains.register({
+			projectId: "p-1",
+			branchId: "br-1",
+			domain: "docs.example.com",
+			entity_type: "function",
+			entity_id: "api",
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual(withStatus);
@@ -149,11 +145,11 @@ describe("functions.customDomains", () => {
 	it("deletes with a 204", async () => {
 		const { neon, calls } = neonRouting(() => ({ status: 204 }));
 
-		const { error } = await neon.functions.customDomains.delete(
-			"p-1",
-			"br-1",
-			"docs.example.com",
-		);
+		const { error } = await neon.functions.customDomains.delete({
+			projectId: "p-1",
+			branchId: "br-1",
+			domain: "docs.example.com",
+		});
 
 		expect(error).toBeUndefined();
 		expect(calls).toHaveLength(1);

--- a/packages/sdk/src/neon/resources/custom-domains.ts
+++ b/packages/sdk/src/neon/resources/custom-domains.ts
@@ -10,6 +10,7 @@ import type {
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { type Paginated, paginate } from "../paginate.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type ListQuery = Omit<
@@ -17,6 +18,20 @@ type ListQuery = Omit<
 	"cursor"
 >;
 type RegisterInput = CustomDomainRegisterRequest;
+
+export type CustomDomainsListParams = {
+	projectId: string;
+	branchId: string;
+} & ListQuery;
+export type CustomDomainsRegisterParams = {
+	projectId: string;
+	branchId: string;
+} & RegisterInput;
+export type CustomDomainsDeleteParams = {
+	projectId: string;
+	branchId: string;
+	domain: string;
+};
 
 /** Branch-scoped custom domains. v1 can only target a function. */
 export class CustomDomains<DThrow extends boolean> {
@@ -27,32 +42,33 @@ export class CustomDomains<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/custom-domains (cursor-paginated) */
-	list(
-		projectId: string,
-		branchId: string,
-		query?: ListQuery,
-	): Paginated<CustomDomain, DThrow>;
+	list(params: CustomDomainsListParams): Paginated<CustomDomain, DThrow>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		query: ListQuery | undefined,
+		params: CustomDomainsListParams,
 		opts: CallOptions<Throw>,
 	): Paginated<CustomDomain, Throw>;
 	list(
-		projectId: string,
-		branchId: string,
-		query?: ListQuery,
+		params: CustomDomainsListParams,
 		opts?: CallOptions,
 	): Paginated<CustomDomain, boolean> {
+		const invalid = validateParams(params, "functions.customDomains.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		const { projectId, branchId, ...query } = invalid
+			? ({} as CustomDomainsListParams)
+			: params;
 		return paginate(
-			(cursor, signal) =>
-				listProjectBranchCustomDomains({
+			async (cursor, signal) => {
+				if (invalid) throw invalid;
+				return listProjectBranchCustomDomains({
 					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					query: { ...query, cursor },
 					throwOnError: false,
 					signal,
-				}),
+				});
+			},
 			(data) => ({
 				items: data?.custom_domains ?? [],
 				cursor: data?.pagination?.next,
@@ -64,22 +80,31 @@ export class CustomDomains<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/custom-domains */
 	register(
-		projectId: string,
-		branchId: string,
-		input: RegisterInput,
+		params: CustomDomainsRegisterParams,
 	): Promise<Outcome<CustomDomain, DThrow>>;
 	register<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: RegisterInput,
+		params: CustomDomainsRegisterParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<CustomDomain, Throw>>;
 	register(
-		projectId: string,
-		branchId: string,
-		input: RegisterInput,
+		params: CustomDomainsRegisterParams,
 		opts?: CallOptions,
 	): Promise<CustomDomain | NeonResult<CustomDomain>> {
+		const invalid = validateParams(
+			params,
+			"functions.customDomains.register",
+			{
+				projectId: "string",
+				branchId: "string",
+			},
+		);
+		if (invalid) {
+			return invalidParamsResult<CustomDomain>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -95,23 +120,31 @@ export class CustomDomains<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/custom-domains/{domain} */
-	delete(
-		projectId: string,
-		branchId: string,
-		domain: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: CustomDomainsDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		domain: string,
+		params: CustomDomainsDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		domain: string,
+		params: CustomDomainsDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(
+			params,
+			"functions.customDomains.delete",
+			{
+				projectId: "string",
+				branchId: "string",
+				domain: "string",
+			},
+		);
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, domain } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchCustomDomain({
 				client,

--- a/packages/sdk/src/neon/resources/dataapi.ts
+++ b/packages/sdk/src/neon/resources/dataapi.ts
@@ -11,7 +11,22 @@ import type {
 	DataApiUpdateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
+
+type DataApiSelectors = {
+	projectId: string;
+	branchId: string;
+	databaseName: string;
+};
+
+export type DataApiGetParams = DataApiSelectors;
+
+export type DataApiCreateParams = DataApiSelectors & DataApiCreateRequest;
+
+export type DataApiUpdateParams = DataApiSelectors & DataApiUpdateRequest;
+
+export type DataApiDeleteParams = DataApiSelectors;
 
 /** Neon Data API resource (branch + database scoped). */
 export class DataApi<DThrow extends boolean> {
@@ -22,23 +37,27 @@ export class DataApi<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
-	get(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-	): Promise<Outcome<DataApiReponse, DThrow>>;
+	get(params: DataApiGetParams): Promise<Outcome<DataApiReponse, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
+		params: DataApiGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<DataApiReponse, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
+		params: DataApiGetParams,
 		opts?: CallOptions,
 	): Promise<DataApiReponse | NeonResult<DataApiReponse>> {
+		const invalid = validateParams(params, "dataApi.get", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<DataApiReponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, databaseName } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -58,25 +77,28 @@ export class DataApi<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
 	create(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-		input?: DataApiCreateRequest,
+		params: DataApiCreateParams,
 	): Promise<Outcome<DataApiCreateResponse, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-		input: DataApiCreateRequest | undefined,
+		params: DataApiCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<DataApiCreateResponse, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-		input?: DataApiCreateRequest,
+		params: DataApiCreateParams,
 		opts?: CallOptions,
 	): Promise<DataApiCreateResponse | NeonResult<DataApiCreateResponse>> {
+		const invalid = validateParams(params, "dataApi.create", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<DataApiCreateResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, databaseName, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -96,26 +118,27 @@ export class DataApi<DThrow extends boolean> {
 	}
 
 	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
-	update(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-		input?: DataApiUpdateRequest,
-	): Promise<Outcome<void, DThrow>>;
+	update(params: DataApiUpdateParams): Promise<Outcome<void, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-		input: DataApiUpdateRequest | undefined,
+		params: DataApiUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	update(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-		input?: DataApiUpdateRequest,
+		params: DataApiUpdateParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "dataApi.update", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, databaseName, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -135,23 +158,27 @@ export class DataApi<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/data-api/{database_name} */
-	delete(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: DataApiDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
+		params: DataApiDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		databaseName: string,
+		params: DataApiDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "dataApi.delete", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, databaseName } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/databases.ts
+++ b/packages/sdk/src/neon/resources/databases.ts
@@ -11,10 +11,26 @@ import type {
 	DatabaseUpdateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = DatabaseCreateRequest["database"];
 type UpdateInput = DatabaseUpdateRequest["database"];
+
+export type DatabasesListParams = {
+	projectId: string;
+	branchId: string;
+};
+
+export type DatabasesGetParams = DatabasesListParams & {
+	databaseName: string;
+};
+
+export type DatabasesCreateParams = DatabasesListParams & CreateInput;
+
+export type DatabasesUpdateParams = DatabasesGetParams & UpdateInput;
+
+export type DatabasesDeleteParams = DatabasesGetParams;
 
 /** Database resource (branch-scoped). */
 export class Databases<DThrow extends boolean> {
@@ -25,20 +41,26 @@ export class Databases<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/databases */
-	list(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<Database[], DThrow>>;
+	list(params: DatabasesListParams): Promise<Outcome<Database[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: DatabasesListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Database[], Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
+		params: DatabasesListParams,
 		opts?: CallOptions,
 	): Promise<Database[] | NeonResult<Database[]>> {
+		const invalid = validateParams(params, "databases.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Database[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -53,23 +75,27 @@ export class Databases<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/databases/{database_name} */
-	get(
-		projectId: string,
-		branchId: string,
-		name: string,
-	): Promise<Outcome<Database, DThrow>>;
+	get(params: DatabasesGetParams): Promise<Outcome<Database, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: DatabasesGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Database, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: DatabasesGetParams,
 		opts?: CallOptions,
 	): Promise<Database | NeonResult<Database>> {
+		const invalid = validateParams(params, "databases.get", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Database>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, databaseName } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -78,7 +104,7 @@ export class Databases<DThrow extends boolean> {
 					path: {
 						project_id: projectId,
 						branch_id: branchId,
-						database_name: name,
+						database_name: databaseName,
 					},
 					throwOnError: false,
 					signal,
@@ -88,23 +114,26 @@ export class Databases<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/databases */
-	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
-	): Promise<Outcome<Database, DThrow>>;
+	create(params: DatabasesCreateParams): Promise<Outcome<Database, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: DatabasesCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Database, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: DatabasesCreateParams,
 		opts?: CallOptions,
 	): Promise<Database | NeonResult<Database>> {
+		const invalid = validateParams(params, "databases.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Database>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -120,26 +149,27 @@ export class Databases<DThrow extends boolean> {
 	}
 
 	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id}/databases/{database_name} */
-	update(
-		projectId: string,
-		branchId: string,
-		name: string,
-		input: UpdateInput,
-	): Promise<Outcome<Database, DThrow>>;
+	update(params: DatabasesUpdateParams): Promise<Outcome<Database, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		name: string,
-		input: UpdateInput,
+		params: DatabasesUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Database, Throw>>;
 	update(
-		projectId: string,
-		branchId: string,
-		name: string,
-		input: UpdateInput,
+		params: DatabasesUpdateParams,
 		opts?: CallOptions,
 	): Promise<Database | NeonResult<Database>> {
+		const invalid = validateParams(params, "databases.update", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Database>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, databaseName, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -148,7 +178,7 @@ export class Databases<DThrow extends boolean> {
 					path: {
 						project_id: projectId,
 						branch_id: branchId,
-						database_name: name,
+						database_name: databaseName,
 					},
 					body: { database: input },
 					throwOnError: false,
@@ -159,30 +189,34 @@ export class Databases<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/databases/{database_name} */
-	delete(
-		projectId: string,
-		branchId: string,
-		name: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: DatabasesDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: DatabasesDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: DatabasesDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "databases.delete", {
+			projectId: "string",
+			branchId: "string",
+			databaseName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, databaseName } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchDatabase({
 				client,
 				path: {
 					project_id: projectId,
 					branch_id: branchId,
-					database_name: name,
+					database_name: databaseName,
 				},
 				throwOnError: false,
 				signal,

--- a/packages/sdk/src/neon/resources/endpoints.ts
+++ b/packages/sdk/src/neon/resources/endpoints.ts
@@ -15,10 +15,35 @@ import type {
 	EndpointUpdateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = EndpointCreateRequest["endpoint"];
 type UpdateInput = EndpointUpdateRequest["endpoint"];
+
+export type EndpointsListParams = {
+	projectId: string;
+};
+
+export type EndpointsListByBranchParams = EndpointsListParams & {
+	branchId: string;
+};
+
+export type EndpointsGetParams = EndpointsListParams & {
+	endpointId: string;
+};
+
+export type EndpointsCreateParams = EndpointsListParams & CreateInput;
+
+export type EndpointsUpdateParams = EndpointsGetParams & UpdateInput;
+
+export type EndpointsDeleteParams = EndpointsGetParams;
+
+export type EndpointsStartParams = EndpointsGetParams;
+
+export type EndpointsSuspendParams = EndpointsGetParams;
+
+export type EndpointsRestartParams = EndpointsGetParams;
 
 /** Compute endpoint resource (project-scoped). */
 export class Endpoints<DThrow extends boolean> {
@@ -29,15 +54,25 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/endpoints */
-	list(projectId: string): Promise<Outcome<Endpoint[], DThrow>>;
+	list(params: EndpointsListParams): Promise<Outcome<Endpoint[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
+		params: EndpointsListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint[], Throw>>;
 	list(
-		projectId: string,
+		params: EndpointsListParams,
 		opts?: CallOptions,
 	): Promise<Endpoint[] | NeonResult<Endpoint[]>> {
+		const invalid = validateParams(params, "endpoints.list", {
+			projectId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -53,19 +88,27 @@ export class Endpoints<DThrow extends boolean> {
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/endpoints */
 	listByBranch(
-		projectId: string,
-		branchId: string,
+		params: EndpointsListByBranchParams,
 	): Promise<Outcome<Endpoint[], DThrow>>;
 	listByBranch<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: EndpointsListByBranchParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint[], Throw>>;
 	listByBranch(
-		projectId: string,
-		branchId: string,
+		params: EndpointsListByBranchParams,
 		opts?: CallOptions,
 	): Promise<Endpoint[] | NeonResult<Endpoint[]>> {
+		const invalid = validateParams(params, "endpoints.listByBranch", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -80,20 +123,26 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/endpoints/{endpoint_id} */
-	get(
-		projectId: string,
-		endpointId: string,
-	): Promise<Outcome<Endpoint, DThrow>>;
+	get(params: EndpointsGetParams): Promise<Outcome<Endpoint, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	get(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsGetParams,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
+		const invalid = validateParams(params, "endpoints.get", {
+			projectId: "string",
+			endpointId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, endpointId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -108,20 +157,25 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/endpoints */
-	create(
-		projectId: string,
-		input: CreateInput,
-	): Promise<Outcome<Endpoint, DThrow>>;
+	create(params: EndpointsCreateParams): Promise<Outcome<Endpoint, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		input: CreateInput,
+		params: EndpointsCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	create(
-		projectId: string,
-		input: CreateInput,
+		params: EndpointsCreateParams,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
+		const invalid = validateParams(params, "endpoints.create", {
+			projectId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -137,23 +191,26 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall PATCH /projects/{project_id}/endpoints/{endpoint_id} */
-	update(
-		projectId: string,
-		endpointId: string,
-		input: UpdateInput,
-	): Promise<Outcome<Endpoint, DThrow>>;
+	update(params: EndpointsUpdateParams): Promise<Outcome<Endpoint, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		endpointId: string,
-		input: UpdateInput,
+		params: EndpointsUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	update(
-		projectId: string,
-		endpointId: string,
-		input: UpdateInput,
+		params: EndpointsUpdateParams,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
+		const invalid = validateParams(params, "endpoints.update", {
+			projectId: "string",
+			endpointId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, endpointId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -169,20 +226,26 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/endpoints/{endpoint_id} */
-	delete(
-		projectId: string,
-		endpointId: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: EndpointsDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "endpoints.delete", {
+			projectId: "string",
+			endpointId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, endpointId } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectEndpoint({
 				client,
@@ -194,20 +257,26 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/endpoints/{endpoint_id}/start */
-	start(
-		projectId: string,
-		endpointId: string,
-	): Promise<Outcome<Endpoint, DThrow>>;
+	start(params: EndpointsStartParams): Promise<Outcome<Endpoint, DThrow>>;
 	start<Throw extends boolean = DThrow>(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsStartParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	start(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsStartParams,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
+		const invalid = validateParams(params, "endpoints.start", {
+			projectId: "string",
+			endpointId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, endpointId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -222,20 +291,26 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/endpoints/{endpoint_id}/suspend */
-	suspend(
-		projectId: string,
-		endpointId: string,
-	): Promise<Outcome<Endpoint, DThrow>>;
+	suspend(params: EndpointsSuspendParams): Promise<Outcome<Endpoint, DThrow>>;
 	suspend<Throw extends boolean = DThrow>(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsSuspendParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	suspend(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsSuspendParams,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
+		const invalid = validateParams(params, "endpoints.suspend", {
+			projectId: "string",
+			endpointId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, endpointId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -250,20 +325,26 @@ export class Endpoints<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/endpoints/{endpoint_id}/restart */
-	restart(
-		projectId: string,
-		endpointId: string,
-	): Promise<Outcome<Endpoint, DThrow>>;
+	restart(params: EndpointsRestartParams): Promise<Outcome<Endpoint, DThrow>>;
 	restart<Throw extends boolean = DThrow>(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsRestartParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Endpoint, Throw>>;
 	restart(
-		projectId: string,
-		endpointId: string,
+		params: EndpointsRestartParams,
 		opts?: CallOptions,
 	): Promise<Endpoint | NeonResult<Endpoint>> {
+		const invalid = validateParams(params, "endpoints.restart", {
+			projectId: "string",
+			endpointId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Endpoint>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, endpointId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/functions.ts
+++ b/packages/sdk/src/neon/resources/functions.ts
@@ -14,6 +14,7 @@ import type {
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { type Paginated, paginate } from "../paginate.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 import { CustomDomains } from "./custom-domains.js";
 
@@ -22,6 +23,19 @@ type ListQuery = Omit<
 	"cursor"
 >;
 type UpdateInput = NeonFunctionUpdateRequest;
+
+export type FunctionsListParams = {
+	projectId: string;
+	branchId: string;
+} & ListQuery;
+export type FunctionsGetParams = {
+	projectId: string;
+	branchId: string;
+	slug: string;
+};
+export type FunctionsUpdateParams = FunctionsGetParams & UpdateInput;
+export type FunctionsDeleteParams = FunctionsGetParams;
+export type FunctionsDeployParams = FunctionsGetParams & FunctionDeployRequest;
 
 /** Branch-scoped Neon Functions. */
 export class Functions<DThrow extends boolean> {
@@ -34,32 +48,33 @@ export class Functions<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/functions (cursor-paginated) */
-	list(
-		projectId: string,
-		branchId: string,
-		query?: ListQuery,
-	): Paginated<NeonFunction, DThrow>;
+	list(params: FunctionsListParams): Paginated<NeonFunction, DThrow>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		query: ListQuery | undefined,
+		params: FunctionsListParams,
 		opts: CallOptions<Throw>,
 	): Paginated<NeonFunction, Throw>;
 	list(
-		projectId: string,
-		branchId: string,
-		query?: ListQuery,
+		params: FunctionsListParams,
 		opts?: CallOptions,
 	): Paginated<NeonFunction, boolean> {
+		const invalid = validateParams(params, "functions.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		const { projectId, branchId, ...query } = invalid
+			? ({} as FunctionsListParams)
+			: params;
 		return paginate(
-			(cursor, signal) =>
-				listProjectBranchFunctions({
+			async (cursor, signal) => {
+				if (invalid) throw invalid;
+				return listProjectBranchFunctions({
 					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
 					query: { ...query, cursor },
 					throwOnError: false,
 					signal,
-				}),
+				});
+			},
 			(data) => ({
 				items: data?.functions ?? [],
 				cursor: data?.pagination?.next,
@@ -70,23 +85,27 @@ export class Functions<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/functions/{slug} */
-	get(
-		projectId: string,
-		branchId: string,
-		slug: string,
-	): Promise<Outcome<NeonFunction, DThrow>>;
+	get(params: FunctionsGetParams): Promise<Outcome<NeonFunction, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		slug: string,
+		params: FunctionsGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonFunction, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
-		slug: string,
+		params: FunctionsGetParams,
 		opts?: CallOptions,
 	): Promise<NeonFunction | NeonResult<NeonFunction>> {
+		const invalid = validateParams(params, "functions.get", {
+			projectId: "string",
+			branchId: "string",
+			slug: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonFunction>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, slug } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -106,25 +125,28 @@ export class Functions<DThrow extends boolean> {
 
 	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id}/functions/{slug} */
 	update(
-		projectId: string,
-		branchId: string,
-		slug: string,
-		input: UpdateInput,
+		params: FunctionsUpdateParams,
 	): Promise<Outcome<NeonFunction, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		slug: string,
-		input: UpdateInput,
+		params: FunctionsUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonFunction, Throw>>;
 	update(
-		projectId: string,
-		branchId: string,
-		slug: string,
-		input: UpdateInput,
+		params: FunctionsUpdateParams,
 		opts?: CallOptions,
 	): Promise<NeonFunction | NeonResult<NeonFunction>> {
+		const invalid = validateParams(params, "functions.update", {
+			projectId: "string",
+			branchId: "string",
+			slug: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonFunction>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, slug, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -144,23 +166,27 @@ export class Functions<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/functions/{slug} */
-	delete(
-		projectId: string,
-		branchId: string,
-		slug: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: FunctionsDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		slug: string,
+		params: FunctionsDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		slug: string,
+		params: FunctionsDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "functions.delete", {
+			projectId: "string",
+			branchId: "string",
+			slug: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, slug } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchFunction({
 				client,
@@ -177,25 +203,28 @@ export class Functions<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/functions/{slug}/deployments */
 	deploy(
-		projectId: string,
-		branchId: string,
-		slug: string,
-		input?: FunctionDeployRequest,
+		params: FunctionsDeployParams,
 	): Promise<Outcome<NeonFunctionDeployment, DThrow>>;
 	deploy<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		slug: string,
-		input: FunctionDeployRequest | undefined,
+		params: FunctionsDeployParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<NeonFunctionDeployment, Throw>>;
 	deploy(
-		projectId: string,
-		branchId: string,
-		slug: string,
-		input?: FunctionDeployRequest,
+		params: FunctionsDeployParams,
 		opts?: CallOptions,
 	): Promise<NeonFunctionDeployment | NeonResult<NeonFunctionDeployment>> {
+		const invalid = validateParams(params, "functions.deploy", {
+			projectId: "string",
+			branchId: "string",
+			slug: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<NeonFunctionDeployment>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, slug, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/logs.test.ts
+++ b/packages/sdk/src/neon/resources/logs.test.ts
@@ -56,7 +56,12 @@ describe("logs.query pagination", () => {
 		]);
 
 		const { data, error } = await neon.logs
-			.query("p-1", "br-1", { since: "1h", minimum_severity: "warn" })
+			.query({
+				projectId: "p-1",
+				branchId: "br-1",
+				since: "1h",
+				minimum_severity: "warn",
+			})
 			.all();
 
 		expect(error).toBeUndefined();
@@ -88,7 +93,9 @@ describe("logs.query pagination", () => {
 			},
 		]);
 
-		const { data } = await neon.logs.query("p-1", "br-1").all();
+		const { data } = await neon.logs
+			.query({ projectId: "p-1", branchId: "br-1" })
+			.all();
 
 		expect(data?.map((r) => r.message)).toEqual(["only"]);
 		expect(calls).toHaveLength(1);
@@ -97,7 +104,7 @@ describe("logs.query pagination", () => {
 	it("sends no filters when none are given", async () => {
 		const { neon, calls } = neonQueued([{ logs: [], is_truncated: false }]);
 
-		await neon.logs.query("p-1", "br-1").all();
+		await neon.logs.query({ projectId: "p-1", branchId: "br-1" }).all();
 
 		expect(calls[0]?.body).toEqual({});
 	});
@@ -109,7 +116,11 @@ describe("logs.query pagination", () => {
 		]);
 		const input = { since: "1h" };
 
-		const page = neon.logs.query("p-1", "br-1", input);
+		const page = neon.logs.query({
+			projectId: "p-1",
+			branchId: "br-1",
+			...input,
+		});
 		input.since = "6h";
 		await page.all();
 
@@ -122,7 +133,9 @@ describe("logs.query pagination", () => {
 			{ logs: [record("a")], is_truncated: true },
 		]);
 
-		const { data, error } = await neon.logs.query("p-1", "br-1").all();
+		const { data, error } = await neon.logs
+			.query({ projectId: "p-1", branchId: "br-1" })
+			.all();
 
 		expect(data).toBeUndefined();
 		expect(error?.message).toContain("no cursor");
@@ -137,7 +150,10 @@ describe("logs field discovery", () => {
 			{ fields: ["source", "severity_text"] },
 		]);
 
-		const { data } = await neon.logs.fields("p-1", "br-1");
+		const { data } = await neon.logs.fields({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 
 		expect(data).toEqual(["source", "severity_text"]);
 		expect(calls[0]?.url).toContain(
@@ -150,7 +166,10 @@ describe("logs field discovery", () => {
 			{ values: ["function"], is_truncated: true },
 		]);
 
-		const { data } = await neon.logs.fieldValues("p-1", "br-1", "source", {
+		const { data } = await neon.logs.fieldValues({
+			projectId: "p-1",
+			branchId: "br-1",
+			fieldName: "source",
 			since: "6h",
 			limit: 1,
 		});
@@ -176,7 +195,10 @@ describe("logs error propagation", () => {
 			404,
 		);
 
-		const { data, error } = await neon.logs.fields("p-1", "br-1");
+		const { data, error } = await neon.logs.fields({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 
 		expect(data).toBeUndefined();
 		expect(error?.kind).toBe("not_found");

--- a/packages/sdk/src/neon/resources/logs.ts
+++ b/packages/sdk/src/neon/resources/logs.ts
@@ -13,6 +13,7 @@ import type {
 import type { CallOptions, RequestContext } from "../context.js";
 import { NeonClientError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 /**
@@ -28,6 +29,17 @@ export type LogQueryInput = Omit<ProjectBranchLogsQueryRequest, "cursor">;
 export type LogFieldValuesQuery = NonNullable<
 	ListProjectBranchLogFieldValuesData["query"]
 >;
+
+export type LogsQueryParams = {
+	projectId: string;
+	branchId: string;
+} & LogQueryInput;
+export type LogsFieldsParams = { projectId: string; branchId: string };
+export type LogsFieldValuesParams = {
+	projectId: string;
+	branchId: string;
+	fieldName: string;
+} & LogFieldValuesQuery;
 
 /**
  * Branch-scoped logs emitted by the services running on a branch — Neon Functions,
@@ -62,29 +74,29 @@ export class Logs<DThrow extends boolean> {
 	 *
 	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/logs/query (cursor-paginated)
 	 */
-	query(
-		projectId: string,
-		branchId: string,
-		input?: LogQueryInput,
-	): Paginated<ProjectBranchLogRecord, DThrow>;
+	query(params: LogsQueryParams): Paginated<ProjectBranchLogRecord, DThrow>;
 	query<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: LogQueryInput | undefined,
+		params: LogsQueryParams,
 		opts: CallOptions<Throw>,
 	): Paginated<ProjectBranchLogRecord, Throw>;
 	query(
-		projectId: string,
-		branchId: string,
-		input?: LogQueryInput,
+		params: LogsQueryParams,
 		opts?: CallOptions,
 	): Paginated<ProjectBranchLogRecord, boolean> {
+		const invalid = validateParams(params, "logs.query", {
+			projectId: "string",
+			branchId: "string",
+		});
+		const { projectId, branchId, ...input } = invalid
+			? ({} as LogsQueryParams)
+			: params;
 		// Snapshot the filters. The endpoint returns wrong results unless every page
 		// repeats them unchanged, and a `Paginated` is lazy — reading `input` per page
 		// would let a caller mutating it afterwards change the query mid-walk.
 		const filters = { ...input };
 		return paginate<ProjectBranchLogRecord, ProjectBranchLogsQueryResponse>(
 			async (cursor, signal) => {
+				if (invalid) throw invalid;
 				const page = await queryProjectBranchLogs({
 					client: this.#ctx.client,
 					path: { project_id: projectId, branch_id: branchId },
@@ -123,20 +135,26 @@ export class Logs<DThrow extends boolean> {
 	 *
 	 * @apiCall GET /projects/{project_id}/branches/{branch_id}/logs/fields
 	 */
-	fields(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<string[], DThrow>>;
+	fields(params: LogsFieldsParams): Promise<Outcome<string[], DThrow>>;
 	fields<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: LogsFieldsParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<string[], Throw>>;
 	fields(
-		projectId: string,
-		branchId: string,
+		params: LogsFieldsParams,
 		opts?: CallOptions,
 	): Promise<string[] | NeonResult<string[]>> {
+		const invalid = validateParams(params, "logs.fields", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<string[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -165,28 +183,31 @@ export class Logs<DThrow extends boolean> {
 	 * @apiCall GET /projects/{project_id}/branches/{branch_id}/logs/fields/{field_name}/values
 	 */
 	fieldValues(
-		projectId: string,
-		branchId: string,
-		fieldName: string,
-		query?: LogFieldValuesQuery,
+		params: LogsFieldValuesParams,
 	): Promise<Outcome<ProjectBranchLogFieldValuesResponse, DThrow>>;
 	fieldValues<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		fieldName: string,
-		query: LogFieldValuesQuery | undefined,
+		params: LogsFieldValuesParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<ProjectBranchLogFieldValuesResponse, Throw>>;
 	fieldValues(
-		projectId: string,
-		branchId: string,
-		fieldName: string,
-		query?: LogFieldValuesQuery,
+		params: LogsFieldValuesParams,
 		opts?: CallOptions,
 	): Promise<
 		| ProjectBranchLogFieldValuesResponse
 		| NeonResult<ProjectBranchLogFieldValuesResponse>
 	> {
+		const invalid = validateParams(params, "logs.fieldValues", {
+			projectId: "string",
+			branchId: "string",
+			fieldName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<ProjectBranchLogFieldValuesResponse>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, fieldName, ...query } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/members.test.ts
+++ b/packages/sdk/src/neon/resources/members.test.ts
@@ -55,7 +55,9 @@ describe("projects.members.list", () => {
 			{ project_members: [member("m-2")] },
 		]);
 
-		const { data, error } = await neon.projects.members.list("p-1").all();
+		const { data, error } = await neon.projects.members
+			.list({ projectId: "p-1" })
+			.all();
 
 		expect(error).toBeUndefined();
 		expect(data?.map((m) => m.member_id)).toEqual(["m-1", "m-2"]);
@@ -67,7 +69,7 @@ describe("projects.members.list", () => {
 	it("forwards the limit query parameter", async () => {
 		const { neon, calls } = neonQueued([{ project_members: [] }]);
 
-		await neon.projects.members.list("p-1", { limit: 25 }).all();
+		await neon.projects.members.list({ projectId: "p-1", limit: 25 }).all();
 
 		expect(calls[0]?.url).toContain("limit=25");
 	});
@@ -87,7 +89,11 @@ describe("projects.members.setRole", () => {
 	it("sends the role and withholds the self-demotion acknowledgement", async () => {
 		const { neon, calls } = neonQueued([roleResponse]);
 
-		await neon.projects.members.setRole("p-1", "m-1", "viewer");
+		await neon.projects.members.setRole({
+			projectId: "p-1",
+			memberId: "m-1",
+			role: "viewer",
+		});
 
 		expect(calls[0]?.method).toBe("PUT");
 		expect(calls[0]?.url).toContain("/projects/p-1/members/m-1/role");
@@ -98,7 +104,10 @@ describe("projects.members.setRole", () => {
 	it("adds confirm_self_demotion only when acknowledged", async () => {
 		const { neon, calls } = neonQueued([roleResponse]);
 
-		await neon.projects.members.setRole("p-1", "m-1", "viewer", {
+		await neon.projects.members.setRole({
+			projectId: "p-1",
+			memberId: "m-1",
+			role: "viewer",
 			confirmSelfDemotion: true,
 		});
 
@@ -108,11 +117,11 @@ describe("projects.members.setRole", () => {
 	it("returns the rotation hints rather than just the role", async () => {
 		const { neon } = neonQueued([roleResponse]);
 
-		const { data } = await neon.projects.members.setRole(
-			"p-1",
-			"m-1",
-			"viewer",
-		);
+		const { data } = await neon.projects.members.setRole({
+			projectId: "p-1",
+			memberId: "m-1",
+			role: "viewer",
+		});
 
 		expect(data?.credential_rotation_recommended).toBe(true);
 		expect(data?.org_api_key_rotation_recommended).toBe(false);
@@ -130,7 +139,10 @@ describe("projects.members.removeRole", () => {
 	it("withholds the self-lockout acknowledgement by default", async () => {
 		const { neon, calls } = neonQueued([removed]);
 
-		await neon.projects.members.removeRole("p-1", "m-1");
+		await neon.projects.members.removeRole({
+			projectId: "p-1",
+			memberId: "m-1",
+		});
 
 		expect(calls[0]?.method).toBe("DELETE");
 		expect(calls[0]?.url).toContain("/projects/p-1/members/m-1/role");
@@ -140,7 +152,9 @@ describe("projects.members.removeRole", () => {
 	it("adds confirm_self_lockout only when acknowledged", async () => {
 		const { neon, calls } = neonQueued([removed]);
 
-		await neon.projects.members.removeRole("p-1", "m-1", {
+		await neon.projects.members.removeRole({
+			projectId: "p-1",
+			memberId: "m-1",
 			confirmSelfLockout: true,
 		});
 

--- a/packages/sdk/src/neon/resources/operations.ts
+++ b/packages/sdk/src/neon/resources/operations.ts
@@ -5,6 +5,7 @@ import {
 import type { Operation } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { type Paginated, paginate } from "../paginate.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 import { type WaitForOptions, waitForOperations } from "../wait.js";
 
@@ -18,6 +19,10 @@ import { type WaitForOptions, waitForOperations } from "../wait.js";
 export type WaitForForOptions<Throw extends boolean> = WaitForOptions &
 	Omit<CallOptions<Throw>, "requestTimeoutMs" | "waitForReadiness" | "wait">;
 
+export type OperationsListParams = { projectId: string };
+export type OperationsGetParams = { projectId: string; operationId: string };
+export type OperationsWaitForParams = { operations: readonly Operation[] };
+
 /** Operation resource — read operations and wait for them to finish. */
 export class Operations<DThrow extends boolean> {
 	readonly #ctx: RequestContext;
@@ -27,21 +32,30 @@ export class Operations<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/operations (cursor-paginated) */
-	list(projectId: string): Paginated<Operation, DThrow>;
+	list(params: OperationsListParams): Paginated<Operation, DThrow>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
+		params: OperationsListParams,
 		opts: CallOptions<Throw>,
 	): Paginated<Operation, Throw>;
-	list(projectId: string, opts?: CallOptions): Paginated<Operation, boolean> {
+	list(
+		params: OperationsListParams,
+		opts?: CallOptions,
+	): Paginated<Operation, boolean> {
+		const invalid = validateParams(params, "operations.list", {
+			projectId: "string",
+		});
+		const { projectId } = invalid ? ({} as OperationsListParams) : params;
 		return paginate(
-			(cursor, signal) =>
-				listProjectOperations({
+			async (cursor, signal) => {
+				if (invalid) throw invalid;
+				return listProjectOperations({
 					client: this.#ctx.client,
 					path: { project_id: projectId },
 					query: { cursor },
 					throwOnError: false,
 					signal,
-				}),
+				});
+			},
 			(data) => ({
 				items: data?.operations ?? [],
 				cursor: data?.pagination?.cursor,
@@ -52,20 +66,26 @@ export class Operations<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/operations/{operation_id} */
-	get(
-		projectId: string,
-		operationId: string,
-	): Promise<Outcome<Operation, DThrow>>;
+	get(params: OperationsGetParams): Promise<Outcome<Operation, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		operationId: string,
+		params: OperationsGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Operation, Throw>>;
 	get(
-		projectId: string,
-		operationId: string,
+		params: OperationsGetParams,
 		opts?: CallOptions,
 	): Promise<Operation | NeonResult<Operation>> {
+		const invalid = validateParams(params, "operations.get", {
+			projectId: "string",
+			operationId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Operation>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, operationId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -84,15 +104,25 @@ export class Operations<DThrow extends boolean> {
 	 * The primitive behind `waitForReadiness`; use it directly with operations obtained
 	 * from any source (e.g. a raw call or a create response).
 	 */
-	waitFor(operations: readonly Operation[]): Promise<Outcome<void, DThrow>>;
+	waitFor(params: OperationsWaitForParams): Promise<Outcome<void, DThrow>>;
 	waitFor<Throw extends boolean = DThrow>(
-		operations: readonly Operation[],
+		params: OperationsWaitForParams,
 		opts: WaitForForOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	async waitFor(
-		operations: readonly Operation[],
+		params: OperationsWaitForParams,
 		opts?: WaitForForOptions<boolean>,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "operations.waitFor", {
+			operations: "array",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { operations } = params;
 		const defaults = this.#ctx.defaults;
 		const shouldThrow = opts?.throwOnError ?? defaults.throwOnError;
 		const result = await waitForOperations(this.#ctx.client, operations, {

--- a/packages/sdk/src/neon/resources/phase1.test.ts
+++ b/packages/sdk/src/neon/resources/phase1.test.ts
@@ -20,14 +20,20 @@ describe("phase-1 namespaces map responses to the ergonomic shape", () => {
 			branch_id: "br-1",
 			db_name: "neondb",
 		});
-		const { data, error } = await neon.auth.get("p-1", "br-1");
+		const { data, error } = await neon.auth.get({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 		expect(error).toBeUndefined();
 		expect(data?.branch_id).toBe("br-1");
 	});
 
 	it("auth.oauthProviders.list unwraps the providers array", async () => {
 		const neon = neonReturning(200, { providers: [{ id: "google" }] });
-		const { data } = await neon.auth.oauthProviders.list("p-1", "br-1");
+		const { data } = await neon.auth.oauthProviders.list({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 		expect(data).toEqual([{ id: "google" }]);
 	});
 
@@ -37,7 +43,9 @@ describe("phase-1 namespaces map responses to the ergonomic shape", () => {
 				{ id: "perm-1", granted_to_email: "a@b.c", granted_at: "now" },
 			],
 		});
-		const { data } = await neon.projects.permissions.list("p-1");
+		const { data } = await neon.projects.permissions.list({
+			projectId: "p-1",
+		});
 		expect(data).toHaveLength(1);
 		expect(data?.[0]?.granted_to_email).toBe("a@b.c");
 	});
@@ -47,22 +55,24 @@ describe("phase-1 namespaces map responses to the ergonomic shape", () => {
 			project: { id: "p-1" },
 			branches: [],
 		});
-		const { data } = await neon.projects.recover("p-1");
+		const { data } = await neon.projects.recover({ projectId: "p-1" });
 		expect(data).toEqual({ id: "p-1" });
 	});
 
 	it("postgres.endpoints.listByBranch unwraps endpoints", async () => {
 		const neon = neonReturning(200, { endpoints: [{ id: "ep-1" }] });
-		const { data } = await neon.postgres.endpoints.listByBranch(
-			"p-1",
-			"br-1",
-		);
+		const { data } = await neon.postgres.endpoints.listByBranch({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 		expect(data).toEqual([{ id: "ep-1" }]);
 	});
 
 	it("propagates typed errors through the ergonomic channel", async () => {
 		const neon = neonReturning(403, { message: "forbidden" });
-		const { data, error } = await neon.projects.permissions.list("p-1");
+		const { data, error } = await neon.projects.permissions.list({
+			projectId: "p-1",
+		});
 		expect(data).toBeUndefined();
 		expect(error?.kind).toBe("auth");
 	});

--- a/packages/sdk/src/neon/resources/projects.ts
+++ b/packages/sdk/src/neon/resources/projects.ts
@@ -30,6 +30,7 @@ import { withConnectionString } from "../connection.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { NeonClientError } from "../errors.js";
 import { type Paginated, paginate } from "../paginate.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import { err, finalize, type NeonResult, type Outcome } from "../result.js";
 
 /** Input for {@link Projects.transfer} (org → org). */
@@ -50,29 +51,64 @@ type MemberListQuery = Omit<
 >;
 
 /** Per-call options for {@link Members.setRole}. */
-export interface SetRoleOptions<Throw extends boolean = boolean>
-	extends CallOptions<Throw> {
+export type SetRoleOptions<Throw extends boolean = boolean> =
+	CallOptions<Throw>;
+
+/** Per-call options for {@link Members.removeRole}. */
+export type RemoveRoleOptions<Throw extends boolean = boolean> =
+	CallOptions<Throw>;
+
+export type ProjectListParams = ListQuery;
+export interface ProjectGetParams {
+	projectId: string;
+}
+export type ProjectCreateParams = CreateInput;
+export type ProjectCreateAndConnectParams = CreateInput & {
+	/** Return a pooled connection string (default `true`). */
+	pooled?: boolean;
+};
+export type ProjectUpdateParams = UpdateInput & { projectId: string };
+export interface ProjectDeleteParams {
+	projectId: string;
+}
+export interface ProjectRecoverParams {
+	projectId: string;
+}
+export type ProjectTransferParams = TransferProjectsInput;
+export interface ProjectTransferFromUserParams {
+	toOrgId: string;
+	projectIds: string[];
+}
+export interface ProjectPermissionListParams {
+	projectId: string;
+}
+export interface ProjectPermissionGrantParams {
+	projectId: string;
+	email: string;
+}
+export interface ProjectPermissionRevokeParams {
+	projectId: string;
+	permissionId: string;
+}
+export type ProjectMemberListParams = MemberListQuery & { projectId: string };
+export interface ProjectMemberSetRoleParams {
+	projectId: string;
+	memberId: string;
+	role: ProjectRole;
 	/**
 	 * Acknowledge that the call lowers the caller's own role. The API rejects a
 	 * self-demotion without it, so it is left off by default.
 	 */
 	confirmSelfDemotion?: boolean;
 }
-
-/** Per-call options for {@link Members.removeRole}. */
-export interface RemoveRoleOptions<Throw extends boolean = boolean>
-	extends CallOptions<Throw> {
+export interface ProjectMemberRemoveRoleParams {
+	projectId: string;
+	memberId: string;
 	/**
 	 * Acknowledge that the call can cost the caller management access. The API
 	 * rejects such a self-removal without it, so it is left off by default.
 	 */
 	confirmSelfLockout?: boolean;
-}
-
-/** Per-call options for the connect workflow. */
-interface WorkflowOptions<Throw extends boolean> extends CallOptions<Throw> {
-	/** Return a pooled connection string (default `true`). */
-	pooled?: boolean;
 }
 
 /** A project with a ready-to-use connection string to its default branch. */
@@ -90,15 +126,26 @@ export class Permissions<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/permissions */
-	list(projectId: string): Promise<Outcome<ProjectPermission[], DThrow>>;
+	list(
+		params: ProjectPermissionListParams,
+	): Promise<Outcome<ProjectPermission[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
+		params: ProjectPermissionListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<ProjectPermission[], Throw>>;
 	list(
-		projectId: string,
+		params: ProjectPermissionListParams,
 		opts?: CallOptions,
 	): Promise<ProjectPermission[] | NeonResult<ProjectPermission[]>> {
+		const error = validateParams(params, "projects.permissions.list", {
+			projectId: "string",
+		});
+		if (error)
+			return invalidParamsResult<ProjectPermission[]>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -114,19 +161,26 @@ export class Permissions<DThrow extends boolean> {
 
 	/** @apiCall POST /projects/{project_id}/permissions */
 	grant(
-		projectId: string,
-		email: string,
+		params: ProjectPermissionGrantParams,
 	): Promise<Outcome<ProjectPermission, DThrow>>;
 	grant<Throw extends boolean = DThrow>(
-		projectId: string,
-		email: string,
+		params: ProjectPermissionGrantParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<ProjectPermission, Throw>>;
 	grant(
-		projectId: string,
-		email: string,
+		params: ProjectPermissionGrantParams,
 		opts?: CallOptions,
 	): Promise<ProjectPermission | NeonResult<ProjectPermission>> {
+		const error = validateParams(params, "projects.permissions.grant", {
+			projectId: "string",
+			email: "string",
+		});
+		if (error)
+			return invalidParamsResult<ProjectPermission>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, email } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -143,19 +197,26 @@ export class Permissions<DThrow extends boolean> {
 
 	/** @apiCall DELETE /projects/{project_id}/permissions/{permission_id} */
 	revoke(
-		projectId: string,
-		permissionId: string,
+		params: ProjectPermissionRevokeParams,
 	): Promise<Outcome<ProjectPermission, DThrow>>;
 	revoke<Throw extends boolean = DThrow>(
-		projectId: string,
-		permissionId: string,
+		params: ProjectPermissionRevokeParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<ProjectPermission, Throw>>;
 	revoke(
-		projectId: string,
-		permissionId: string,
+		params: ProjectPermissionRevokeParams,
 		opts?: CallOptions,
 	): Promise<ProjectPermission | NeonResult<ProjectPermission>> {
+		const error = validateParams(params, "projects.permissions.revoke", {
+			projectId: "string",
+			permissionId: "string",
+		});
+		if (error)
+			return invalidParamsResult<ProjectPermission>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, permissionId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -195,29 +256,32 @@ export class Members<DThrow extends boolean> {
 	 *
 	 * @apiCall GET /projects/{project_id}/members (cursor-paginated)
 	 */
-	list(
-		projectId: string,
-		query?: MemberListQuery,
-	): Paginated<ProjectMember, DThrow>;
+	list(params: ProjectMemberListParams): Paginated<ProjectMember, DThrow>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		query: MemberListQuery | undefined,
+		params: ProjectMemberListParams,
 		opts: CallOptions<Throw>,
 	): Paginated<ProjectMember, Throw>;
 	list(
-		projectId: string,
-		query?: MemberListQuery,
+		params: ProjectMemberListParams,
 		opts?: CallOptions,
 	): Paginated<ProjectMember, boolean> {
+		const error = validateParams(params, "projects.members.list", {
+			projectId: "string",
+		});
+		const { projectId, ...query } = error
+			? ({} as ProjectMemberListParams)
+			: params;
 		return paginate(
-			(cursor, signal) =>
-				listProjectMembers({
+			async (cursor, signal) => {
+				if (error) throw error;
+				return listProjectMembers({
 					client: this.#ctx.client,
 					path: { project_id: projectId },
 					query: { ...query, cursor },
 					throwOnError: false,
 					signal,
-				}),
+				});
+			},
 			(data) => ({
 				items: data?.project_members ?? [],
 				cursor: data?.pagination?.next,
@@ -236,31 +300,36 @@ export class Members<DThrow extends boolean> {
 	 * @apiCall PUT /projects/{project_id}/members/{member_id}/role
 	 */
 	setRole(
-		projectId: string,
-		memberId: string,
-		role: ProjectRole,
+		params: ProjectMemberSetRoleParams,
 	): Promise<Outcome<ProjectMemberRoleResponse, DThrow>>;
 	setRole<Throw extends boolean = DThrow>(
-		projectId: string,
-		memberId: string,
-		role: ProjectRole,
-		opts: SetRoleOptions<Throw>,
+		params: ProjectMemberSetRoleParams,
+		opts: CallOptions<Throw>,
 	): Promise<Outcome<ProjectMemberRoleResponse, Throw>>;
 	setRole(
-		projectId: string,
-		memberId: string,
-		role: ProjectRole,
-		opts?: SetRoleOptions<boolean>,
+		params: ProjectMemberSetRoleParams,
+		opts?: CallOptions<boolean>,
 	): Promise<
 		ProjectMemberRoleResponse | NeonResult<ProjectMemberRoleResponse>
 	> {
+		const error = validateParams(params, "projects.members.setRole", {
+			projectId: "string",
+			memberId: "string",
+			role: "string",
+		});
+		if (error)
+			return invalidParamsResult<ProjectMemberRoleResponse>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, memberId, role, confirmSelfDemotion } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				setProjectMemberRole({
 					client,
 					path: { project_id: projectId, member_id: memberId },
-					query: opts?.confirmSelfDemotion
+					query: confirmSelfDemotion
 						? { confirm_self_demotion: true }
 						: undefined,
 					body: { role },
@@ -279,28 +348,35 @@ export class Members<DThrow extends boolean> {
 	 * @apiCall DELETE /projects/{project_id}/members/{member_id}/role
 	 */
 	removeRole(
-		projectId: string,
-		memberId: string,
+		params: ProjectMemberRemoveRoleParams,
 	): Promise<Outcome<ProjectMemberRoleResponse, DThrow>>;
 	removeRole<Throw extends boolean = DThrow>(
-		projectId: string,
-		memberId: string,
-		opts: RemoveRoleOptions<Throw>,
+		params: ProjectMemberRemoveRoleParams,
+		opts: CallOptions<Throw>,
 	): Promise<Outcome<ProjectMemberRoleResponse, Throw>>;
 	removeRole(
-		projectId: string,
-		memberId: string,
-		opts?: RemoveRoleOptions<boolean>,
+		params: ProjectMemberRemoveRoleParams,
+		opts?: CallOptions<boolean>,
 	): Promise<
 		ProjectMemberRoleResponse | NeonResult<ProjectMemberRoleResponse>
 	> {
+		const error = validateParams(params, "projects.members.removeRole", {
+			projectId: "string",
+			memberId: "string",
+		});
+		if (error)
+			return invalidParamsResult<ProjectMemberRoleResponse>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, memberId, confirmSelfLockout } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				removeProjectMemberRole({
 					client,
 					path: { project_id: projectId, member_id: memberId },
-					query: opts?.confirmSelfLockout
+					query: confirmSelfLockout
 						? { confirm_self_lockout: true }
 						: undefined,
 					throwOnError: false,
@@ -331,13 +407,13 @@ export class Projects<DThrow extends boolean> {
 	 *
 	 * @apiCall GET /projects
 	 */
-	list(query?: ListQuery): Paginated<ProjectListItem, DThrow>;
+	list(params?: ProjectListParams): Paginated<ProjectListItem, DThrow>;
 	list<Throw extends boolean = DThrow>(
-		query: ListQuery | undefined,
+		params: ProjectListParams | undefined,
 		opts: CallOptions<Throw>,
 	): Paginated<ProjectListItem, Throw>;
 	list(
-		query?: ListQuery,
+		query: ProjectListParams = {},
 		opts?: CallOptions,
 	): Paginated<ProjectListItem, boolean> {
 		return paginate(
@@ -362,21 +438,30 @@ export class Projects<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id} */
-	get(id: string): Promise<Outcome<Project, DThrow>>;
+	get(params: ProjectGetParams): Promise<Outcome<Project, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		id: string,
+		params: ProjectGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Project, Throw>>;
 	get(
-		id: string,
+		params: ProjectGetParams,
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
+		const error = validateParams(params, "projects.get", {
+			projectId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Project>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				getProject({
 					client,
-					path: { project_id: id },
+					path: { project_id: projectId },
 					throwOnError: false,
 					signal,
 				}),
@@ -390,13 +475,13 @@ export class Projects<DThrow extends boolean> {
 	 * {@link Projects.createAndConnect} or `postgres.connectionString` when a
 	 * connection string is needed.
 	 */
-	create(input?: CreateInput): Promise<Outcome<Project, DThrow>>;
+	create(params?: ProjectCreateParams): Promise<Outcome<Project, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		input: CreateInput | undefined,
+		params: ProjectCreateParams | undefined,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Project, Throw>>;
 	create(
-		input?: CreateInput,
+		input: ProjectCreateParams = {},
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
 		return this.#ctx.run(
@@ -430,16 +515,23 @@ export class Projects<DThrow extends boolean> {
 	 * @workflow createProject + waitForReadiness
 	 */
 	createAndConnect(
-		input?: CreateInput,
+		params?: ProjectCreateAndConnectParams,
 	): Promise<Outcome<ProjectConnection, DThrow>>;
 	createAndConnect<Throw extends boolean = DThrow>(
-		input: CreateInput | undefined,
-		opts: WorkflowOptions<Throw>,
+		params: ProjectCreateAndConnectParams | undefined,
+		opts: CallOptions<Throw>,
 	): Promise<Outcome<ProjectConnection, Throw>>;
 	async createAndConnect(
-		input?: CreateInput,
-		opts?: WorkflowOptions<boolean>,
+		params: ProjectCreateAndConnectParams = {},
+		opts?: CallOptions<boolean>,
 	): Promise<ProjectConnection | NeonResult<ProjectConnection>> {
+		const error = validateParams(params, "projects.createAndConnect");
+		if (error)
+			return invalidParamsResult<ProjectConnection>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { pooled = true, ...input } = params;
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const result = await this.#ctx.execute(
@@ -467,29 +559,36 @@ export class Projects<DThrow extends boolean> {
 				project: data.project,
 				connectionString,
 			}),
-			opts?.pooled ?? true,
+			pooled,
 		);
 		return finalize(out, shouldThrow);
 	}
 
 	/** @apiCall PATCH /projects/{project_id} */
-	update(id: string, input: UpdateInput): Promise<Outcome<Project, DThrow>>;
+	update(params: ProjectUpdateParams): Promise<Outcome<Project, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		id: string,
-		input: UpdateInput,
+		params: ProjectUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Project, Throw>>;
 	update(
-		id: string,
-		input: UpdateInput,
+		params: ProjectUpdateParams,
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
+		const error = validateParams(params, "projects.update", {
+			projectId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Project>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				updateProject({
 					client,
-					path: { project_id: id },
+					path: { project_id: projectId },
 					body: { project: input },
 					throwOnError: false,
 					signal,
@@ -499,21 +598,30 @@ export class Projects<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id} */
-	delete(id: string): Promise<Outcome<Project, DThrow>>;
+	delete(params: ProjectDeleteParams): Promise<Outcome<Project, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		id: string,
+		params: ProjectDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Project, Throw>>;
 	delete(
-		id: string,
+		params: ProjectDeleteParams,
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
+		const error = validateParams(params, "projects.delete", {
+			projectId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Project>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				deleteProject({
 					client,
-					path: { project_id: id },
+					path: { project_id: projectId },
 					throwOnError: false,
 					signal,
 				}),
@@ -526,21 +634,30 @@ export class Projects<DThrow extends boolean> {
 	 *
 	 * @apiCall POST /projects/{project_id}/recover
 	 */
-	recover(id: string): Promise<Outcome<Project, DThrow>>;
+	recover(params: ProjectRecoverParams): Promise<Outcome<Project, DThrow>>;
 	recover<Throw extends boolean = DThrow>(
-		id: string,
+		params: ProjectRecoverParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Project, Throw>>;
 	recover(
-		id: string,
+		params: ProjectRecoverParams,
 		opts?: CallOptions,
 	): Promise<Project | NeonResult<Project>> {
+		const error = validateParams(params, "projects.recover", {
+			projectId: "string",
+		});
+		if (error)
+			return invalidParamsResult<Project>(
+				error,
+				this.#ctx.shouldThrow(opts),
+			);
+		const { projectId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				recoverProject({
 					client,
-					path: { project_id: id },
+					path: { project_id: projectId },
 					throwOnError: false,
 					signal,
 				}),
@@ -554,13 +671,13 @@ export class Projects<DThrow extends boolean> {
 	 *
 	 * @apiCall POST /organizations/{source_org_id}/projects/transfer
 	 */
-	transfer(input: TransferProjectsInput): Promise<Outcome<void, DThrow>>;
+	transfer(params: ProjectTransferParams): Promise<Outcome<void, DThrow>>;
 	transfer<Throw extends boolean = DThrow>(
-		input: TransferProjectsInput,
+		params: ProjectTransferParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	async transfer(
-		input: TransferProjectsInput,
+		input: ProjectTransferParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
 		const shouldThrow =
@@ -598,16 +715,15 @@ export class Projects<DThrow extends boolean> {
 	 *
 	 * @apiCall POST /users/me/projects/transfer
 	 */
-	transferFromUser(input: {
-		toOrgId: string;
-		projectIds: string[];
-	}): Promise<Outcome<void, DThrow>>;
+	transferFromUser(
+		params: ProjectTransferFromUserParams,
+	): Promise<Outcome<void, DThrow>>;
 	transferFromUser<Throw extends boolean = DThrow>(
-		input: { toOrgId: string; projectIds: string[] },
+		params: ProjectTransferFromUserParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	transferFromUser(
-		input: { toOrgId: string; projectIds: string[] },
+		input: ProjectTransferFromUserParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
 		return this.#ctx.run(

--- a/packages/sdk/src/neon/resources/roles.ts
+++ b/packages/sdk/src/neon/resources/roles.ts
@@ -8,9 +8,27 @@ import {
 } from "../../client/sdk.gen.js";
 import type { Role, RoleCreateRequest } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = RoleCreateRequest["role"];
+
+export type RolesListParams = {
+	projectId: string;
+	branchId: string;
+};
+
+export type RolesGetParams = RolesListParams & {
+	roleName: string;
+};
+
+export type RolesCreateParams = RolesListParams & CreateInput;
+
+export type RolesDeleteParams = RolesGetParams;
+
+export type RolesPasswordParams = RolesGetParams;
+
+export type RolesResetPasswordParams = RolesGetParams;
 
 /** Role resource (branch-scoped). */
 export class Roles<DThrow extends boolean> {
@@ -21,17 +39,26 @@ export class Roles<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/roles */
-	list(projectId: string, branchId: string): Promise<Outcome<Role[], DThrow>>;
+	list(params: RolesListParams): Promise<Outcome<Role[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: RolesListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Role[], Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
+		params: RolesListParams,
 		opts?: CallOptions,
 	): Promise<Role[] | NeonResult<Role[]>> {
+		const invalid = validateParams(params, "roles.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Role[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -46,23 +73,27 @@ export class Roles<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/roles/{role_name} */
-	get(
-		projectId: string,
-		branchId: string,
-		name: string,
-	): Promise<Outcome<Role, DThrow>>;
+	get(params: RolesGetParams): Promise<Outcome<Role, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Role, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesGetParams,
 		opts?: CallOptions,
 	): Promise<Role | NeonResult<Role>> {
+		const invalid = validateParams(params, "roles.get", {
+			projectId: "string",
+			branchId: "string",
+			roleName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Role>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, roleName } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -71,7 +102,7 @@ export class Roles<DThrow extends boolean> {
 					path: {
 						project_id: projectId,
 						branch_id: branchId,
-						role_name: name,
+						role_name: roleName,
 					},
 					throwOnError: false,
 					signal,
@@ -81,23 +112,26 @@ export class Roles<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/roles */
-	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
-	): Promise<Outcome<Role, DThrow>>;
+	create(params: RolesCreateParams): Promise<Outcome<Role, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: RolesCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Role, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: RolesCreateParams,
 		opts?: CallOptions,
 	): Promise<Role | NeonResult<Role>> {
+		const invalid = validateParams(params, "roles.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Role>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -113,30 +147,34 @@ export class Roles<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/roles/{role_name} */
-	delete(
-		projectId: string,
-		branchId: string,
-		name: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: RolesDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "roles.delete", {
+			projectId: "string",
+			branchId: "string",
+			roleName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, roleName } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchRole({
 				client,
 				path: {
 					project_id: projectId,
 					branch_id: branchId,
-					role_name: name,
+					role_name: roleName,
 				},
 				throwOnError: false,
 				signal,
@@ -149,23 +187,27 @@ export class Roles<DThrow extends boolean> {
 	 *
 	 * @apiCall GET /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reveal_password
 	 */
-	password(
-		projectId: string,
-		branchId: string,
-		name: string,
-	): Promise<Outcome<string, DThrow>>;
+	password(params: RolesPasswordParams): Promise<Outcome<string, DThrow>>;
 	password<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesPasswordParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<string, Throw>>;
 	password(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesPasswordParams,
 		opts?: CallOptions,
 	): Promise<string | NeonResult<string>> {
+		const invalid = validateParams(params, "roles.password", {
+			projectId: "string",
+			branchId: "string",
+			roleName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<string>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, roleName } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -174,7 +216,7 @@ export class Roles<DThrow extends boolean> {
 					path: {
 						project_id: projectId,
 						branch_id: branchId,
-						role_name: name,
+						role_name: roleName,
 					},
 					throwOnError: false,
 					signal,
@@ -189,22 +231,28 @@ export class Roles<DThrow extends boolean> {
 	 * @apiCall POST /projects/{project_id}/branches/{branch_id}/roles/{role_name}/reset_password
 	 */
 	resetPassword(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesResetPasswordParams,
 	): Promise<Outcome<Role, DThrow>>;
 	resetPassword<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesResetPasswordParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Role, Throw>>;
 	resetPassword(
-		projectId: string,
-		branchId: string,
-		name: string,
+		params: RolesResetPasswordParams,
 		opts?: CallOptions,
 	): Promise<Role | NeonResult<Role>> {
+		const invalid = validateParams(params, "roles.resetPassword", {
+			projectId: "string",
+			branchId: "string",
+			roleName: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Role>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, roleName } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -213,7 +261,7 @@ export class Roles<DThrow extends boolean> {
 					path: {
 						project_id: projectId,
 						branch_id: branchId,
-						role_name: name,
+						role_name: roleName,
 					},
 					throwOnError: false,
 					signal,

--- a/packages/sdk/src/neon/resources/snapshots.test.ts
+++ b/packages/sdk/src/neon/resources/snapshots.test.ts
@@ -37,7 +37,9 @@ function neonCapturing() {
 describe("snapshots.update maps the ergonomic input to the API body", () => {
 	it("sends camelCase expiresAt as snake_case expires_at", async () => {
 		const { neon, calls } = neonCapturing();
-		await neon.snapshots.update("p-1", "snap-1", {
+		await neon.snapshots.update({
+			projectId: "p-1",
+			snapshotId: "snap-1",
 			name: "renamed",
 			expiresAt: "2030-01-01T00:00:00Z",
 		});
@@ -48,13 +50,21 @@ describe("snapshots.update maps the ergonomic input to the API body", () => {
 
 	it("forwards an explicit null to clear the expiration", async () => {
 		const { neon, calls } = neonCapturing();
-		await neon.snapshots.update("p-1", "snap-1", { expiresAt: null });
+		await neon.snapshots.update({
+			projectId: "p-1",
+			snapshotId: "snap-1",
+			expiresAt: null,
+		});
 		expect(calls[0]?.body).toEqual({ snapshot: { expires_at: null } });
 	});
 
 	it("omits expires_at entirely when not provided", async () => {
 		const { neon, calls } = neonCapturing();
-		await neon.snapshots.update("p-1", "snap-1", { name: "renamed" });
+		await neon.snapshots.update({
+			projectId: "p-1",
+			snapshotId: "snap-1",
+			name: "renamed",
+		});
 		expect(calls[0]?.body).toEqual({ snapshot: { name: "renamed" } });
 	});
 });
@@ -86,9 +96,9 @@ describe("snapshots.restore keeps the result contract around its preview callbac
 		const controller = new AbortController();
 
 		const { error } = await neon.snapshots.restore(
-			"p-1",
-			"snap-1",
 			{
+				projectId: "p-1",
+				snapshotId: "snap-1",
 				targetBranchId: "br-1",
 				preview: async (_branch, { signal }) => {
 					controller.abort();
@@ -106,7 +116,9 @@ describe("snapshots.restore keeps the result contract around its preview callbac
 	it("reports a callback that throws for its own reasons as a client error", async () => {
 		const neon = neonRestoring();
 
-		const { error } = await neon.snapshots.restore("p-1", "snap-1", {
+		const { error } = await neon.snapshots.restore({
+			projectId: "p-1",
+			snapshotId: "snap-1",
 			targetBranchId: "br-1",
 			preview: async () => {
 				throw new Error("my checks blew up");
@@ -121,7 +133,9 @@ describe("snapshots.restore keeps the result contract around its preview callbac
 describe("snapshots.setSchedule forwards the schedule body verbatim", () => {
 	it("sends the narrowed schedule as the request body", async () => {
 		const { neon, calls } = neonCapturing();
-		await neon.snapshots.setSchedule("p-1", "br-1", {
+		await neon.snapshots.setSchedule({
+			projectId: "p-1",
+			branchId: "br-1",
 			schedule: [
 				{ frequency: "weekly", day: 1, hour: 2 },
 				{ frequency: "daily", hour: 3, retention_seconds: 604800 },

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -17,6 +17,7 @@ import type {
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
 import { NeonAbortError, NeonClientError } from "../errors.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 /**
@@ -106,6 +107,29 @@ export interface SetScheduleInput {
 	schedule: BackupScheduleItemInput[];
 }
 
+export type SnapshotsListParams = { projectId: string };
+export type SnapshotsCreateParams = {
+	projectId: string;
+	branchId: string;
+} & CreateSnapshotInput;
+export type SnapshotsUpdateParams = {
+	projectId: string;
+	snapshotId: string;
+} & UpdateSnapshotInput;
+export type SnapshotsDeleteParams = { projectId: string; snapshotId: string };
+export type SnapshotsRestoreParams = {
+	projectId: string;
+	snapshotId: string;
+} & RestoreSnapshotInput;
+export type SnapshotsGetScheduleParams = {
+	projectId: string;
+	branchId: string;
+};
+export type SnapshotsSetScheduleParams = {
+	projectId: string;
+	branchId: string;
+} & SetScheduleInput;
+
 /** Snapshot resource. */
 export class Snapshots<DThrow extends boolean> {
 	readonly #ctx: RequestContext;
@@ -115,15 +139,25 @@ export class Snapshots<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/snapshots */
-	list(projectId: string): Promise<Outcome<Snapshot[], DThrow>>;
+	list(params: SnapshotsListParams): Promise<Outcome<Snapshot[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
+		params: SnapshotsListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Snapshot[], Throw>>;
 	list(
-		projectId: string,
+		params: SnapshotsListParams,
 		opts?: CallOptions,
 	): Promise<Snapshot[] | NeonResult<Snapshot[]>> {
+		const invalid = validateParams(params, "snapshots.list", {
+			projectId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Snapshot[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -138,23 +172,26 @@ export class Snapshots<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/snapshot */
-	create(
-		projectId: string,
-		branchId: string,
-		input?: CreateSnapshotInput,
-	): Promise<Outcome<Snapshot, DThrow>>;
+	create(params: SnapshotsCreateParams): Promise<Outcome<Snapshot, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CreateSnapshotInput | undefined,
+		params: SnapshotsCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Snapshot, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input?: CreateSnapshotInput,
+		params: SnapshotsCreateParams,
 		opts?: CallOptions,
 	): Promise<Snapshot | NeonResult<Snapshot>> {
+		const invalid = validateParams(params, "snapshots.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Snapshot>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -175,23 +212,26 @@ export class Snapshots<DThrow extends boolean> {
 	}
 
 	/** @apiCall PATCH /projects/{project_id}/snapshots/{snapshot_id} */
-	update(
-		projectId: string,
-		snapshotId: string,
-		input: UpdateSnapshotInput,
-	): Promise<Outcome<Snapshot, DThrow>>;
+	update(params: SnapshotsUpdateParams): Promise<Outcome<Snapshot, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		snapshotId: string,
-		input: UpdateSnapshotInput,
+		params: SnapshotsUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Snapshot, Throw>>;
 	update(
-		projectId: string,
-		snapshotId: string,
-		input: UpdateSnapshotInput,
+		params: SnapshotsUpdateParams,
 		opts?: CallOptions,
 	): Promise<Snapshot | NeonResult<Snapshot>> {
+		const invalid = validateParams(params, "snapshots.update", {
+			projectId: "string",
+			snapshotId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Snapshot>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, snapshotId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -215,20 +255,26 @@ export class Snapshots<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/snapshots/{snapshot_id} */
-	delete(
-		projectId: string,
-		snapshotId: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: SnapshotsDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		snapshotId: string,
+		params: SnapshotsDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		snapshotId: string,
+		params: SnapshotsDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "snapshots.delete", {
+			projectId: "string",
+			snapshotId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, snapshotId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -256,23 +302,26 @@ export class Snapshots<DThrow extends boolean> {
 	 *
 	 * @apiCall POST /projects/{project_id}/snapshots/{snapshot_id}/restore
 	 */
-	restore(
-		projectId: string,
-		snapshotId: string,
-		input?: RestoreSnapshotInput,
-	): Promise<Outcome<Branch, DThrow>>;
+	restore(params: SnapshotsRestoreParams): Promise<Outcome<Branch, DThrow>>;
 	restore<Throw extends boolean = DThrow>(
-		projectId: string,
-		snapshotId: string,
-		input: RestoreSnapshotInput | undefined,
+		params: SnapshotsRestoreParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Branch, Throw>>;
 	async restore(
-		projectId: string,
-		snapshotId: string,
-		input?: RestoreSnapshotInput,
+		params: SnapshotsRestoreParams,
 		opts?: CallOptions,
 	): Promise<Branch | NeonResult<Branch>> {
+		const invalid = validateParams(params, "snapshots.restore", {
+			projectId: "string",
+			snapshotId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Branch>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, snapshotId, ...input } = params;
 		const shouldThrow =
 			opts?.throwOnError ?? this.#ctx.defaults.throwOnError;
 		const preview = input?.preview;
@@ -391,19 +440,27 @@ export class Snapshots<DThrow extends boolean> {
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/backup_schedule */
 	getSchedule(
-		projectId: string,
-		branchId: string,
+		params: SnapshotsGetScheduleParams,
 	): Promise<Outcome<BackupSchedule, DThrow>>;
 	getSchedule<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: SnapshotsGetScheduleParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<BackupSchedule, Throw>>;
 	getSchedule(
-		projectId: string,
-		branchId: string,
+		params: SnapshotsGetScheduleParams,
 		opts?: CallOptions,
 	): Promise<BackupSchedule | NeonResult<BackupSchedule>> {
+		const invalid = validateParams(params, "snapshots.getSchedule", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<BackupSchedule>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -429,29 +486,35 @@ export class Snapshots<DThrow extends boolean> {
 	 * @apiCall PUT /projects/{project_id}/branches/{branch_id}/backup_schedule
 	 */
 	setSchedule(
-		projectId: string,
-		branchId: string,
-		schedule: SetScheduleInput,
+		params: SnapshotsSetScheduleParams,
 	): Promise<Outcome<void, DThrow>>;
 	setSchedule<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		schedule: SetScheduleInput,
+		params: SnapshotsSetScheduleParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	setSchedule(
-		projectId: string,
-		branchId: string,
-		schedule: SetScheduleInput,
+		params: SnapshotsSetScheduleParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "snapshots.setSchedule", {
+			projectId: "string",
+			branchId: "string",
+			schedule: "array",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, schedule } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
 				setSnapshotSchedule({
 					client,
 					path: { project_id: projectId, branch_id: branchId },
-					body: schedule,
+					body: { schedule },
 					throwOnError: false,
 					signal,
 				}),

--- a/packages/sdk/src/neon/resources/snapshots.ts
+++ b/packages/sdk/src/neon/resources/snapshots.ts
@@ -21,10 +21,6 @@ import { invalidParamsResult, validateParams } from "../params.js";
 import { err, finalize, type NeonResult, type Outcome, ok } from "../result.js";
 
 /**
- * Inspect a freshly restored (not-yet-finalized) branch and decide whether to commit.
- * Return `true` to finalize the restore, `false` to abort it.
- */
-/**
  * Inspect a restored-but-un-finalized branch and decide whether to commit it.
  *
  * The second argument carries the call's `signal`. The SDK cannot interrupt this callback

--- a/packages/sdk/src/neon/resources/storage.ts
+++ b/packages/sdk/src/neon/resources/storage.ts
@@ -1,9 +1,12 @@
 import { getProjectBranchStorage } from "../../client/sdk.gen.js";
 import type { BranchStorage } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 import { BucketObjects } from "./bucket-objects.js";
 import { Buckets } from "./buckets.js";
+
+export type StorageGetParams = { projectId: string; branchId: string };
 
 /**
  * Branch-scoped object storage: branch storage state, buckets, and bucket objects.
@@ -21,20 +24,26 @@ export class Storage<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/storage */
-	get(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<BranchStorage, DThrow>>;
+	get(params: StorageGetParams): Promise<Outcome<BranchStorage, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: StorageGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<BranchStorage, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
+		params: StorageGetParams,
 		opts?: CallOptions,
 	): Promise<BranchStorage | NeonResult<BranchStorage>> {
+		const invalid = validateParams(params, "storage.get", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<BranchStorage>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>

--- a/packages/sdk/src/neon/resources/triggers.test.ts
+++ b/packages/sdk/src/neon/resources/triggers.test.ts
@@ -65,7 +65,10 @@ describe("triggers", () => {
 			body: { triggers: [trigger] },
 		}));
 
-		const { data, error } = await neon.triggers.list("p-1", "br-1");
+		const { data, error } = await neon.triggers.list({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual([trigger]);
@@ -81,7 +84,10 @@ describe("triggers", () => {
 			body: { triggers: [] },
 		}));
 
-		const { data, error } = await neon.triggers.list("p-1", "br-1");
+		const { data, error } = await neon.triggers.list({
+			projectId: "p-1",
+			branchId: "br-1",
+		});
 		expect(error).toBeUndefined();
 		expect(data).toEqual([]);
 	});
@@ -99,11 +105,11 @@ describe("triggers", () => {
 			schedule: { cron: "0 9 * * *" },
 			enabled: false,
 		};
-		const { data, error } = await neon.triggers.create(
-			"p-1",
-			"br-1",
-			input,
-		);
+		const { data, error } = await neon.triggers.create({
+			projectId: "p-1",
+			branchId: "br-1",
+			...input,
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual(trigger);
@@ -124,7 +130,11 @@ describe("triggers", () => {
 			body: { trigger: inherited },
 		}));
 
-		const { data, error } = await neon.triggers.get("p-1", "br-1", "trg-1");
+		const { data, error } = await neon.triggers.get({
+			projectId: "p-1",
+			branchId: "br-1",
+			triggerId: "trg-1",
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual(inherited);
@@ -141,12 +151,13 @@ describe("triggers", () => {
 			body: { trigger: enabled },
 		}));
 
-		const { data, error } = await neon.triggers.update(
-			"p-1",
-			"br-1",
-			"trg-1",
-			{ type: "schedule", enabled: true },
-		);
+		const { data, error } = await neon.triggers.update({
+			projectId: "p-1",
+			branchId: "br-1",
+			triggerId: "trg-1",
+			type: "schedule",
+			enabled: true,
+		});
 
 		expect(error).toBeUndefined();
 		expect(data).toEqual(enabled);
@@ -157,7 +168,11 @@ describe("triggers", () => {
 	it("deletes with a 204", async () => {
 		const { neon, calls } = neonRouting(() => ({ status: 204 }));
 
-		const { error } = await neon.triggers.delete("p-1", "br-1", "trg-1");
+		const { error } = await neon.triggers.delete({
+			projectId: "p-1",
+			branchId: "br-1",
+			triggerId: "trg-1",
+		});
 
 		expect(error).toBeUndefined();
 		expect(calls).toHaveLength(1);
@@ -173,7 +188,11 @@ describe("triggers", () => {
 			body: { message: "missing" },
 		}));
 
-		const { error } = await neon.triggers.get("p-1", "br-1", "missing");
+		const { error } = await neon.triggers.get({
+			projectId: "p-1",
+			branchId: "br-1",
+			triggerId: "missing",
+		});
 		expect(error).toBeInstanceOf(NeonNotFoundError);
 	});
 });

--- a/packages/sdk/src/neon/resources/triggers.ts
+++ b/packages/sdk/src/neon/resources/triggers.ts
@@ -11,10 +11,24 @@ import type {
 	TriggerUpdateRequest,
 } from "../../client/types.gen.js";
 import type { CallOptions, RequestContext } from "../context.js";
+import { invalidParamsResult, validateParams } from "../params.js";
 import type { NeonResult, Outcome } from "../result.js";
 
 type CreateInput = TriggerCreateRequest;
 type UpdateInput = TriggerUpdateRequest;
+
+export type TriggersListParams = { projectId: string; branchId: string };
+export type TriggersCreateParams = {
+	projectId: string;
+	branchId: string;
+} & CreateInput;
+export type TriggersGetParams = {
+	projectId: string;
+	branchId: string;
+	triggerId: string;
+};
+export type TriggersUpdateParams = TriggersGetParams & UpdateInput;
+export type TriggersDeleteParams = TriggersGetParams;
 
 /** Branch-scoped Function triggers. v1 only supports `type: "schedule"`. */
 export class Triggers<DThrow extends boolean> {
@@ -25,20 +39,26 @@ export class Triggers<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/triggers */
-	list(
-		projectId: string,
-		branchId: string,
-	): Promise<Outcome<Trigger[], DThrow>>;
+	list(params: TriggersListParams): Promise<Outcome<Trigger[], DThrow>>;
 	list<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
+		params: TriggersListParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Trigger[], Throw>>;
 	list(
-		projectId: string,
-		branchId: string,
+		params: TriggersListParams,
 		opts?: CallOptions,
 	): Promise<Trigger[] | NeonResult<Trigger[]>> {
+		const invalid = validateParams(params, "triggers.list", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Trigger[]>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -53,23 +73,26 @@ export class Triggers<DThrow extends boolean> {
 	}
 
 	/** @apiCall POST /projects/{project_id}/branches/{branch_id}/triggers */
-	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
-	): Promise<Outcome<Trigger, DThrow>>;
+	create(params: TriggersCreateParams): Promise<Outcome<Trigger, DThrow>>;
 	create<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: TriggersCreateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Trigger, Throw>>;
 	create(
-		projectId: string,
-		branchId: string,
-		input: CreateInput,
+		params: TriggersCreateParams,
 		opts?: CallOptions,
 	): Promise<Trigger | NeonResult<Trigger>> {
+		const invalid = validateParams(params, "triggers.create", {
+			projectId: "string",
+			branchId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Trigger>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -85,23 +108,27 @@ export class Triggers<DThrow extends boolean> {
 	}
 
 	/** @apiCall GET /projects/{project_id}/branches/{branch_id}/triggers/{trigger_id} */
-	get(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
-	): Promise<Outcome<Trigger, DThrow>>;
+	get(params: TriggersGetParams): Promise<Outcome<Trigger, DThrow>>;
 	get<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
+		params: TriggersGetParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Trigger, Throw>>;
 	get(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
+		params: TriggersGetParams,
 		opts?: CallOptions,
 	): Promise<Trigger | NeonResult<Trigger>> {
+		const invalid = validateParams(params, "triggers.get", {
+			projectId: "string",
+			branchId: "string",
+			triggerId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Trigger>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, triggerId } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -120,26 +147,27 @@ export class Triggers<DThrow extends boolean> {
 	}
 
 	/** @apiCall PATCH /projects/{project_id}/branches/{branch_id}/triggers/{trigger_id} */
-	update(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
-		input: UpdateInput,
-	): Promise<Outcome<Trigger, DThrow>>;
+	update(params: TriggersUpdateParams): Promise<Outcome<Trigger, DThrow>>;
 	update<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
-		input: UpdateInput,
+		params: TriggersUpdateParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<Trigger, Throw>>;
 	update(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
-		input: UpdateInput,
+		params: TriggersUpdateParams,
 		opts?: CallOptions,
 	): Promise<Trigger | NeonResult<Trigger>> {
+		const invalid = validateParams(params, "triggers.update", {
+			projectId: "string",
+			branchId: "string",
+			triggerId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<Trigger>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, triggerId, ...input } = params;
 		return this.#ctx.run(
 			opts,
 			(client, signal) =>
@@ -159,23 +187,27 @@ export class Triggers<DThrow extends boolean> {
 	}
 
 	/** @apiCall DELETE /projects/{project_id}/branches/{branch_id}/triggers/{trigger_id} */
-	delete(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
-	): Promise<Outcome<void, DThrow>>;
+	delete(params: TriggersDeleteParams): Promise<Outcome<void, DThrow>>;
 	delete<Throw extends boolean = DThrow>(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
+		params: TriggersDeleteParams,
 		opts: CallOptions<Throw>,
 	): Promise<Outcome<void, Throw>>;
 	delete(
-		projectId: string,
-		branchId: string,
-		triggerId: string,
+		params: TriggersDeleteParams,
 		opts?: CallOptions,
 	): Promise<void | NeonResult<void>> {
+		const invalid = validateParams(params, "triggers.delete", {
+			projectId: "string",
+			branchId: "string",
+			triggerId: "string",
+		});
+		if (invalid) {
+			return invalidParamsResult<void>(
+				invalid,
+				this.#ctx.shouldThrow(opts),
+			);
+		}
+		const { projectId, branchId, triggerId } = params;
 		return this.#ctx.runVoid(opts, (client, signal) =>
 			deleteProjectBranchTrigger({
 				client,

--- a/packages/sdk/src/neon/wait-for-readiness.test.ts
+++ b/packages/sdk/src/neon/wait-for-readiness.test.ts
@@ -153,8 +153,11 @@ const methods = [
 			opts?: CallOptions<false>,
 		): Promise<NeonResult<unknown>> =>
 			opts
-				? neon.branches.create("p-1", { name: "feature" }, opts)
-				: neon.branches.create("p-1", { name: "feature" }),
+				? neon.branches.create(
+						{ projectId: "p-1", name: "feature" },
+						opts,
+					)
+				: neon.branches.create({ projectId: "p-1", name: "feature" }),
 	},
 	{
 		name: "branches.createAndConnect",
@@ -165,11 +168,13 @@ const methods = [
 		): Promise<NeonResult<unknown>> =>
 			opts
 				? neon.branches.createAndConnect(
-						"p-1",
-						{ name: "feature" },
+						{ projectId: "p-1", name: "feature" },
 						opts,
 					)
-				: neon.branches.createAndConnect("p-1", { name: "feature" }),
+				: neon.branches.createAndConnect({
+						projectId: "p-1",
+						name: "feature",
+					}),
 	},
 ];
 
@@ -250,7 +255,8 @@ describe("create-family waitForReadiness precedence", () => {
 				},
 			};
 		});
-		const { error } = await neon.projects.update("p-1", {
+		const { error } = await neon.projects.update({
+			projectId: "p-1",
 			name: "renamed",
 		});
 		expect(error).toBeUndefined();
@@ -278,7 +284,8 @@ describe("create-family waitForReadiness precedence", () => {
 			},
 			{ waitForReadiness: true },
 		);
-		const { error } = await neon.projects.update("p-1", {
+		const { error } = await neon.projects.update({
+			projectId: "p-1",
 			name: "renamed",
 		});
 		expect(error).toBeUndefined();

--- a/packages/tools/src/catalog.test.ts
+++ b/packages/tools/src/catalog.test.ts
@@ -173,7 +173,33 @@ describe("special mappings", () => {
 		expect(await requests[0].json()).toEqual({ key_name: "agent" });
 	});
 
-	test("maps member confirmation flags into SDK options", async () => {
+	test("keeps the database selector distinct from its new name", async () => {
+		const requests: Request[] = [];
+		const tool = createNeonTool("postgres.databases.update", {
+			apiKey: "test-key",
+			fetch: async (input, init) => {
+				requests.push(new Request(input, init));
+				return jsonResponse({ database: { name: "renamed" } });
+			},
+		});
+
+		await tool.execute({
+			project_id: "project-id",
+			branch_id: "branch-id",
+			database_name: "original",
+			name: "renamed",
+		});
+
+		expect(requests).toHaveLength(1);
+		expect(new URL(requests[0].url).pathname).toBe(
+			"/api/v2/projects/project-id/branches/branch-id/databases/original",
+		);
+		expect(await requests[0].json()).toEqual({
+			database: { name: "renamed" },
+		});
+	});
+
+	test("maps member confirmation flags into SDK input", async () => {
 		const requests: Request[] = [];
 		const tools = createNeonTools({
 			apiKey: "test-key",

--- a/packages/tools/src/lib/ergonomic/bind.ts
+++ b/packages/tools/src/lib/ergonomic/bind.ts
@@ -144,10 +144,10 @@ export const collectObjectList = async (
 	for (;;) {
 		const page = objectListPage(
 			await neon.storage.objects.list(
-				input.project_id,
-				input.branch_id,
-				input.bucket_name,
 				{
+					projectId: input.project_id,
+					branchId: input.branch_id,
+					bucketName: input.bucket_name,
 					...(input.prefix === undefined
 						? {}
 						: { prefix: input.prefix }),

--- a/packages/tools/src/lib/ergonomic/catalog.ts
+++ b/packages/tools/src/lib/ergonomic/catalog.ts
@@ -58,7 +58,7 @@ export const toolFactories = {
 			id: "projects.get",
 			generated: "getProject",
 			run: (neon, input, signal) =>
-				neon.projects.get(input.project_id, { signal }),
+				neon.projects.get({ projectId: input.project_id }, { signal }),
 		}),
 	"projects.create": createProjectTool,
 	"projects.createAndConnect": createProjectAndConnectTool,
@@ -68,8 +68,8 @@ export const toolFactories = {
 			generated: "updateProject",
 			run: (neon, input, signal) =>
 				neon.projects.update(
-					input.project_id,
 					{
+						projectId: input.project_id,
 						settings: input.settings,
 						name: input.name,
 						default_endpoint_settings:
@@ -85,14 +85,20 @@ export const toolFactories = {
 			id: "projects.delete",
 			generated: "deleteProject",
 			run: (neon, input, signal) =>
-				neon.projects.delete(input.project_id, { signal }),
+				neon.projects.delete(
+					{ projectId: input.project_id },
+					{ signal },
+				),
 		}),
 	"projects.recover": (options) =>
 		fromGenerated(options, {
 			id: "projects.recover",
 			generated: "recoverProject",
 			run: (neon, input, signal) =>
-				neon.projects.recover(input.project_id, { signal }),
+				neon.projects.recover(
+					{ projectId: input.project_id },
+					{ signal },
+				),
 		}),
 	"projects.transfer": (options) =>
 		fromGenerated(options, {
@@ -126,16 +132,22 @@ export const toolFactories = {
 			id: "projects.permissions.list",
 			generated: "listProjectPermissions",
 			run: (neon, input, signal) =>
-				neon.projects.permissions.list(input.project_id, { signal }),
+				neon.projects.permissions.list(
+					{ projectId: input.project_id },
+					{ signal },
+				),
 		}),
 	"projects.permissions.grant": (options) =>
 		fromGenerated(options, {
 			id: "projects.permissions.grant",
 			generated: "grantPermissionToProject",
 			run: (neon, input, signal) =>
-				neon.projects.permissions.grant(input.project_id, input.email, {
-					signal,
-				}),
+				neon.projects.permissions.grant(
+					{ projectId: input.project_id, email: input.email },
+					{
+						signal,
+					},
+				),
 		}),
 	"projects.permissions.revoke": (options) =>
 		fromGenerated(options, {
@@ -143,8 +155,10 @@ export const toolFactories = {
 			generated: "revokePermissionFromProject",
 			run: (neon, input, signal) =>
 				neon.projects.permissions.revoke(
-					input.project_id,
-					input.permission_id,
+					{
+						projectId: input.project_id,
+						permissionId: input.permission_id,
+					},
 					{ signal },
 				),
 		}),
@@ -157,8 +171,7 @@ export const toolFactories = {
 			run: (neon, input, signal) =>
 				collectPages(
 					neon.projects.members.list(
-						input.project_id,
-						{ limit: input.limit },
+						{ projectId: input.project_id, limit: input.limit },
 						{ signal },
 					),
 					input.limit,
@@ -170,15 +183,15 @@ export const toolFactories = {
 			generated: "setProjectMemberRole",
 			run: (neon, input, signal) =>
 				neon.projects.members.setRole(
-					input.project_id,
-					input.member_id,
-					input.role,
 					{
-						signal,
+						projectId: input.project_id,
+						memberId: input.member_id,
+						role: input.role,
 						...(input.confirm_self_demotion
 							? { confirmSelfDemotion: true }
 							: {}),
 					},
+					{ signal },
 				),
 		}),
 	"projects.members.removeRole": (options) =>
@@ -187,14 +200,14 @@ export const toolFactories = {
 			generated: "removeProjectMemberRole",
 			run: (neon, input, signal) =>
 				neon.projects.members.removeRole(
-					input.project_id,
-					input.member_id,
 					{
-						signal,
+						projectId: input.project_id,
+						memberId: input.member_id,
 						...(input.confirm_self_lockout
 							? { confirmSelfLockout: true }
 							: {}),
 					},
+					{ signal },
 				),
 		}),
 	"branches.list": (options) =>
@@ -206,8 +219,8 @@ export const toolFactories = {
 			run: (neon, input, signal) =>
 				collectPages(
 					neon.branches.list(
-						input.project_id,
 						{
+							projectId: input.project_id,
 							search: input.search,
 							sort_by: input.sort_by,
 							sort_order: input.sort_order,
@@ -224,9 +237,12 @@ export const toolFactories = {
 			id: "branches.get",
 			generated: "getProjectBranch",
 			run: (neon, input, signal) =>
-				neon.branches.get(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.branches.get(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"branches.create": createBranchTool,
 	"branches.createAndConnect": createBranchAndConnectTool,
@@ -236,9 +252,9 @@ export const toolFactories = {
 			generated: "updateProjectBranch",
 			run: (neon, input, signal) =>
 				neon.branches.update(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						name: input.name,
 						protected: input.protected,
 						expires_at: input.expires_at,
@@ -251,9 +267,12 @@ export const toolFactories = {
 			id: "branches.delete",
 			generated: "deleteProjectBranch",
 			run: (neon, input, signal) =>
-				neon.branches.delete(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.branches.delete(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"branches.getDefault": getDefaultTool,
 	"branches.setDefault": (options) =>
@@ -261,9 +280,12 @@ export const toolFactories = {
 			id: "branches.setDefault",
 			generated: "setDefaultProjectBranch",
 			run: (neon, input, signal) =>
-				neon.branches.setDefault(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.branches.setDefault(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"branches.resetFromParent": resetFromParentTool,
 	"branches.compareSchema": compareSchemaTool,
@@ -273,9 +295,11 @@ export const toolFactories = {
 			generated: "finalizeRestoreBranch",
 			run: (neon, input, signal) =>
 				neon.branches.finalizeRestore(
-					input.project_id,
-					input.branch_id,
-					{ name: input.name },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						name: input.name,
+					},
 					{ signal },
 				),
 		}),
@@ -285,7 +309,10 @@ export const toolFactories = {
 			id: "postgres.endpoints.list",
 			generated: "listProjectEndpoints",
 			run: (neon, input, signal) =>
-				neon.postgres.endpoints.list(input.project_id, { signal }),
+				neon.postgres.endpoints.list(
+					{ projectId: input.project_id },
+					{ signal },
+				),
 		}),
 	"postgres.endpoints.listByBranch": (options) =>
 		fromGenerated(options, {
@@ -293,8 +320,7 @@ export const toolFactories = {
 			generated: "listProjectBranchEndpoints",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.listByBranch(
-					input.project_id,
-					input.branch_id,
+					{ projectId: input.project_id, branchId: input.branch_id },
 					{ signal },
 				),
 		}),
@@ -304,8 +330,10 @@ export const toolFactories = {
 			generated: "getProjectEndpoint",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.get(
-					input.project_id,
-					input.endpoint_id,
+					{
+						projectId: input.project_id,
+						endpointId: input.endpoint_id,
+					},
 					{ signal },
 				),
 		}),
@@ -315,8 +343,8 @@ export const toolFactories = {
 			generated: "createProjectEndpoint",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.create(
-					input.project_id,
 					{
+						projectId: input.project_id,
 						branch_id: input.branch_id,
 						region_id: input.region_id,
 						type: input.type,
@@ -342,9 +370,9 @@ export const toolFactories = {
 			generated: "updateProjectEndpoint",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.update(
-					input.project_id,
-					input.endpoint_id,
 					{
+						projectId: input.project_id,
+						endpointId: input.endpoint_id,
 						branch_id: input.branch_id,
 						autoscaling_limit_min_cu:
 							input.autoscaling_limit_min_cu,
@@ -368,8 +396,10 @@ export const toolFactories = {
 			generated: "deleteProjectEndpoint",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.delete(
-					input.project_id,
-					input.endpoint_id,
+					{
+						projectId: input.project_id,
+						endpointId: input.endpoint_id,
+					},
 					{ signal },
 				),
 		}),
@@ -379,8 +409,10 @@ export const toolFactories = {
 			generated: "startProjectEndpoint",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.start(
-					input.project_id,
-					input.endpoint_id,
+					{
+						projectId: input.project_id,
+						endpointId: input.endpoint_id,
+					},
 					{ signal },
 				),
 		}),
@@ -390,8 +422,10 @@ export const toolFactories = {
 			generated: "suspendProjectEndpoint",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.suspend(
-					input.project_id,
-					input.endpoint_id,
+					{
+						projectId: input.project_id,
+						endpointId: input.endpoint_id,
+					},
 					{ signal },
 				),
 		}),
@@ -401,8 +435,10 @@ export const toolFactories = {
 			generated: "restartProjectEndpoint",
 			run: (neon, input, signal) =>
 				neon.postgres.endpoints.restart(
-					input.project_id,
-					input.endpoint_id,
+					{
+						projectId: input.project_id,
+						endpointId: input.endpoint_id,
+					},
 					{ signal },
 				),
 		}),
@@ -411,9 +447,12 @@ export const toolFactories = {
 			id: "postgres.roles.list",
 			generated: "listProjectBranchRoles",
 			run: (neon, input, signal) =>
-				neon.postgres.roles.list(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.postgres.roles.list(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"postgres.roles.get": (options) =>
 		fromGenerated(options, {
@@ -421,9 +460,11 @@ export const toolFactories = {
 			generated: "getProjectBranchRole",
 			run: (neon, input, signal) =>
 				neon.postgres.roles.get(
-					input.project_id,
-					input.branch_id,
-					input.role_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						roleName: input.role_name,
+					},
 					{ signal },
 				),
 		}),
@@ -433,9 +474,12 @@ export const toolFactories = {
 			generated: "createProjectBranchRole",
 			run: (neon, input, signal) =>
 				neon.postgres.roles.create(
-					input.project_id,
-					input.branch_id,
-					{ name: input.name, no_login: input.no_login },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						name: input.name,
+						no_login: input.no_login,
+					},
 					{ signal },
 				),
 		}),
@@ -445,9 +489,11 @@ export const toolFactories = {
 			generated: "deleteProjectBranchRole",
 			run: (neon, input, signal) =>
 				neon.postgres.roles.delete(
-					input.project_id,
-					input.branch_id,
-					input.role_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						roleName: input.role_name,
+					},
 					{ signal },
 				),
 		}),
@@ -457,9 +503,11 @@ export const toolFactories = {
 			generated: "resetProjectBranchRolePassword",
 			run: (neon, input, signal) =>
 				neon.postgres.roles.resetPassword(
-					input.project_id,
-					input.branch_id,
-					input.role_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						roleName: input.role_name,
+					},
 					{ signal },
 				),
 		}),
@@ -469,8 +517,7 @@ export const toolFactories = {
 			generated: "listProjectBranchDatabases",
 			run: (neon, input, signal) =>
 				neon.postgres.databases.list(
-					input.project_id,
-					input.branch_id,
+					{ projectId: input.project_id, branchId: input.branch_id },
 					{
 						signal,
 					},
@@ -482,9 +529,11 @@ export const toolFactories = {
 			generated: "getProjectBranchDatabase",
 			run: (neon, input, signal) =>
 				neon.postgres.databases.get(
-					input.project_id,
-					input.branch_id,
-					input.database_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						databaseName: input.database_name,
+					},
 					{ signal },
 				),
 		}),
@@ -494,9 +543,12 @@ export const toolFactories = {
 			generated: "createProjectBranchDatabase",
 			run: (neon, input, signal) =>
 				neon.postgres.databases.create(
-					input.project_id,
-					input.branch_id,
-					{ name: input.name, owner_name: input.owner_name },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						name: input.name,
+						owner_name: input.owner_name,
+					},
 					{ signal },
 				),
 		}),
@@ -506,10 +558,13 @@ export const toolFactories = {
 			generated: "updateProjectBranchDatabase",
 			run: (neon, input, signal) =>
 				neon.postgres.databases.update(
-					input.project_id,
-					input.branch_id,
-					input.database_name,
-					{ name: input.name, owner_name: input.owner_name },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						databaseName: input.database_name,
+						name: input.name,
+						owner_name: input.owner_name,
+					},
 					{ signal },
 				),
 		}),
@@ -519,9 +574,11 @@ export const toolFactories = {
 			generated: "deleteProjectBranchDatabase",
 			run: (neon, input, signal) =>
 				neon.postgres.databases.delete(
-					input.project_id,
-					input.branch_id,
-					input.database_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						databaseName: input.database_name,
+					},
 					{ signal },
 				),
 		}),
@@ -531,9 +588,11 @@ export const toolFactories = {
 			generated: "getProjectBranchDataAPI",
 			run: (neon, input, signal) =>
 				neon.postgres.dataApi.get(
-					input.project_id,
-					input.branch_id,
-					input.database_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						databaseName: input.database_name,
+					},
 					{ signal },
 				),
 		}),
@@ -543,10 +602,10 @@ export const toolFactories = {
 			generated: "createProjectBranchDataAPI",
 			run: (neon, input, signal) =>
 				neon.postgres.dataApi.create(
-					input.project_id,
-					input.branch_id,
-					input.database_name,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						databaseName: input.database_name,
 						auth_provider: input.auth_provider,
 						jwks_url: input.jwks_url,
 						provider_name: input.provider_name,
@@ -564,10 +623,10 @@ export const toolFactories = {
 			generated: "updateProjectBranchDataAPI",
 			run: (neon, input, signal) =>
 				neon.postgres.dataApi.update(
-					input.project_id,
-					input.branch_id,
-					input.database_name,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						databaseName: input.database_name,
 						settings: {
 							db_aggregates_enabled: input.db_aggregates_enabled,
 							db_anon_role: input.db_anon_role,
@@ -592,9 +651,11 @@ export const toolFactories = {
 			generated: "deleteProjectBranchDataAPI",
 			run: (neon, input, signal) =>
 				neon.postgres.dataApi.delete(
-					input.project_id,
-					input.branch_id,
-					input.database_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						databaseName: input.database_name,
+					},
 					{ signal },
 				),
 		}),
@@ -603,16 +664,22 @@ export const toolFactories = {
 			id: "storage.get",
 			generated: "getProjectBranchStorage",
 			run: (neon, input, signal) =>
-				neon.storage.get(input.project_id, input.branch_id, { signal }),
+				neon.storage.get(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{ signal },
+				),
 		}),
 	"storage.buckets.list": (options) =>
 		fromGenerated(options, {
 			id: "storage.buckets.list",
 			generated: "listProjectBranchBuckets",
 			run: (neon, input, signal) =>
-				neon.storage.buckets.list(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.storage.buckets.list(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"storage.buckets.create": (options) =>
 		fromGenerated(options, {
@@ -620,9 +687,12 @@ export const toolFactories = {
 			generated: "createProjectBranchBucket",
 			run: (neon, input, signal) =>
 				neon.storage.buckets.create(
-					input.project_id,
-					input.branch_id,
-					{ name: input.name, access_level: input.access_level },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						name: input.name,
+						access_level: input.access_level,
+					},
 					{ signal },
 				),
 		}),
@@ -632,9 +702,11 @@ export const toolFactories = {
 			generated: "deleteProjectBranchBucket",
 			run: (neon, input, signal) =>
 				neon.storage.buckets.delete(
-					input.project_id,
-					input.branch_id,
-					input.bucket_name,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						bucketName: input.bucket_name,
+					},
 					{ signal },
 				),
 		}),
@@ -664,10 +736,12 @@ export const toolFactories = {
 			generated: "deleteProjectBranchBucketObject",
 			run: (neon, input, signal) =>
 				neon.storage.objects.delete(
-					input.project_id,
-					input.branch_id,
-					input.bucket_name,
-					input.object_key,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						bucketName: input.bucket_name,
+						objectKey: input.object_key,
+					},
 					{ signal },
 				),
 		}),
@@ -677,10 +751,12 @@ export const toolFactories = {
 			generated: "deleteProjectBranchBucketObjectsByPrefix",
 			run: (neon, input, signal) =>
 				neon.storage.objects.deleteByPrefix(
-					input.project_id,
-					input.branch_id,
-					input.bucket_name,
-					input.prefix,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						bucketName: input.bucket_name,
+						prefix: input.prefix,
+					},
 					{ signal },
 				),
 		}),
@@ -690,11 +766,11 @@ export const toolFactories = {
 			generated: "presignProjectBranchBucketObject",
 			run: (neon, input, signal) =>
 				neon.storage.objects.presign(
-					input.project_id,
-					input.branch_id,
-					input.bucket_name,
-					input.object_key,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						bucketName: input.bucket_name,
+						objectKey: input.object_key,
 						operation: input.operation,
 						content_type: input.content_type,
 						expires_in_seconds: input.expires_in_seconds,
@@ -711,9 +787,11 @@ export const toolFactories = {
 			run: (neon, input, signal) =>
 				collectPages(
 					neon.functions.list(
-						input.project_id,
-						input.branch_id,
-						{ limit: input.limit },
+						{
+							projectId: input.project_id,
+							branchId: input.branch_id,
+							limit: input.limit,
+						},
 						{ signal },
 					),
 					input.limit,
@@ -725,9 +803,11 @@ export const toolFactories = {
 			generated: "getProjectBranchFunction",
 			run: (neon, input, signal) =>
 				neon.functions.get(
-					input.project_id,
-					input.branch_id,
-					input.slug,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						slug: input.slug,
+					},
 					{ signal },
 				),
 		}),
@@ -737,10 +817,12 @@ export const toolFactories = {
 			generated: "updateProjectBranchFunction",
 			run: (neon, input, signal) =>
 				neon.functions.update(
-					input.project_id,
-					input.branch_id,
-					input.slug,
-					{ name: input.name },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						slug: input.slug,
+						name: input.name,
+					},
 					{ signal },
 				),
 		}),
@@ -750,9 +832,11 @@ export const toolFactories = {
 			generated: "deleteProjectBranchFunction",
 			run: (neon, input, signal) =>
 				neon.functions.delete(
-					input.project_id,
-					input.branch_id,
-					input.slug,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						slug: input.slug,
+					},
 					{ signal },
 				),
 		}),
@@ -762,10 +846,10 @@ export const toolFactories = {
 			generated: "createProjectBranchFunctionDeployment",
 			run: (neon, input, signal) =>
 				neon.functions.deploy(
-					input.project_id,
-					input.branch_id,
-					input.slug,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						slug: input.slug,
 						zip:
 							input.zip === undefined
 								? undefined
@@ -785,9 +869,11 @@ export const toolFactories = {
 			run: (neon, input, signal) =>
 				collectPages(
 					neon.functions.customDomains.list(
-						input.project_id,
-						input.branch_id,
-						{ limit: input.limit },
+						{
+							projectId: input.project_id,
+							branchId: input.branch_id,
+							limit: input.limit,
+						},
 						{ signal },
 					),
 					input.limit,
@@ -799,9 +885,9 @@ export const toolFactories = {
 			generated: "registerProjectBranchCustomDomain",
 			run: (neon, input, signal) =>
 				neon.functions.customDomains.register(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						domain: input.domain,
 						entity_type: input.entity_type,
 						entity_id: input.entity_id,
@@ -815,9 +901,11 @@ export const toolFactories = {
 			generated: "deleteProjectBranchCustomDomain",
 			run: (neon, input, signal) =>
 				neon.functions.customDomains.delete(
-					input.project_id,
-					input.branch_id,
-					input.domain,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						domain: input.domain,
+					},
 					{ signal },
 				),
 		}),
@@ -826,9 +914,12 @@ export const toolFactories = {
 			id: "triggers.list",
 			generated: "listProjectBranchTriggers",
 			run: (neon, input, signal) =>
-				neon.triggers.list(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.triggers.list(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"triggers.get": (options) =>
 		fromGenerated(options, {
@@ -836,9 +927,11 @@ export const toolFactories = {
 			generated: "getProjectBranchTrigger",
 			run: (neon, input, signal) =>
 				neon.triggers.get(
-					input.project_id,
-					input.branch_id,
-					input.trigger_id,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						triggerId: input.trigger_id,
+					},
 					{ signal },
 				),
 		}),
@@ -848,9 +941,11 @@ export const toolFactories = {
 			generated: "createProjectBranchTrigger",
 			run: (neon, input, signal) =>
 				neon.triggers.create(
-					input.project_id,
-					input.branch_id,
-					input.body,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						...input.body,
+					},
 					{ signal },
 				),
 		}),
@@ -860,10 +955,12 @@ export const toolFactories = {
 			generated: "updateProjectBranchTrigger",
 			run: (neon, input, signal) =>
 				neon.triggers.update(
-					input.project_id,
-					input.branch_id,
-					input.trigger_id,
-					input.body,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						triggerId: input.trigger_id,
+						...input.body,
+					},
 					{ signal },
 				),
 		}),
@@ -873,9 +970,11 @@ export const toolFactories = {
 			generated: "deleteProjectBranchTrigger",
 			run: (neon, input, signal) =>
 				neon.triggers.delete(
-					input.project_id,
-					input.branch_id,
-					input.trigger_id,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						triggerId: input.trigger_id,
+					},
 					{ signal },
 				),
 		}),
@@ -884,9 +983,12 @@ export const toolFactories = {
 			id: "credentials.list",
 			generated: "listCredentials",
 			run: (neon, input, signal) =>
-				neon.credentials.list(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.credentials.list(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"credentials.create": (options) =>
 		fromGenerated(options, {
@@ -894,9 +996,9 @@ export const toolFactories = {
 			generated: "createCredential",
 			run: (neon, input, signal) =>
 				neon.credentials.create(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						name: input.name,
 						scopes: input.scopes,
 						principal_type: input.principal_type,
@@ -910,9 +1012,11 @@ export const toolFactories = {
 			generated: "revokeCredential",
 			run: (neon, input, signal) =>
 				neon.credentials.revoke(
-					input.project_id,
-					input.branch_id,
-					input.token_id,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						tokenId: input.token_id,
+					},
 					{ signal },
 				),
 		}),
@@ -928,9 +1032,11 @@ export const toolFactories = {
 			},
 			run: (neon, input, signal) =>
 				neon.credentials.rotate(
-					input.project_id,
-					input.branch_id,
-					input.token_id,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						tokenId: input.token_id,
+					},
 					{ signal },
 				),
 		}),
@@ -939,9 +1045,12 @@ export const toolFactories = {
 			id: "aiGateway.get",
 			generated: "getProjectBranchAiGateway",
 			run: (neon, input, signal) =>
-				neon.aiGateway.get(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.aiGateway.get(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"logs.query": (options) =>
 		fromGenerated(options, {
@@ -954,9 +1063,9 @@ export const toolFactories = {
 			run: (neon, input, signal) =>
 				collectPages(
 					neon.logs.query(
-						input.project_id,
-						input.branch_id,
 						{
+							projectId: input.project_id,
+							branchId: input.branch_id,
 							since: input.since,
 							start_time: input.start_time,
 							end_time: input.end_time,
@@ -981,7 +1090,10 @@ export const toolFactories = {
 			id: "logs.fields",
 			generated: "listProjectBranchLogFields",
 			run: (neon, input, signal) =>
-				neon.logs.fields(input.project_id, input.branch_id, { signal }),
+				neon.logs.fields(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{ signal },
+				),
 		}),
 	"logs.fieldValues": (options) =>
 		fromGenerated(options, {
@@ -989,10 +1101,10 @@ export const toolFactories = {
 			generated: "listProjectBranchLogFieldValues",
 			run: (neon, input, signal) =>
 				neon.logs.fieldValues(
-					input.project_id,
-					input.branch_id,
-					input.field_name,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						fieldName: input.field_name,
 						since: input.since,
 						start_time: input.start_time,
 						end_time: input.end_time,
@@ -1007,7 +1119,10 @@ export const toolFactories = {
 			id: "snapshots.list",
 			generated: "listSnapshots",
 			run: (neon, input, signal) =>
-				neon.snapshots.list(input.project_id, { signal }),
+				neon.snapshots.list(
+					{ projectId: input.project_id },
+					{ signal },
+				),
 		}),
 	"snapshots.create": (options) =>
 		fromGenerated(options, {
@@ -1015,9 +1130,9 @@ export const toolFactories = {
 			generated: "createSnapshot",
 			run: (neon, input, signal) =>
 				neon.snapshots.create(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						name: input.name,
 						timestamp: input.timestamp,
 						lsn: input.lsn,
@@ -1032,9 +1147,9 @@ export const toolFactories = {
 			generated: "updateSnapshot",
 			run: (neon, input, signal) =>
 				neon.snapshots.update(
-					input.project_id,
-					input.snapshot_id,
 					{
+						projectId: input.project_id,
+						snapshotId: input.snapshot_id,
 						name: input.name,
 						expiresAt: input.expires_at,
 					},
@@ -1046,9 +1161,15 @@ export const toolFactories = {
 			id: "snapshots.delete",
 			generated: "deleteSnapshot",
 			run: (neon, input, signal) =>
-				neon.snapshots.delete(input.project_id, input.snapshot_id, {
-					signal,
-				}),
+				neon.snapshots.delete(
+					{
+						projectId: input.project_id,
+						snapshotId: input.snapshot_id,
+					},
+					{
+						signal,
+					},
+				),
 		}),
 	"snapshots.restore": restoreSnapshotTool,
 	"snapshots.getSchedule": (options) =>
@@ -1056,9 +1177,12 @@ export const toolFactories = {
 			id: "snapshots.getSchedule",
 			generated: "getSnapshotSchedule",
 			run: (neon, input, signal) =>
-				neon.snapshots.getSchedule(input.project_id, input.branch_id, {
-					signal,
-				}),
+				neon.snapshots.getSchedule(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{
+						signal,
+					},
+				),
 		}),
 	"snapshots.setSchedule": setScheduleTool,
 	"operations.list": (options) =>
@@ -1069,7 +1193,10 @@ export const toolFactories = {
 			list: true,
 			run: (neon, input, signal) =>
 				collectPages(
-					neon.operations.list(input.project_id, { signal }),
+					neon.operations.list(
+						{ projectId: input.project_id },
+						{ signal },
+					),
 					input.limit,
 				),
 		}),
@@ -1078,16 +1205,25 @@ export const toolFactories = {
 			id: "operations.get",
 			generated: "getProjectOperation",
 			run: (neon, input, signal) =>
-				neon.operations.get(input.project_id, input.operation_id, {
-					signal,
-				}),
+				neon.operations.get(
+					{
+						projectId: input.project_id,
+						operationId: input.operation_id,
+					},
+					{
+						signal,
+					},
+				),
 		}),
 	"auth.get": (options) =>
 		fromGenerated(options, {
 			id: "auth.get",
 			generated: "getNeonAuth",
 			run: (neon, input, signal) =>
-				neon.auth.get(input.project_id, input.branch_id, { signal }),
+				neon.auth.get(
+					{ projectId: input.project_id, branchId: input.branch_id },
+					{ signal },
+				),
 		}),
 	"auth.create": (options) =>
 		fromGenerated(options, {
@@ -1095,9 +1231,9 @@ export const toolFactories = {
 			generated: "createNeonAuth",
 			run: (neon, input, signal) =>
 				neon.auth.create(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						auth_provider: input.auth_provider,
 						database_name: input.database_name,
 					},
@@ -1110,9 +1246,11 @@ export const toolFactories = {
 			generated: "disableNeonAuth",
 			run: (neon, input, signal) =>
 				neon.auth.disable(
-					input.project_id,
-					input.branch_id,
-					{ deleteData: input.delete_data },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						deleteData: input.delete_data,
+					},
 					{ signal },
 				),
 		}),
@@ -1122,9 +1260,11 @@ export const toolFactories = {
 			generated: "updateNeonAuthConfig",
 			run: (neon, input, signal) =>
 				neon.auth.updateConfig(
-					input.project_id,
-					input.branch_id,
-					{ name: input.name },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						name: input.name,
+					},
 					{ signal },
 				),
 		}),
@@ -1134,8 +1274,7 @@ export const toolFactories = {
 			generated: "listBranchNeonAuthOauthProviders",
 			run: (neon, input, signal) =>
 				neon.auth.oauthProviders.list(
-					input.project_id,
-					input.branch_id,
+					{ projectId: input.project_id, branchId: input.branch_id },
 					{
 						signal,
 					},
@@ -1147,9 +1286,9 @@ export const toolFactories = {
 			generated: "addBranchNeonAuthOauthProvider",
 			run: (neon, input, signal) =>
 				neon.auth.oauthProviders.add(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						id: input.id,
 						client_id: input.client_id,
 						client_secret: input.client_secret,
@@ -1164,10 +1303,10 @@ export const toolFactories = {
 			generated: "updateBranchNeonAuthOauthProvider",
 			run: (neon, input, signal) =>
 				neon.auth.oauthProviders.update(
-					input.project_id,
-					input.branch_id,
-					input.oauth_provider_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						providerId: input.oauth_provider_id,
 						client_id: input.client_id,
 						client_secret: input.client_secret,
 						microsoft_tenant_id: input.microsoft_tenant_id,
@@ -1181,9 +1320,11 @@ export const toolFactories = {
 			generated: "deleteBranchNeonAuthOauthProvider",
 			run: (neon, input, signal) =>
 				neon.auth.oauthProviders.delete(
-					input.project_id,
-					input.branch_id,
-					input.oauth_provider_id,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						providerId: input.oauth_provider_id,
+					},
 					{ signal },
 				),
 		}),
@@ -1193,8 +1334,7 @@ export const toolFactories = {
 			generated: "listBranchNeonAuthTrustedDomains",
 			run: (neon, input, signal) =>
 				neon.auth.trustedDomains.list(
-					input.project_id,
-					input.branch_id,
+					{ projectId: input.project_id, branchId: input.branch_id },
 					{
 						signal,
 					},
@@ -1206,9 +1346,9 @@ export const toolFactories = {
 			generated: "addBranchNeonAuthTrustedDomain",
 			run: (neon, input, signal) =>
 				neon.auth.trustedDomains.add(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						domain: input.domain,
 						auth_provider: input.auth_provider,
 					},
@@ -1221,9 +1361,9 @@ export const toolFactories = {
 			generated: "deleteBranchNeonAuthTrustedDomain",
 			run: (neon, input, signal) =>
 				neon.auth.trustedDomains.delete(
-					input.project_id,
-					input.branch_id,
 					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
 						auth_provider: input.auth_provider,
 						domains: input.domains,
 					},
@@ -1236,9 +1376,12 @@ export const toolFactories = {
 			generated: "createBranchNeonAuthNewUser",
 			run: (neon, input, signal) =>
 				neon.auth.users.create(
-					input.project_id,
-					input.branch_id,
-					{ email: input.email, name: input.name },
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						email: input.email,
+						name: input.name,
+					},
 					{ signal },
 				),
 		}),
@@ -1248,9 +1391,11 @@ export const toolFactories = {
 			generated: "deleteBranchNeonAuthUser",
 			run: (neon, input, signal) =>
 				neon.auth.users.delete(
-					input.project_id,
-					input.branch_id,
-					input.auth_user_id,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						authUserId: input.auth_user_id,
+					},
 					{ signal },
 				),
 		}),
@@ -1260,10 +1405,12 @@ export const toolFactories = {
 			generated: "updateNeonAuthUserRole",
 			run: (neon, input, signal) =>
 				neon.auth.users.updateRole(
-					input.project_id,
-					input.branch_id,
-					input.auth_user_id,
-					input.roles,
+					{
+						projectId: input.project_id,
+						branchId: input.branch_id,
+						authUserId: input.auth_user_id,
+						roles: input.roles,
+					},
 					{ signal },
 				),
 		}),
@@ -1349,14 +1496,14 @@ export const toolFactories = {
 			id: "apiKeys.create",
 			generated: "createApiKey",
 			run: (neon, input, signal) =>
-				neon.apiKeys.create(input.key_name, { signal }),
+				neon.apiKeys.create({ keyName: input.key_name }, { signal }),
 		}),
 	"apiKeys.revoke": (options) =>
 		fromGenerated(options, {
 			id: "apiKeys.revoke",
 			generated: "revokeApiKey",
 			run: (neon, input, signal) =>
-				neon.apiKeys.revoke(input.key_id, { signal }),
+				neon.apiKeys.revoke({ keyId: input.key_id }, { signal }),
 		}),
 	"regions.list": (options) =>
 		bindTool(

--- a/packages/tools/src/lib/ergonomic/composed.ts
+++ b/packages/tools/src/lib/ergonomic/composed.ts
@@ -175,8 +175,8 @@ export const createBranchTool = (options: ToolClientOptions) =>
 		(neon, input, signal) => {
 			if (input.no_compute === true) {
 				return neon.branches.create(
-					input.project_id,
 					{
+						projectId: input.project_id,
 						name: input.name,
 						parent_id: input.parent_id,
 						noCompute: true,
@@ -185,8 +185,8 @@ export const createBranchTool = (options: ToolClientOptions) =>
 				);
 			}
 			return neon.branches.create(
-				input.project_id,
 				{
+					projectId: input.project_id,
 					name: input.name,
 					parent_id: input.parent_id,
 					compute: mapCompute(input.compute),
@@ -218,18 +218,16 @@ export const createBranchAndConnectTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) =>
 			neon.branches.createAndConnect(
-				input.project_id,
 				{
+					projectId: input.project_id,
 					name: input.name,
 					parentId: input.parent_id,
 					compute: mapCompute(input.compute),
-				},
-				{
-					signal,
 					...(input.pooled === undefined
 						? {}
 						: { pooled: input.pooled }),
 				},
+				{ signal },
 			),
 	);
 
@@ -276,13 +274,8 @@ export const createProjectAndConnectTool = (options: ToolClientOptions) =>
 				tags: ["Project"],
 			},
 		},
-		(neon, input, signal) => {
-			const { pooled, ...project } = input;
-			return neon.projects.createAndConnect(project, {
-				signal,
-				...(pooled === undefined ? {} : { pooled }),
-			});
-		},
+		(neon, input, signal) =>
+			neon.projects.createAndConnect(input, { signal }),
 	);
 
 export const getDefaultTool = (options: ToolClientOptions) =>
@@ -306,7 +299,10 @@ export const getDefaultTool = (options: ToolClientOptions) =>
 			},
 		},
 		(neon, input, signal) =>
-			neon.branches.getDefault(input.project_id, { signal }),
+			neon.branches.getDefault(
+				{ projectId: input.project_id },
+				{ signal },
+			),
 	);
 
 export const resetFromParentTool = (options: ToolClientOptions) =>
@@ -331,11 +327,13 @@ export const resetFromParentTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) =>
 			neon.branches.resetFromParent(
-				input.project_id,
-				input.branch_id,
-				input.preserve_under_name === undefined
-					? undefined
-					: { preserveUnderName: input.preserve_under_name },
+				{
+					projectId: input.project_id,
+					branchId: input.branch_id,
+					...(input.preserve_under_name === undefined
+						? undefined
+						: { preserveUnderName: input.preserve_under_name }),
+				},
 				{ signal },
 			),
 	);
@@ -362,9 +360,9 @@ export const compareSchemaTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) =>
 			neon.branches.compareSchema(
-				input.project_id,
-				input.branch_id,
 				{
+					projectId: input.project_id,
+					branchId: input.branch_id,
 					databaseName: input.database_name,
 					...(input.base_branch_id === undefined
 						? {}
@@ -450,9 +448,9 @@ export const restoreSnapshotTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) =>
 			neon.snapshots.restore(
-				input.project_id,
-				input.snapshot_id,
 				{
+					projectId: input.project_id,
+					snapshotId: input.snapshot_id,
 					name: input.name,
 					targetBranchId: input.target_branch_id,
 					finalize: input.finalize,
@@ -483,9 +481,11 @@ export const setScheduleTool = (options: ToolClientOptions) =>
 		},
 		(neon, input, signal) =>
 			neon.snapshots.setSchedule(
-				input.project_id,
-				input.branch_id,
-				{ schedule: input.schedule },
+				{
+					projectId: input.project_id,
+					branchId: input.branch_id,
+					schedule: input.schedule,
+				},
 				{ signal },
 			),
 	);


### PR DESCRIPTION
## Problem

`@neon/sdk` v4 spreads resource identifiers, request fields and workflow choices across positional arguments. Calls such as `branches.get(projectId, branchId)` take two strings, so TypeScript accepts them in the wrong order. Update calls also require a separate payload object and list calls put query filters before execution options.

This PR moves ergonomic resource methods to one named input object followed by optional execution options. It includes a major changeset for `@neon/sdk` v5.

## Interface

### Migrating from v4

```ts
// v4
await neon.branches.get(projectId, branchId);
await neon.branches.update(projectId, branchId, { name: "preview" });
await neon.branches.list(projectId, { limit: 10 }).all();
await neon.projects.createAndConnect({ name: "app" }, { pooled: false });
await neon.operations.waitFor(operations);

// v5
await neon.branches.get({ projectId, branchId });
await neon.branches.update({ projectId, branchId, name: "preview" });
await neon.branches.list({ projectId, limit: 10 }).all();
await neon.projects.createAndConnect({ name: "app", pooled: false });
await neon.operations.waitFor({ operations });
```

Selectors and payload fields share the first object. Existing payload spelling stays the same, including `parent_id` and `owner_name`. For database rename, `databaseName` selects the current database and `name` supplies the replacement:

```ts
await neon.postgres.databases.update({
  projectId,
  branchId,
  databaseName: "app",
  name: "app_archive",
});
```

Named parameter types are exported from the package root:

```ts
import type { BranchGetParams } from "@neon/sdk";

const params: BranchGetParams = { projectId, branchId };
const { data, error } = await neon.branches.get(params);
```

### Workflow fields and execution options

`pooled` moves into the project and branch `createAndConnect` input, with its default still `true`. Membership confirmations also move into the input:

```ts
await neon.projects.members.setRole({
  projectId,
  memberId,
  role: "viewer",
  confirmSelfDemotion: true,
});
await neon.projects.members.removeRole({
  projectId,
  memberId,
  confirmSelfLockout: true,
});
```

Client configuration stays unchanged. `CallOptions` still accepts `throwOnError`, `waitForReadiness`, `requestTimeoutMs`, `wait` and `signal`. Per-call values override client defaults; `signal` remains call-only.

```ts
import { createNeonClient } from "@neon/sdk";

const neon = createNeonClient({
  apiKey: process.env.NEON_API_KEY!,
  orgId,
  throwOnError: true,
  requestTimeoutMs: 30_000,
});

const { project, connectionString } = await neon.projects.createAndConnect(
  { name: "app", pooled: false },
  {
    waitForReadiness: true,
    wait: { timeoutMs: 120_000 },
    signal: controller.signal,
  },
);
```

The default result remains `{ data, error }`. `throwOnError: true` still returns the bare resource and throws typed errors. Paginated methods keep `.page()`, `.all()` and async iteration, with `CallOptions` second.

`operations.waitFor({ operations }, options?)` keeps its specific options: `pollIntervalMs`, `timeoutMs`, `signal` and `throwOnError`. It excludes `requestTimeoutMs`, `waitForReadiness` and nested `wait`.

Zero-input methods such as `user.me()` and `regions.list()` keep their call shape. Existing object-input calls such as `postgres.connectionString({ projectId })` keep theirs. The generated raw client and `@neon/sdk/raw` are unchanged.

### Migration errors

Removed positional calls and missing selectors return `NeonClientError` with `kind: "client"` before a request. Passing `pooled`, `confirmSelfDemotion` or `confirmSelfLockout` on execution options also returns a client error, including through a shared options variable that TypeScript accepts structurally.

Observed with the built SDK:

```text
client: branches.get expects a named parameter object.
client: branches.get requires branchId in its parameter object (string).
client: pooled belongs in the operation input, not in execution options.
```

These errors follow `throwOnError`. Invalid paginated calls stay lazy: `.page()` and `.all()` report the error on consumption; async iteration throws it.

## Also in here

- `@neon/tools` bindings use the new SDK calls while retaining their published tool names and input schemas. Its changeset is a patch.
- The SDK README, request-mapping tests, type tests and live e2e call sites use named inputs.
- Pagination preserves `NeonClientError` when an invalid named input or execution option is consumed.

## Verification

Run locally at `df04c911` against `origin/main` at `7615d4bc`:

| Command | Result |
| --- | --- |
| `pnpm --filter @neon/sdk build` | Passed, including the distribution guard |
| `pnpm --filter @neon/tools build` | Passed |
| `pnpm --filter @neon/sdk test:ci` | 331 tests passed |
| `pnpm --filter @neon/sdk test:types` | 35 tests passed; no type errors |
| `pnpm --filter @neon/tools exec vitest run` | 149 tests passed after rebuilding the SDK |

Coverage includes removed positional inputs, missing selectors, relocated options on shared variables, database rename path/body separation, confirmation query parameters, pooled connection strings, lazy pagination and `throwOnError` inference. Existing readiness, cancellation and timeout tests also pass, including the local HTTP-server suite.

The built SDK was invoked directly to verify the three migration errors above. Live Neon e2e suites were updated but were not run during this description update; the local results do not establish live API compatibility. The full monorepo suite and tools regeneration check were not run here. Both builds emitted tsdown warnings about the deprecated `bundle` option and an invalid `define` option.

## For your attention

- This removes positional overloads. Applications must migrate affected calls before upgrading from 4.x to 5.0.0, including shared options objects containing the relocated fields.
- The major version is declared through a changeset. Package versioning and publication remain separate release steps.
- Runtime validation checks the named-object boundary and required selectors. Payload validation beyond those checks remains with the existing types and API.
