### PR TITLE
fix(config): name both platform-beta regions in neon.ts errors

### DIFF
--- a/.changeset/platform-beta-eu-region.md
+++ b/.changeset/platform-beta-eu-region.md
@@ -1,0 +1,6 @@
+---
+"@neon/config": patch
+"neon": patch
+---
+
+Name `aws-eu-central-1` alongside `aws-us-east-2` in neon.ts unavailable-feature errors and `neon logs` help.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1003,7 +1003,7 @@ neon inspect db stalled-queries --output json
 
 ## Logs (`logs`)
 
-`neon logs` reads the log records the services on a branch emit — Neon Functions, object storage, and Postgres computes. **Logs require Neon Platform Beta and are currently available only for projects in `aws-us-east-2`.**
+`neon logs` reads the log records the services on a branch emit — Neon Functions, object storage, and Postgres computes. **Logs require Neon Platform Beta and are currently available only for projects in `aws-us-east-2` and `aws-eu-central-1`.**
 
 Every sub-command resolves the project through the standard chain (`--project-id`, then the `.neon` context file, then a single-project auto-detect), and takes `--branch <id|name>`, defaulting to the project's default branch. `logs query` searches the previous hour by default; `logs field-values` searches the previous six hours. The maximum time window is seven days.
 

--- a/packages/cli/src/commands/logs.test.ts
+++ b/packages/cli/src/commands/logs.test.ts
@@ -88,7 +88,7 @@ describe("logs", () => {
 			mockDir: "single_org",
 			snapshot: false,
 			stdout: expect.stringContaining(
-				"Logs require Neon Platform Beta and are currently available only for projects in aws-us-east-2.",
+				"Logs require Neon Platform Beta and are currently available only for projects in aws-us-east-2 and aws-eu-central-1.",
 			),
 		});
 	});
@@ -100,7 +100,7 @@ describe("logs", () => {
 			mockDir: "single_org",
 			snapshot: false,
 			stdout: expect.stringContaining(
-				"Logs require Neon Platform Beta and are currently available only for projects in aws-us-east-2.",
+				"Logs require Neon Platform Beta and are currently available only for projects in aws-us-east-2 and aws-eu-central-1.",
 			),
 		});
 	});

--- a/packages/cli/src/commands/logs.ts
+++ b/packages/cli/src/commands/logs.ts
@@ -13,7 +13,7 @@ import { noPassthrough, single } from "../utils/flags.js";
 import { writer } from "../writer.js";
 
 const BETA_NOTE =
