### PR TITLE
feat(functions): parse Function Trigger deliveries

### DIFF
--- a/.changeset/functions-triggers.md
+++ b/.changeset/functions-triggers.md
@@ -1,0 +1,5 @@
+---
+"@neon/functions": minor
+---
+
+Add `@neon/functions/triggers` (`parseTriggerInvocation`) for Function Trigger deliveries, and `parseTrigger(c)` on `@neon/functions/hono`.

--- a/.changeset/functions-triggers.md
+++ b/.changeset/functions-triggers.md
@@ -2,4 +2,4 @@
 "@neon/functions": minor
 ---
 
-Add `@neon/functions/triggers` (`parseTriggerInvocation`) for Function Trigger deliveries, and `parseTrigger(c)` on `@neon/functions/hono`.
+Add `@neon/functions/triggers` (`parseTriggerInvocation(request)` or `{ headers, data }`) for Function Trigger deliveries, and `parseTrigger(c)` on `@neon/functions/hono`.

--- a/.changeset/functions-triggers.md
+++ b/.changeset/functions-triggers.md
@@ -2,4 +2,4 @@
 "@neon/functions": minor
 ---
 
-Add `@neon/functions/triggers` (`parseTriggerInvocation(request)` or `{ headers, data }`) for Function Trigger deliveries, and `parseTrigger(c)` on `@neon/functions/hono`.
+Add `@neon/functions/triggers` (`parseTriggerInvocation(request)` or `{ headers, body }`) for Function Trigger deliveries, and `parseTrigger(c)` on `@neon/functions/hono`.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you're looking for a single package's docs, see its own `README.md` under `pa
 | --- | --- |
 | `@neon/sdk` | The official TypeScript SDK for the Neon API — a modern, Fetch-based client generated from Neon's OpenAPI spec (successor to `@neondatabase/api-client`). |
 | `@neon/tools` | Type-safe agent tools for the `@neon/sdk` ergonomic client, with MCP, Eve, and Mastra adapters. |
-| `@neon/functions` | Runtime helpers for Neon Functions: `waitUntil`, `upgradeWebSocket` (fetch handler or Hono route via `@neon/functions/hono`), and `attachDatabasePool`. |
+| `@neon/functions` | Runtime helpers for Neon Functions: `waitUntil`, `upgradeWebSocket` (fetch handler or Hono route via `@neon/functions/hono`), `attachDatabasePool`, and `parseTriggerInvocation` (`@neon/functions/triggers`). |
 | `@neon/ai-sdk-provider` | Community [Vercel AI SDK](https://ai-sdk.dev) provider for the Neon AI Gateway. |
 
 `neon-new` and `vite-plugin-neon-new` are **deprecated**. Use Claimable Neon in the Neon CLI: `npx neon@latest claim create`. The old alias packages (`get-db`, `neondb`, `vite-plugin-db`, `@neondatabase/vite-plugin-postgres`) still re-export them.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -6,6 +6,7 @@ Runtime helpers for [Neon Functions](https://neon.com):
 - **`upgradeWebSocket`** — serve WebSockets from a `fetch` handler, or from a
   [Hono](https://hono.dev) route via `@neon/functions/hono`.
 - **`attachDatabasePool`** — keep a module-scope `pg.Pool` from killing the isolate when Postgres drops an idle client.
+- **`parseTriggerInvocation`** — parse a Function Trigger delivery (`@neon/functions/triggers`), or `parseTrigger(c)` on a Hono context via `@neon/functions/hono`.
 
 ## Install
 
@@ -327,6 +328,63 @@ If `onUnexpectedError` throws, or returns a promise that rejects, both the pool 
 the reporter error are logged. Neither is rethrown from the listener, so the isolate stays up.
 
 This does not close the pool. Isolate teardown tears the connections down with the process.
+
+## Function Trigger deliveries
+
+A [Function Trigger](https://neon.com/docs/cli/triggers) POSTs JSON to your function. The
+Functions proxy drops client-supplied `x-neon-*` headers, so
+`x-neon-trigger-invocation-id` only arrives on a real delivery. The header value must
+match `invocation_id` in the body.
+
+```ts
+import {
+	TRIGGER_INVOCATION_ID_HEADER,
+	parseTriggerInvocation,
+} from "@neon/functions/triggers";
+
+export default {
+	async fetch(request: Request): Promise<Response> {
+		let body: unknown;
+		try {
+			body = await request.json();
+		} catch {
+			return new Response("Invalid JSON body", { status: 400 });
+		}
+
+		const parsed = parseTriggerInvocation({
+			header: request.headers.get(TRIGGER_INVOCATION_ID_HEADER),
+			body,
+		});
+		if (!parsed.ok) {
+			const status = parsed.error === "invalid_body" ? 400 : 401;
+			return new Response(parsed.error, { status });
+		}
+
+		return Response.json({ ok: true, invocationId: parsed.invocation.invocationId });
+	},
+};
+```
+
+`parseTriggerInvocation` returns `{ ok: true, invocation }` or `{ ok: false, error }`.
+`error` is `missing_header`, `invalid_body`, or `invocation_id_mismatch`. Unknown
+`trigger.type` values fail as `invalid_body` until this package adds them.
+
+### `parseTrigger` (Hono)
+
+On a Hono route, `parseTrigger(c)` reads the header and JSON body, throws
+`HTTPException` (401 / 400) on failure, and returns the invocation.
+
+```ts
+import { Hono } from "hono";
+import { parseTrigger } from "@neon/functions/hono";
+
+const app = new Hono();
+
+app.post("/cron", async (c) => {
+	const invocation = await parseTrigger(c);
+	return c.json({ ok: true, invocationId: invocation.invocationId });
+});
+```
 
 ## Runtime integration
 

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -337,24 +337,11 @@ Functions proxy drops client-supplied `x-neon-*` headers, so
 match `invocation_id` in the body.
 
 ```ts
