### PR TITLE
chore: release @neon/functions@0.10.0

### DIFF
--- a/.changeset/functions-triggers.md
+++ b/.changeset/functions-triggers.md
@@ -1,5 +1,0 @@
----
-"@neon/functions": minor
----
-
-Add `@neon/functions/triggers` (`parseTriggerInvocation(request)` or `{ headers, body }`) for Function Trigger deliveries, and `parseTrigger(c)` on `@neon/functions/hono`.

--- a/.changeset/platform-beta-eu-region.md
+++ b/.changeset/platform-beta-eu-region.md
@@ -1,6 +1,0 @@
----
-"@neon/config": patch
-"neon": patch
----
-
-Name `aws-eu-central-1` alongside `aws-us-east-2` in neon.ts unavailable-feature errors and `neon logs` help.

--- a/internals/env-core/CHANGELOG.md
+++ b/internals/env-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neon-internals/env-core
 
+## 0.0.14
+
+### Patch Changes
+
+- Updated dependencies [0607d8e]
+  - @neon/config@1.4.2
+
 ## 0.0.13
 
 ### Patch Changes

--- a/internals/env-core/package.json
+++ b/internals/env-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon-internals/env-core",
-	"version": "0.0.13",
+	"version": "0.0.14",
 	"private": true,
 	"description": "Branch env resolution and credential reuse shared by the `neon` and `@neon/env` CLIs. Never published - bundled into each consumer.",
 	"type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,14 @@
 # neon
 
+## 4.17.3
+
+### Patch Changes
+
+- 0607d8e: Name `aws-eu-central-1` alongside `aws-us-east-2` in neon.ts unavailable-feature errors and `neon logs` help.
+- Updated dependencies [0607d8e]
+  - @neon/config@1.4.2
+  - @neon/config-runtime@1.3.2
+
 ## 4.17.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "neon",
-	"version": "4.17.2",
+	"version": "4.17.3",
 	"description": "CLI tool for Neon, the cloud backend primitives built around Lakebase Postgres",
 	"keywords": [
 		"neon",

--- a/packages/config-runtime/CHANGELOG.md
+++ b/packages/config-runtime/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/config-runtime
 
+## 1.3.2
+
+### Patch Changes
+
+- Updated dependencies [0607d8e]
+  - @neon/config@1.4.2
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/config-runtime/package.json
+++ b/packages/config-runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config-runtime",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Imperative runtime for @neon/config: inspect/plan/apply a neon.ts policy against the Neon API and bundle + deploy Neon Functions. Pulls in esbuild; import this from CLIs and CI, not from neon.ts.",
 	"keywords": [
 		"neon",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/config
 
+## 1.4.2
+
+### Patch Changes
+
+- 0607d8e: Name `aws-eu-central-1` alongside `aws-us-east-2` in neon.ts unavailable-feature errors and `neon logs` help.
+
 ## 1.4.1
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/config",
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"description": "Config-as-Code for Neon. Define a `neon.ts` policy and inspect/diff/deploy it against the Neon API as plain TypeScript functions.",
 	"keywords": [
 		"neon",

--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @neondatabase/env
 
+## 1.3.2
+
+### Patch Changes
+
+- Updated dependencies [0607d8e]
+  - @neon/config@1.4.2
+
 ## 1.3.1
 
 ### Patch Changes

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/env",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Resolve and inject Neon connection strings for the branch selected by your neon.ts policy. fetchEnv / parseEnv plus a `neon-env` CLI with `run` and `export`.",
 	"keywords": [
 		"neon",

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @neondatabase/functions
 
+## 0.10.0
+
+### Minor Changes
+
+- 7c086cb: Add `@neon/functions/triggers` (`parseTriggerInvocation(request)` or `{ headers, body }`) for Function Trigger deliveries, and `parseTrigger(c)` on `@neon/functions/hono`.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@neon/functions",
-	"version": "0.9.0",
+	"version": "0.10.0",
 	"description": "Runtime helpers for Neon Functions: `waitUntil` for deferring async work past a response, `upgradeWebSocket` for serving WebSockets from a fetch handler or a Hono route, `attachDatabasePool` for node-postgres idle-client errors, and `parseTriggerInvocation` for Function Trigger deliveries.",
 	"keywords": [
 		"neon",

--- a/packages/neonctl/CHANGELOG.md
+++ b/packages/neonctl/CHANGELOG.md
@@ -1,5 +1,12 @@
 # neonctl
 
+## 4.17.3
+
+### Patch Changes
+
+- Updated dependencies [0607d8e]
+  - neon@4.17.3
+
 ## 4.17.2
 
 ### Patch Changes

--- a/packages/neonctl/package.json
+++ b/packages/neonctl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neonctl",
-  "version": "4.17.2",
+  "version": "4.17.3",
   "description": "Compatibility command for the Neon CLI",
   "keywords": [
     "neon",


### PR DESCRIPTION
## Bumped

| Package | From | To | Why |
| --- | --- | --- | --- |
| `@neon/functions` | 0.9.0 | 0.10.0 | minor: `parseTriggerInvocation` / `parseTrigger` |
| `@neon/config` | 1.4.1 | 1.4.2 | patch: name `aws-eu-central-1` in neon.ts errors |
| `@neon/config-runtime` | 1.3.1 | 1.3.2 | dependent cascade |
| `@neon/env` | 1.3.1 | 1.3.2 | dependent cascade |
| `neon` | 4.17.2 | 4.17.3 | patch + cascade |
| `neonctl` | 4.17.2 | 4.17.3 | fixed group with `neon` |

`@neon-internals/env-core` 0.0.13 → 0.0.14 (private, not published).

## Publish after merge

One workflow run per package, leaf first:

1. `@neon/functions`
2. `@neon/config`
3. `@neon/config-runtime`
4. `@neon/env`
5. `neon`
6. `neonctl`

`@neon/config@1.4.1` and `neon@4.17.2` are on `main` and unpublished; this bump supersedes them.