-	"Logs require Neon Platform Beta and are currently available only for projects in aws-us-east-2.";
+	"Logs require Neon Platform Beta and are currently available only for projects in aws-us-east-2 and aws-eu-central-1.";
 const LOGS_EPILOG = `
 ${BETA_NOTE}
 

--- a/packages/config/src/lib/neon-api-real.test.ts
+++ b/packages/config/src/lib/neon-api-real.test.ts
@@ -205,7 +205,7 @@ describe("isPreviewFeatureUnavailable", () => {
 });
 
 describe("previewUnavailableError", () => {
-	test("503 with region-unavailable API body: points at aws-us-east-2 beta rollout", () => {
+	test("503 with region-unavailable API body: points at beta regions", () => {
 		const original = new PlatformError(ErrorCode.ServerError, "boom", {
 			details: {
 				status: 503,
@@ -232,13 +232,15 @@ describe("previewUnavailableError", () => {
 		expect(wrapped.message).toMatch(/currently in beta/);
 		expect(wrapped.message).toMatch(/more regions are coming shortly/);
 		expect(wrapped.message).toMatch(/aws-us-east-2/);
+		expect(wrapped.message).toMatch(/aws-eu-central-1/);
+		expect(wrapped.message).toMatch(/one of those regions/);
 		expect(wrapped.message).not.toMatch(/private preview/);
 		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
 		expect(wrapped.details.status).toBe(503);
 		expect(wrapped.details.requestId).toBe("req-503-region");
 	});
 
-	test("503 with project-unavailable API body: points at aws-us-east-2 beta rollout", () => {
+	test("503 with project-unavailable API body: points at beta regions", () => {
 		const original = new PlatformError(ErrorCode.ServerError, "boom", {
 			details: {
 				status: 503,
@@ -262,6 +264,8 @@ describe("previewUnavailableError", () => {
 		expect(wrapped.message).toMatch(/currently in beta/);
 		expect(wrapped.message).toMatch(/more regions are coming shortly/);
 		expect(wrapped.message).toMatch(/aws-us-east-2/);
+		expect(wrapped.message).toMatch(/aws-eu-central-1/);
+		expect(wrapped.message).toMatch(/one of those regions/);
 		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
 		expect(wrapped.details.status).toBe(503);
 		expect(wrapped.details.requestId).toBe("req-503");
@@ -280,9 +284,10 @@ describe("previewUnavailableError", () => {
 		expect(wrapped.message).toMatch(/incident/);
 		expect(wrapped.message).toMatch(/neonstatus\.com/);
 		expect(wrapped.message).not.toMatch(/aws-us-east-2/);
+		expect(wrapped.message).not.toMatch(/aws-eu-central-1/);
 	});
 
-	test("404: points at aws-us-east-2 beta rollout", () => {
+	test("404: points at beta regions", () => {
 		const original = new PlatformError(ErrorCode.NotFound, "boom", {
 			details: { status: 404, neonMessage: "this route does not exist" },
 		});
@@ -296,6 +301,8 @@ describe("previewUnavailableError", () => {
 		expect(wrapped.message).toMatch(/currently in beta/);
 		expect(wrapped.message).toMatch(/more regions are coming shortly/);
 		expect(wrapped.message).toMatch(/aws-us-east-2/);
+		expect(wrapped.message).toMatch(/aws-eu-central-1/);
+		expect(wrapped.message).toMatch(/one of those regions/);
 		expect(wrapped.message).not.toMatch(/private preview/);
 		expect(wrapped.message).not.toMatch(/neonstatus\.com/);
 		expect(wrapped.details.status).toBe(404);

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1577,16 +1577,17 @@ const HTTP_STATUS_TEXT: Record<number, string> = {
 	503: "Service Unavailable",
 };
 
-/** AWS region where Neon features are currently available in beta. */
-const PLATFORM_BETA_REGION_ID = "aws-us-east-2";
+/** AWS regions where Neon features are currently available in beta. */
+const PLATFORM_BETA_REGIONS =
+	"AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`)";
 
 const PLATFORM_BETA_REGION_GUIDANCE =
-	"Neon features (Functions and Object Storage) are currently in beta and only available in the AWS US East (Ohio) region " +
-	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to link or create a new project in that region.`;
+	"Neon features (Functions and Object Storage) are currently in beta and only available in " +
+	`${PLATFORM_BETA_REGIONS}; more regions are coming shortly. Run \`neon link\` to link or create a new project in one of those regions.`;
 
 const PLATFORM_BETA_REGION_GUIDANCE_SHORT =
-	"Neon features are currently in beta and only available in the AWS US East (Ohio) region " +
-	`(\`${PLATFORM_BETA_REGION_ID}\`); more regions are coming shortly. Run \`neon link\` to link or create a new project in that region.`;
+	"Neon features are currently in beta and only available in " +
+	`${PLATFORM_BETA_REGIONS}; more regions are coming shortly. Run \`neon link\` to link or create a new project in one of those regions.`;
 
 /**
  * True when the Neon API body indicates the feature isn't deployed for this project's
@@ -1608,11 +1609,12 @@ function isRegionUnavailableNeonMessage(
 /**
  * Per-status guidance for a platform feature that came back "unavailable". These features
  * are currently in beta and rolling out region by region — today only in
- * {@link PLATFORM_BETA_REGION_ID} — so we tailor the next step instead of emitting one
+ * {@link PLATFORM_BETA_REGIONS} — so we tailor the next step instead of emitting one
  * catch-all:
  *
  * - 404 / 501, or an API message that names region/project unavailability — the route
- *   isn't deployed for this project's region: create a project in `aws-us-east-2`.
+ *   isn't deployed for this project's region: create a project in `aws-us-east-2` or
+ *   `aws-eu-central-1`.
  * - 503 without a region-unavailable body — the route exists but is refusing right now;
  *   Neon may be having a transient incident. Retry; if it persists check neonstatus.com.
  * - anything else — point at the beta region requirement.

--- a/packages/config/src/lib/neon-api-real.ts
+++ b/packages/config/src/lib/neon-api-real.ts
@@ -1577,7 +1577,6 @@ const HTTP_STATUS_TEXT: Record<number, string> = {
 	503: "Service Unavailable",
 };
 
-/** AWS regions where Neon features are currently available in beta. */
 const PLATFORM_BETA_REGIONS =
 	"AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`)";
 