-import {
-	TRIGGER_INVOCATION_ID_HEADER,
-	parseTriggerInvocation,
-} from "@neon/functions/triggers";
+import { parseTriggerInvocation } from "@neon/functions/triggers";
 
 export default {
 	async fetch(request: Request): Promise<Response> {
-		let body: unknown;
-		try {
-			body = await request.json();
-		} catch {
-			return new Response("Invalid JSON body", { status: 400 });
-		}
-
-		const parsed = parseTriggerInvocation({
-			header: request.headers.get(TRIGGER_INVOCATION_ID_HEADER),
-			body,
-		});
+		const parsed = await parseTriggerInvocation(request);
 		if (!parsed.ok) {
 			const status = parsed.error === "invalid_body" ? 400 : 401;
 			return new Response(parsed.error, { status });
@@ -363,6 +350,18 @@ export default {
 		return Response.json({ ok: true, invocationId: parsed.invocation.invocationId });
 	},
 };
+```
+
+`parseTriggerInvocation(request)` clones the Request before reading JSON, so
+`request.json()` still works afterwards.
+
+If you already have the JSON body, pass headers and data instead:
+
+```ts
+const parsed = parseTriggerInvocation({
+	headers: request.headers,
+	data,
+});
 ```
 
 `parseTriggerInvocation` returns `{ ok: true, invocation }` or `{ ok: false, error }`.

--- a/packages/functions/README.md
+++ b/packages/functions/README.md
@@ -331,10 +331,9 @@ This does not close the pool. Isolate teardown tears the connections down with t
 
 ## Function Trigger deliveries
 
-A [Function Trigger](https://neon.com/docs/cli/triggers) POSTs JSON to your function. The
-Functions proxy drops client-supplied `x-neon-*` headers, so
-`x-neon-trigger-invocation-id` only arrives on a real delivery. The header value must
-match `invocation_id` in the body.
+A [Function Trigger](https://neon.com/docs/cli/triggers) POSTs JSON to your function.
+`parseTriggerInvocation` checks `x-neon-trigger-invocation-id` against
+`invocation_id` in that JSON.
 
 ```ts
 import { parseTriggerInvocation } from "@neon/functions/triggers";
@@ -352,26 +351,36 @@ export default {
 };
 ```
 
-`parseTriggerInvocation(request)` clones the Request before reading JSON, so
-`request.json()` still works afterwards.
+`parseTriggerInvocation(request)` checks the header first, then clones the Request
+and reads JSON from the clone, so `request.json()` still works afterwards.
 
-If you already have the JSON body, pass headers and data instead:
+If you already have the JSON:
 
 ```ts
+const body = await request.json();
 const parsed = parseTriggerInvocation({
 	headers: request.headers,
-	data,
+	body,
 });
 ```
 
-`parseTriggerInvocation` returns `{ ok: true, invocation }` or `{ ok: false, error }`.
-`error` is `missing_header`, `invalid_body`, or `invocation_id_mismatch`. Unknown
-`trigger.type` values fail as `invalid_body` until this package adds them.
+On success, `parsed.invocation` is camelCase: `invocationId`, `trigger.id`,
+`trigger.name`, `trigger.type` (`"schedule"`), `data.scheduledAt`.
+
+On failure, `parsed.error` is `missing_header`, `invalid_body`, or
+`invocation_id_mismatch`. Invalid JSON on the Request path is `invalid_body`.
+Unknown `trigger.type` values fail as `invalid_body` until this package adds them.
 
 ### `parseTrigger` (Hono)
 
-On a Hono route, `parseTrigger(c)` reads the header and JSON body, throws
-`HTTPException` (401 / 400) on failure, and returns the invocation.
+`parseTrigger(c)` runs the Request overload on `c.req.raw` and throws
+`HTTPException`. `c.req.json()` still works afterwards.
+
+| Failure | Status | Message |
+| --- | --- | --- |
+| missing header | 401 | `Missing x-neon-trigger-invocation-id header` |
+| header ≠ `invocation_id` | 401 | `Invocation id mismatch` |
+| invalid JSON or payload | 400 | `Invalid trigger payload` |
 
 ```ts
 import { Hono } from "hono";

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@neon/functions",
 	"version": "0.9.0",
-	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, `upgradeWebSocket` for serving WebSockets from a fetch handler or a Hono route, and `attachDatabasePool` for node-postgres idle-client errors.",
+	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, `upgradeWebSocket` for serving WebSockets from a fetch handler or a Hono route, `attachDatabasePool` for node-postgres idle-client errors, and `parseTriggerInvocation` for Function Trigger deliveries.",
 	"keywords": [
 		"neon",
 		"database",
@@ -9,7 +9,8 @@
 		"functions",
 		"serverless",
 		"platform",
-		"websocket"
+		"websocket",
+		"triggers"
 	],
 	"repository": {
 		"type": "git",
@@ -33,6 +34,11 @@
 			"types": "./dist/hono.d.ts",
 			"import": "./dist/hono.js",
 			"default": "./dist/hono.js"
+		},
+		"./triggers": {
+			"types": "./dist/triggers.d.ts",
+			"import": "./dist/triggers.js",
+			"default": "./dist/triggers.js"
 		}
 	},
 	"files": [

--- a/packages/functions/src/hono.ts
+++ b/packages/functions/src/hono.ts
@@ -1,5 +1,6 @@
 /**
- * `@neon/functions/hono` — the Hono binding for `upgradeWebSocket`.
+ * `@neon/functions/hono` — Hono bindings for `upgradeWebSocket` and
+ * `parseTrigger`.
  *
  * Split from the root entry so importing `@neon/functions` never reaches for
  * `hono`, which is an optional peer.
@@ -9,6 +10,11 @@ import type { WSContext, WSEvents } from "hono/ws";
 
 export type { SendOptions, WSMessageReceive, WSReadyState } from "hono/ws";
 export { upgradeWebSocket } from "./lib/hono-websocket.js";
+export { parseTrigger } from "./lib/parse-trigger.js";
+export type {
+	ScheduleTriggerInvocation,
+	TriggerInvocation,
+} from "./lib/parse-trigger-invocation.js";
 export type { UpgradeWebSocketOptions } from "./lib/upgrade-websocket.js";
 
 /**

--- a/packages/functions/src/lib/parse-trigger-invocation.test.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.test.ts
@@ -1,11 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import {
-	parseTriggerInvocation,
-	TRIGGER_INVOCATION_ID_HEADER,
-} from "./parse-trigger-invocation.js";
+import { parseTriggerInvocation } from "./parse-trigger-invocation.js";
 
 const invocationId = "ucBDafV0gB8qoEM4UcdIu84Qx5JCAXYwpRnPVAagPa0";
+const invocationIdHeader = "x-neon-trigger-invocation-id";
 
 const scheduleBody = {
 	version: 1,
@@ -18,32 +16,56 @@ const scheduleBody = {
 	data: { scheduled_at: "2026-09-11T08:34:00Z" },
 };
 
-describe("parseTriggerInvocation", () => {
+const parsedSchedule = {
+	version: 1,
+	invocationId,
+	trigger: {
+		type: "schedule",
+		id: "trigger-66360036-ee42-4174-8ed5-416fa31757eb",
+		name: "every-minute",
+	},
+	data: { scheduledAt: "2026-09-11T08:34:00Z" },
+} as const;
+
+function scheduleHeaders(header?: string): Headers {
+	const headers = new Headers({ "content-type": "application/json" });
+	if (header !== undefined) {
+		headers.set(invocationIdHeader, header);
+	}
+	return headers;
+}
+
+function scheduleRequest(init?: {
+	header?: string;
+	body?: string | object;
+}): Request {
+	return new Request("https://example.test/cron", {
+		method: "POST",
+		headers: scheduleHeaders(init?.header ?? invocationId),
+		body:
+			typeof init?.body === "string"
+				? init.body
+				: JSON.stringify(init?.body ?? scheduleBody),
+	});
+}
+
+describe("parseTriggerInvocation({ headers, data })", () => {
 	it("accepts a schedule delivery whose header matches invocation_id", () => {
 		const result = parseTriggerInvocation({
-			header: invocationId,
-			body: scheduleBody,
+			headers: scheduleHeaders(invocationId),
+			data: scheduleBody,
 		});
 
 		expect(result).toEqual({
 			ok: true,
-			invocation: {
-				version: 1,
-				invocationId,
-				trigger: {
-					type: "schedule",
-					id: "trigger-66360036-ee42-4174-8ed5-416fa31757eb",
-					name: "every-minute",
-				},
-				data: { scheduledAt: "2026-09-11T08:34:00Z" },
-			},
+			invocation: parsedSchedule,
 		});
 	});
 
 	it("trims the header before comparing", () => {
 		const result = parseTriggerInvocation({
-			header: ` ${invocationId} `,
-			body: scheduleBody,
+			headers: scheduleHeaders(` ${invocationId} `),
+			data: scheduleBody,
 		});
 
 		expect(result.ok).toBe(true);
@@ -51,36 +73,45 @@ describe("parseTriggerInvocation", () => {
 
 	it("fails missing_header when the header is absent or blank", () => {
 		expect(
-			parseTriggerInvocation({ header: undefined, body: scheduleBody }),
+			parseTriggerInvocation({
+				headers: scheduleHeaders(),
+				data: scheduleBody,
+			}),
 		).toEqual({ ok: false, error: "missing_header" });
 		expect(
-			parseTriggerInvocation({ header: "  ", body: scheduleBody }),
+			parseTriggerInvocation({
+				headers: scheduleHeaders("  "),
+				data: scheduleBody,
+			}),
 		).toEqual({ ok: false, error: "missing_header" });
 	});
 
 	it("fails invocation_id_mismatch when the header does not match the body", () => {
 		expect(
 			parseTriggerInvocation({
-				header: "other-id",
-				body: scheduleBody,
+				headers: scheduleHeaders("other-id"),
+				data: scheduleBody,
 			}),
 		).toEqual({ ok: false, error: "invocation_id_mismatch" });
 	});
 
 	it("fails invalid_body for a malformed payload even when the header is set", () => {
 		expect(
-			parseTriggerInvocation({ header: invocationId, body: null }),
-		).toEqual({ ok: false, error: "invalid_body" });
-		expect(
 			parseTriggerInvocation({
-				header: invocationId,
-				body: { ...scheduleBody, version: 2 },
+				headers: scheduleHeaders(invocationId),
+				data: null,
 			}),
 		).toEqual({ ok: false, error: "invalid_body" });
 		expect(
 			parseTriggerInvocation({
-				header: invocationId,
-				body: {
+				headers: scheduleHeaders(invocationId),
+				data: { ...scheduleBody, version: 2 },
+			}),
+		).toEqual({ ok: false, error: "invalid_body" });
+		expect(
+			parseTriggerInvocation({
+				headers: scheduleHeaders(invocationId),
+				data: {
 					...scheduleBody,
 					trigger: {
 						...scheduleBody.trigger,
@@ -90,10 +121,45 @@ describe("parseTriggerInvocation", () => {
 			}),
 		).toEqual({ ok: false, error: "invalid_body" });
 	});
+});
 
-	it("exports the delivery header name", () => {
-		expect(TRIGGER_INVOCATION_ID_HEADER).toBe(
-			"x-neon-trigger-invocation-id",
-		);
+describe("parseTriggerInvocation(request)", () => {
+	it("accepts a schedule delivery Request", async () => {
+		const result = await parseTriggerInvocation(scheduleRequest());
+
+		expect(result).toEqual({
+			ok: true,
+			invocation: parsedSchedule,
+		});
+	});
+
+	it("leaves the original Request body readable", async () => {
+		const request = scheduleRequest();
+		const parsed = await parseTriggerInvocation(request);
+
+		expect(parsed.ok).toBe(true);
+		expect(await request.json()).toEqual(scheduleBody);
+	});
+
+	it("fails invalid_body when the Request body is not JSON", async () => {
+		expect(
+			await parseTriggerInvocation(scheduleRequest({ body: "not-json" })),
+		).toEqual({
+			ok: false,
+			error: "invalid_body",
+		});
+	});
+
+	it("fails missing_header when the Request has no trigger header", async () => {
+		const request = new Request("https://example.test/cron", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(scheduleBody),
+		});
+
+		expect(await parseTriggerInvocation(request)).toEqual({
+			ok: false,
+			error: "missing_header",
+		});
 	});
 });

--- a/packages/functions/src/lib/parse-trigger-invocation.test.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.test.ts
@@ -49,11 +49,11 @@ function scheduleRequest(init?: {
 	});
 }
 
-describe("parseTriggerInvocation({ headers, data })", () => {
+describe("parseTriggerInvocation({ headers, body })", () => {
 	it("accepts a schedule delivery whose header matches invocation_id", () => {
 		const result = parseTriggerInvocation({
 			headers: scheduleHeaders(invocationId),
-			data: scheduleBody,
+			body: scheduleBody,
 		});
 
 		expect(result).toEqual({
@@ -65,7 +65,7 @@ describe("parseTriggerInvocation({ headers, data })", () => {
 	it("trims the header before comparing", () => {
 		const result = parseTriggerInvocation({
 			headers: scheduleHeaders(` ${invocationId} `),
-			data: scheduleBody,
+			body: scheduleBody,
 		});
 
 		expect(result.ok).toBe(true);
@@ -75,13 +75,13 @@ describe("parseTriggerInvocation({ headers, data })", () => {
 		expect(
 			parseTriggerInvocation({
 				headers: scheduleHeaders(),
-				data: scheduleBody,
+				body: scheduleBody,
 			}),
 		).toEqual({ ok: false, error: "missing_header" });
 		expect(
 			parseTriggerInvocation({
 				headers: scheduleHeaders("  "),
-				data: scheduleBody,
+				body: scheduleBody,
 			}),
 		).toEqual({ ok: false, error: "missing_header" });
 	});
@@ -90,7 +90,7 @@ describe("parseTriggerInvocation({ headers, data })", () => {
 		expect(
 			parseTriggerInvocation({
 				headers: scheduleHeaders("other-id"),
-				data: scheduleBody,
+				body: scheduleBody,
 			}),
 		).toEqual({ ok: false, error: "invocation_id_mismatch" });
 	});
@@ -99,19 +99,19 @@ describe("parseTriggerInvocation({ headers, data })", () => {
 		expect(
 			parseTriggerInvocation({
 				headers: scheduleHeaders(invocationId),
-				data: null,
+				body: null,
 			}),
 		).toEqual({ ok: false, error: "invalid_body" });
 		expect(
 			parseTriggerInvocation({
 				headers: scheduleHeaders(invocationId),
-				data: { ...scheduleBody, version: 2 },
+				body: { ...scheduleBody, version: 2 },
 			}),
 		).toEqual({ ok: false, error: "invalid_body" });
 		expect(
 			parseTriggerInvocation({
 				headers: scheduleHeaders(invocationId),
-				data: {
+				body: {
 					...scheduleBody,
 					trigger: {
 						...scheduleBody.trigger,

--- a/packages/functions/src/lib/parse-trigger-invocation.test.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+	parseTriggerInvocation,
+	TRIGGER_INVOCATION_ID_HEADER,
+} from "./parse-trigger-invocation.js";
+
+const invocationId = "ucBDafV0gB8qoEM4UcdIu84Qx5JCAXYwpRnPVAagPa0";
+
+const scheduleBody = {
+	version: 1,
+	invocation_id: invocationId,
+	trigger: {
+		type: "schedule",
+		id: "trigger-66360036-ee42-4174-8ed5-416fa31757eb",
+		name: "every-minute",
+	},
+	data: { scheduled_at: "2026-09-11T08:34:00Z" },
+};
+
+describe("parseTriggerInvocation", () => {
+	it("accepts a schedule delivery whose header matches invocation_id", () => {
+		const result = parseTriggerInvocation({
+			header: invocationId,
+			body: scheduleBody,
+		});
+
+		expect(result).toEqual({
+			ok: true,
+			invocation: {
+				version: 1,
+				invocationId,
+				trigger: {
+					type: "schedule",
+					id: "trigger-66360036-ee42-4174-8ed5-416fa31757eb",
+					name: "every-minute",
+				},
+				data: { scheduledAt: "2026-09-11T08:34:00Z" },
+			},
+		});
+	});
+
+	it("trims the header before comparing", () => {
+		const result = parseTriggerInvocation({
+			header: ` ${invocationId} `,
+			body: scheduleBody,
+		});
+
+		expect(result.ok).toBe(true);
+	});
+
+	it("fails missing_header when the header is absent or blank", () => {
+		expect(
+			parseTriggerInvocation({ header: undefined, body: scheduleBody }),
+		).toEqual({ ok: false, error: "missing_header" });
+		expect(
+			parseTriggerInvocation({ header: "  ", body: scheduleBody }),
+		).toEqual({ ok: false, error: "missing_header" });
+	});
+
+	it("fails invocation_id_mismatch when the header does not match the body", () => {
+		expect(
+			parseTriggerInvocation({
+				header: "other-id",
+				body: scheduleBody,
+			}),
+		).toEqual({ ok: false, error: "invocation_id_mismatch" });
+	});
+
+	it("fails invalid_body for a malformed payload even when the header is set", () => {
+		expect(
+			parseTriggerInvocation({ header: invocationId, body: null }),
+		).toEqual({ ok: false, error: "invalid_body" });
+		expect(
+			parseTriggerInvocation({
+				header: invocationId,
+				body: { ...scheduleBody, version: 2 },
+			}),
+		).toEqual({ ok: false, error: "invalid_body" });
+		expect(
+			parseTriggerInvocation({
+				header: invocationId,
+				body: {
+					...scheduleBody,
+					trigger: {
+						...scheduleBody.trigger,
+						type: "object_storage",
+					},
+				},
+			}),
+		).toEqual({ ok: false, error: "invalid_body" });
+	});
+
+	it("exports the delivery header name", () => {
+		expect(TRIGGER_INVOCATION_ID_HEADER).toBe(
+			"x-neon-trigger-invocation-id",
+		);
+	});
+});

--- a/packages/functions/src/lib/parse-trigger-invocation.test.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.test.ts
@@ -162,4 +162,17 @@ describe("parseTriggerInvocation(request)", () => {
 			error: "missing_header",
 		});
 	});
+
+	it("fails missing_header before reading JSON when the header is absent", async () => {
+		const request = new Request("https://example.test/cron", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: "not-json",
+		});
+
+		expect(await parseTriggerInvocation(request)).toEqual({
+			ok: false,
+			error: "missing_header",
+		});
+	});
 });

--- a/packages/functions/src/lib/parse-trigger-invocation.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.ts
@@ -1,6 +1,6 @@
 // The Functions proxy drops client-supplied x-neon-* headers, so a present
 // value is from a trigger delivery. It must match body.invocation_id.
-export const TRIGGER_INVOCATION_ID_HEADER = "x-neon-trigger-invocation-id";
+const TRIGGER_INVOCATION_ID_HEADER = "x-neon-trigger-invocation-id";
 
 export type ScheduleTriggerInvocation = {
 	version: 1;
@@ -18,8 +18,8 @@ export type ScheduleTriggerInvocation = {
 export type TriggerInvocation = ScheduleTriggerInvocation;
 
 export type ParseTriggerInvocationInput = {
-	header: string | null | undefined;
-	body: unknown;
+	headers: HeadersInit;
+	data: unknown;
 };
 
 export type ParseTriggerInvocationResult =
@@ -31,6 +31,12 @@ export type ParseTriggerInvocationResult =
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRequest(
+	input: Request | ParseTriggerInvocationInput,
+): input is Request {
+	return input instanceof Request;
 }
 
 function parseScheduleInvocation(
@@ -62,16 +68,18 @@ function parseScheduleInvocation(
 	};
 }
 
-export function parseTriggerInvocation({
-	header,
-	body,
-}: ParseTriggerInvocationInput): ParseTriggerInvocationResult {
-	const headerId = header?.trim();
+function parseFromHeadersAndData(
+	headers: HeadersInit,
+	data: unknown,
+): ParseTriggerInvocationResult {
+	const headerId = new Headers(headers)
+		.get(TRIGGER_INVOCATION_ID_HEADER)
+		?.trim();
 	if (!headerId) {
 		return { ok: false, error: "missing_header" };
 	}
 
-	const invocation = parseScheduleInvocation(body);
+	const invocation = parseScheduleInvocation(data);
 	if (!invocation) {
 		return { ok: false, error: "invalid_body" };
 	}
@@ -80,4 +88,32 @@ export function parseTriggerInvocation({
 	}
 
 	return { ok: true, invocation };
+}
+
+async function parseFromRequest(
+	request: Request,
+): Promise<ParseTriggerInvocationResult> {
+	let data: unknown;
+	try {
+		// Clone so the caller can still request.json() after this returns.
+		data = await request.clone().json();
+	} catch {
+		return { ok: false, error: "invalid_body" };
+	}
+	return parseFromHeadersAndData(request.headers, data);
+}
+
+export function parseTriggerInvocation(
+	request: Request,
+): Promise<ParseTriggerInvocationResult>;
+export function parseTriggerInvocation(
+	input: ParseTriggerInvocationInput,
+): ParseTriggerInvocationResult;
+export function parseTriggerInvocation(
+	input: Request | ParseTriggerInvocationInput,
+): ParseTriggerInvocationResult | Promise<ParseTriggerInvocationResult> {
+	if (isRequest(input)) {
+		return parseFromRequest(input);
+	}
+	return parseFromHeadersAndData(input.headers, input.data);
 }

--- a/packages/functions/src/lib/parse-trigger-invocation.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.ts
@@ -1,0 +1,83 @@
+// The Functions proxy drops client-supplied x-neon-* headers, so a present
+// value is from a trigger delivery. It must match body.invocation_id.
+export const TRIGGER_INVOCATION_ID_HEADER = "x-neon-trigger-invocation-id";
+
+export type ScheduleTriggerInvocation = {
+	version: 1;
+	invocationId: string;
+	trigger: {
+		type: "schedule";
+		id: string;
+		name: string;
+	};
+	data: {
+		scheduledAt: string;
+	};
+};
+
+export type TriggerInvocation = ScheduleTriggerInvocation;
+
+export type ParseTriggerInvocationInput = {
+	header: string | null | undefined;
+	body: unknown;
+};
+
+export type ParseTriggerInvocationResult =
+	| { ok: true; invocation: TriggerInvocation }
+	| {
+			ok: false;
+			error: "missing_header" | "invalid_body" | "invocation_id_mismatch";
+	  };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseScheduleInvocation(
+	body: unknown,
+): ScheduleTriggerInvocation | undefined {
+	if (!isRecord(body) || body.version !== 1) return undefined;
+
+	const invocationId = body.invocation_id;
+	if (typeof invocationId !== "string" || invocationId === "")
+		return undefined;
+
+	if (!isRecord(body.trigger) || body.trigger.type !== "schedule") {
+		return undefined;
+	}
+	const triggerId = body.trigger.id;
+	const triggerName = body.trigger.name;
+	if (typeof triggerId !== "string" || triggerId === "") return undefined;
+	if (typeof triggerName !== "string" || triggerName === "") return undefined;
+
+	if (!isRecord(body.data)) return undefined;
+	const scheduledAt = body.data.scheduled_at;
+	if (typeof scheduledAt !== "string" || scheduledAt === "") return undefined;
+
+	return {
+		version: 1,
+		invocationId,
+		trigger: { type: "schedule", id: triggerId, name: triggerName },
+		data: { scheduledAt },
+	};
+}
+
+export function parseTriggerInvocation({
+	header,
+	body,
+}: ParseTriggerInvocationInput): ParseTriggerInvocationResult {
+	const headerId = header?.trim();
+	if (!headerId) {
+		return { ok: false, error: "missing_header" };
+	}
+
+	const invocation = parseScheduleInvocation(body);
+	if (!invocation) {
+		return { ok: false, error: "invalid_body" };
+	}
+	if (invocation.invocationId !== headerId) {
+		return { ok: false, error: "invocation_id_mismatch" };
+	}
+
+	return { ok: true, invocation };
+}

--- a/packages/functions/src/lib/parse-trigger-invocation.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.ts
@@ -93,6 +93,11 @@ function parseFromHeadersAndData(
 async function parseFromRequest(
 	request: Request,
 ): Promise<ParseTriggerInvocationResult> {
+	const headerId = request.headers.get(TRIGGER_INVOCATION_ID_HEADER)?.trim();
+	if (!headerId) {
+		return { ok: false, error: "missing_header" };
+	}
+
 	let data: unknown;
 	try {
 		// Clone so the caller can still request.json() after this returns.

--- a/packages/functions/src/lib/parse-trigger-invocation.ts
+++ b/packages/functions/src/lib/parse-trigger-invocation.ts
@@ -19,7 +19,7 @@ export type TriggerInvocation = ScheduleTriggerInvocation;
 
 export type ParseTriggerInvocationInput = {
 	headers: HeadersInit;
-	data: unknown;
+	body: unknown;
 };
 
 export type ParseTriggerInvocationResult =
@@ -70,7 +70,7 @@ function parseScheduleInvocation(
 
 function parseFromHeadersAndData(
 	headers: HeadersInit,
-	data: unknown,
+	body: unknown,
 ): ParseTriggerInvocationResult {
 	const headerId = new Headers(headers)
 		.get(TRIGGER_INVOCATION_ID_HEADER)
@@ -79,7 +79,7 @@ function parseFromHeadersAndData(
 		return { ok: false, error: "missing_header" };
 	}
 
-	const invocation = parseScheduleInvocation(data);
+	const invocation = parseScheduleInvocation(body);
 	if (!invocation) {
 		return { ok: false, error: "invalid_body" };
 	}
@@ -98,14 +98,14 @@ async function parseFromRequest(
 		return { ok: false, error: "missing_header" };
 	}
 
-	let data: unknown;
+	let body: unknown;
 	try {
 		// Clone so the caller can still request.json() after this returns.
-		data = await request.clone().json();
+		body = await request.clone().json();
 	} catch {
 		return { ok: false, error: "invalid_body" };
 	}
-	return parseFromHeadersAndData(request.headers, data);
+	return parseFromHeadersAndData(request.headers, body);
 }
 
 export function parseTriggerInvocation(
@@ -120,5 +120,5 @@ export function parseTriggerInvocation(
 	if (isRequest(input)) {
 		return parseFromRequest(input);
 	}
-	return parseFromHeadersAndData(input.headers, input.data);
+	return parseFromHeadersAndData(input.headers, input.body);
 }

--- a/packages/functions/src/lib/parse-trigger.test.ts
+++ b/packages/functions/src/lib/parse-trigger.test.ts
@@ -1,0 +1,100 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { parseTrigger } from "./parse-trigger.js";
+import { TRIGGER_INVOCATION_ID_HEADER } from "./parse-trigger-invocation.js";
+
+const invocationId = "ucBDafV0gB8qoEM4UcdIu84Qx5JCAXYwpRnPVAagPa0";
+
+const scheduleBody = {
+	version: 1,
+	invocation_id: invocationId,
+	trigger: {
+		type: "schedule",
+		id: "trigger-66360036-ee42-4174-8ed5-416fa31757eb",
+		name: "every-minute",
+	},
+	data: { scheduled_at: "2026-09-11T08:34:00Z" },
+};
+
+const app = new Hono();
+app.post("/cron", async (c) => c.json(await parseTrigger(c)));
+
+describe("parseTrigger", () => {
+	it("returns the parsed schedule invocation", async () => {
+		const response = await app.request("/cron", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				[TRIGGER_INVOCATION_ID_HEADER]: invocationId,
+			},
+			body: JSON.stringify(scheduleBody),
+		});
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			version: 1,
+			invocationId,
+			trigger: {
+				type: "schedule",
+				id: "trigger-66360036-ee42-4174-8ed5-416fa31757eb",
+				name: "every-minute",
+			},
+			data: { scheduledAt: "2026-09-11T08:34:00Z" },
+		});
+	});
+
+	it("returns 401 when the trigger header is missing", async () => {
+		const response = await app.request("/cron", {
+			method: "POST",
+			headers: { "content-type": "application/json" },
+			body: JSON.stringify(scheduleBody),
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe(
+			`Missing ${TRIGGER_INVOCATION_ID_HEADER} header`,
+		);
+	});
+
+	it("returns 401 when the header does not match invocation_id", async () => {
+		const response = await app.request("/cron", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				[TRIGGER_INVOCATION_ID_HEADER]: "other-id",
+			},
+			body: JSON.stringify(scheduleBody),
+		});
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe("Invocation id mismatch");
+	});
+
+	it("returns 400 when the JSON body is not a schedule delivery", async () => {
+		const response = await app.request("/cron", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				[TRIGGER_INVOCATION_ID_HEADER]: invocationId,
+			},
+			body: JSON.stringify({}),
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toBe("Invalid trigger payload");
+	});
+
+	it("returns 400 when the body is not JSON", async () => {
+		const response = await app.request("/cron", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+				[TRIGGER_INVOCATION_ID_HEADER]: invocationId,
+			},
+			body: "not-json",
+		});
+
+		expect(response.status).toBe(400);
+		expect(await response.text()).toBe("Invalid JSON body");
+	});
+});

--- a/packages/functions/src/lib/parse-trigger.test.ts
+++ b/packages/functions/src/lib/parse-trigger.test.ts
@@ -1,9 +1,9 @@
 import { Hono } from "hono";
 import { describe, expect, it } from "vitest";
 import { parseTrigger } from "./parse-trigger.js";
-import { TRIGGER_INVOCATION_ID_HEADER } from "./parse-trigger-invocation.js";
 
 const invocationId = "ucBDafV0gB8qoEM4UcdIu84Qx5JCAXYwpRnPVAagPa0";
+const invocationIdHeader = "x-neon-trigger-invocation-id";
 
 const scheduleBody = {
 	version: 1,
@@ -18,17 +18,39 @@ const scheduleBody = {
 
 const app = new Hono();
 app.post("/cron", async (c) => c.json(await parseTrigger(c)));
+app.post("/cron-reread", async (c) => {
+	const invocation = await parseTrigger(c);
+	const data = await c.req.json();
+	return c.json({
+		invocationId: invocation.invocationId,
+		bodyId: data.invocation_id,
+	});
+});
+
+function cronRequest(init?: {
+	omitHeader?: boolean;
+	header?: string;
+	body?: string | object;
+}): RequestInit {
+	const headers: Record<string, string> = {
+		"content-type": "application/json",
+	};
+	if (!init?.omitHeader) {
+		headers[invocationIdHeader] = init?.header ?? invocationId;
+	}
+	return {
+		method: "POST",
+		headers,
+		body:
+			typeof init?.body === "string"
+				? init.body
+				: JSON.stringify(init?.body ?? scheduleBody),
+	};
+}
 
 describe("parseTrigger", () => {
 	it("returns the parsed schedule invocation", async () => {
-		const response = await app.request("/cron", {
-			method: "POST",
-			headers: {
-				"content-type": "application/json",
-				[TRIGGER_INVOCATION_ID_HEADER]: invocationId,
-			},
-			body: JSON.stringify(scheduleBody),
-		});
+		const response = await app.request("/cron", cronRequest());
 
 		expect(response.status).toBe(200);
 		expect(await response.json()).toEqual({
@@ -43,58 +65,52 @@ describe("parseTrigger", () => {
 		});
 	});
 
-	it("returns 401 when the trigger header is missing", async () => {
-		const response = await app.request("/cron", {
-			method: "POST",
-			headers: { "content-type": "application/json" },
-			body: JSON.stringify(scheduleBody),
+	it("leaves the Hono request body readable", async () => {
+		const response = await app.request("/cron-reread", cronRequest());
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			invocationId,
+			bodyId: invocationId,
 		});
+	});
+
+	it("returns 401 when the trigger header is missing", async () => {
+		const response = await app.request(
+			"/cron",
+			cronRequest({ omitHeader: true }),
+		);
 
 		expect(response.status).toBe(401);
 		expect(await response.text()).toBe(
-			`Missing ${TRIGGER_INVOCATION_ID_HEADER} header`,
+			`Missing ${invocationIdHeader} header`,
 		);
 	});
 
 	it("returns 401 when the header does not match invocation_id", async () => {
-		const response = await app.request("/cron", {
-			method: "POST",
-			headers: {
-				"content-type": "application/json",
-				[TRIGGER_INVOCATION_ID_HEADER]: "other-id",
-			},
-			body: JSON.stringify(scheduleBody),
-		});
+		const response = await app.request(
+			"/cron",
+			cronRequest({ header: "other-id" }),
+		);
 
 		expect(response.status).toBe(401);
 		expect(await response.text()).toBe("Invocation id mismatch");
 	});
 
 	it("returns 400 when the JSON body is not a schedule delivery", async () => {
-		const response = await app.request("/cron", {
-			method: "POST",
-			headers: {
-				"content-type": "application/json",
-				[TRIGGER_INVOCATION_ID_HEADER]: invocationId,
-			},
-			body: JSON.stringify({}),
-		});
+		const response = await app.request("/cron", cronRequest({ body: {} }));
 
 		expect(response.status).toBe(400);
 		expect(await response.text()).toBe("Invalid trigger payload");
 	});
 
 	it("returns 400 when the body is not JSON", async () => {
-		const response = await app.request("/cron", {
-			method: "POST",
-			headers: {
-				"content-type": "application/json",
-				[TRIGGER_INVOCATION_ID_HEADER]: invocationId,
-			},
-			body: "not-json",
-		});
+		const response = await app.request(
+			"/cron",
+			cronRequest({ body: "not-json" }),
+		);
 
 		expect(response.status).toBe(400);
-		expect(await response.text()).toBe("Invalid JSON body");
+		expect(await response.text()).toBe("Invalid trigger payload");
 	});
 });

--- a/packages/functions/src/lib/parse-trigger.test.ts
+++ b/packages/functions/src/lib/parse-trigger.test.ts
@@ -113,4 +113,16 @@ describe("parseTrigger", () => {
 		expect(response.status).toBe(400);
 		expect(await response.text()).toBe("Invalid trigger payload");
 	});
+
+	it("returns 401 when the trigger header is missing even if the body is not JSON", async () => {
+		const response = await app.request(
+			"/cron",
+			cronRequest({ omitHeader: true, body: "not-json" }),
+		);
+
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe(
+			`Missing ${invocationIdHeader} header`,
+		);
+	});
 });

--- a/packages/functions/src/lib/parse-trigger.ts
+++ b/packages/functions/src/lib/parse-trigger.ts
@@ -1,0 +1,42 @@
+import type { Context } from "hono";
+import { HTTPException } from "hono/http-exception";
+
+import {
+	parseTriggerInvocation,
+	TRIGGER_INVOCATION_ID_HEADER,
+	type TriggerInvocation,
+} from "./parse-trigger-invocation.js";
+
+const PARSE_TRIGGER_MESSAGES = {
+	missing_header: `Missing ${TRIGGER_INVOCATION_ID_HEADER} header`,
+	invalid_body: "Invalid trigger payload",
+	invocation_id_mismatch: "Invocation id mismatch",
+} as const;
+
+/**
+ * Parses a Function Trigger delivery from a Hono context.
+ *
+ * Throws `HTTPException` (401 / 400) so the handler cannot proceed on a bad
+ * delivery. Lives on the route rather than middleware: a `c.set` helper would
+ * need a `Variables` generic and would type the payload on every route.
+ */
+export async function parseTrigger(c: Context): Promise<TriggerInvocation> {
+	let body: unknown;
+	try {
+		body = await c.req.json();
+	} catch {
+		throw new HTTPException(400, { message: "Invalid JSON body" });
+	}
+
+	const parsed = parseTriggerInvocation({
+		header: c.req.header(TRIGGER_INVOCATION_ID_HEADER),
+		body,
+	});
+	if (!parsed.ok) {
+		const status = parsed.error === "invalid_body" ? 400 : 401;
+		throw new HTTPException(status, {
+			message: PARSE_TRIGGER_MESSAGES[parsed.error],
+		});
+	}
+	return parsed.invocation;
+}

--- a/packages/functions/src/lib/parse-trigger.ts
+++ b/packages/functions/src/lib/parse-trigger.ts
@@ -3,12 +3,11 @@ import { HTTPException } from "hono/http-exception";
 
 import {
 	parseTriggerInvocation,
-	TRIGGER_INVOCATION_ID_HEADER,
 	type TriggerInvocation,
 } from "./parse-trigger-invocation.js";
 
 const PARSE_TRIGGER_MESSAGES = {
-	missing_header: `Missing ${TRIGGER_INVOCATION_ID_HEADER} header`,
+	missing_header: "Missing x-neon-trigger-invocation-id header",
 	invalid_body: "Invalid trigger payload",
 	invocation_id_mismatch: "Invocation id mismatch",
 } as const;
@@ -21,17 +20,7 @@ const PARSE_TRIGGER_MESSAGES = {
  * need a `Variables` generic and would type the payload on every route.
  */
 export async function parseTrigger(c: Context): Promise<TriggerInvocation> {
-	let body: unknown;
-	try {
-		body = await c.req.json();
-	} catch {
-		throw new HTTPException(400, { message: "Invalid JSON body" });
-	}
-
-	const parsed = parseTriggerInvocation({
-		header: c.req.header(TRIGGER_INVOCATION_ID_HEADER),
-		body,
-	});
+	const parsed = await parseTriggerInvocation(c.req.raw);
 	if (!parsed.ok) {
 		const status = parsed.error === "invalid_body" ? 400 : 401;
 		throw new HTTPException(status, {

--- a/packages/functions/src/triggers.ts
+++ b/packages/functions/src/triggers.ts
@@ -1,0 +1,8 @@
+export {
+	type ParseTriggerInvocationInput,
+	type ParseTriggerInvocationResult,
+	parseTriggerInvocation,
+	type ScheduleTriggerInvocation,
+	TRIGGER_INVOCATION_ID_HEADER,
+	type TriggerInvocation,
+} from "./lib/parse-trigger-invocation.js";

--- a/packages/functions/src/triggers.ts
+++ b/packages/functions/src/triggers.ts
@@ -3,6 +3,5 @@ export {
 	type ParseTriggerInvocationResult,
 	parseTriggerInvocation,
 	type ScheduleTriggerInvocation,
-	TRIGGER_INVOCATION_ID_HEADER,
 	type TriggerInvocation,
 } from "./lib/parse-trigger-invocation.js";

--- a/packages/functions/tsdown.config.ts
+++ b/packages/functions/tsdown.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 	entry: [
 		"src/index.ts",
 		"src/hono.ts",
+		"src/triggers.ts",
 		"src/lib/**/*.ts",
 		"!src/**/*.test.*",
 	],


### PR DESCRIPTION
## Problem

A Function Trigger POSTs JSON to a Neon Function. The handler has to check `x-neon-trigger-invocation-id` against `invocation_id` in the body and parse the payload. Every app copies that check today, including the header name.

## Diagnosis

The delivery is a Function runtime concern: a header plus a JSON body, same class of helper as `waitUntil` and `upgradeWebSocket`. `@neon/config` declares the trigger. `@neon/sdk` is CRUD. Parsing belongs on `@neon/functions`.

Callers pass a `Request` (or headers plus the JSON they already read). They do not pass the header name.

## Interface

```ts
import { parseTriggerInvocation } from "@neon/functions/triggers";

export default {
  async fetch(request: Request): Promise<Response> {
    const parsed = await parseTriggerInvocation(request);
    if (!parsed.ok) {
      const status = parsed.error === "invalid_body" ? 400 : 401;
      return new Response(parsed.error, { status });
    }
    return Response.json({ ok: true, invocationId: parsed.invocation.invocationId });
  },
};
```

`parseTriggerInvocation(request)` checks the trigger header first, then clones the Request and reads JSON from the clone, so `request.json()` still works afterwards. A missing header is `missing_header` even when the body is not JSON.

If the JSON is already parsed:

```ts
const body = await request.json();
const parsed = parseTriggerInvocation({
  headers: request.headers,
  body,
});
```

`parsed` is `{ ok: true, invocation }` or `{ ok: false, error }`. `error` is `missing_header`, `invalid_body`, or `invocation_id_mismatch`. Invalid JSON on the Request path is `invalid_body`. The domain type is camelCase (`invocationId`, `trigger.id`, `trigger.name`, `data.scheduledAt`). Wire JSON stays snake_case.

Hono, on the trigger route:

```ts
import { parseTrigger } from "@neon/functions/hono";

app.post("/cron", async (c) => {
  const invocation = await parseTrigger(c);
  return c.json({ ok: true, invocationId: invocation.invocationId });
});
```

`parseTrigger` uses the Request overload on `c.req.raw`, so `c.req.json()` still works after it returns.

| Failure | Status | Message |
| --- | --- | --- |
| missing header | 401 | `Missing x-neon-trigger-invocation-id header` |
| header ≠ `invocation_id` | 401 | `Invocation id mismatch` |
| invalid JSON or payload | 400 | `Invalid trigger payload` |

It is a function the route calls, not middleware that `c.set`s the payload.

Only `trigger.type === "schedule"` parses. Unknown types fail as `invalid_body` until this package adds them.

Existing `waitUntil`, `upgradeWebSocket`, and `attachDatabasePool` callers are unchanged. The root `@neon/functions` entry still has no runtime dependencies. `hono` stays an optional peer of `./hono`. `./triggers` does not import Hono.

## Also in here

Minor changeset for `@neon/functions`. README, package description, `./triggers` export, and tsdown entry.

## Verification

`pnpm --filter @neon/functions test:ci` — 44 tests, including 10 parser cases (headers+body and Request: success, body still readable, missing header, missing header before JSON parse, id mismatch, invalid payload, invalid JSON) and 7 Hono `app.request` cases (success, body still readable, missing header, missing header with non-JSON body, id mismatch, invalid payload, invalid JSON).

`pnpm --filter @neon/functions build` (tsc + tsdown).

Not verified against a live Functions proxy delivery in this PR. Creating a schedule trigger currently 404s (`function triggers not available for this project`) on Functions-capable projects where `neon functions deploy` succeeds.

## For your attention

- The Cron Job bootstrap example still hand-rolls this check until a follow-up in `neondatabase/examples`.
- Auth is header presence plus matching `invocation_id`. There is no shared secret in this helper.
- No zod. Validation is hand-rolled so `@neon/functions` still installs nothing.