### PR TITLE
chore: release @neon/sdk@4.2.0

### DIFF
--- a/.changeset/sdk-consumption-orgid.md
+++ b/.changeset/sdk-consumption-orgid.md
@@ -1,5 +1,0 @@
----
-"@neon/sdk": minor
----
-
-`consumption.perProject`, `perProjectV2`, and `perBranchV2` now default `org_id` from the client's `orgId` and accept a camelCase `orgId` override. Snake_case `org_id` still works.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon-internals/env-core
 
+## 0.0.13
+
+### Patch Changes
+
+- @neon/config@1.4.1
+
 ## 0.0.12
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.12",
+	"version": "0.0.13",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # neon
 
+## 4.17.2
+
+### Patch Changes
+
+- Updated dependencies [ad78f8b]
+  - @neon/sdk@4.2.0
+  - @neon/config@1.4.1
+  - @neon/config-runtime@1.3.1
+
 ## 4.17.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.17.1",
+	"version": "4.17.2",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config-runtime
 
+## 1.3.1
+
+### Patch Changes
+
+- @neon/config@1.4.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config
 
+## 1.4.1
+
+### Patch Changes
+
+- Updated dependencies [ad78f8b]
+  - @neon/sdk@4.2.0
+
 ## 1.4.0
 
 ### Minor Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/env
 
+## 1.3.1
+
+### Patch Changes
+
+- @neon/config@1.4.1
+
 ## 1.3.0
 
 ### Minor Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,11 @@
 # neonctl
 
+## 4.17.2
+
+### Patch Changes
+
+- neon@4.17.2
+
 ## 4.17.1
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.17.1",
+  "version": "4.17.2",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neon/sdk
 
+## 4.2.0
+
+### Minor Changes
+
+- ad78f8b: `consumption.perProject`, `perProjectV2`, and `perBranchV2` now default `org_id` from the client's `orgId` and accept a camelCase `orgId` override. Snake_case `org_id` still works.
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/sdk",
-	"version": "4.1.0",
+	"version": "4.2.0",
 	"description": "The official TypeScript SDK for the Neon API, generated from Neon's OpenAPI specification. A modern, fetch-based replacement for @neondatabase/api-client.",
 	"keywords": [
 		"neon",

--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neon/tools
 
+## 1.3.3
+
+### Patch Changes
+
+- Updated dependencies [ad78f8b]
+  - @neon/sdk@4.2.0
+
 ## 1.3.2
 
 ### Patch Changes

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/tools",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "Agent tools for the Neon SDK ergonomic client, compatible with MCP, Eve, and Mastra.",
 	"keywords": [
 		"neon",


### PR DESCRIPTION
## Problem

Prepare `@neon/sdk` 4.2.0 for publication. The consumption `orgId` support is already on `main`; this PR consumes its changeset and updates package versions and changelogs. The diff contains no source changes.

## SDK usage

`consumption.perProject`, `perProjectV2` and `perBranchV2` default `org_id` from the client's `orgId` and accept a per-call camelCase override:

```ts
import { createNeonClient } from "@neon/sdk";

const neon = createNeonClient({
  apiKey: process.env.NEON_API_KEY!,
  orgId: "org-example",
});

const query = {
  from: "2026-06-01T00:00:00Z",
  to: "2026-06-30T00:00:00Z",
  granularity: "daily" as const,
};

await neon.consumption.perProject(query).all();
await neon.consumption.perProject({
  ...query,
  orgId: "org-other",
}).all();
```

Existing `org_id` overrides remain supported. If both spellings are supplied, `orgId` wins. The v2 methods require an org from the client or the call.

## Package versions

| Package | Before | After | Reason |
| --- | --- | --- | --- |
| `@neon/sdk` | 4.1.0 | 4.2.0 | Consumption `orgId` support |
| `@neon/tools` | 1.3.2 | 1.3.3 | Dependency update |
| `@neon/config` | 1.4.0 | 1.4.1 | Dependency update |
| `@neon/config-runtime` | 1.3.0 | 1.3.1 | Dependency update |
| `@neon/env` | 1.3.0 | 1.3.1 | Dependency update |
| `neon` / `neonctl` | 4.17.1 | 4.17.2 | Dependency update; Changesets fixed group |
| `@neon-internals/env-core` | 0.0.12 | 0.0.13 | Dependency update; private, unpublished |

The dependent patches follow Changesets' `updateInternalDependencies: "patch"` setting. `.changeset/sdk-consumption-orgid.md` is consumed into the changelogs.

## Verification

At `6417e48`:

- `git diff --check origin/main...HEAD` passed.
- `pnpm lint:ci` passed, checking 764 files.
- Reviewed the branch diff: package versions, changelog entries and the consumed changeset only.

Runtime tests and live consumption requests were not rerun for this metadata-only PR. Package publication and verification of the published versions remain separate release steps.