@@ -1608,13 +1607,10 @@ function isRegionUnavailableNeonMessage(
 
 /**
  * Per-status guidance for a platform feature that came back "unavailable". These features
- * are currently in beta and rolling out region by region — today only in
- * {@link PLATFORM_BETA_REGIONS} — so we tailor the next step instead of emitting one
- * catch-all:
+ * roll out region by region, so we tailor the next step instead of emitting one catch-all:
  *
  * - 404 / 501, or an API message that names region/project unavailability — the route
- *   isn't deployed for this project's region: create a project in `aws-us-east-2` or
- *   `aws-eu-central-1`.
+ *   isn't deployed for this project's region.
  * - 503 without a region-unavailable body — the route exists but is refusing right now;
  *   Neon may be having a transient incident. Retry; if it persists check neonstatus.com.
  * - anything else — point at the beta region requirement.


### PR DESCRIPTION
## Problem

`neon deploy` / `neon config plan` still tell you platform beta is only in AWS US East (Ohio) (`aws-us-east-2`) when Functions or Object Storage come back unavailable. That is wrong now: those services also run in AWS Europe (Frankfurt) (`aws-eu-central-1`). Someone whose project is already in Frankfurt is sent to create another project in Ohio.

Public docs already list both regions ([backend beta](https://neon.com/docs/get-started/backend-beta), [Functions overview](https://neon.com/docs/compute/functions/overview)). The Neon agent skills on `main` already say `us-east-2` and `eu-central-1`. The neon.ts error did not.

## Diagnosis

`previewUnavailableError` interpolates a single `PLATFORM_BETA_REGION_ID`. The API still region-gates everywhere else; only the next-step text was stale.

Live production, new projects:

| Region | `neon functions list` | `neon buckets list` | `neon logs query` |
|---|---|---|---|
| `aws-eu-central-1` | `[]` | `[]` | empty records |
| `aws-us-east-1` | `platform functions not available for this project` | `platform branchable-storage is not available in this region` | `telemetry is not available in this region` |

## User-facing interface

A region-gated Functions or Object Storage error now names both regions:

```text
Functions isn't available for this Neon project (HTTP 503 Service Unavailable; Neon API said: "platform functions not available for this project"; request id …). Neon features (Functions and Object Storage) are currently in beta and only available in AWS US East (Ohio) (`aws-us-east-2`) and AWS Europe (Frankfurt) (`aws-eu-central-1`); more regions are coming shortly. Run `neon link` to link or create a new project in one of those regions. If you don't need it, remove the corresponding feature from the `preview` block of your neon.ts and re-run.
```

`neon logs --help` and `neon logs query --help` use the same region list:

```text
Logs require Neon Platform Beta and are currently available only for projects in aws-us-east-2 and aws-eu-central-1.
```

`neon deploy` still applies the same policy. Successful deploys and plans are unchanged; only unavailable-feature guidance changes. A 503 without a region/project-unavailable body still points at a transient incident, not at the region list.

## Also in here

- Patch changeset for `@neon/config` and `neon`.
- CLI README logs section matches the help epilog.

## Verification

- `pnpm --filter @neon/config exec vitest run src/lib/neon-api-real.test.ts` — 22 passed (region-unavailable 503, project-unavailable 503, and 404 all assert both region ids; incident 503 asserts neither).
- `pnpm --filter neon exec vitest run src/commands/logs.test.ts` — 49 passed, including the two help assertions.
- Live `functions` / `buckets` / `logs` calls above.

Not run: `neon deploy` of a `preview.functions` / `preview.buckets` policy on a Frankfurt project. The control-plane list routes succeeded there; apply was not exercised.